### PR TITLE
Add github action tests for native workers (presto_cpp)

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -1,8 +1,9 @@
 name: test native
-
+# test
 on:
   pull_request:
 
+# test
 env:
   MAVEN_OPTS: "-Xmx1024M -XX:+ExitOnOutOfMemoryError"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
@@ -73,7 +74,7 @@ jobs:
       - name: Install presto-hive
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          mvn install ${MAVEN_FAST_INSTALL} -am -pl presto-hive
+          mvn install ${MAVEN_FAST_INSTALL} -DskipTests -am -pl presto-hive
 
       - name: Run e2e tests
         run: mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -1,0 +1,79 @@
+name: test native
+
+on:
+  pull_request:
+
+env:
+  MAVEN_OPTS: "-Xmx1024M -XX:+ExitOnOutOfMemoryError"
+  MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+  MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+  MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    container: prestocpp/prestocpp-circleci:mikesh-20220331
+
+    env:
+      CC: /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Get date for ccache
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
+      - name: Setup ccache cache
+        id: presto_cpp_ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-presto-native-ccache-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-presto-native-ccache-
+
+      - name: Initialize ccache
+        if: steps.presto_cpp_ccache.outputs.cache-hit != 'true'
+        run: ccache -sz -M 6Gi
+
+      - name: Build presto_cpp
+        run: |
+          source /opt/rh/gcc-toolset-9/enable
+          cd ${GITHUB_WORKSPACE}/presto-native-execution
+          make velox-submodule
+          cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          ninja -C _build/debug -j 1
+          ccache -s
+
+      - name: Run unit tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/presto-native-execution/_build/debug
+          ctest -j 1 -VV --output-on-failure --exclude-regex velox.*
+
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+
+      - name: Install presto-hive
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          mvn install ${MAVEN_FAST_INSTALL} -am -pl presto-hive
+
+      - name: Run e2e tests
+        run: mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -57,4 +57,5 @@ jobs:
             !presto-redis,
             !presto-elasticsearch,
             !presto-orc,
-            !presto-thrift-connector'
+            !presto-thrift-connector,
+            !presto-native-execution'

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
         <module>presto-lark-sheets</module>
         <module>presto-test-coverage</module>
         <module>presto-hudi</module>
+        <module>presto-native-execution</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -93,8 +93,6 @@ find_path(
   PATH_SUFFIXES antlr4-runtime)
 include_directories(SYSTEM ${ANTLR4_RUNTIME_INCLUDE_DIR})
 
-find_library(GMock gmock)
-
 find_library(GLOG glog)
 
 find_library(FMT fmt)
@@ -157,7 +155,8 @@ add_subdirectory(velox)
 if(PRESTO_ENABLE_TESTING)
   include(CTest) # include after project() but before add_subdirectory()
   include_directories(velox/third_party/googletest/googletest/include)
-  include_directories(veloxs/third_party/googletest/googlemock/include)
+else()
+  add_definitions(-DVELOX_DISABLE_GOOGLETEST)
 endif()
 
 add_subdirectory(presto_cpp)

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -2,19 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>presto-root</artifactId>
-        <groupId>com.facebook.presto</groupId>
-        <version>0.274-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>presto-native-tests</artifactId>
-    <name>presto-native-tests</name>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.274-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-native-execution</artifactId>
+    <name>presto-native-execution</name>
     <description>Presto - Tests for Native (C++) Worker</description>
 
     <properties>
-        <air.main.basedir>${project.basedir}</air.main.basedir>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.checkstyle.config-file>src/checkstyle/presto-checks.xml</air.checkstyle.config-file>
     </properties>
 
@@ -27,7 +28,6 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
@@ -100,5 +100,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -114,7 +114,7 @@ std::string getLocalIp() {
     boost::asio::ip::address addr = (it++)->endpoint().address();
     // simple check to see if the address is not ::
     if (addr.to_string().length() > 4) {
-      return fmt::format("[{}]", addr.to_string());
+      return fmt::format("{}", addr.to_string());
     }
   }
   VELOX_FAIL(
@@ -152,21 +152,28 @@ void PrestoServer::run() {
   folly::setUnsafeMutableGlobalIOExecutor(executor);
 
   auto systemConfig = SystemConfig::instance();
-  systemConfig->initialize(configDirectoryPath_ + "/config.properties");
   auto nodeConfig = NodeConfig::instance();
-  nodeConfig->initialize(configDirectoryPath_ + "/node.properties");
-
-  auto servicePort = systemConfig->httpServerHttpPort();
-  nodeVersion_ = systemConfig->prestoVersion();
-  int httpExecThreads = systemConfig->httpExecThreads();
-  environment_ = nodeConfig->nodeEnvironment();
-  nodeId_ = nodeConfig->nodeId();
-  address_ = nodeConfig->nodeIp(getLocalIp);
-  nodeLocation_ = nodeConfig->nodeLocation();
-  if (address_.find(':') != std::string::npos && address_.front() != '[') {
-    address_ = fmt::format("[{}]", address_);
+  int servicePort;
+  int httpExecThreads;
+  try {
+    systemConfig->initialize(configDirectoryPath_ + "/config.properties");
+    nodeConfig->initialize(configDirectoryPath_ + "/node.properties");
+    servicePort = systemConfig->httpServerHttpPort();
+    nodeVersion_ = systemConfig->prestoVersion();
+    httpExecThreads = systemConfig->httpExecThreads();
+    environment_ = nodeConfig->nodeEnvironment();
+    nodeId_ = nodeConfig->nodeId();
+    address_ = nodeConfig->nodeIp(getLocalIp);
+    // Add [] to an ipv6 address.
+    if (address_.find(':') != std::string::npos && address_.front() != '[') {
+      address_ = fmt::format("[{}]", address_);
+    }
+    nodeLocation_ = nodeConfig->nodeLocation();
+  } catch (const VeloxUserError& e) {
+    // VeloxUserError is always logged as an error.
+    // Avoid logging again.
+    exit(EXIT_FAILURE);
   }
-
   initializeAsyncCache();
 
   auto catalogNames = registerConnectors(fs::path(configDirectoryPath_));
@@ -393,11 +400,17 @@ void PrestoServer::stop() {
 }
 
 std::function<folly::SocketAddress()> PrestoServer::discoveryAddressLookup() {
-  auto uri = folly::Uri(SystemConfig::instance()->discoveryUri());
+  try {
+    auto uri = folly::Uri(SystemConfig::instance()->discoveryUri());
 
-  return [uri]() {
-    return folly::SocketAddress(uri.hostname(), uri.port(), true);
-  };
+    return [uri]() {
+      return folly::SocketAddress(uri.hostname(), uri.port(), true);
+    };
+  } catch (const VeloxUserError& e) {
+    // VeloxUserError is always logged as an error.
+    // Avoid logging again.
+    exit(EXIT_FAILURE);
+  }
 }
 
 std::shared_ptr<velox::exec::TaskListener> PrestoServer::getTaskListiner() {

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -118,7 +118,7 @@ void getData(
       maxSize.getValue(protocol::DataUnit::BYTE),
       token,
       [taskId = taskId, bufferId = bufferId, promiseHolder](
-          std::vector<std::shared_ptr<exec::SerializedPage>>& pages,
+          std::vector<std::unique_ptr<folly::IOBuf>> pages,
           int64_t sequence) mutable {
         bool complete = pages.empty();
         int64_t nextSequence = sequence;
@@ -128,10 +128,10 @@ void getData(
           if (page) {
             VELOX_CHECK(!complete, "Received data after end marker");
             if (!iobuf) {
-              iobuf = page->getIOBuf();
+              iobuf = std::move(page);
               bytes = iobuf->length();
             } else {
-              auto next = page->getIOBuf();
+              auto next = std::move(page);
               bytes += next->length();
               iobuf->prev()->appendChain(std::move(next));
             }

--- a/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
+++ b/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
@@ -14,6 +14,7 @@
 
 #include "presto_cpp/main/common/ConfigReader.h"
 #include <fstream>
+#include "velox/common/base/Exceptions.h"
 #include "velox/core/Context.h"
 
 namespace facebook::presto::util {
@@ -24,8 +25,7 @@ std::unordered_map<std::string, std::string> readConfig(
 
   std::ifstream configFile(filePath);
   if (!configFile.is_open()) {
-    throw std::runtime_error(
-        fmt::format("Couldn't open config file {} for reading.", filePath));
+    VELOX_USER_FAIL("Couldn't open config file {} for reading.", filePath);
   }
 
   std::unordered_map<std::string, std::string> properties;
@@ -49,8 +49,7 @@ std::string requiredProperty(
     const std::string& name) {
   auto it = properties.find(name);
   if (it == properties.end()) {
-    throw std::runtime_error(
-        std::string("Missing configuration property ") + name);
+    VELOX_USER_FAIL("Missing configuration property {}", name);
   }
   return it->second;
 }
@@ -60,8 +59,7 @@ std::string requiredProperty(
     const std::string& name) {
   auto value = properties.get(name);
   if (!value.hasValue()) {
-    throw std::runtime_error(
-        std::string("Missing configuration property ") + name);
+    VELOX_USER_FAIL("Missing configuration property {}", name);
   }
   return value.value();
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -34,7 +34,8 @@ class ConfigBase {
     if (propertyValue.has_value()) {
       return propertyValue.value();
     } else {
-      VELOX_FAIL("{} is required in the {} file.", propertyName, filePath_);
+      VELOX_USER_FAIL(
+          "{} is required in the {} file.", propertyName, filePath_);
     }
   }
 
@@ -43,7 +44,8 @@ class ConfigBase {
     if (propertyValue.has_value()) {
       return propertyValue.value();
     } else {
-      VELOX_FAIL("{} is required in the {} file.", propertyName, filePath_);
+      VELOX_USER_FAIL(
+          "{} is required in the {} file.", propertyName, filePath_);
     }
   }
 

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
@@ -58,95 +58,37 @@ namespace facebook::presto::protocol {
 // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<StageExecutionStrategy, json>
-    StageExecutionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
-        {StageExecutionStrategy::UNGROUPED_EXECUTION, "UNGROUPED_EXECUTION"},
-        {StageExecutionStrategy::FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-         "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
-        {StageExecutionStrategy::DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-         "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
-        {StageExecutionStrategy::RECOVERABLE_GROUPED_EXECUTION,
-         "RECOVERABLE_GROUPED_EXECUTION"}};
-void to_json(json& j, const StageExecutionStrategy& e) {
-  static_assert(
-      std::is_enum<StageExecutionStrategy>::value,
-      "StageExecutionStrategy must be an enum!");
+static const std::pair<ColumnType, json> ColumnType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {ColumnType::PARTITION_KEY, "PARTITION_KEY"},
+        {ColumnType::REGULAR, "REGULAR"},
+        {ColumnType::SYNTHESIZED, "SYNTHESIZED"},
+        {ColumnType::AGGREGATED, "AGGREGATED"}};
+void to_json(json& j, const ColumnType& e) {
+  static_assert(std::is_enum<ColumnType>::value, "ColumnType must be an enum!");
   const auto* it = std::find_if(
-      std::begin(StageExecutionStrategy_enum_table),
-      std::end(StageExecutionStrategy_enum_table),
-      [e](const std::pair<StageExecutionStrategy, json>& ej_pair) -> bool {
+      std::begin(ColumnType_enum_table),
+      std::end(ColumnType_enum_table),
+      [e](const std::pair<ColumnType, json>& ej_pair) -> bool {
         return ej_pair.first == e;
       });
-  j = ((it != std::end(StageExecutionStrategy_enum_table))
+  j = ((it != std::end(ColumnType_enum_table))
            ? it
-           : std::begin(StageExecutionStrategy_enum_table))
+           : std::begin(ColumnType_enum_table))
           ->second;
 }
-void from_json(const json& j, StageExecutionStrategy& e) {
-  static_assert(
-      std::is_enum<StageExecutionStrategy>::value,
-      "StageExecutionStrategy must be an enum!");
+void from_json(const json& j, ColumnType& e) {
+  static_assert(std::is_enum<ColumnType>::value, "ColumnType must be an enum!");
   const auto* it = std::find_if(
-      std::begin(StageExecutionStrategy_enum_table),
-      std::end(StageExecutionStrategy_enum_table),
-      [&j](const std::pair<StageExecutionStrategy, json>& ej_pair) -> bool {
+      std::begin(ColumnType_enum_table),
+      std::end(ColumnType_enum_table),
+      [&j](const std::pair<ColumnType, json>& ej_pair) -> bool {
         return ej_pair.second == j;
       });
-  e = ((it != std::end(StageExecutionStrategy_enum_table))
+  e = ((it != std::end(ColumnType_enum_table))
            ? it
-           : std::begin(StageExecutionStrategy_enum_table))
+           : std::begin(ColumnType_enum_table))
           ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const StageExecutionDescriptor& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "stageExecutionStrategy",
-      p.stageExecutionStrategy,
-      "StageExecutionDescriptor",
-      "StageExecutionStrategy",
-      "stageExecutionStrategy");
-  to_json_key(
-      j,
-      "groupedExecutionScanNodes",
-      p.groupedExecutionScanNodes,
-      "StageExecutionDescriptor",
-      "List<PlanNodeId>",
-      "groupedExecutionScanNodes");
-  to_json_key(
-      j,
-      "totalLifespans",
-      p.totalLifespans,
-      "StageExecutionDescriptor",
-      "int",
-      "totalLifespans");
-}
-
-void from_json(const json& j, StageExecutionDescriptor& p) {
-  from_json_key(
-      j,
-      "stageExecutionStrategy",
-      p.stageExecutionStrategy,
-      "StageExecutionDescriptor",
-      "StageExecutionStrategy",
-      "stageExecutionStrategy");
-  from_json_key(
-      j,
-      "groupedExecutionScanNodes",
-      p.groupedExecutionScanNodes,
-      "StageExecutionDescriptor",
-      "List<PlanNodeId>",
-      "groupedExecutionScanNodes");
-  from_json_key(
-      j,
-      "totalLifespans",
-      p.totalLifespans,
-      "StageExecutionDescriptor",
-      "int",
-      "totalLifespans");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -160,726 +102,6 @@ void to_json(json& j, const SourceLocation& p) {
 void from_json(const json& j, SourceLocation& p) {
   from_json_key(j, "line", p.line, "SourceLocation", "int", "line");
   from_json_key(j, "column", p.column, "SourceLocation", "int", "column");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-VariableReferenceExpression::VariableReferenceExpression() noexcept {
-  _type = "variable";
-}
-
-void to_json(json& j, const VariableReferenceExpression& p) {
-  j = json::object();
-  j["@type"] = "variable";
-  to_json_key(
-      j,
-      "sourceLocation",
-      p.sourceLocation,
-      "VariableReferenceExpression",
-      "SourceLocation",
-      "sourceLocation");
-  to_json_key(
-      j, "name", p.name, "VariableReferenceExpression", "String", "name");
-  to_json_key(j, "type", p.type, "VariableReferenceExpression", "Type", "type");
-}
-
-void from_json(const json& j, VariableReferenceExpression& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j,
-      "sourceLocation",
-      p.sourceLocation,
-      "VariableReferenceExpression",
-      "SourceLocation",
-      "sourceLocation");
-  from_json_key(
-      j, "name", p.name, "VariableReferenceExpression", "String", "name");
-  from_json_key(
-      j, "type", p.type, "VariableReferenceExpression", "Type", "type");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const EquiJoinClause& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "left",
-      p.left,
-      "EquiJoinClause",
-      "VariableReferenceExpression",
-      "left");
-  to_json_key(
-      j,
-      "right",
-      p.right,
-      "EquiJoinClause",
-      "VariableReferenceExpression",
-      "right");
-}
-
-void from_json(const json& j, EquiJoinClause& p) {
-  from_json_key(
-      j,
-      "left",
-      p.left,
-      "EquiJoinClause",
-      "VariableReferenceExpression",
-      "left");
-  from_json_key(
-      j,
-      "right",
-      p.right,
-      "EquiJoinClause",
-      "VariableReferenceExpression",
-      "right");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const LongVariableConstraint& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "LongVariableConstraint", "String", "name");
-  to_json_key(
-      j,
-      "expression",
-      p.expression,
-      "LongVariableConstraint",
-      "String",
-      "expression");
-}
-
-void from_json(const json& j, LongVariableConstraint& p) {
-  from_json_key(j, "name", p.name, "LongVariableConstraint", "String", "name");
-  from_json_key(
-      j,
-      "expression",
-      p.expression,
-      "LongVariableConstraint",
-      "String",
-      "expression");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<FunctionKind, json> FunctionKind_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {FunctionKind::SCALAR, "SCALAR"},
-        {FunctionKind::AGGREGATE, "AGGREGATE"},
-        {FunctionKind::WINDOW, "WINDOW"}};
-void to_json(json& j, const FunctionKind& e) {
-  static_assert(
-      std::is_enum<FunctionKind>::value, "FunctionKind must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(FunctionKind_enum_table),
-      std::end(FunctionKind_enum_table),
-      [e](const std::pair<FunctionKind, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(FunctionKind_enum_table))
-           ? it
-           : std::begin(FunctionKind_enum_table))
-          ->second;
-}
-void from_json(const json& j, FunctionKind& e) {
-  static_assert(
-      std::is_enum<FunctionKind>::value, "FunctionKind must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(FunctionKind_enum_table),
-      std::end(FunctionKind_enum_table),
-      [&j](const std::pair<FunctionKind, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(FunctionKind_enum_table))
-           ? it
-           : std::begin(FunctionKind_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TypeVariableConstraint& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "TypeVariableConstraint", "String", "name");
-  to_json_key(
-      j,
-      "comparableRequired",
-      p.comparableRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "comparableRequired");
-  to_json_key(
-      j,
-      "orderableRequired",
-      p.orderableRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "orderableRequired");
-  to_json_key(
-      j,
-      "variadicBound",
-      p.variadicBound,
-      "TypeVariableConstraint",
-      "String",
-      "variadicBound");
-  to_json_key(
-      j,
-      "nonDecimalNumericRequired",
-      p.nonDecimalNumericRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "nonDecimalNumericRequired");
-}
-
-void from_json(const json& j, TypeVariableConstraint& p) {
-  from_json_key(j, "name", p.name, "TypeVariableConstraint", "String", "name");
-  from_json_key(
-      j,
-      "comparableRequired",
-      p.comparableRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "comparableRequired");
-  from_json_key(
-      j,
-      "orderableRequired",
-      p.orderableRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "orderableRequired");
-  from_json_key(
-      j,
-      "variadicBound",
-      p.variadicBound,
-      "TypeVariableConstraint",
-      "String",
-      "variadicBound");
-  from_json_key(
-      j,
-      "nonDecimalNumericRequired",
-      p.nonDecimalNumericRequired,
-      "TypeVariableConstraint",
-      "bool",
-      "nonDecimalNumericRequired");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Signature& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "Signature", "QualifiedObjectName", "name");
-  to_json_key(j, "kind", p.kind, "Signature", "FunctionKind", "kind");
-  to_json_key(
-      j,
-      "typeVariableConstraints",
-      p.typeVariableConstraints,
-      "Signature",
-      "List<TypeVariableConstraint>",
-      "typeVariableConstraints");
-  to_json_key(
-      j,
-      "longVariableConstraints",
-      p.longVariableConstraints,
-      "Signature",
-      "List<LongVariableConstraint>",
-      "longVariableConstraints");
-  to_json_key(
-      j,
-      "returnType",
-      p.returnType,
-      "Signature",
-      "TypeSignature",
-      "returnType");
-  to_json_key(
-      j,
-      "argumentTypes",
-      p.argumentTypes,
-      "Signature",
-      "List<TypeSignature>",
-      "argumentTypes");
-  to_json_key(
-      j,
-      "variableArity",
-      p.variableArity,
-      "Signature",
-      "bool",
-      "variableArity");
-}
-
-void from_json(const json& j, Signature& p) {
-  from_json_key(j, "name", p.name, "Signature", "QualifiedObjectName", "name");
-  from_json_key(j, "kind", p.kind, "Signature", "FunctionKind", "kind");
-  from_json_key(
-      j,
-      "typeVariableConstraints",
-      p.typeVariableConstraints,
-      "Signature",
-      "List<TypeVariableConstraint>",
-      "typeVariableConstraints");
-  from_json_key(
-      j,
-      "longVariableConstraints",
-      p.longVariableConstraints,
-      "Signature",
-      "List<LongVariableConstraint>",
-      "longVariableConstraints");
-  from_json_key(
-      j,
-      "returnType",
-      p.returnType,
-      "Signature",
-      "TypeSignature",
-      "returnType");
-  from_json_key(
-      j,
-      "argumentTypes",
-      p.argumentTypes,
-      "Signature",
-      "List<TypeSignature>",
-      "argumentTypes");
-  from_json_key(
-      j,
-      "variableArity",
-      p.variableArity,
-      "Signature",
-      "bool",
-      "variableArity");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Determinism, json> Determinism_enum_table[] = {
-    // NOLINT: cert-err58-cpp
-    {Determinism::DETERMINISTIC, "DETERMINISTIC"},
-    {Determinism::NOT_DETERMINISTIC, "NOT_DETERMINISTIC"},
-};
-void to_json(json& j, const Determinism& e) {
-  static_assert(
-      std::is_enum<Determinism>::value, "Determinism must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Determinism_enum_table),
-      std::end(Determinism_enum_table),
-      [e](const std::pair<Determinism, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Determinism_enum_table))
-           ? it
-           : std::begin(Determinism_enum_table))
-          ->second;
-}
-void from_json(const json& j, Determinism& e) {
-  static_assert(
-      std::is_enum<Determinism>::value, "Determinism must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Determinism_enum_table),
-      std::end(Determinism_enum_table),
-      [&j](const std::pair<Determinism, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Determinism_enum_table))
-           ? it
-           : std::begin(Determinism_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Language& p) {
-  j = json::object();
-  to_json_key(j, "language", p.language, "Language", "String", "language");
-}
-
-void from_json(const json& j, Language& p) {
-  from_json_key(j, "language", p.language, "Language", "String", "language");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<NullCallClause, json> NullCallClause_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {NullCallClause::RETURNS_NULL_ON_NULL_INPUT,
-         "RETURNS_NULL_ON_NULL_INPUT"},
-        {NullCallClause::CALLED_ON_NULL_INPUT, "CALLED_ON_NULL_INPUT"}};
-void to_json(json& j, const NullCallClause& e) {
-  static_assert(
-      std::is_enum<NullCallClause>::value, "NullCallClause must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NullCallClause_enum_table),
-      std::end(NullCallClause_enum_table),
-      [e](const std::pair<NullCallClause, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(NullCallClause_enum_table))
-           ? it
-           : std::begin(NullCallClause_enum_table))
-          ->second;
-}
-void from_json(const json& j, NullCallClause& e) {
-  static_assert(
-      std::is_enum<NullCallClause>::value, "NullCallClause must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NullCallClause_enum_table),
-      std::end(NullCallClause_enum_table),
-      [&j](const std::pair<NullCallClause, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(NullCallClause_enum_table))
-           ? it
-           : std::begin(NullCallClause_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const RoutineCharacteristics& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "language",
-      p.language,
-      "RoutineCharacteristics",
-      "Language",
-      "language");
-  to_json_key(
-      j,
-      "determinism",
-      p.determinism,
-      "RoutineCharacteristics",
-      "Determinism",
-      "determinism");
-  to_json_key(
-      j,
-      "nullCallClause",
-      p.nullCallClause,
-      "RoutineCharacteristics",
-      "NullCallClause",
-      "nullCallClause");
-}
-
-void from_json(const json& j, RoutineCharacteristics& p) {
-  from_json_key(
-      j,
-      "language",
-      p.language,
-      "RoutineCharacteristics",
-      "Language",
-      "language");
-  from_json_key(
-      j,
-      "determinism",
-      p.determinism,
-      "RoutineCharacteristics",
-      "Determinism",
-      "determinism");
-  from_json_key(
-      j,
-      "nullCallClause",
-      p.nullCallClause,
-      "RoutineCharacteristics",
-      "NullCallClause",
-      "nullCallClause");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Parameter& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "Parameter", "String", "name");
-  to_json_key(j, "type", p.type, "Parameter", "TypeSignature", "type");
-}
-
-void from_json(const json& j, Parameter& p) {
-  from_json_key(j, "name", p.name, "Parameter", "String", "name");
-  from_json_key(j, "type", p.type, "Parameter", "TypeSignature", "type");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const SqlInvokedFunction& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "parameters",
-      p.parameters,
-      "SqlInvokedFunction",
-      "List<Parameter>",
-      "parameters");
-  to_json_key(
-      j,
-      "description",
-      p.description,
-      "SqlInvokedFunction",
-      "String",
-      "description");
-  to_json_key(
-      j,
-      "routineCharacteristics",
-      p.routineCharacteristics,
-      "SqlInvokedFunction",
-      "RoutineCharacteristics",
-      "routineCharacteristics");
-  to_json_key(j, "body", p.body, "SqlInvokedFunction", "String", "body");
-  to_json_key(
-      j,
-      "signature",
-      p.signature,
-      "SqlInvokedFunction",
-      "Signature",
-      "signature");
-  to_json_key(
-      j,
-      "functionId",
-      p.functionId,
-      "SqlInvokedFunction",
-      "SqlFunctionId",
-      "functionId");
-}
-
-void from_json(const json& j, SqlInvokedFunction& p) {
-  from_json_key(
-      j,
-      "parameters",
-      p.parameters,
-      "SqlInvokedFunction",
-      "List<Parameter>",
-      "parameters");
-  from_json_key(
-      j,
-      "description",
-      p.description,
-      "SqlInvokedFunction",
-      "String",
-      "description");
-  from_json_key(
-      j,
-      "routineCharacteristics",
-      p.routineCharacteristics,
-      "SqlInvokedFunction",
-      "RoutineCharacteristics",
-      "routineCharacteristics");
-  from_json_key(j, "body", p.body, "SqlInvokedFunction", "String", "body");
-  from_json_key(
-      j,
-      "signature",
-      p.signature,
-      "SqlInvokedFunction",
-      "Signature",
-      "signature");
-  from_json_key(
-      j,
-      "functionId",
-      p.functionId,
-      "SqlInvokedFunction",
-      "SqlFunctionId",
-      "functionId");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-HiveTableHandle::HiveTableHandle() noexcept {
-  _type = "hive";
-}
-
-void to_json(json& j, const HiveTableHandle& p) {
-  j = json::object();
-  j["@type"] = "hive";
-  to_json_key(
-      j, "schemaName", p.schemaName, "HiveTableHandle", "String", "schemaName");
-  to_json_key(
-      j, "tableName", p.tableName, "HiveTableHandle", "String", "tableName");
-  to_json_key(
-      j,
-      "analyzePartitionValues",
-      p.analyzePartitionValues,
-      "HiveTableHandle",
-      "List<List<String>>",
-      "analyzePartitionValues");
-}
-
-void from_json(const json& j, HiveTableHandle& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j, "schemaName", p.schemaName, "HiveTableHandle", "String", "schemaName");
-  from_json_key(
-      j, "tableName", p.tableName, "HiveTableHandle", "String", "tableName");
-  from_json_key(
-      j,
-      "analyzePartitionValues",
-      p.analyzePartitionValues,
-      "HiveTableHandle",
-      "List<List<String>>",
-      "analyzePartitionValues");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-BuiltInFunctionHandle::BuiltInFunctionHandle() noexcept {
-  _type = "$static";
-}
-
-void to_json(json& j, const BuiltInFunctionHandle& p) {
-  j = json::object();
-  j["@type"] = "$static";
-  to_json_key(
-      j,
-      "signature",
-      p.signature,
-      "BuiltInFunctionHandle",
-      "Signature",
-      "signature");
-}
-
-void from_json(const json& j, BuiltInFunctionHandle& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j,
-      "signature",
-      p.signature,
-      "BuiltInFunctionHandle",
-      "Signature",
-      "signature");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == "$remote") {
-    j = *std::static_pointer_cast<SystemPartitioningHandle>(p);
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HivePartitioningHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorPartitioningHandle");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " ConnectorPartitioningHandle");
-  }
-
-  if (type == "$remote") {
-    auto k = std::make_shared<SystemPartitioningHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HivePartitioningHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorPartitioningHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == "$remote") {
-    j = *std::static_pointer_cast<RemoteTransactionHandle>(p);
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveTransactionHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTransactionHandle");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ConnectorTransactionHandle  ConnectorTransactionHandle");
-  }
-
-  if (type == "$remote") {
-    auto k = std::make_shared<RemoteTransactionHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HiveTransactionHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTransactionHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const PartitioningHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "PartitioningHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "PartitioningHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "PartitioningHandle",
-      "ConnectorPartitioningHandle",
-      "connectorHandle");
-}
-
-void from_json(const json& j, PartitioningHandle& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "PartitioningHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "PartitioningHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "PartitioningHandle",
-      "ConnectorPartitioningHandle",
-      "connectorHandle");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -957,1165 +179,6 @@ void from_json(const json& j, std::shared_ptr<RowExpression>& p) {
   }
 
   throw TypeError(type + " no abstract type RowExpression ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Partitioning& p) {
-  j = json::object();
-  to_json_key(
-      j, "handle", p.handle, "Partitioning", "PartitioningHandle", "handle");
-  to_json_key(
-      j,
-      "arguments",
-      p.arguments,
-      "Partitioning",
-      "List<std::shared_ptr<RowExpression>>",
-      "arguments");
-}
-
-void from_json(const json& j, Partitioning& p) {
-  from_json_key(
-      j, "handle", p.handle, "Partitioning", "PartitioningHandle", "handle");
-  from_json_key(
-      j,
-      "arguments",
-      p.arguments,
-      "Partitioning",
-      "List<std::shared_ptr<RowExpression>>",
-      "arguments");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const PartitioningScheme& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "partitioning",
-      p.partitioning,
-      "PartitioningScheme",
-      "Partitioning",
-      "partitioning");
-  to_json_key(
-      j,
-      "outputLayout",
-      p.outputLayout,
-      "PartitioningScheme",
-      "List<VariableReferenceExpression>",
-      "outputLayout");
-  to_json_key(
-      j,
-      "hashColumn",
-      p.hashColumn,
-      "PartitioningScheme",
-      "VariableReferenceExpression",
-      "hashColumn");
-  to_json_key(
-      j,
-      "replicateNullsAndAny",
-      p.replicateNullsAndAny,
-      "PartitioningScheme",
-      "bool",
-      "replicateNullsAndAny");
-  to_json_key(
-      j,
-      "bucketToPartition",
-      p.bucketToPartition,
-      "PartitioningScheme",
-      "List<int>",
-      "bucketToPartition");
-}
-
-void from_json(const json& j, PartitioningScheme& p) {
-  from_json_key(
-      j,
-      "partitioning",
-      p.partitioning,
-      "PartitioningScheme",
-      "Partitioning",
-      "partitioning");
-  from_json_key(
-      j,
-      "outputLayout",
-      p.outputLayout,
-      "PartitioningScheme",
-      "List<VariableReferenceExpression>",
-      "outputLayout");
-  from_json_key(
-      j,
-      "hashColumn",
-      p.hashColumn,
-      "PartitioningScheme",
-      "VariableReferenceExpression",
-      "hashColumn");
-  from_json_key(
-      j,
-      "replicateNullsAndAny",
-      p.replicateNullsAndAny,
-      "PartitioningScheme",
-      "bool",
-      "replicateNullsAndAny");
-  from_json_key(
-      j,
-      "bucketToPartition",
-      p.bucketToPartition,
-      "PartitioningScheme",
-      "List<int>",
-      "bucketToPartition");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Assignments& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "assignments",
-      p.assignments,
-      "Assignments",
-      "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
-      "assignments");
-}
-
-void from_json(const json& j, Assignments& p) {
-  from_json_key(
-      j,
-      "assignments",
-      p.assignments,
-      "Assignments",
-      "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
-      "assignments");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<PlanNode>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == ".AggregationNode") {
-    j = *std::static_pointer_cast<AggregationNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.GroupIdNode") {
-    j = *std::static_pointer_cast<GroupIdNode>(p);
-    return;
-  }
-  if (type == ".DistinctLimitNode") {
-    j = *std::static_pointer_cast<DistinctLimitNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode") {
-    j = *std::static_pointer_cast<EnforceSingleRowNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.ExchangeNode") {
-    j = *std::static_pointer_cast<ExchangeNode>(p);
-    return;
-  }
-  if (type == ".FilterNode") {
-    j = *std::static_pointer_cast<FilterNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.JoinNode") {
-    j = *std::static_pointer_cast<JoinNode>(p);
-    return;
-  }
-  if (type == ".LimitNode") {
-    j = *std::static_pointer_cast<LimitNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.SortNode") {
-    j = *std::static_pointer_cast<SortNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.OutputNode") {
-    j = *std::static_pointer_cast<OutputNode>(p);
-    return;
-  }
-  if (type == ".ProjectNode") {
-    j = *std::static_pointer_cast<ProjectNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.RowNumberNode") {
-    j = *std::static_pointer_cast<RowNumberNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.RemoteSourceNode") {
-    j = *std::static_pointer_cast<RemoteSourceNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.SemiJoinNode") {
-    j = *std::static_pointer_cast<SemiJoinNode>(p);
-    return;
-  }
-  if (type == ".TableScanNode") {
-    j = *std::static_pointer_cast<TableScanNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.TableWriterNode") {
-    j = *std::static_pointer_cast<TableWriterNode>(p);
-    return;
-  }
-  if (type == ".TopNNode") {
-    j = *std::static_pointer_cast<TopNNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.UnnestNode") {
-    j = *std::static_pointer_cast<UnnestNode>(p);
-    return;
-  }
-  if (type == ".ValuesNode") {
-    j = *std::static_pointer_cast<ValuesNode>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.AssignUniqueId") {
-    j = *std::static_pointer_cast<AssignUniqueId>(p);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.MergeJoinNode") {
-    j = *std::static_pointer_cast<MergeJoinNode>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type PlanNode ");
-}
-
-void from_json(const json& j, std::shared_ptr<PlanNode>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " PlanNode  PlanNode");
-  }
-
-  if (type == ".AggregationNode") {
-    std::shared_ptr<AggregationNode> k = std::make_shared<AggregationNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.GroupIdNode") {
-    std::shared_ptr<GroupIdNode> k = std::make_shared<GroupIdNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".DistinctLimitNode") {
-    std::shared_ptr<DistinctLimitNode> k =
-        std::make_shared<DistinctLimitNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode") {
-    std::shared_ptr<EnforceSingleRowNode> k =
-        std::make_shared<EnforceSingleRowNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.ExchangeNode") {
-    std::shared_ptr<ExchangeNode> k = std::make_shared<ExchangeNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".FilterNode") {
-    std::shared_ptr<FilterNode> k = std::make_shared<FilterNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.JoinNode") {
-    std::shared_ptr<JoinNode> k = std::make_shared<JoinNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".LimitNode") {
-    std::shared_ptr<LimitNode> k = std::make_shared<LimitNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.SortNode") {
-    std::shared_ptr<SortNode> k = std::make_shared<SortNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.OutputNode") {
-    std::shared_ptr<OutputNode> k = std::make_shared<OutputNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".ProjectNode") {
-    std::shared_ptr<ProjectNode> k = std::make_shared<ProjectNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.RowNumberNode") {
-    std::shared_ptr<RowNumberNode> k = std::make_shared<RowNumberNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.RemoteSourceNode") {
-    std::shared_ptr<RemoteSourceNode> k = std::make_shared<RemoteSourceNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.SemiJoinNode") {
-    std::shared_ptr<SemiJoinNode> k = std::make_shared<SemiJoinNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".TableScanNode") {
-    std::shared_ptr<TableScanNode> k = std::make_shared<TableScanNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.TableWriterNode") {
-    std::shared_ptr<TableWriterNode> k = std::make_shared<TableWriterNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".TopNNode") {
-    std::shared_ptr<TopNNode> k = std::make_shared<TopNNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.UnnestNode") {
-    std::shared_ptr<UnnestNode> k = std::make_shared<UnnestNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == ".ValuesNode") {
-    std::shared_ptr<ValuesNode> k = std::make_shared<ValuesNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.AssignUniqueId") {
-    std::shared_ptr<AssignUniqueId> k = std::make_shared<AssignUniqueId>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-  if (type == "com.facebook.presto.sql.planner.plan.MergeJoinNode") {
-    std::shared_ptr<MergeJoinNode> k = std::make_shared<MergeJoinNode>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<PlanNode>(k);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type PlanNode ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Step, json> Step_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Step::SINGLE, "SINGLE"},
-        {Step::PARTIAL, "PARTIAL"},
-        {Step::FINAL, "FINAL"}};
-void to_json(json& j, const Step& e) {
-  static_assert(std::is_enum<Step>::value, "Step must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Step_enum_table),
-      std::end(Step_enum_table),
-      [e](const std::pair<Step, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Step_enum_table)) ? it : std::begin(Step_enum_table))
-          ->second;
-}
-void from_json(const json& j, Step& e) {
-  static_assert(std::is_enum<Step>::value, "Step must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Step_enum_table),
-      std::end(Step_enum_table),
-      [&j](const std::pair<Step, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Step_enum_table)) ? it : std::begin(Step_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<SortOrder, json> SortOrder_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {SortOrder::ASC_NULLS_FIRST, "ASC_NULLS_FIRST"},
-        {SortOrder::ASC_NULLS_LAST, "ASC_NULLS_LAST"},
-        {SortOrder::DESC_NULLS_FIRST, "DESC_NULLS_FIRST"},
-        {SortOrder::DESC_NULLS_LAST, "DESC_NULLS_LAST"}};
-void to_json(json& j, const SortOrder& e) {
-  static_assert(std::is_enum<SortOrder>::value, "SortOrder must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(SortOrder_enum_table),
-      std::end(SortOrder_enum_table),
-      [e](const std::pair<SortOrder, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(SortOrder_enum_table))
-           ? it
-           : std::begin(SortOrder_enum_table))
-          ->second;
-}
-void from_json(const json& j, SortOrder& e) {
-  static_assert(std::is_enum<SortOrder>::value, "SortOrder must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(SortOrder_enum_table),
-      std::end(SortOrder_enum_table),
-      [&j](const std::pair<SortOrder, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(SortOrder_enum_table))
-           ? it
-           : std::begin(SortOrder_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Ordering& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "variable",
-      p.variable,
-      "Ordering",
-      "VariableReferenceExpression",
-      "variable");
-  to_json_key(
-      j, "sortOrder", p.sortOrder, "Ordering", "SortOrder", "sortOrder");
-}
-
-void from_json(const json& j, Ordering& p) {
-  from_json_key(
-      j,
-      "variable",
-      p.variable,
-      "Ordering",
-      "VariableReferenceExpression",
-      "variable");
-  from_json_key(
-      j, "sortOrder", p.sortOrder, "Ordering", "SortOrder", "sortOrder");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const OrderingScheme& p) {
-  j = json::object();
-  to_json_key(
-      j, "orderBy", p.orderBy, "OrderingScheme", "List<Ordering>", "orderBy");
-}
-
-void from_json(const json& j, OrderingScheme& p) {
-  from_json_key(
-      j, "orderBy", p.orderBy, "OrderingScheme", "List<Ordering>", "orderBy");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-TopNNode::TopNNode() noexcept {
-  _type = ".TopNNode";
-}
-
-void to_json(json& j, const TopNNode& p) {
-  j = json::object();
-  j["@type"] = ".TopNNode";
-  to_json_key(j, "id", p.id, "TopNNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "TopNNode", "PlanNode", "source");
-  to_json_key(j, "count", p.count, "TopNNode", "int64_t", "count");
-  to_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "TopNNode",
-      "OrderingScheme",
-      "orderingScheme");
-  to_json_key(j, "step", p.step, "TopNNode", "Step", "step");
-}
-
-void from_json(const json& j, TopNNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "TopNNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "TopNNode", "PlanNode", "source");
-  from_json_key(j, "count", p.count, "TopNNode", "int64_t", "count");
-  from_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "TopNNode",
-      "OrderingScheme",
-      "orderingScheme");
-  from_json_key(j, "step", p.step, "TopNNode", "Step", "step");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Column& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "Column", "String", "name");
-  to_json_key(j, "type", p.type, "Column", "String", "type");
-}
-
-void from_json(const json& j, Column& p) {
-  from_json_key(j, "name", p.name, "Column", "String", "name");
-  from_json_key(j, "type", p.type, "Column", "String", "type");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Block& p) {
-  j = p.data;
-}
-
-void from_json(const json& j, Block& p) {
-  p.data = std::string(j);
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-ConstantExpression::ConstantExpression() noexcept {
-  _type = "constant";
-}
-
-void to_json(json& j, const ConstantExpression& p) {
-  j = json::object();
-  j["@type"] = "constant";
-  to_json_key(
-      j,
-      "valueBlock",
-      p.valueBlock,
-      "ConstantExpression",
-      "Block",
-      "valueBlock");
-  to_json_key(j, "type", p.type, "ConstantExpression", "Type", "type");
-}
-
-void from_json(const json& j, ConstantExpression& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j,
-      "valueBlock",
-      p.valueBlock,
-      "ConstantExpression",
-      "Block",
-      "valueBlock");
-  from_json_key(j, "type", p.type, "ConstantExpression", "Type", "type");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-EmptySplit::EmptySplit() noexcept {
-  _type = "$empty";
-}
-
-void to_json(json& j, const EmptySplit& p) {
-  j = json::object();
-  j["@type"] = "$empty";
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "EmptySplit",
-      "ConnectorId",
-      "connectorId");
-}
-
-void from_json(const json& j, EmptySplit& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "EmptySplit",
-      "ConnectorId",
-      "connectorId");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Bound, json> Bound_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Bound::BELOW, "BELOW"},
-        {Bound::EXACTLY, "EXACTLY"},
-        {Bound::ABOVE, "ABOVE"}};
-void to_json(json& j, const Bound& e) {
-  static_assert(std::is_enum<Bound>::value, "Bound must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Bound_enum_table),
-      std::end(Bound_enum_table),
-      [e](const std::pair<Bound, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Bound_enum_table)) ? it : std::begin(Bound_enum_table))
-          ->second;
-}
-void from_json(const json& j, Bound& e) {
-  static_assert(std::is_enum<Bound>::value, "Bound must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Bound_enum_table),
-      std::end(Bound_enum_table),
-      [&j](const std::pair<Bound, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Bound_enum_table)) ? it : std::begin(Bound_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Marker& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "Marker", "Type", "type");
-  to_json_key(j, "valueBlock", p.valueBlock, "Marker", "Block", "valueBlock");
-  to_json_key(j, "bound", p.bound, "Marker", "Bound", "bound");
-}
-
-void from_json(const json& j, Marker& p) {
-  from_json_key(j, "type", p.type, "Marker", "Type", "type");
-  from_json_key(j, "valueBlock", p.valueBlock, "Marker", "Block", "valueBlock");
-  from_json_key(j, "bound", p.bound, "Marker", "Bound", "bound");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Range& p) {
-  j = json::object();
-  to_json_key(j, "low", p.low, "Range", "Marker", "low");
-  to_json_key(j, "high", p.high, "Range", "Marker", "high");
-}
-
-void from_json(const json& j, Range& p) {
-  from_json_key(j, "low", p.low, "Range", "Marker", "low");
-  from_json_key(j, "high", p.high, "Range", "Marker", "high");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TableToPartitionMapping& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "tableToPartitionColumns",
-      p.tableToPartitionColumns,
-      "TableToPartitionMapping",
-      "Map<Integer, Integer>",
-      "tableToPartitionColumns");
-  to_json_key(
-      j,
-      "partitionSchemaDifference",
-      p.partitionSchemaDifference,
-      "TableToPartitionMapping",
-      "Map<Integer, Column>",
-      "partitionSchemaDifference");
-}
-
-void from_json(const json& j, TableToPartitionMapping& p) {
-  from_json_key(
-      j,
-      "tableToPartitionColumns",
-      p.tableToPartitionColumns,
-      "TableToPartitionMapping",
-      "Map<Integer, Integer>",
-      "tableToPartitionColumns");
-  from_json_key(
-      j,
-      "partitionSchemaDifference",
-      p.partitionSchemaDifference,
-      "TableToPartitionMapping",
-      "Map<Integer, Column>",
-      "partitionSchemaDifference");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const DwrfEncryptionMetadata& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "fieldToKeyData",
-      p.fieldToKeyData,
-      "DwrfEncryptionMetadata",
-      "Map<String, String>",
-      "fieldToKeyData");
-  to_json_key(
-      j,
-      "extraMetadata",
-      p.extraMetadata,
-      "DwrfEncryptionMetadata",
-      "Map<String, String>",
-      "extraMetadata");
-  to_json_key(
-      j,
-      "encryptionAlgorithm",
-      p.encryptionAlgorithm,
-      "DwrfEncryptionMetadata",
-      "String",
-      "encryptionAlgorithm");
-  to_json_key(
-      j,
-      "encryptionProvider",
-      p.encryptionProvider,
-      "DwrfEncryptionMetadata",
-      "String",
-      "encryptionProvider");
-}
-
-void from_json(const json& j, DwrfEncryptionMetadata& p) {
-  from_json_key(
-      j,
-      "fieldToKeyData",
-      p.fieldToKeyData,
-      "DwrfEncryptionMetadata",
-      "Map<String, String>",
-      "fieldToKeyData");
-  from_json_key(
-      j,
-      "extraMetadata",
-      p.extraMetadata,
-      "DwrfEncryptionMetadata",
-      "Map<String, String>",
-      "extraMetadata");
-  from_json_key(
-      j,
-      "encryptionAlgorithm",
-      p.encryptionAlgorithm,
-      "DwrfEncryptionMetadata",
-      "String",
-      "encryptionAlgorithm");
-  from_json_key(
-      j,
-      "encryptionProvider",
-      p.encryptionProvider,
-      "DwrfEncryptionMetadata",
-      "String",
-      "encryptionProvider");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const EncryptionInformation& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "dwrfEncryptionMetadata",
-      p.dwrfEncryptionMetadata,
-      "EncryptionInformation",
-      "DwrfEncryptionMetadata",
-      "dwrfEncryptionMetadata");
-}
-
-void from_json(const json& j, EncryptionInformation& p) {
-  from_json_key(
-      j,
-      "dwrfEncryptionMetadata",
-      p.dwrfEncryptionMetadata,
-      "EncryptionInformation",
-      "DwrfEncryptionMetadata",
-      "dwrfEncryptionMetadata");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<BucketFunctionType, json>
-    BucketFunctionType_enum_table[] = { // NOLINT: cert-err58-cpp
-        {BucketFunctionType::HIVE_COMPATIBLE, "HIVE_COMPATIBLE"},
-        {BucketFunctionType::PRESTO_NATIVE, "PRESTO_NATIVE"}};
-void to_json(json& j, const BucketFunctionType& e) {
-  static_assert(
-      std::is_enum<BucketFunctionType>::value,
-      "BucketFunctionType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(BucketFunctionType_enum_table),
-      std::end(BucketFunctionType_enum_table),
-      [e](const std::pair<BucketFunctionType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(BucketFunctionType_enum_table))
-           ? it
-           : std::begin(BucketFunctionType_enum_table))
-          ->second;
-}
-void from_json(const json& j, BucketFunctionType& e) {
-  static_assert(
-      std::is_enum<BucketFunctionType>::value,
-      "BucketFunctionType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(BucketFunctionType_enum_table),
-      std::end(BucketFunctionType_enum_table),
-      [&j](const std::pair<BucketFunctionType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(BucketFunctionType_enum_table))
-           ? it
-           : std::begin(BucketFunctionType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Order, json> Order_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Order::ASCENDING, "ASCENDING"},
-        {Order::DESCENDING, "DESCENDING"}};
-void to_json(json& j, const Order& e) {
-  static_assert(std::is_enum<Order>::value, "Order must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Order_enum_table),
-      std::end(Order_enum_table),
-      [e](const std::pair<Order, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Order_enum_table)) ? it : std::begin(Order_enum_table))
-          ->second;
-}
-void from_json(const json& j, Order& e) {
-  static_assert(std::is_enum<Order>::value, "Order must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Order_enum_table),
-      std::end(Order_enum_table),
-      [&j](const std::pair<Order, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Order_enum_table)) ? it : std::begin(Order_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const SortingColumn& p) {
-  j = json::object();
-  to_json_key(
-      j, "columnName", p.columnName, "SortingColumn", "String", "columnName");
-  to_json_key(j, "order", p.order, "SortingColumn", "Order", "order");
-}
-
-void from_json(const json& j, SortingColumn& p) {
-  from_json_key(
-      j, "columnName", p.columnName, "SortingColumn", "String", "columnName");
-  from_json_key(j, "order", p.order, "SortingColumn", "Order", "order");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const HiveBucketProperty& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "bucketedBy",
-      p.bucketedBy,
-      "HiveBucketProperty",
-      "List<String>",
-      "bucketedBy");
-  to_json_key(
-      j,
-      "bucketCount",
-      p.bucketCount,
-      "HiveBucketProperty",
-      "int",
-      "bucketCount");
-  to_json_key(
-      j,
-      "sortedBy",
-      p.sortedBy,
-      "HiveBucketProperty",
-      "List<SortingColumn>",
-      "sortedBy");
-  to_json_key(
-      j,
-      "bucketFunctionType",
-      p.bucketFunctionType,
-      "HiveBucketProperty",
-      "BucketFunctionType",
-      "bucketFunctionType");
-  to_json_key(j, "types", p.types, "HiveBucketProperty", "List<Type>", "types");
-}
-
-void from_json(const json& j, HiveBucketProperty& p) {
-  from_json_key(
-      j,
-      "bucketedBy",
-      p.bucketedBy,
-      "HiveBucketProperty",
-      "List<String>",
-      "bucketedBy");
-  from_json_key(
-      j,
-      "bucketCount",
-      p.bucketCount,
-      "HiveBucketProperty",
-      "int",
-      "bucketCount");
-  from_json_key(
-      j,
-      "sortedBy",
-      p.sortedBy,
-      "HiveBucketProperty",
-      "List<SortingColumn>",
-      "sortedBy");
-  from_json_key(
-      j,
-      "bucketFunctionType",
-      p.bucketFunctionType,
-      "HiveBucketProperty",
-      "BucketFunctionType",
-      "bucketFunctionType");
-  from_json_key(
-      j, "types", p.types, "HiveBucketProperty", "List<Type>", "types");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const StorageFormat& p) {
-  j = json::object();
-  to_json_key(j, "serDe", p.serDe, "StorageFormat", "String", "serDe");
-  to_json_key(
-      j,
-      "inputFormat",
-      p.inputFormat,
-      "StorageFormat",
-      "String",
-      "inputFormat");
-  to_json_key(
-      j,
-      "outputFormat",
-      p.outputFormat,
-      "StorageFormat",
-      "String",
-      "outputFormat");
-}
-
-void from_json(const json& j, StorageFormat& p) {
-  from_json_key(j, "serDe", p.serDe, "StorageFormat", "String", "serDe");
-  from_json_key(
-      j,
-      "inputFormat",
-      p.inputFormat,
-      "StorageFormat",
-      "String",
-      "inputFormat");
-  from_json_key(
-      j,
-      "outputFormat",
-      p.outputFormat,
-      "StorageFormat",
-      "String",
-      "outputFormat");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Storage& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "storageFormat",
-      p.storageFormat,
-      "Storage",
-      "StorageFormat",
-      "storageFormat");
-  to_json_key(j, "location", p.location, "Storage", "String", "location");
-  to_json_key(
-      j,
-      "bucketProperty",
-      p.bucketProperty,
-      "Storage",
-      "HiveBucketProperty",
-      "bucketProperty");
-  to_json_key(j, "skewed", p.skewed, "Storage", "bool", "skewed");
-  to_json_key(
-      j,
-      "serdeParameters",
-      p.serdeParameters,
-      "Storage",
-      "Map<String, String>",
-      "serdeParameters");
-  to_json_key(
-      j,
-      "parameters",
-      p.parameters,
-      "Storage",
-      "Map<String, String>",
-      "parameters");
-}
-
-void from_json(const json& j, Storage& p) {
-  from_json_key(
-      j,
-      "storageFormat",
-      p.storageFormat,
-      "Storage",
-      "StorageFormat",
-      "storageFormat");
-  from_json_key(j, "location", p.location, "Storage", "String", "location");
-  from_json_key(
-      j,
-      "bucketProperty",
-      p.bucketProperty,
-      "Storage",
-      "HiveBucketProperty",
-      "bucketProperty");
-  from_json_key(j, "skewed", p.skewed, "Storage", "bool", "skewed");
-  from_json_key(
-      j,
-      "serdeParameters",
-      p.serdeParameters,
-      "Storage",
-      "Map<String, String>",
-      "serdeParameters");
-  from_json_key(
-      j,
-      "parameters",
-      p.parameters,
-      "Storage",
-      "Map<String, String>",
-      "parameters");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<NodeSelectionStrategy, json>
-    NodeSelectionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
-        {NodeSelectionStrategy::HARD_AFFINITY, "HARD_AFFINITY"},
-        {NodeSelectionStrategy::SOFT_AFFINITY, "SOFT_AFFINITY"},
-        {NodeSelectionStrategy::NO_PREFERENCE, "NO_PREFERENCE"}};
-void to_json(json& j, const NodeSelectionStrategy& e) {
-  static_assert(
-      std::is_enum<NodeSelectionStrategy>::value,
-      "NodeSelectionStrategy must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NodeSelectionStrategy_enum_table),
-      std::end(NodeSelectionStrategy_enum_table),
-      [e](const std::pair<NodeSelectionStrategy, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(NodeSelectionStrategy_enum_table))
-           ? it
-           : std::begin(NodeSelectionStrategy_enum_table))
-          ->second;
-}
-void from_json(const json& j, NodeSelectionStrategy& e) {
-  static_assert(
-      std::is_enum<NodeSelectionStrategy>::value,
-      "NodeSelectionStrategy must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NodeSelectionStrategy_enum_table),
-      std::end(NodeSelectionStrategy_enum_table),
-      [&j](const std::pair<NodeSelectionStrategy, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(NodeSelectionStrategy_enum_table))
-           ? it
-           : std::begin(NodeSelectionStrategy_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ColumnHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveColumnHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ColumnHandle ");
-}
-
-void from_json(const json& j, std::shared_ptr<ColumnHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " ColumnHandle  ColumnHandle");
-  }
-
-  if (getConnectorKey(type) == "hive") {
-    std::shared_ptr<HiveColumnHandle> k = std::make_shared<HiveColumnHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ColumnHandle>(k);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ColumnHandle ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const HivePartitionKey& p) {
-  j = json::object();
-  to_json_key(j, "name", p.name, "HivePartitionKey", "String", "name");
-  to_json_key(j, "value", p.value, "HivePartitionKey", "String", "value");
-}
-
-void from_json(const json& j, HivePartitionKey& p) {
-  from_json_key(j, "name", p.name, "HivePartitionKey", "String", "name");
-  from_json_key(j, "value", p.value, "HivePartitionKey", "String", "value");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<ColumnType, json> ColumnType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {ColumnType::PARTITION_KEY, "PARTITION_KEY"},
-        {ColumnType::REGULAR, "REGULAR"},
-        {ColumnType::SYNTHESIZED, "SYNTHESIZED"},
-        {ColumnType::AGGREGATED, "AGGREGATED"}};
-void to_json(json& j, const ColumnType& e) {
-  static_assert(std::is_enum<ColumnType>::value, "ColumnType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(ColumnType_enum_table),
-      std::end(ColumnType_enum_table),
-      [e](const std::pair<ColumnType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(ColumnType_enum_table))
-           ? it
-           : std::begin(ColumnType_enum_table))
-          ->second;
-}
-void from_json(const json& j, ColumnType& e) {
-  static_assert(std::is_enum<ColumnType>::value, "ColumnType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(ColumnType_enum_table),
-      std::end(ColumnType_enum_table),
-      [&j](const std::pair<ColumnType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(ColumnType_enum_table))
-           ? it
-           : std::begin(ColumnType_enum_table))
-          ->first;
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -2224,6 +287,118 @@ void from_json(const json& j, CallExpression& p) {
       "CallExpression",
       "List<std::shared_ptr<RowExpression>>",
       "arguments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+VariableReferenceExpression::VariableReferenceExpression() noexcept {
+  _type = "variable";
+}
+
+void to_json(json& j, const VariableReferenceExpression& p) {
+  j = json::object();
+  j["@type"] = "variable";
+  to_json_key(
+      j,
+      "sourceLocation",
+      p.sourceLocation,
+      "VariableReferenceExpression",
+      "SourceLocation",
+      "sourceLocation");
+  to_json_key(
+      j, "name", p.name, "VariableReferenceExpression", "String", "name");
+  to_json_key(j, "type", p.type, "VariableReferenceExpression", "Type", "type");
+}
+
+void from_json(const json& j, VariableReferenceExpression& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "sourceLocation",
+      p.sourceLocation,
+      "VariableReferenceExpression",
+      "SourceLocation",
+      "sourceLocation");
+  from_json_key(
+      j, "name", p.name, "VariableReferenceExpression", "String", "name");
+  from_json_key(
+      j, "type", p.type, "VariableReferenceExpression", "Type", "type");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<SortOrder, json> SortOrder_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {SortOrder::ASC_NULLS_FIRST, "ASC_NULLS_FIRST"},
+        {SortOrder::ASC_NULLS_LAST, "ASC_NULLS_LAST"},
+        {SortOrder::DESC_NULLS_FIRST, "DESC_NULLS_FIRST"},
+        {SortOrder::DESC_NULLS_LAST, "DESC_NULLS_LAST"}};
+void to_json(json& j, const SortOrder& e) {
+  static_assert(std::is_enum<SortOrder>::value, "SortOrder must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SortOrder_enum_table),
+      std::end(SortOrder_enum_table),
+      [e](const std::pair<SortOrder, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(SortOrder_enum_table))
+           ? it
+           : std::begin(SortOrder_enum_table))
+          ->second;
+}
+void from_json(const json& j, SortOrder& e) {
+  static_assert(std::is_enum<SortOrder>::value, "SortOrder must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SortOrder_enum_table),
+      std::end(SortOrder_enum_table),
+      [&j](const std::pair<SortOrder, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(SortOrder_enum_table))
+           ? it
+           : std::begin(SortOrder_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Ordering& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "variable",
+      p.variable,
+      "Ordering",
+      "VariableReferenceExpression",
+      "variable");
+  to_json_key(
+      j, "sortOrder", p.sortOrder, "Ordering", "SortOrder", "sortOrder");
+}
+
+void from_json(const json& j, Ordering& p) {
+  from_json_key(
+      j,
+      "variable",
+      p.variable,
+      "Ordering",
+      "VariableReferenceExpression",
+      "variable");
+  from_json_key(
+      j, "sortOrder", p.sortOrder, "Ordering", "SortOrder", "sortOrder");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const OrderingScheme& p) {
+  j = json::object();
+  to_json_key(
+      j, "orderBy", p.orderBy, "OrderingScheme", "List<Ordering>", "orderBy");
+}
+
+void from_json(const json& j, OrderingScheme& p) {
+  from_json_key(
+      j, "orderBy", p.orderBy, "OrderingScheme", "List<Ordering>", "orderBy");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -2384,1605 +559,6 @@ void from_json(const json& j, HiveColumnHandle& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const BucketConversion& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "tableBucketCount",
-      p.tableBucketCount,
-      "BucketConversion",
-      "int",
-      "tableBucketCount");
-  to_json_key(
-      j,
-      "partitionBucketCount",
-      p.partitionBucketCount,
-      "BucketConversion",
-      "int",
-      "partitionBucketCount");
-  to_json_key(
-      j,
-      "bucketColumnHandles",
-      p.bucketColumnHandles,
-      "BucketConversion",
-      "List<HiveColumnHandle>",
-      "bucketColumnHandles");
-}
-
-void from_json(const json& j, BucketConversion& p) {
-  from_json_key(
-      j,
-      "tableBucketCount",
-      p.tableBucketCount,
-      "BucketConversion",
-      "int",
-      "tableBucketCount");
-  from_json_key(
-      j,
-      "partitionBucketCount",
-      p.partitionBucketCount,
-      "BucketConversion",
-      "int",
-      "partitionBucketCount");
-  from_json_key(
-      j,
-      "bucketColumnHandles",
-      p.bucketColumnHandles,
-      "BucketConversion",
-      "List<HiveColumnHandle>",
-      "bucketColumnHandles");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<CacheQuotaScope, json> CacheQuotaScope_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {CacheQuotaScope::GLOBAL, "GLOBAL"},
-        {CacheQuotaScope::SCHEMA, "SCHEMA"},
-        {CacheQuotaScope::TABLE, "TABLE"},
-        {CacheQuotaScope::PARTITION, "PARTITION"}};
-void to_json(json& j, const CacheQuotaScope& e) {
-  static_assert(
-      std::is_enum<CacheQuotaScope>::value, "CacheQuotaScope must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(CacheQuotaScope_enum_table),
-      std::end(CacheQuotaScope_enum_table),
-      [e](const std::pair<CacheQuotaScope, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(CacheQuotaScope_enum_table))
-           ? it
-           : std::begin(CacheQuotaScope_enum_table))
-          ->second;
-}
-void from_json(const json& j, CacheQuotaScope& e) {
-  static_assert(
-      std::is_enum<CacheQuotaScope>::value, "CacheQuotaScope must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(CacheQuotaScope_enum_table),
-      std::end(CacheQuotaScope_enum_table),
-      [&j](const std::pair<CacheQuotaScope, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(CacheQuotaScope_enum_table))
-           ? it
-           : std::begin(CacheQuotaScope_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(nlohmann::json& j, const DataSize& p) {
-  j = p.toString();
-}
-
-void from_json(const nlohmann::json& j, DataSize& p) {
-  p = DataSize(std::string(j));
-}
-
-std::ostream& operator<<(std::ostream& os, const DataSize& d) {
-  return os << d.toString();
-}
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const CacheQuotaRequirement& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "cacheQuotaScope",
-      p.cacheQuotaScope,
-      "CacheQuotaRequirement",
-      "CacheQuotaScope",
-      "cacheQuotaScope");
-  to_json_key(
-      j, "quota", p.quota, "CacheQuotaRequirement", "DataSize", "quota");
-}
-
-void from_json(const json& j, CacheQuotaRequirement& p) {
-  from_json_key(
-      j,
-      "cacheQuotaScope",
-      p.cacheQuotaScope,
-      "CacheQuotaRequirement",
-      "CacheQuotaScope",
-      "cacheQuotaScope");
-  from_json_key(
-      j, "quota", p.quota, "CacheQuotaRequirement", "DataSize", "quota");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-HiveSplit::HiveSplit() noexcept {
-  _type = "hive";
-}
-
-void to_json(json& j, const HiveSplit& p) {
-  j = json::object();
-  j["@type"] = "hive";
-  to_json_key(j, "database", p.database, "HiveSplit", "String", "database");
-  to_json_key(j, "table", p.table, "HiveSplit", "String", "table");
-  to_json_key(
-      j,
-      "partitionName",
-      p.partitionName,
-      "HiveSplit",
-      "String",
-      "partitionName");
-  to_json_key(j, "path", p.path, "HiveSplit", "String", "path");
-  to_json_key(j, "start", p.start, "HiveSplit", "int64_t", "start");
-  to_json_key(j, "length", p.length, "HiveSplit", "int64_t", "length");
-  to_json_key(j, "fileSize", p.fileSize, "HiveSplit", "int64_t", "fileSize");
-  to_json_key(
-      j,
-      "fileModifiedTime",
-      p.fileModifiedTime,
-      "HiveSplit",
-      "int64_t",
-      "fileModifiedTime");
-  to_json_key(j, "storage", p.storage, "HiveSplit", "Storage", "storage");
-  to_json_key(
-      j,
-      "partitionKeys",
-      p.partitionKeys,
-      "HiveSplit",
-      "List<HivePartitionKey>",
-      "partitionKeys");
-  to_json_key(
-      j,
-      "addresses",
-      p.addresses,
-      "HiveSplit",
-      "List<HostAddress>",
-      "addresses");
-  to_json_key(
-      j,
-      "readBucketNumber",
-      p.readBucketNumber,
-      "HiveSplit",
-      "int",
-      "readBucketNumber");
-  to_json_key(
-      j,
-      "tableBucketNumber",
-      p.tableBucketNumber,
-      "HiveSplit",
-      "int",
-      "tableBucketNumber");
-  to_json_key(
-      j,
-      "nodeSelectionStrategy",
-      p.nodeSelectionStrategy,
-      "HiveSplit",
-      "NodeSelectionStrategy",
-      "nodeSelectionStrategy");
-  to_json_key(
-      j,
-      "partitionDataColumnCount",
-      p.partitionDataColumnCount,
-      "HiveSplit",
-      "int",
-      "partitionDataColumnCount");
-  to_json_key(
-      j,
-      "tableToPartitionMapping",
-      p.tableToPartitionMapping,
-      "HiveSplit",
-      "TableToPartitionMapping",
-      "tableToPartitionMapping");
-  to_json_key(
-      j,
-      "bucketConversion",
-      p.bucketConversion,
-      "HiveSplit",
-      "BucketConversion",
-      "bucketConversion");
-  to_json_key(
-      j,
-      "s3SelectPushdownEnabled",
-      p.s3SelectPushdownEnabled,
-      "HiveSplit",
-      "bool",
-      "s3SelectPushdownEnabled");
-  to_json_key(
-      j,
-      "extraFileInfo",
-      p.extraFileInfo,
-      "HiveSplit",
-      "String",
-      "extraFileInfo");
-  to_json_key(
-      j,
-      "cacheQuota",
-      p.cacheQuota,
-      "HiveSplit",
-      "CacheQuotaRequirement",
-      "cacheQuota");
-  to_json_key(
-      j,
-      "encryptionMetadata",
-      p.encryptionMetadata,
-      "HiveSplit",
-      "EncryptionInformation",
-      "encryptionMetadata");
-  to_json_key(
-      j,
-      "customSplitInfo",
-      p.customSplitInfo,
-      "HiveSplit",
-      "Map<String, String>",
-      "customSplitInfo");
-  to_json_key(
-      j,
-      "redundantColumnDomains",
-      p.redundantColumnDomains,
-      "HiveSplit",
-      "List<std::shared_ptr<ColumnHandle>>",
-      "redundantColumnDomains");
-  to_json_key(
-      j,
-      "splitWeight",
-      p.splitWeight,
-      "HiveSplit",
-      "SplitWeight",
-      "splitWeight");
-}
-
-void from_json(const json& j, HiveSplit& p) {
-  p._type = j["@type"];
-  from_json_key(j, "database", p.database, "HiveSplit", "String", "database");
-  from_json_key(j, "table", p.table, "HiveSplit", "String", "table");
-  from_json_key(
-      j,
-      "partitionName",
-      p.partitionName,
-      "HiveSplit",
-      "String",
-      "partitionName");
-  from_json_key(j, "path", p.path, "HiveSplit", "String", "path");
-  from_json_key(j, "start", p.start, "HiveSplit", "int64_t", "start");
-  from_json_key(j, "length", p.length, "HiveSplit", "int64_t", "length");
-  from_json_key(j, "fileSize", p.fileSize, "HiveSplit", "int64_t", "fileSize");
-  from_json_key(
-      j,
-      "fileModifiedTime",
-      p.fileModifiedTime,
-      "HiveSplit",
-      "int64_t",
-      "fileModifiedTime");
-  from_json_key(j, "storage", p.storage, "HiveSplit", "Storage", "storage");
-  from_json_key(
-      j,
-      "partitionKeys",
-      p.partitionKeys,
-      "HiveSplit",
-      "List<HivePartitionKey>",
-      "partitionKeys");
-  from_json_key(
-      j,
-      "addresses",
-      p.addresses,
-      "HiveSplit",
-      "List<HostAddress>",
-      "addresses");
-  from_json_key(
-      j,
-      "readBucketNumber",
-      p.readBucketNumber,
-      "HiveSplit",
-      "int",
-      "readBucketNumber");
-  from_json_key(
-      j,
-      "tableBucketNumber",
-      p.tableBucketNumber,
-      "HiveSplit",
-      "int",
-      "tableBucketNumber");
-  from_json_key(
-      j,
-      "nodeSelectionStrategy",
-      p.nodeSelectionStrategy,
-      "HiveSplit",
-      "NodeSelectionStrategy",
-      "nodeSelectionStrategy");
-  from_json_key(
-      j,
-      "partitionDataColumnCount",
-      p.partitionDataColumnCount,
-      "HiveSplit",
-      "int",
-      "partitionDataColumnCount");
-  from_json_key(
-      j,
-      "tableToPartitionMapping",
-      p.tableToPartitionMapping,
-      "HiveSplit",
-      "TableToPartitionMapping",
-      "tableToPartitionMapping");
-  from_json_key(
-      j,
-      "bucketConversion",
-      p.bucketConversion,
-      "HiveSplit",
-      "BucketConversion",
-      "bucketConversion");
-  from_json_key(
-      j,
-      "s3SelectPushdownEnabled",
-      p.s3SelectPushdownEnabled,
-      "HiveSplit",
-      "bool",
-      "s3SelectPushdownEnabled");
-  from_json_key(
-      j,
-      "extraFileInfo",
-      p.extraFileInfo,
-      "HiveSplit",
-      "String",
-      "extraFileInfo");
-  from_json_key(
-      j,
-      "cacheQuota",
-      p.cacheQuota,
-      "HiveSplit",
-      "CacheQuotaRequirement",
-      "cacheQuota");
-  from_json_key(
-      j,
-      "encryptionMetadata",
-      p.encryptionMetadata,
-      "HiveSplit",
-      "EncryptionInformation",
-      "encryptionMetadata");
-  from_json_key(
-      j,
-      "customSplitInfo",
-      p.customSplitInfo,
-      "HiveSplit",
-      "Map<String, String>",
-      "customSplitInfo");
-  from_json_key(
-      j,
-      "redundantColumnDomains",
-      p.redundantColumnDomains,
-      "HiveSplit",
-      "List<std::shared_ptr<ColumnHandle>>",
-      "redundantColumnDomains");
-  from_json_key(
-      j,
-      "splitWeight",
-      p.splitWeight,
-      "HiveSplit",
-      "SplitWeight",
-      "splitWeight");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<BufferType, json> BufferType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {BufferType::PARTITIONED, "PARTITIONED"},
-        {BufferType::BROADCAST, "BROADCAST"},
-        {BufferType::ARBITRARY, "ARBITRARY"},
-        {BufferType::DISCARDING, "DISCARDING"},
-        {BufferType::SPOOLING, "SPOOLING"}};
-void to_json(json& j, const BufferType& e) {
-  static_assert(std::is_enum<BufferType>::value, "BufferType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(BufferType_enum_table),
-      std::end(BufferType_enum_table),
-      [e](const std::pair<BufferType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(BufferType_enum_table))
-           ? it
-           : std::begin(BufferType_enum_table))
-          ->second;
-}
-void from_json(const json& j, BufferType& e) {
-  static_assert(std::is_enum<BufferType>::value, "BufferType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(BufferType_enum_table),
-      std::end(BufferType_enum_table),
-      [&j](const std::pair<BufferType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(BufferType_enum_table))
-           ? it
-           : std::begin(BufferType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const OutputBuffers& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "OutputBuffers", "BufferType", "type");
-  to_json_key(j, "version", p.version, "OutputBuffers", "int64_t", "version");
-  to_json_key(
-      j,
-      "noMoreBufferIds",
-      p.noMoreBufferIds,
-      "OutputBuffers",
-      "bool",
-      "noMoreBufferIds");
-  to_json_key(
-      j,
-      "buffers",
-      p.buffers,
-      "OutputBuffers",
-      "Map<OutputBufferId, Integer>",
-      "buffers");
-}
-
-void from_json(const json& j, OutputBuffers& p) {
-  from_json_key(j, "type", p.type, "OutputBuffers", "BufferType", "type");
-  from_json_key(j, "version", p.version, "OutputBuffers", "int64_t", "version");
-  from_json_key(
-      j,
-      "noMoreBufferIds",
-      p.noMoreBufferIds,
-      "OutputBuffers",
-      "bool",
-      "noMoreBufferIds");
-  from_json_key(
-      j,
-      "buffers",
-      p.buffers,
-      "OutputBuffers",
-      "Map<OutputBufferId, Integer>",
-      "buffers");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<SelectedRoleType, json> SelectedRoleType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {SelectedRoleType::ROLE, "ROLE"},
-        {SelectedRoleType::ALL, "ALL"},
-        {SelectedRoleType::NONE, "NONE"}};
-void to_json(json& j, const SelectedRoleType& e) {
-  static_assert(
-      std::is_enum<SelectedRoleType>::value,
-      "SelectedRoleType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(SelectedRoleType_enum_table),
-      std::end(SelectedRoleType_enum_table),
-      [e](const std::pair<SelectedRoleType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(SelectedRoleType_enum_table))
-           ? it
-           : std::begin(SelectedRoleType_enum_table))
-          ->second;
-}
-void from_json(const json& j, SelectedRoleType& e) {
-  static_assert(
-      std::is_enum<SelectedRoleType>::value,
-      "SelectedRoleType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(SelectedRoleType_enum_table),
-      std::end(SelectedRoleType_enum_table),
-      [&j](const std::pair<SelectedRoleType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(SelectedRoleType_enum_table))
-           ? it
-           : std::begin(SelectedRoleType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const SelectedRole& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "SelectedRole", "SelectedRoleType", "type");
-  to_json_key(j, "role", p.role, "SelectedRole", "String", "role");
-}
-
-void from_json(const json& j, SelectedRole& p) {
-  from_json_key(j, "type", p.type, "SelectedRole", "SelectedRoleType", "type");
-  from_json_key(j, "role", p.role, "SelectedRole", "String", "role");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Duration& p) {
-  j = p.toString();
-}
-
-void from_json(const json& j, Duration& p) {
-  p = Duration(std::string(j));
-}
-
-std::ostream& operator<<(std::ostream& os, const Duration& d) {
-  return os << d.toString();
-}
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const ResourceEstimates& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "executionTime",
-      p.executionTime,
-      "ResourceEstimates",
-      "Duration",
-      "executionTime");
-  to_json_key(
-      j, "cpuTime", p.cpuTime, "ResourceEstimates", "Duration", "cpuTime");
-  to_json_key(
-      j,
-      "peakMemory",
-      p.peakMemory,
-      "ResourceEstimates",
-      "DataSize",
-      "peakMemory");
-  to_json_key(
-      j,
-      "peakTaskMemory",
-      p.peakTaskMemory,
-      "ResourceEstimates",
-      "DataSize",
-      "peakTaskMemory");
-}
-
-void from_json(const json& j, ResourceEstimates& p) {
-  from_json_key(
-      j,
-      "executionTime",
-      p.executionTime,
-      "ResourceEstimates",
-      "Duration",
-      "executionTime");
-  from_json_key(
-      j, "cpuTime", p.cpuTime, "ResourceEstimates", "Duration", "cpuTime");
-  from_json_key(
-      j,
-      "peakMemory",
-      p.peakMemory,
-      "ResourceEstimates",
-      "DataSize",
-      "peakMemory");
-  from_json_key(
-      j,
-      "peakTaskMemory",
-      p.peakTaskMemory,
-      "ResourceEstimates",
-      "DataSize",
-      "peakTaskMemory");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const SessionRepresentation& p) {
-  j = json::object();
-  to_json_key(
-      j, "queryId", p.queryId, "SessionRepresentation", "String", "queryId");
-  to_json_key(
-      j,
-      "transactionId",
-      p.transactionId,
-      "SessionRepresentation",
-      "TransactionId",
-      "transactionId");
-  to_json_key(
-      j,
-      "clientTransactionSupport",
-      p.clientTransactionSupport,
-      "SessionRepresentation",
-      "bool",
-      "clientTransactionSupport");
-  to_json_key(j, "user", p.user, "SessionRepresentation", "String", "user");
-  to_json_key(
-      j,
-      "principal",
-      p.principal,
-      "SessionRepresentation",
-      "String",
-      "principal");
-  to_json_key(
-      j, "source", p.source, "SessionRepresentation", "String", "source");
-  to_json_key(
-      j, "catalog", p.catalog, "SessionRepresentation", "String", "catalog");
-  to_json_key(
-      j, "schema", p.schema, "SessionRepresentation", "String", "schema");
-  to_json_key(
-      j,
-      "traceToken",
-      p.traceToken,
-      "SessionRepresentation",
-      "String",
-      "traceToken");
-  to_json_key(
-      j,
-      "timeZoneKey",
-      p.timeZoneKey,
-      "SessionRepresentation",
-      "TimeZoneKey",
-      "timeZoneKey");
-  to_json_key(
-      j, "locale", p.locale, "SessionRepresentation", "Locale", "locale");
-  to_json_key(
-      j,
-      "remoteUserAddress",
-      p.remoteUserAddress,
-      "SessionRepresentation",
-      "String",
-      "remoteUserAddress");
-  to_json_key(
-      j,
-      "userAgent",
-      p.userAgent,
-      "SessionRepresentation",
-      "String",
-      "userAgent");
-  to_json_key(
-      j,
-      "clientInfo",
-      p.clientInfo,
-      "SessionRepresentation",
-      "String",
-      "clientInfo");
-  to_json_key(
-      j,
-      "clientTags",
-      p.clientTags,
-      "SessionRepresentation",
-      "List<String>",
-      "clientTags");
-  to_json_key(
-      j,
-      "resourceEstimates",
-      p.resourceEstimates,
-      "SessionRepresentation",
-      "ResourceEstimates",
-      "resourceEstimates");
-  to_json_key(
-      j,
-      "startTime",
-      p.startTime,
-      "SessionRepresentation",
-      "int64_t",
-      "startTime");
-  to_json_key(
-      j,
-      "systemProperties",
-      p.systemProperties,
-      "SessionRepresentation",
-      "Map<String, String>",
-      "systemProperties");
-  to_json_key(
-      j,
-      "catalogProperties",
-      p.catalogProperties,
-      "SessionRepresentation",
-      "Map<ConnectorId, Map<String, String>>",
-      "catalogProperties");
-  to_json_key(
-      j,
-      "unprocessedCatalogProperties",
-      p.unprocessedCatalogProperties,
-      "SessionRepresentation",
-      "Map<String, Map<String, String>>",
-      "unprocessedCatalogProperties");
-  to_json_key(
-      j,
-      "roles",
-      p.roles,
-      "SessionRepresentation",
-      "Map<String, SelectedRole>",
-      "roles");
-  to_json_key(
-      j,
-      "preparedStatements",
-      p.preparedStatements,
-      "SessionRepresentation",
-      "Map<String, String>",
-      "preparedStatements");
-  to_json_key(
-      j,
-      "sessionFunctions",
-      p.sessionFunctions,
-      "SessionRepresentation",
-      "Map<SqlFunctionId, SqlInvokedFunction>",
-      "sessionFunctions");
-}
-
-void from_json(const json& j, SessionRepresentation& p) {
-  from_json_key(
-      j, "queryId", p.queryId, "SessionRepresentation", "String", "queryId");
-  from_json_key(
-      j,
-      "transactionId",
-      p.transactionId,
-      "SessionRepresentation",
-      "TransactionId",
-      "transactionId");
-  from_json_key(
-      j,
-      "clientTransactionSupport",
-      p.clientTransactionSupport,
-      "SessionRepresentation",
-      "bool",
-      "clientTransactionSupport");
-  from_json_key(j, "user", p.user, "SessionRepresentation", "String", "user");
-  from_json_key(
-      j,
-      "principal",
-      p.principal,
-      "SessionRepresentation",
-      "String",
-      "principal");
-  from_json_key(
-      j, "source", p.source, "SessionRepresentation", "String", "source");
-  from_json_key(
-      j, "catalog", p.catalog, "SessionRepresentation", "String", "catalog");
-  from_json_key(
-      j, "schema", p.schema, "SessionRepresentation", "String", "schema");
-  from_json_key(
-      j,
-      "traceToken",
-      p.traceToken,
-      "SessionRepresentation",
-      "String",
-      "traceToken");
-  from_json_key(
-      j,
-      "timeZoneKey",
-      p.timeZoneKey,
-      "SessionRepresentation",
-      "TimeZoneKey",
-      "timeZoneKey");
-  from_json_key(
-      j, "locale", p.locale, "SessionRepresentation", "Locale", "locale");
-  from_json_key(
-      j,
-      "remoteUserAddress",
-      p.remoteUserAddress,
-      "SessionRepresentation",
-      "String",
-      "remoteUserAddress");
-  from_json_key(
-      j,
-      "userAgent",
-      p.userAgent,
-      "SessionRepresentation",
-      "String",
-      "userAgent");
-  from_json_key(
-      j,
-      "clientInfo",
-      p.clientInfo,
-      "SessionRepresentation",
-      "String",
-      "clientInfo");
-  from_json_key(
-      j,
-      "clientTags",
-      p.clientTags,
-      "SessionRepresentation",
-      "List<String>",
-      "clientTags");
-  from_json_key(
-      j,
-      "resourceEstimates",
-      p.resourceEstimates,
-      "SessionRepresentation",
-      "ResourceEstimates",
-      "resourceEstimates");
-  from_json_key(
-      j,
-      "startTime",
-      p.startTime,
-      "SessionRepresentation",
-      "int64_t",
-      "startTime");
-  from_json_key(
-      j,
-      "systemProperties",
-      p.systemProperties,
-      "SessionRepresentation",
-      "Map<String, String>",
-      "systemProperties");
-  from_json_key(
-      j,
-      "catalogProperties",
-      p.catalogProperties,
-      "SessionRepresentation",
-      "Map<ConnectorId, Map<String, String>>",
-      "catalogProperties");
-  from_json_key(
-      j,
-      "unprocessedCatalogProperties",
-      p.unprocessedCatalogProperties,
-      "SessionRepresentation",
-      "Map<String, Map<String, String>>",
-      "unprocessedCatalogProperties");
-  from_json_key(
-      j,
-      "roles",
-      p.roles,
-      "SessionRepresentation",
-      "Map<String, SelectedRole>",
-      "roles");
-  from_json_key(
-      j,
-      "preparedStatements",
-      p.preparedStatements,
-      "SessionRepresentation",
-      "Map<String, String>",
-      "preparedStatements");
-  from_json_key(
-      j,
-      "sessionFunctions",
-      p.sessionFunctions,
-      "SessionRepresentation",
-      "Map<SqlFunctionId, SqlInvokedFunction>",
-      "sessionFunctions");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveTableLayoutHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTableLayoutHandle");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ConnectorTableLayoutHandle  ConnectorTableLayoutHandle");
-  }
-
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HiveTableLayoutHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTableLayoutHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveTableHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTableHandle");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) + " ConnectorTableHandle  ConnectorTableHandle");
-  }
-
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HiveTableHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorTableHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TableHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "TableHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "TableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-  to_json_key(
-      j,
-      "transaction",
-      p.transaction,
-      "TableHandle",
-      "ConnectorTransactionHandle",
-      "transaction");
-  to_json_key(
-      j,
-      "connectorTableLayout",
-      p.connectorTableLayout,
-      "TableHandle",
-      "ConnectorTableLayoutHandle",
-      "connectorTableLayout");
-}
-
-void from_json(const json& j, TableHandle& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "TableHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "TableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-  from_json_key(
-      j,
-      "transaction",
-      p.transaction,
-      "TableHandle",
-      "ConnectorTransactionHandle",
-      "transaction");
-  from_json_key(
-      j,
-      "connectorTableLayout",
-      p.connectorTableLayout,
-      "TableHandle",
-      "ConnectorTableLayoutHandle",
-      "connectorTableLayout");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const DeleteScanInfo& p) {
-  j = json::object();
-  to_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
-  to_json_key(
-      j,
-      "tableHandle",
-      p.tableHandle,
-      "DeleteScanInfo",
-      "TableHandle",
-      "tableHandle");
-}
-
-void from_json(const json& j, DeleteScanInfo& p) {
-  from_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
-  from_json_key(
-      j,
-      "tableHandle",
-      p.tableHandle,
-      "DeleteScanInfo",
-      "TableHandle",
-      "tableHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const AnalyzeTableHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "AnalyzeTableHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "AnalyzeTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "AnalyzeTableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-}
-
-void from_json(const json& j, AnalyzeTableHandle& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "AnalyzeTableHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "AnalyzeTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "AnalyzeTableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == "CreateHandle") {
-    j = *std::static_pointer_cast<CreateHandle>(p);
-    return;
-  }
-  if (type == "InsertHandle") {
-    j = *std::static_pointer_cast<InsertHandle>(p);
-    return;
-  }
-  if (type == "DeleteHandle") {
-    j = *std::static_pointer_cast<DeleteHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ExecutionWriterTarget ");
-}
-
-void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ExecutionWriterTarget  ExecutionWriterTarget");
-  }
-
-  if (type == "CreateHandle") {
-    std::shared_ptr<CreateHandle> k = std::make_shared<CreateHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
-    return;
-  }
-  if (type == "InsertHandle") {
-    std::shared_ptr<InsertHandle> k = std::make_shared<InsertHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
-    return;
-  }
-  if (type == "DeleteHandle") {
-    std::shared_ptr<DeleteHandle> k = std::make_shared<DeleteHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ExecutionWriterTarget ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TableWriteInfo& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "writerTarget",
-      p.writerTarget,
-      "TableWriteInfo",
-      "ExecutionWriterTarget",
-      "writerTarget");
-  to_json_key(
-      j,
-      "analyzeTableHandle",
-      p.analyzeTableHandle,
-      "TableWriteInfo",
-      "AnalyzeTableHandle",
-      "analyzeTableHandle");
-  to_json_key(
-      j,
-      "deleteScanInfo",
-      p.deleteScanInfo,
-      "TableWriteInfo",
-      "DeleteScanInfo",
-      "deleteScanInfo");
-}
-
-void from_json(const json& j, TableWriteInfo& p) {
-  from_json_key(
-      j,
-      "writerTarget",
-      p.writerTarget,
-      "TableWriteInfo",
-      "ExecutionWriterTarget",
-      "writerTarget");
-  from_json_key(
-      j,
-      "analyzeTableHandle",
-      p.analyzeTableHandle,
-      "TableWriteInfo",
-      "AnalyzeTableHandle",
-      "analyzeTableHandle");
-  from_json_key(
-      j,
-      "deleteScanInfo",
-      p.deleteScanInfo,
-      "TableWriteInfo",
-      "DeleteScanInfo",
-      "deleteScanInfo");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorSplit>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == "$remote") {
-    j = *std::static_pointer_cast<RemoteSplit>(p);
-    return;
-  }
-  if (type == "$empty") {
-    j = *std::static_pointer_cast<EmptySplit>(p);
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveSplit>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorSplit");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorSplit>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " ConnectorSplit");
-  }
-
-  if (type == "$remote") {
-    auto k = std::make_shared<RemoteSplit>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-  if (type == "$empty") {
-    auto k = std::make_shared<EmptySplit>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HiveSplit>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorSplit");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const SplitContext& p) {
-  j = json::object();
-  to_json_key(j, "cacheable", p.cacheable, "SplitContext", "bool", "cacheable");
-}
-
-void from_json(const json& j, SplitContext& p) {
-  from_json_key(
-      j, "cacheable", p.cacheable, "SplitContext", "bool", "cacheable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Lifespan& p) {
-  if (p.isgroup) {
-    j = "Group" + std::to_string(p.groupid);
-  } else {
-    j = "TaskWide";
-  }
-}
-
-void from_json(const json& j, Lifespan& p) {
-  String lifespan = j;
-
-  if (lifespan == "TaskWide") {
-    p.isgroup = false;
-    p.groupid = 0;
-  } else {
-    if (lifespan != "Group") {
-      // fail...
-    }
-    p.isgroup = true;
-    p.groupid = std::stoi(lifespan.substr(strlen("Group")));
-  }
-}
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Split& p) {
-  j = json::object();
-  to_json_key(
-      j, "connectorId", p.connectorId, "Split", "ConnectorId", "connectorId");
-  to_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "Split",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  to_json_key(
-      j,
-      "connectorSplit",
-      p.connectorSplit,
-      "Split",
-      "ConnectorSplit",
-      "connectorSplit");
-  to_json_key(j, "lifespan", p.lifespan, "Split", "Lifespan", "lifespan");
-  to_json_key(
-      j,
-      "splitContext",
-      p.splitContext,
-      "Split",
-      "SplitContext",
-      "splitContext");
-}
-
-void from_json(const json& j, Split& p) {
-  from_json_key(
-      j, "connectorId", p.connectorId, "Split", "ConnectorId", "connectorId");
-  from_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "Split",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  from_json_key(
-      j,
-      "connectorSplit",
-      p.connectorSplit,
-      "Split",
-      "ConnectorSplit",
-      "connectorSplit");
-  from_json_key(j, "lifespan", p.lifespan, "Split", "Lifespan", "lifespan");
-  from_json_key(
-      j,
-      "splitContext",
-      p.splitContext,
-      "Split",
-      "SplitContext",
-      "splitContext");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const ScheduledSplit& p) {
-  j = json::object();
-  to_json_key(
-      j, "sequenceId", p.sequenceId, "ScheduledSplit", "int64_t", "sequenceId");
-  to_json_key(
-      j,
-      "planNodeId",
-      p.planNodeId,
-      "ScheduledSplit",
-      "PlanNodeId",
-      "planNodeId");
-  to_json_key(j, "split", p.split, "ScheduledSplit", "Split", "split");
-}
-
-void from_json(const json& j, ScheduledSplit& p) {
-  from_json_key(
-      j, "sequenceId", p.sequenceId, "ScheduledSplit", "int64_t", "sequenceId");
-  from_json_key(
-      j,
-      "planNodeId",
-      p.planNodeId,
-      "ScheduledSplit",
-      "PlanNodeId",
-      "planNodeId");
-  from_json_key(j, "split", p.split, "ScheduledSplit", "Split", "split");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TaskSource& p) {
-  j = json::object();
-  to_json_key(
-      j, "planNodeId", p.planNodeId, "TaskSource", "PlanNodeId", "planNodeId");
-  to_json_key(
-      j, "splits", p.splits, "TaskSource", "List<ScheduledSplit>", "splits");
-  to_json_key(
-      j,
-      "noMoreSplitsForLifespan",
-      p.noMoreSplitsForLifespan,
-      "TaskSource",
-      "List<Lifespan>",
-      "noMoreSplitsForLifespan");
-  to_json_key(
-      j, "noMoreSplits", p.noMoreSplits, "TaskSource", "bool", "noMoreSplits");
-}
-
-void from_json(const json& j, TaskSource& p) {
-  from_json_key(
-      j, "planNodeId", p.planNodeId, "TaskSource", "PlanNodeId", "planNodeId");
-  from_json_key(
-      j, "splits", p.splits, "TaskSource", "List<ScheduledSplit>", "splits");
-  from_json_key(
-      j,
-      "noMoreSplitsForLifespan",
-      p.noMoreSplitsForLifespan,
-      "TaskSource",
-      "List<Lifespan>",
-      "noMoreSplitsForLifespan");
-  from_json_key(
-      j, "noMoreSplits", p.noMoreSplits, "TaskSource", "bool", "noMoreSplits");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TaskUpdateRequest& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "session",
-      p.session,
-      "TaskUpdateRequest",
-      "SessionRepresentation",
-      "session");
-  to_json_key(
-      j,
-      "extraCredentials",
-      p.extraCredentials,
-      "TaskUpdateRequest",
-      "Map<String, String>",
-      "extraCredentials");
-  to_json_key(
-      j, "fragment", p.fragment, "TaskUpdateRequest", "String", "fragment");
-  to_json_key(
-      j,
-      "sources",
-      p.sources,
-      "TaskUpdateRequest",
-      "List<TaskSource>",
-      "sources");
-  to_json_key(
-      j,
-      "outputIds",
-      p.outputIds,
-      "TaskUpdateRequest",
-      "OutputBuffers",
-      "outputIds");
-  to_json_key(
-      j,
-      "tableWriteInfo",
-      p.tableWriteInfo,
-      "TaskUpdateRequest",
-      "TableWriteInfo",
-      "tableWriteInfo");
-}
-
-void from_json(const json& j, TaskUpdateRequest& p) {
-  from_json_key(
-      j,
-      "session",
-      p.session,
-      "TaskUpdateRequest",
-      "SessionRepresentation",
-      "session");
-  from_json_key(
-      j,
-      "extraCredentials",
-      p.extraCredentials,
-      "TaskUpdateRequest",
-      "Map<String, String>",
-      "extraCredentials");
-  from_json_key(
-      j, "fragment", p.fragment, "TaskUpdateRequest", "String", "fragment");
-  from_json_key(
-      j,
-      "sources",
-      p.sources,
-      "TaskUpdateRequest",
-      "List<TaskSource>",
-      "sources");
-  from_json_key(
-      j,
-      "outputIds",
-      p.outputIds,
-      "TaskUpdateRequest",
-      "OutputBuffers",
-      "outputIds");
-  from_json_key(
-      j,
-      "tableWriteInfo",
-      p.tableWriteInfo,
-      "TaskUpdateRequest",
-      "TableWriteInfo",
-      "tableWriteInfo");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-AssignUniqueId::AssignUniqueId() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.AssignUniqueId";
-}
-
-void to_json(json& j, const AssignUniqueId& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.AssignUniqueId";
-  to_json_key(j, "id", p.id, "AssignUniqueId", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "AssignUniqueId", "PlanNode", "source");
-  to_json_key(
-      j,
-      "idVariable",
-      p.idVariable,
-      "AssignUniqueId",
-      "VariableReferenceExpression",
-      "idVariable");
-}
-
-void from_json(const json& j, AssignUniqueId& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "AssignUniqueId", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "AssignUniqueId", "PlanNode", "source");
-  from_json_key(
-      j,
-      "idVariable",
-      p.idVariable,
-      "AssignUniqueId",
-      "VariableReferenceExpression",
-      "idVariable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveOutputTableHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorOutputTableHandle ");
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ConnectorOutputTableHandle  ConnectorOutputTableHandle");
-  }
-
-  if (getConnectorKey(type) == "hive") {
-    std::shared_ptr<HiveOutputTableHandle> k =
-        std::make_shared<HiveOutputTableHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ConnectorOutputTableHandle>(k);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorOutputTableHandle ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const OutputTableHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "OutputTableHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "OutputTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "OutputTableHandle",
-      "ConnectorOutputTableHandle",
-      "connectorHandle");
-}
-
-void from_json(const json& j, OutputTableHandle& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "OutputTableHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "OutputTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "OutputTableHandle",
-      "ConnectorOutputTableHandle",
-      "connectorHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
 void to_json(json& j, const SchemaTableName& p) {
   j = json::object();
   to_json_key(j, "schema", p.schema, "SchemaTableName", "String", "schema");
@@ -3995,1419 +571,874 @@ void from_json(const json& j, SchemaTableName& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-CreateHandle::CreateHandle() noexcept {
-  _type = "CreateHandle";
-}
-
-void to_json(json& j, const CreateHandle& p) {
-  j = json::object();
-  j["@type"] = "CreateHandle";
-  to_json_key(
-      j, "handle", p.handle, "CreateHandle", "OutputTableHandle", "handle");
-  to_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "CreateHandle",
-      "SchemaTableName",
-      "schemaTableName");
-}
-
-void from_json(const json& j, CreateHandle& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j, "handle", p.handle, "CreateHandle", "OutputTableHandle", "handle");
-  from_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "CreateHandle",
-      "SchemaTableName",
-      "schemaTableName");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<ErrorType, json> ErrorType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {ErrorType::USER_ERROR, "USER_ERROR"},
-        {ErrorType::INTERNAL_ERROR, "INTERNAL_ERROR"},
-        {ErrorType::INSUFFICIENT_RESOURCES, "INSUFFICIENT_RESOURCES"},
-        {ErrorType::EXTERNAL, "EXTERNAL"}};
-void to_json(json& j, const ErrorType& e) {
-  static_assert(std::is_enum<ErrorType>::value, "ErrorType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(ErrorType_enum_table),
-      std::end(ErrorType_enum_table),
-      [e](const std::pair<ErrorType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(ErrorType_enum_table))
-           ? it
-           : std::begin(ErrorType_enum_table))
-          ->second;
-}
-void from_json(const json& j, ErrorType& e) {
-  static_assert(std::is_enum<ErrorType>::value, "ErrorType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(ErrorType_enum_table),
-      std::end(ErrorType_enum_table),
-      [&j](const std::pair<ErrorType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(ErrorType_enum_table))
-           ? it
-           : std::begin(ErrorType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const ErrorCode& p) {
-  j = json::object();
-  to_json_key(j, "code", p.code, "ErrorCode", "int", "code");
-  to_json_key(j, "name", p.name, "ErrorCode", "String", "name");
-  to_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
-  to_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
-}
-
-void from_json(const json& j, ErrorCode& p) {
-  from_json_key(j, "code", p.code, "ErrorCode", "int", "code");
-  from_json_key(j, "name", p.name, "ErrorCode", "String", "name");
-  from_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
-  from_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const ErrorLocation& p) {
-  j = json::object();
-  to_json_key(
-      j, "lineNumber", p.lineNumber, "ErrorLocation", "int", "lineNumber");
-  to_json_key(
-      j,
-      "columnNumber",
-      p.columnNumber,
-      "ErrorLocation",
-      "int",
-      "columnNumber");
-}
-
-void from_json(const json& j, ErrorLocation& p) {
-  from_json_key(
-      j, "lineNumber", p.lineNumber, "ErrorLocation", "int", "lineNumber");
-  from_json_key(
-      j,
-      "columnNumber",
-      p.columnNumber,
-      "ErrorLocation",
-      "int",
-      "columnNumber");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const ExecutionFailureInfo& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "ExecutionFailureInfo", "String", "type");
-  to_json_key(
-      j, "message", p.message, "ExecutionFailureInfo", "String", "message");
-  to_json_key(
-      j,
-      "cause",
-      p.cause,
-      "ExecutionFailureInfo",
-      "ExecutionFailureInfo",
-      "cause");
-  to_json_key(
-      j,
-      "suppressed",
-      p.suppressed,
-      "ExecutionFailureInfo",
-      "List<ExecutionFailureInfo>",
-      "suppressed");
-  to_json_key(
-      j, "stack", p.stack, "ExecutionFailureInfo", "List<String>", "stack");
-  to_json_key(
-      j,
-      "errorLocation",
-      p.errorLocation,
-      "ExecutionFailureInfo",
-      "ErrorLocation",
-      "errorLocation");
-  to_json_key(
-      j,
-      "errorCode",
-      p.errorCode,
-      "ExecutionFailureInfo",
-      "ErrorCode",
-      "errorCode");
-  to_json_key(
-      j,
-      "remoteHost",
-      p.remoteHost,
-      "ExecutionFailureInfo",
-      "HostAddress",
-      "remoteHost");
-}
-
-void from_json(const json& j, ExecutionFailureInfo& p) {
-  from_json_key(j, "type", p.type, "ExecutionFailureInfo", "String", "type");
-  from_json_key(
-      j, "message", p.message, "ExecutionFailureInfo", "String", "message");
-  from_json_key(
-      j,
-      "cause",
-      p.cause,
-      "ExecutionFailureInfo",
-      "ExecutionFailureInfo",
-      "cause");
-  from_json_key(
-      j,
-      "suppressed",
-      p.suppressed,
-      "ExecutionFailureInfo",
-      "List<ExecutionFailureInfo>",
-      "suppressed");
-  from_json_key(
-      j, "stack", p.stack, "ExecutionFailureInfo", "List<String>", "stack");
-  from_json_key(
-      j,
-      "errorLocation",
-      p.errorLocation,
-      "ExecutionFailureInfo",
-      "ErrorLocation",
-      "errorLocation");
-  from_json_key(
-      j,
-      "errorCode",
-      p.errorCode,
-      "ExecutionFailureInfo",
-      "ErrorCode",
-      "errorCode");
-  from_json_key(
-      j,
-      "remoteHost",
-      p.remoteHost,
-      "ExecutionFailureInfo",
-      "HostAddress",
-      "remoteHost");
-}
-} // namespace facebook::presto::protocol
-// dependency KeyedSubclass
-
-namespace facebook::presto::protocol {
-
-std::string JsonEncodedSubclass::getSubclassKey(nlohmann::json j) {
-  return j["@type"];
-}
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-SortedRangeSet::SortedRangeSet() noexcept {
-  _type = "sortable";
-}
-
-void to_json(json& j, const SortedRangeSet& p) {
-  j = json::object();
-  j["@type"] = "sortable";
-  to_json_key(j, "type", p.type, "SortedRangeSet", "Type", "type");
-  to_json_key(j, "ranges", p.ranges, "SortedRangeSet", "List<Range>", "ranges");
-}
-
-void from_json(const json& j, SortedRangeSet& p) {
-  p._type = j["@type"];
-  from_json_key(j, "type", p.type, "SortedRangeSet", "Type", "type");
-  from_json_key(
-      j, "ranges", p.ranges, "SortedRangeSet", "List<Range>", "ranges");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-ValuesNode::ValuesNode() noexcept {
-  _type = ".ValuesNode";
-}
-
-void to_json(json& j, const ValuesNode& p) {
-  j = json::object();
-  j["@type"] = ".ValuesNode";
-  to_json_key(j, "id", p.id, "ValuesNode", "PlanNodeId", "id");
-  to_json_key(
-      j,
-      "outputVariables",
-      p.outputVariables,
-      "ValuesNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  to_json_key(
-      j,
-      "rows",
-      p.rows,
-      "ValuesNode",
-      "List<List<std::shared_ptr<RowExpression>>>",
-      "rows");
-}
-
-void from_json(const json& j, ValuesNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "ValuesNode", "PlanNodeId", "id");
-  from_json_key(
-      j,
-      "outputVariables",
-      p.outputVariables,
-      "ValuesNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  from_json_key(
-      j,
-      "rows",
-      p.rows,
-      "ValuesNode",
-      "List<List<std::shared_ptr<RowExpression>>>",
-      "rows");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Locality, json> Locality_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Locality::UNKNOWN, "UNKNOWN"},
-        {Locality::LOCAL, "LOCAL"},
-        {Locality::REMOTE, "REMOTE"}};
-void to_json(json& j, const Locality& e) {
-  static_assert(std::is_enum<Locality>::value, "Locality must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Locality_enum_table),
-      std::end(Locality_enum_table),
-      [e](const std::pair<Locality, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Locality_enum_table)) ? it
-                                             : std::begin(Locality_enum_table))
-          ->second;
-}
-void from_json(const json& j, Locality& e) {
-  static_assert(std::is_enum<Locality>::value, "Locality must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Locality_enum_table),
-      std::end(Locality_enum_table),
-      [&j](const std::pair<Locality, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Locality_enum_table)) ? it
-                                             : std::begin(Locality_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-ProjectNode::ProjectNode() noexcept {
-  _type = ".ProjectNode";
-}
-
-void to_json(json& j, const ProjectNode& p) {
-  j = json::object();
-  j["@type"] = ".ProjectNode";
-  to_json_key(j, "id", p.id, "ProjectNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "ProjectNode", "PlanNode", "source");
-  to_json_key(
-      j,
-      "assignments",
-      p.assignments,
-      "ProjectNode",
-      "Assignments",
-      "assignments");
-  to_json_key(j, "locality", p.locality, "ProjectNode", "Locality", "locality");
-}
-
-void from_json(const json& j, ProjectNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "ProjectNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "ProjectNode", "PlanNode", "source");
-  from_json_key(
-      j,
-      "assignments",
-      p.assignments,
-      "ProjectNode",
-      "Assignments",
-      "assignments");
-  from_json_key(
-      j, "locality", p.locality, "ProjectNode", "Locality", "locality");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorInsertTableHandle>& p) {
+void to_json(json& j, const std::shared_ptr<ColumnHandle>& p) {
   if (p == nullptr) {
     return;
   }
   String type = p->_type;
 
-  if (type == "hive") {
-    j = *std::static_pointer_cast<HiveInsertTableHandle>(p);
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveColumnHandle>(p);
     return;
   }
 
-  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+  throw TypeError(type + " no abstract type ColumnHandle ");
 }
 
-void from_json(const json& j, std::shared_ptr<ConnectorInsertTableHandle>& p) {
+void from_json(const json& j, std::shared_ptr<ColumnHandle>& p) {
   String type;
   try {
     type = p->getSubclassKey(j);
   } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ConnectorInsertTableHandle  ConnectorInsertTableHandle");
+    throw ParseError(std::string(e.what()) + " ColumnHandle  ColumnHandle");
   }
 
-  if (type == "hive") {
-    std::shared_ptr<HiveInsertTableHandle> k =
-        std::make_shared<HiveInsertTableHandle>();
+  if (getConnectorKey(type) == "hive") {
+    std::shared_ptr<HiveColumnHandle> k = std::make_shared<HiveColumnHandle>();
     j.get_to(*k);
-    p = std::static_pointer_cast<ConnectorInsertTableHandle>(k);
+    p = std::static_pointer_cast<ColumnHandle>(k);
     return;
   }
 
-  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+  throw TypeError(type + " no abstract type ColumnHandle ");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const InsertTableHandle& p) {
+void to_json(json& j, const Column& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "Column", "String", "name");
+  to_json_key(j, "type", p.type, "Column", "String", "type");
+}
+
+void from_json(const json& j, Column& p) {
+  from_json_key(j, "name", p.name, "Column", "String", "name");
+  from_json_key(j, "type", p.type, "Column", "String", "type");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ValueSet>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == "equatable") {
+    j = *std::static_pointer_cast<EquatableValueSet>(p);
+    return;
+  }
+  if (type == "sortable") {
+    j = *std::static_pointer_cast<SortedRangeSet>(p);
+    return;
+  }
+  if (type == "allOrNone") {
+    j = *std::static_pointer_cast<AllOrNoneValueSet>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ValueSet ");
+}
+
+void from_json(const json& j, std::shared_ptr<ValueSet>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(std::string(e.what()) + " ValueSet  ValueSet");
+  }
+
+  if (type == "equatable") {
+    std::shared_ptr<EquatableValueSet> k =
+        std::make_shared<EquatableValueSet>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ValueSet>(k);
+    return;
+  }
+  if (type == "sortable") {
+    std::shared_ptr<SortedRangeSet> k = std::make_shared<SortedRangeSet>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ValueSet>(k);
+    return;
+  }
+  if (type == "allOrNone") {
+    std::shared_ptr<AllOrNoneValueSet> k =
+        std::make_shared<AllOrNoneValueSet>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ValueSet>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ValueSet ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Domain& p) {
+  j = json::object();
+  to_json_key(j, "values", p.values, "Domain", "ValueSet", "values");
+  to_json_key(j, "nullAllowed", p.nullAllowed, "Domain", "bool", "nullAllowed");
+}
+
+void from_json(const json& j, Domain& p) {
+  from_json_key(j, "values", p.values, "Domain", "ValueSet", "values");
+  from_json_key(
+      j, "nullAllowed", p.nullAllowed, "Domain", "bool", "nullAllowed");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const HiveBucketFilter& p) {
   j = json::object();
   to_json_key(
       j,
-      "connectorId",
-      p.connectorId,
-      "InsertTableHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "InsertTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "InsertTableHandle",
-      "ConnectorInsertTableHandle",
-      "connectorHandle");
+      "bucketsToKeep",
+      p.bucketsToKeep,
+      "HiveBucketFilter",
+      "List<Integer>",
+      "bucketsToKeep");
 }
 
-void from_json(const json& j, InsertTableHandle& p) {
+void from_json(const json& j, HiveBucketFilter& p) {
   from_json_key(
       j,
-      "connectorId",
-      p.connectorId,
-      "InsertTableHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "transactionHandle",
-      p.transactionHandle,
-      "InsertTableHandle",
-      "ConnectorTransactionHandle",
-      "transactionHandle");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "InsertTableHandle",
-      "ConnectorInsertTableHandle",
-      "connectorHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<RuntimeUnit, json> RuntimeUnit_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {RuntimeUnit::NONE, "NONE"},
-        {RuntimeUnit::NANO, "NANO"},
-        {RuntimeUnit::BYTE, "BYTE"}};
-void to_json(json& j, const RuntimeUnit& e) {
-  static_assert(
-      std::is_enum<RuntimeUnit>::value, "RuntimeUnit must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(RuntimeUnit_enum_table),
-      std::end(RuntimeUnit_enum_table),
-      [e](const std::pair<RuntimeUnit, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(RuntimeUnit_enum_table))
-           ? it
-           : std::begin(RuntimeUnit_enum_table))
-          ->second;
-}
-void from_json(const json& j, RuntimeUnit& e) {
-  static_assert(
-      std::is_enum<RuntimeUnit>::value, "RuntimeUnit must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(RuntimeUnit_enum_table),
-      std::end(RuntimeUnit_enum_table),
-      [&j](const std::pair<RuntimeUnit, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(RuntimeUnit_enum_table))
-           ? it
-           : std::begin(RuntimeUnit_enum_table))
-          ->first;
+      "bucketsToKeep",
+      p.bucketsToKeep,
+      "HiveBucketFilter",
+      "List<Integer>",
+      "bucketsToKeep");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const RuntimeMetric& p) {
+void to_json(json& j, const HiveBucketHandle& p) {
   j = json::object();
-  to_json_key(j, "name", p.name, "RuntimeMetric", "String", "name");
-  to_json_key(j, "unit", p.unit, "RuntimeMetric", "RuntimeUnit", "unit");
-  to_json_key(j, "sum", p.sum, "RuntimeMetric", "int64_t", "sum");
-  to_json_key(j, "count", p.count, "RuntimeMetric", "int64_t", "count");
-  to_json_key(j, "max", p.max, "RuntimeMetric", "int64_t", "max");
-  to_json_key(j, "min", p.min, "RuntimeMetric", "int64_t", "min");
+  to_json_key(
+      j,
+      "columns",
+      p.columns,
+      "HiveBucketHandle",
+      "List<HiveColumnHandle>",
+      "columns");
+  to_json_key(
+      j,
+      "tableBucketCount",
+      p.tableBucketCount,
+      "HiveBucketHandle",
+      "int",
+      "tableBucketCount");
+  to_json_key(
+      j,
+      "readBucketCount",
+      p.readBucketCount,
+      "HiveBucketHandle",
+      "int",
+      "readBucketCount");
 }
 
-void from_json(const json& j, RuntimeMetric& p) {
-  from_json_key(j, "name", p.name, "RuntimeMetric", "String", "name");
-  from_json_key(j, "unit", p.unit, "RuntimeMetric", "RuntimeUnit", "unit");
-  from_json_key(j, "sum", p.sum, "RuntimeMetric", "int64_t", "sum");
-  from_json_key(j, "count", p.count, "RuntimeMetric", "int64_t", "count");
-  from_json_key(j, "max", p.max, "RuntimeMetric", "int64_t", "max");
-  from_json_key(j, "min", p.min, "RuntimeMetric", "int64_t", "min");
+void from_json(const json& j, HiveBucketHandle& p) {
+  from_json_key(
+      j,
+      "columns",
+      p.columns,
+      "HiveBucketHandle",
+      "List<HiveColumnHandle>",
+      "columns");
+  from_json_key(
+      j,
+      "tableBucketCount",
+      p.tableBucketCount,
+      "HiveBucketHandle",
+      "int",
+      "tableBucketCount");
+  from_json_key(
+      j,
+      "readBucketCount",
+      p.readBucketCount,
+      "HiveBucketHandle",
+      "int",
+      "readBucketCount");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-HiveTransactionHandle::HiveTransactionHandle() noexcept {
+HiveTableLayoutHandle::HiveTableLayoutHandle() noexcept {
   _type = "hive";
 }
 
-void to_json(json& j, const HiveTransactionHandle& p) {
+void to_json(json& j, const HiveTableLayoutHandle& p) {
   j = json::object();
   j["@type"] = "hive";
-  to_json_key(j, "uuid", p.uuid, "HiveTransactionHandle", "UUID", "uuid");
-}
-
-void from_json(const json& j, HiveTransactionHandle& p) {
-  p._type = j["@type"];
-  from_json_key(j, "uuid", p.uuid, "HiveTransactionHandle", "UUID", "uuid");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<JoinNodeType, json> JoinNodeType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {JoinNodeType::INNER, "INNER"},
-        {JoinNodeType::LEFT, "LEFT"},
-        {JoinNodeType::RIGHT, "RIGHT"},
-        {JoinNodeType::FULL, "FULL"}};
-void to_json(json& j, const JoinNodeType& e) {
-  static_assert(
-      std::is_enum<JoinNodeType>::value, "JoinNodeType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(JoinNodeType_enum_table),
-      std::end(JoinNodeType_enum_table),
-      [e](const std::pair<JoinNodeType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(JoinNodeType_enum_table))
-           ? it
-           : std::begin(JoinNodeType_enum_table))
-          ->second;
-}
-void from_json(const json& j, JoinNodeType& e) {
-  static_assert(
-      std::is_enum<JoinNodeType>::value, "JoinNodeType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(JoinNodeType_enum_table),
-      std::end(JoinNodeType_enum_table),
-      [&j](const std::pair<JoinNodeType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(JoinNodeType_enum_table))
-           ? it
-           : std::begin(JoinNodeType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<DistributionType, json> DistributionType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {DistributionType::PARTITIONED, "PARTITIONED"},
-        {DistributionType::REPLICATED, "REPLICATED"}};
-void to_json(json& j, const DistributionType& e) {
-  static_assert(
-      std::is_enum<DistributionType>::value,
-      "DistributionType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(DistributionType_enum_table),
-      std::end(DistributionType_enum_table),
-      [e](const std::pair<DistributionType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(DistributionType_enum_table))
-           ? it
-           : std::begin(DistributionType_enum_table))
-          ->second;
-}
-void from_json(const json& j, DistributionType& e) {
-  static_assert(
-      std::is_enum<DistributionType>::value,
-      "DistributionType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(DistributionType_enum_table),
-      std::end(DistributionType_enum_table),
-      [&j](const std::pair<DistributionType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(DistributionType_enum_table))
-           ? it
-           : std::begin(DistributionType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-JoinNode::JoinNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.JoinNode";
-}
-
-void to_json(json& j, const JoinNode& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.JoinNode";
-  to_json_key(j, "id", p.id, "JoinNode", "PlanNodeId", "id");
-  to_json_key(j, "type", p.type, "JoinNode", "JoinNodeType", "type");
-  to_json_key(j, "left", p.left, "JoinNode", "PlanNode", "left");
-  to_json_key(j, "right", p.right, "JoinNode", "PlanNode", "right");
   to_json_key(
       j,
-      "criteria",
-      p.criteria,
-      "JoinNode",
-      "List<EquiJoinClause>",
-      "criteria");
+      "schemaTableName",
+      p.schemaTableName,
+      "HiveTableLayoutHandle",
+      "SchemaTableName",
+      "schemaTableName");
   to_json_key(
       j,
-      "outputVariables",
-      p.outputVariables,
-      "JoinNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  to_json_key(
-      j,
-      "filter",
-      p.filter,
-      "JoinNode",
-      "std::shared_ptr<RowExpression>",
-      "filter");
-  to_json_key(
-      j,
-      "leftHashVariable",
-      p.leftHashVariable,
-      "JoinNode",
-      "VariableReferenceExpression",
-      "leftHashVariable");
-  to_json_key(
-      j,
-      "rightHashVariable",
-      p.rightHashVariable,
-      "JoinNode",
-      "VariableReferenceExpression",
-      "rightHashVariable");
-  to_json_key(
-      j,
-      "distributionType",
-      p.distributionType,
-      "JoinNode",
-      "DistributionType",
-      "distributionType");
-  to_json_key(
-      j,
-      "dynamicFilters",
-      p.dynamicFilters,
-      "JoinNode",
-      "Map<String, VariableReferenceExpression>",
-      "dynamicFilters");
-}
-
-void from_json(const json& j, JoinNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "JoinNode", "PlanNodeId", "id");
-  from_json_key(j, "type", p.type, "JoinNode", "JoinNodeType", "type");
-  from_json_key(j, "left", p.left, "JoinNode", "PlanNode", "left");
-  from_json_key(j, "right", p.right, "JoinNode", "PlanNode", "right");
-  from_json_key(
-      j,
-      "criteria",
-      p.criteria,
-      "JoinNode",
-      "List<EquiJoinClause>",
-      "criteria");
-  from_json_key(
-      j,
-      "outputVariables",
-      p.outputVariables,
-      "JoinNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  from_json_key(
-      j,
-      "filter",
-      p.filter,
-      "JoinNode",
-      "std::shared_ptr<RowExpression>",
-      "filter");
-  from_json_key(
-      j,
-      "leftHashVariable",
-      p.leftHashVariable,
-      "JoinNode",
-      "VariableReferenceExpression",
-      "leftHashVariable");
-  from_json_key(
-      j,
-      "rightHashVariable",
-      p.rightHashVariable,
-      "JoinNode",
-      "VariableReferenceExpression",
-      "rightHashVariable");
-  from_json_key(
-      j,
-      "distributionType",
-      p.distributionType,
-      "JoinNode",
-      "DistributionType",
-      "distributionType");
-  from_json_key(
-      j,
-      "dynamicFilters",
-      p.dynamicFilters,
-      "JoinNode",
-      "Map<String, VariableReferenceExpression>",
-      "dynamicFilters");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-MergeJoinNode::MergeJoinNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.MergeJoinNode";
-}
-
-void to_json(json& j, const MergeJoinNode& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.MergeJoinNode";
-  to_json_key(j, "id", p.id, "MergeJoinNode", "PlanNodeId", "id");
-  to_json_key(j, "type", p.type, "MergeJoinNode", "JoinNode.Type", "type");
-  to_json_key(j, "left", p.left, "MergeJoinNode", "PlanNode", "left");
-  to_json_key(j, "right", p.right, "MergeJoinNode", "PlanNode", "right");
-  to_json_key(
-      j,
-      "criteria",
-      p.criteria,
-      "MergeJoinNode",
-      "List<JoinNode.EquiJoinClause>",
-      "criteria");
-  to_json_key(
-      j,
-      "outputVariables",
-      p.outputVariables,
-      "MergeJoinNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  to_json_key(
-      j,
-      "filter",
-      p.filter,
-      "MergeJoinNode",
-      "std::shared_ptr<RowExpression>",
-      "filter");
-  to_json_key(
-      j,
-      "leftHashVariable",
-      p.leftHashVariable,
-      "MergeJoinNode",
-      "VariableReferenceExpression",
-      "leftHashVariable");
-  to_json_key(
-      j,
-      "rightHashVariable",
-      p.rightHashVariable,
-      "MergeJoinNode",
-      "VariableReferenceExpression",
-      "rightHashVariable");
-}
-
-void from_json(const json& j, MergeJoinNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "MergeJoinNode", "PlanNodeId", "id");
-  from_json_key(j, "type", p.type, "MergeJoinNode", "JoinNode.Type", "type");
-  from_json_key(j, "left", p.left, "MergeJoinNode", "PlanNode", "left");
-  from_json_key(j, "right", p.right, "MergeJoinNode", "PlanNode", "right");
-  from_json_key(
-      j,
-      "criteria",
-      p.criteria,
-      "MergeJoinNode",
-      "List<JoinNode.EquiJoinClause>",
-      "criteria");
-  from_json_key(
-      j,
-      "outputVariables",
-      p.outputVariables,
-      "MergeJoinNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
-  from_json_key(
-      j,
-      "filter",
-      p.filter,
-      "MergeJoinNode",
-      "std::shared_ptr<RowExpression>",
-      "filter");
-  from_json_key(
-      j,
-      "leftHashVariable",
-      p.leftHashVariable,
-      "MergeJoinNode",
-      "VariableReferenceExpression",
-      "leftHashVariable");
-  from_json_key(
-      j,
-      "rightHashVariable",
-      p.rightHashVariable,
-      "MergeJoinNode",
-      "VariableReferenceExpression",
-      "rightHashVariable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const NodeVersion& p) {
-  j = json::object();
-  to_json_key(j, "version", p.version, "NodeVersion", "String", "version");
-}
-
-void from_json(const json& j, NodeVersion& p) {
-  from_json_key(j, "version", p.version, "NodeVersion", "String", "version");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const MemoryAllocation& p) {
-  j = json::object();
-  to_json_key(j, "tag", p.tag, "MemoryAllocation", "String", "tag");
-  to_json_key(
-      j,
-      "allocation",
-      p.allocation,
-      "MemoryAllocation",
-      "int64_t",
-      "allocation");
-}
-
-void from_json(const json& j, MemoryAllocation& p) {
-  from_json_key(j, "tag", p.tag, "MemoryAllocation", "String", "tag");
-  from_json_key(
-      j,
-      "allocation",
-      p.allocation,
-      "MemoryAllocation",
-      "int64_t",
-      "allocation");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const MemoryPoolInfo& p) {
-  j = json::object();
-  to_json_key(
-      j, "maxBytes", p.maxBytes, "MemoryPoolInfo", "int64_t", "maxBytes");
-  to_json_key(
-      j,
-      "reservedBytes",
-      p.reservedBytes,
-      "MemoryPoolInfo",
-      "int64_t",
-      "reservedBytes");
-  to_json_key(
-      j,
-      "reservedRevocableBytes",
-      p.reservedRevocableBytes,
-      "MemoryPoolInfo",
-      "int64_t",
-      "reservedRevocableBytes");
-  to_json_key(
-      j,
-      "queryMemoryReservations",
-      p.queryMemoryReservations,
-      "MemoryPoolInfo",
-      "Map<QueryId, Long>",
-      "queryMemoryReservations");
-  to_json_key(
-      j,
-      "queryMemoryAllocations",
-      p.queryMemoryAllocations,
-      "MemoryPoolInfo",
-      "Map<QueryId, List<MemoryAllocation>>",
-      "queryMemoryAllocations");
-  to_json_key(
-      j,
-      "queryMemoryRevocableReservations",
-      p.queryMemoryRevocableReservations,
-      "MemoryPoolInfo",
-      "Map<QueryId, Long>",
-      "queryMemoryRevocableReservations");
-}
-
-void from_json(const json& j, MemoryPoolInfo& p) {
-  from_json_key(
-      j, "maxBytes", p.maxBytes, "MemoryPoolInfo", "int64_t", "maxBytes");
-  from_json_key(
-      j,
-      "reservedBytes",
-      p.reservedBytes,
-      "MemoryPoolInfo",
-      "int64_t",
-      "reservedBytes");
-  from_json_key(
-      j,
-      "reservedRevocableBytes",
-      p.reservedRevocableBytes,
-      "MemoryPoolInfo",
-      "int64_t",
-      "reservedRevocableBytes");
-  from_json_key(
-      j,
-      "queryMemoryReservations",
-      p.queryMemoryReservations,
-      "MemoryPoolInfo",
-      "Map<QueryId, Long>",
-      "queryMemoryReservations");
-  from_json_key(
-      j,
-      "queryMemoryAllocations",
-      p.queryMemoryAllocations,
-      "MemoryPoolInfo",
-      "Map<QueryId, List<MemoryAllocation>>",
-      "queryMemoryAllocations");
-  from_json_key(
-      j,
-      "queryMemoryRevocableReservations",
-      p.queryMemoryRevocableReservations,
-      "MemoryPoolInfo",
-      "Map<QueryId, Long>",
-      "queryMemoryRevocableReservations");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const MemoryInfo& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "totalNodeMemory",
-      p.totalNodeMemory,
-      "MemoryInfo",
-      "DataSize",
-      "totalNodeMemory");
-  to_json_key(
-      j,
-      "pools",
-      p.pools,
-      "MemoryInfo",
-      "Map<MemoryPoolId, MemoryPoolInfo>",
-      "pools");
-}
-
-void from_json(const json& j, MemoryInfo& p) {
-  from_json_key(
-      j,
-      "totalNodeMemory",
-      p.totalNodeMemory,
-      "MemoryInfo",
-      "DataSize",
-      "totalNodeMemory");
-  from_json_key(
-      j,
-      "pools",
-      p.pools,
-      "MemoryInfo",
-      "Map<MemoryPoolId, MemoryPoolInfo>",
-      "pools");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const NodeStatus& p) {
-  j = json::object();
-  to_json_key(j, "nodeId", p.nodeId, "NodeStatus", "String", "nodeId");
-  to_json_key(
-      j,
-      "nodeVersion",
-      p.nodeVersion,
-      "NodeStatus",
-      "NodeVersion",
-      "nodeVersion");
-  to_json_key(
-      j, "environment", p.environment, "NodeStatus", "String", "environment");
-  to_json_key(
-      j, "coordinator", p.coordinator, "NodeStatus", "bool", "coordinator");
-  to_json_key(j, "uptime", p.uptime, "NodeStatus", "Duration", "uptime");
-  to_json_key(
-      j,
-      "externalAddress",
-      p.externalAddress,
-      "NodeStatus",
+      "tablePath",
+      p.tablePath,
+      "HiveTableLayoutHandle",
       "String",
-      "externalAddress");
+      "tablePath");
   to_json_key(
       j,
-      "internalAddress",
-      p.internalAddress,
-      "NodeStatus",
-      "String",
-      "internalAddress");
-  to_json_key(
-      j, "memoryInfo", p.memoryInfo, "NodeStatus", "MemoryInfo", "memoryInfo");
-  to_json_key(j, "processors", p.processors, "NodeStatus", "int", "processors");
+      "partitionColumns",
+      p.partitionColumns,
+      "HiveTableLayoutHandle",
+      "List<HiveColumnHandle>",
+      "partitionColumns");
   to_json_key(
       j,
-      "processCpuLoad",
-      p.processCpuLoad,
-      "NodeStatus",
-      "double",
-      "processCpuLoad");
+      "dataColumns",
+      p.dataColumns,
+      "HiveTableLayoutHandle",
+      "List<Column>",
+      "dataColumns");
   to_json_key(
       j,
-      "systemCpuLoad",
-      p.systemCpuLoad,
-      "NodeStatus",
-      "double",
-      "systemCpuLoad");
-  to_json_key(j, "heapUsed", p.heapUsed, "NodeStatus", "int64_t", "heapUsed");
+      "tableParameters",
+      p.tableParameters,
+      "HiveTableLayoutHandle",
+      "Map<String, String>",
+      "tableParameters");
   to_json_key(
       j,
-      "heapAvailable",
-      p.heapAvailable,
-      "NodeStatus",
-      "int64_t",
-      "heapAvailable");
-  to_json_key(
-      j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
-}
-
-void from_json(const json& j, NodeStatus& p) {
-  from_json_key(j, "nodeId", p.nodeId, "NodeStatus", "String", "nodeId");
-  from_json_key(
-      j,
-      "nodeVersion",
-      p.nodeVersion,
-      "NodeStatus",
-      "NodeVersion",
-      "nodeVersion");
-  from_json_key(
-      j, "environment", p.environment, "NodeStatus", "String", "environment");
-  from_json_key(
-      j, "coordinator", p.coordinator, "NodeStatus", "bool", "coordinator");
-  from_json_key(j, "uptime", p.uptime, "NodeStatus", "Duration", "uptime");
-  from_json_key(
-      j,
-      "externalAddress",
-      p.externalAddress,
-      "NodeStatus",
-      "String",
-      "externalAddress");
-  from_json_key(
-      j,
-      "internalAddress",
-      p.internalAddress,
-      "NodeStatus",
-      "String",
-      "internalAddress");
-  from_json_key(
-      j, "memoryInfo", p.memoryInfo, "NodeStatus", "MemoryInfo", "memoryInfo");
-  from_json_key(
-      j, "processors", p.processors, "NodeStatus", "int", "processors");
-  from_json_key(
-      j,
-      "processCpuLoad",
-      p.processCpuLoad,
-      "NodeStatus",
-      "double",
-      "processCpuLoad");
-  from_json_key(
-      j,
-      "systemCpuLoad",
-      p.systemCpuLoad,
-      "NodeStatus",
-      "double",
-      "systemCpuLoad");
-  from_json_key(j, "heapUsed", p.heapUsed, "NodeStatus", "int64_t", "heapUsed");
-  from_json_key(
-      j,
-      "heapAvailable",
-      p.heapAvailable,
-      "NodeStatus",
-      "int64_t",
-      "heapAvailable");
-  from_json_key(
-      j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const PlanCostEstimate& p) {
-  j = json::object();
-  to_json_key(j, "cpuCost", p.cpuCost, "PlanCostEstimate", "double", "cpuCost");
-  to_json_key(
-      j, "maxMemory", p.maxMemory, "PlanCostEstimate", "double", "maxMemory");
+      "domainPredicate",
+      p.domainPredicate,
+      "HiveTableLayoutHandle",
+      "TupleDomain<Subfield>",
+      "domainPredicate");
   to_json_key(
       j,
-      "maxMemoryWhenOutputting",
-      p.maxMemoryWhenOutputting,
-      "PlanCostEstimate",
-      "double",
-      "maxMemoryWhenOutputting");
+      "remainingPredicate",
+      p.remainingPredicate,
+      "HiveTableLayoutHandle",
+      "RowExpression",
+      "remainingPredicate");
   to_json_key(
       j,
-      "networkCost",
-      p.networkCost,
-      "PlanCostEstimate",
-      "double",
-      "networkCost");
-}
-
-void from_json(const json& j, PlanCostEstimate& p) {
-  from_json_key(
-      j, "cpuCost", p.cpuCost, "PlanCostEstimate", "double", "cpuCost");
-  from_json_key(
-      j, "maxMemory", p.maxMemory, "PlanCostEstimate", "double", "maxMemory");
-  from_json_key(
-      j,
-      "maxMemoryWhenOutputting",
-      p.maxMemoryWhenOutputting,
-      "PlanCostEstimate",
-      "double",
-      "maxMemoryWhenOutputting");
-  from_json_key(
-      j,
-      "networkCost",
-      p.networkCost,
-      "PlanCostEstimate",
-      "double",
-      "networkCost");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const VariableStatsEstimate& p) {
-  j = json::object();
-  to_json_key(
-      j, "lowValue", p.lowValue, "VariableStatsEstimate", "double", "lowValue");
+      "predicateColumns",
+      p.predicateColumns,
+      "HiveTableLayoutHandle",
+      "Map<String, HiveColumnHandle>",
+      "predicateColumns");
   to_json_key(
       j,
-      "highValue",
-      p.highValue,
-      "VariableStatsEstimate",
-      "double",
-      "highValue");
+      "partitionColumnPredicate",
+      p.partitionColumnPredicate,
+      "HiveTableLayoutHandle",
+      "TupleDomain<std::shared_ptr<ColumnHandle>>",
+      "partitionColumnPredicate");
   to_json_key(
       j,
-      "nullsFraction",
-      p.nullsFraction,
-      "VariableStatsEstimate",
-      "double",
-      "nullsFraction");
+      "bucketHandle",
+      p.bucketHandle,
+      "HiveTableLayoutHandle",
+      "HiveBucketHandle",
+      "bucketHandle");
   to_json_key(
       j,
-      "averageRowSize",
-      p.averageRowSize,
-      "VariableStatsEstimate",
-      "double",
-      "averageRowSize");
+      "bucketFilter",
+      p.bucketFilter,
+      "HiveTableLayoutHandle",
+      "HiveBucketFilter",
+      "bucketFilter");
   to_json_key(
       j,
-      "distinctValuesCount",
-      p.distinctValuesCount,
-      "VariableStatsEstimate",
-      "double",
-      "distinctValuesCount");
-}
-
-void from_json(const json& j, VariableStatsEstimate& p) {
-  from_json_key(
-      j, "lowValue", p.lowValue, "VariableStatsEstimate", "double", "lowValue");
-  from_json_key(
-      j,
-      "highValue",
-      p.highValue,
-      "VariableStatsEstimate",
-      "double",
-      "highValue");
-  from_json_key(
-      j,
-      "nullsFraction",
-      p.nullsFraction,
-      "VariableStatsEstimate",
-      "double",
-      "nullsFraction");
-  from_json_key(
-      j,
-      "averageRowSize",
-      p.averageRowSize,
-      "VariableStatsEstimate",
-      "double",
-      "averageRowSize");
-  from_json_key(
-      j,
-      "distinctValuesCount",
-      p.distinctValuesCount,
-      "VariableStatsEstimate",
-      "double",
-      "distinctValuesCount");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const PlanNodeStatsEstimate& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "outputRowCount",
-      p.outputRowCount,
-      "PlanNodeStatsEstimate",
-      "double",
-      "outputRowCount");
-  to_json_key(
-      j,
-      "totalSize",
-      p.totalSize,
-      "PlanNodeStatsEstimate",
-      "double",
-      "totalSize");
-  to_json_key(
-      j,
-      "confident",
-      p.confident,
-      "PlanNodeStatsEstimate",
+      "pushdownFilterEnabled",
+      p.pushdownFilterEnabled,
+      "HiveTableLayoutHandle",
       "bool",
-      "confident");
+      "pushdownFilterEnabled");
   to_json_key(
       j,
-      "variableStatistics",
-      p.variableStatistics,
-      "PlanNodeStatsEstimate",
-      "Map<VariableReferenceExpression, VariableStatsEstimate>",
-      "variableStatistics");
-}
-
-void from_json(const json& j, PlanNodeStatsEstimate& p) {
-  from_json_key(
+      "layoutString",
+      p.layoutString,
+      "HiveTableLayoutHandle",
+      "String",
+      "layoutString");
+  to_json_key(
       j,
-      "outputRowCount",
-      p.outputRowCount,
-      "PlanNodeStatsEstimate",
-      "double",
-      "outputRowCount");
-  from_json_key(
+      "requestedColumns",
+      p.requestedColumns,
+      "HiveTableLayoutHandle",
+      "List<HiveColumnHandle>",
+      "requestedColumns");
+  to_json_key(
       j,
-      "totalSize",
-      p.totalSize,
-      "PlanNodeStatsEstimate",
-      "double",
-      "totalSize");
-  from_json_key(
-      j,
-      "confident",
-      p.confident,
-      "PlanNodeStatsEstimate",
+      "partialAggregationsPushedDown",
+      p.partialAggregationsPushedDown,
+      "HiveTableLayoutHandle",
       "bool",
-      "confident");
-  from_json_key(
-      j,
-      "variableStatistics",
-      p.variableStatistics,
-      "PlanNodeStatsEstimate",
-      "Map<VariableReferenceExpression, VariableStatsEstimate>",
-      "variableStatistics");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const StatsAndCosts& p) {
-  j = json::object();
+      "partialAggregationsPushedDown");
   to_json_key(
       j,
-      "stats",
-      p.stats,
-      "StatsAndCosts",
-      "Map<PlanNodeId, PlanNodeStatsEstimate>",
-      "stats");
-  to_json_key(
-      j,
-      "costs",
-      p.costs,
-      "StatsAndCosts",
-      "Map<PlanNodeId, PlanCostEstimate>",
-      "costs");
+      "appendRowNumber",
+      p.appendRowNumber,
+      "HiveTableLayoutHandle",
+      "bool",
+      "appendRowNumber");
 }
 
-void from_json(const json& j, StatsAndCosts& p) {
-  from_json_key(
-      j,
-      "stats",
-      p.stats,
-      "StatsAndCosts",
-      "Map<PlanNodeId, PlanNodeStatsEstimate>",
-      "stats");
-  from_json_key(
-      j,
-      "costs",
-      p.costs,
-      "StatsAndCosts",
-      "Map<PlanNodeId, PlanCostEstimate>",
-      "costs");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-LambdaDefinitionExpression::LambdaDefinitionExpression() noexcept {
-  _type = "lambda";
-}
-
-void to_json(json& j, const LambdaDefinitionExpression& p) {
-  j = json::object();
-  j["@type"] = "lambda";
-  to_json_key(
-      j,
-      "sourceLocation",
-      p.sourceLocation,
-      "LambdaDefinitionExpression",
-      "SourceLocation",
-      "sourceLocation");
-  to_json_key(
-      j,
-      "argumentTypes",
-      p.argumentTypes,
-      "LambdaDefinitionExpression",
-      "List<Type>",
-      "argumentTypes");
-  to_json_key(
-      j,
-      "arguments",
-      p.arguments,
-      "LambdaDefinitionExpression",
-      "List<String>",
-      "arguments");
-  to_json_key(
-      j, "body", p.body, "LambdaDefinitionExpression", "RowExpression", "body");
-}
-
-void from_json(const json& j, LambdaDefinitionExpression& p) {
+void from_json(const json& j, HiveTableLayoutHandle& p) {
   p._type = j["@type"];
   from_json_key(
       j,
-      "sourceLocation",
-      p.sourceLocation,
-      "LambdaDefinitionExpression",
-      "SourceLocation",
-      "sourceLocation");
+      "schemaTableName",
+      p.schemaTableName,
+      "HiveTableLayoutHandle",
+      "SchemaTableName",
+      "schemaTableName");
   from_json_key(
       j,
-      "argumentTypes",
-      p.argumentTypes,
-      "LambdaDefinitionExpression",
-      "List<Type>",
-      "argumentTypes");
+      "tablePath",
+      p.tablePath,
+      "HiveTableLayoutHandle",
+      "String",
+      "tablePath");
   from_json_key(
       j,
-      "arguments",
-      p.arguments,
-      "LambdaDefinitionExpression",
-      "List<String>",
-      "arguments");
+      "partitionColumns",
+      p.partitionColumns,
+      "HiveTableLayoutHandle",
+      "List<HiveColumnHandle>",
+      "partitionColumns");
   from_json_key(
-      j, "body", p.body, "LambdaDefinitionExpression", "RowExpression", "body");
+      j,
+      "dataColumns",
+      p.dataColumns,
+      "HiveTableLayoutHandle",
+      "List<Column>",
+      "dataColumns");
+  from_json_key(
+      j,
+      "tableParameters",
+      p.tableParameters,
+      "HiveTableLayoutHandle",
+      "Map<String, String>",
+      "tableParameters");
+  from_json_key(
+      j,
+      "domainPredicate",
+      p.domainPredicate,
+      "HiveTableLayoutHandle",
+      "TupleDomain<Subfield>",
+      "domainPredicate");
+  from_json_key(
+      j,
+      "remainingPredicate",
+      p.remainingPredicate,
+      "HiveTableLayoutHandle",
+      "RowExpression",
+      "remainingPredicate");
+  from_json_key(
+      j,
+      "predicateColumns",
+      p.predicateColumns,
+      "HiveTableLayoutHandle",
+      "Map<String, HiveColumnHandle>",
+      "predicateColumns");
+  from_json_key(
+      j,
+      "partitionColumnPredicate",
+      p.partitionColumnPredicate,
+      "HiveTableLayoutHandle",
+      "TupleDomain<std::shared_ptr<ColumnHandle>>",
+      "partitionColumnPredicate");
+  from_json_key(
+      j,
+      "bucketHandle",
+      p.bucketHandle,
+      "HiveTableLayoutHandle",
+      "HiveBucketHandle",
+      "bucketHandle");
+  from_json_key(
+      j,
+      "bucketFilter",
+      p.bucketFilter,
+      "HiveTableLayoutHandle",
+      "HiveBucketFilter",
+      "bucketFilter");
+  from_json_key(
+      j,
+      "pushdownFilterEnabled",
+      p.pushdownFilterEnabled,
+      "HiveTableLayoutHandle",
+      "bool",
+      "pushdownFilterEnabled");
+  from_json_key(
+      j,
+      "layoutString",
+      p.layoutString,
+      "HiveTableLayoutHandle",
+      "String",
+      "layoutString");
+  from_json_key(
+      j,
+      "requestedColumns",
+      p.requestedColumns,
+      "HiveTableLayoutHandle",
+      "List<HiveColumnHandle>",
+      "requestedColumns");
+  from_json_key(
+      j,
+      "partialAggregationsPushedDown",
+      p.partialAggregationsPushedDown,
+      "HiveTableLayoutHandle",
+      "bool",
+      "partialAggregationsPushedDown");
+  from_json_key(
+      j,
+      "appendRowNumber",
+      p.appendRowNumber,
+      "HiveTableLayoutHandle",
+      "bool",
+      "appendRowNumber");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<PlanNode>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == ".AggregationNode") {
+    j = *std::static_pointer_cast<AggregationNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.GroupIdNode") {
+    j = *std::static_pointer_cast<GroupIdNode>(p);
+    return;
+  }
+  if (type == ".DistinctLimitNode") {
+    j = *std::static_pointer_cast<DistinctLimitNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode") {
+    j = *std::static_pointer_cast<EnforceSingleRowNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.ExchangeNode") {
+    j = *std::static_pointer_cast<ExchangeNode>(p);
+    return;
+  }
+  if (type == ".FilterNode") {
+    j = *std::static_pointer_cast<FilterNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.JoinNode") {
+    j = *std::static_pointer_cast<JoinNode>(p);
+    return;
+  }
+  if (type == ".LimitNode") {
+    j = *std::static_pointer_cast<LimitNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.SortNode") {
+    j = *std::static_pointer_cast<SortNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.OutputNode") {
+    j = *std::static_pointer_cast<OutputNode>(p);
+    return;
+  }
+  if (type == ".ProjectNode") {
+    j = *std::static_pointer_cast<ProjectNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.RowNumberNode") {
+    j = *std::static_pointer_cast<RowNumberNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.RemoteSourceNode") {
+    j = *std::static_pointer_cast<RemoteSourceNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.SemiJoinNode") {
+    j = *std::static_pointer_cast<SemiJoinNode>(p);
+    return;
+  }
+  if (type == ".TableScanNode") {
+    j = *std::static_pointer_cast<TableScanNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.TableWriterNode") {
+    j = *std::static_pointer_cast<TableWriterNode>(p);
+    return;
+  }
+  if (type == ".TopNNode") {
+    j = *std::static_pointer_cast<TopNNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.UnnestNode") {
+    j = *std::static_pointer_cast<UnnestNode>(p);
+    return;
+  }
+  if (type == ".ValuesNode") {
+    j = *std::static_pointer_cast<ValuesNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.AssignUniqueId") {
+    j = *std::static_pointer_cast<AssignUniqueId>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeJoinNode") {
+    j = *std::static_pointer_cast<MergeJoinNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.WindowNode") {
+    j = *std::static_pointer_cast<WindowNode>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type PlanNode ");
+}
+
+void from_json(const json& j, std::shared_ptr<PlanNode>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(std::string(e.what()) + " PlanNode  PlanNode");
+  }
+
+  if (type == ".AggregationNode") {
+    std::shared_ptr<AggregationNode> k = std::make_shared<AggregationNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.GroupIdNode") {
+    std::shared_ptr<GroupIdNode> k = std::make_shared<GroupIdNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".DistinctLimitNode") {
+    std::shared_ptr<DistinctLimitNode> k =
+        std::make_shared<DistinctLimitNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode") {
+    std::shared_ptr<EnforceSingleRowNode> k =
+        std::make_shared<EnforceSingleRowNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.ExchangeNode") {
+    std::shared_ptr<ExchangeNode> k = std::make_shared<ExchangeNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".FilterNode") {
+    std::shared_ptr<FilterNode> k = std::make_shared<FilterNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.JoinNode") {
+    std::shared_ptr<JoinNode> k = std::make_shared<JoinNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".LimitNode") {
+    std::shared_ptr<LimitNode> k = std::make_shared<LimitNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.SortNode") {
+    std::shared_ptr<SortNode> k = std::make_shared<SortNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.OutputNode") {
+    std::shared_ptr<OutputNode> k = std::make_shared<OutputNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".ProjectNode") {
+    std::shared_ptr<ProjectNode> k = std::make_shared<ProjectNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.RowNumberNode") {
+    std::shared_ptr<RowNumberNode> k = std::make_shared<RowNumberNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.RemoteSourceNode") {
+    std::shared_ptr<RemoteSourceNode> k = std::make_shared<RemoteSourceNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.SemiJoinNode") {
+    std::shared_ptr<SemiJoinNode> k = std::make_shared<SemiJoinNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".TableScanNode") {
+    std::shared_ptr<TableScanNode> k = std::make_shared<TableScanNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.TableWriterNode") {
+    std::shared_ptr<TableWriterNode> k = std::make_shared<TableWriterNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".TopNNode") {
+    std::shared_ptr<TopNNode> k = std::make_shared<TopNNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.UnnestNode") {
+    std::shared_ptr<UnnestNode> k = std::make_shared<UnnestNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".ValuesNode") {
+    std::shared_ptr<ValuesNode> k = std::make_shared<ValuesNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.AssignUniqueId") {
+    std::shared_ptr<AssignUniqueId> k = std::make_shared<AssignUniqueId>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeJoinNode") {
+    std::shared_ptr<MergeJoinNode> k = std::make_shared<MergeJoinNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.WindowNode") {
+    std::shared_ptr<WindowNode> k = std::make_shared<WindowNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type PlanNode ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+DistinctLimitNode::DistinctLimitNode() noexcept {
+  _type = ".DistinctLimitNode";
+}
+
+void to_json(json& j, const DistinctLimitNode& p) {
+  j = json::object();
+  j["@type"] = ".DistinctLimitNode";
+  to_json_key(j, "id", p.id, "DistinctLimitNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "DistinctLimitNode", "PlanNode", "source");
+  to_json_key(j, "limit", p.limit, "DistinctLimitNode", "int64_t", "limit");
+  to_json_key(j, "partial", p.partial, "DistinctLimitNode", "bool", "partial");
+  to_json_key(
+      j,
+      "distinctVariables",
+      p.distinctVariables,
+      "DistinctLimitNode",
+      "List<VariableReferenceExpression>",
+      "distinctVariables");
+  to_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "DistinctLimitNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+}
+
+void from_json(const json& j, DistinctLimitNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "DistinctLimitNode", "PlanNodeId", "id");
+  from_json_key(
+      j, "source", p.source, "DistinctLimitNode", "PlanNode", "source");
+  from_json_key(j, "limit", p.limit, "DistinctLimitNode", "int64_t", "limit");
+  from_json_key(
+      j, "partial", p.partial, "DistinctLimitNode", "bool", "partial");
+  from_json_key(
+      j,
+      "distinctVariables",
+      p.distinctVariables,
+      "DistinctLimitNode",
+      "List<VariableReferenceExpression>",
+      "distinctVariables");
+  from_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "DistinctLimitNode",
+      "VariableReferenceExpression",
+      "hashVariable");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const HiveStorageFormat& p) {
-  throw ParseError("Not implemented");
+void to_json(json& j, const TableToPartitionMapping& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "tableToPartitionColumns",
+      p.tableToPartitionColumns,
+      "TableToPartitionMapping",
+      "Map<Integer, Integer>",
+      "tableToPartitionColumns");
+  to_json_key(
+      j,
+      "partitionSchemaDifference",
+      p.partitionSchemaDifference,
+      "TableToPartitionMapping",
+      "Map<Integer, Column>",
+      "partitionSchemaDifference");
 }
 
-static const std::pair<HiveStorageFormat, json> HiveStorageFormat_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {HiveStorageFormat::ORC, "ORC"},
-        {HiveStorageFormat::DWRF, "DWRF"},
-        {HiveStorageFormat::PARQUET, "PARQUET"},
-        {HiveStorageFormat::AVRO, "AVRO"},
-        {HiveStorageFormat::RCBINARY, "RCBINARY"},
-        {HiveStorageFormat::RCTEXT, "RCTEXT"},
-        {HiveStorageFormat::SEQUENCEFILE, "SEQUENCEFILE"},
-        {HiveStorageFormat::JSON, "JSON"},
-        {HiveStorageFormat::TEXTFILE, "TEXTFILE"},
-        {HiveStorageFormat::CSV, "CSV"},
-        {HiveStorageFormat::PAGEFILE, "PAGEFILE"}};
-
-void from_json(const json& j, HiveStorageFormat& e) {
-  static_assert(
-      std::is_enum<HiveStorageFormat>::value,
-      "HiveStorageFormat must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(HiveStorageFormat_enum_table),
-      std::end(HiveStorageFormat_enum_table),
-      [&j](const std::pair<HiveStorageFormat, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(HiveStorageFormat_enum_table))
-           ? it
-           : std::begin(HiveStorageFormat_enum_table))
-          ->first;
+void from_json(const json& j, TableToPartitionMapping& p) {
+  from_json_key(
+      j,
+      "tableToPartitionColumns",
+      p.tableToPartitionColumns,
+      "TableToPartitionMapping",
+      "Map<Integer, Integer>",
+      "tableToPartitionColumns");
+  from_json_key(
+      j,
+      "partitionSchemaDifference",
+      p.partitionSchemaDifference,
+      "TableToPartitionMapping",
+      "Map<Integer, Column>",
+      "partitionSchemaDifference");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<TableType, json> TableType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {TableType::NEW, "NEW"},
-        {TableType::EXISTING, "EXISTING"},
-        {TableType::TEMPORARY, "TEMPORARY"}};
-void to_json(json& j, const TableType& e) {
-  static_assert(std::is_enum<TableType>::value, "TableType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(TableType_enum_table),
-      std::end(TableType_enum_table),
-      [e](const std::pair<TableType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(TableType_enum_table))
-           ? it
-           : std::begin(TableType_enum_table))
-          ->second;
+void to_json(json& j, const DwrfEncryptionMetadata& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "fieldToKeyData",
+      p.fieldToKeyData,
+      "DwrfEncryptionMetadata",
+      "Map<String, String>",
+      "fieldToKeyData");
+  to_json_key(
+      j,
+      "extraMetadata",
+      p.extraMetadata,
+      "DwrfEncryptionMetadata",
+      "Map<String, String>",
+      "extraMetadata");
+  to_json_key(
+      j,
+      "encryptionAlgorithm",
+      p.encryptionAlgorithm,
+      "DwrfEncryptionMetadata",
+      "String",
+      "encryptionAlgorithm");
+  to_json_key(
+      j,
+      "encryptionProvider",
+      p.encryptionProvider,
+      "DwrfEncryptionMetadata",
+      "String",
+      "encryptionProvider");
 }
-void from_json(const json& j, TableType& e) {
-  static_assert(std::is_enum<TableType>::value, "TableType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(TableType_enum_table),
-      std::end(TableType_enum_table),
-      [&j](const std::pair<TableType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(TableType_enum_table))
-           ? it
-           : std::begin(TableType_enum_table))
-          ->first;
+
+void from_json(const json& j, DwrfEncryptionMetadata& p) {
+  from_json_key(
+      j,
+      "fieldToKeyData",
+      p.fieldToKeyData,
+      "DwrfEncryptionMetadata",
+      "Map<String, String>",
+      "fieldToKeyData");
+  from_json_key(
+      j,
+      "extraMetadata",
+      p.extraMetadata,
+      "DwrfEncryptionMetadata",
+      "Map<String, String>",
+      "extraMetadata");
+  from_json_key(
+      j,
+      "encryptionAlgorithm",
+      p.encryptionAlgorithm,
+      "DwrfEncryptionMetadata",
+      "String",
+      "encryptionAlgorithm");
+  from_json_key(
+      j,
+      "encryptionProvider",
+      p.encryptionProvider,
+      "DwrfEncryptionMetadata",
+      "String",
+      "encryptionProvider");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const EncryptionInformation& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "dwrfEncryptionMetadata",
+      p.dwrfEncryptionMetadata,
+      "EncryptionInformation",
+      "DwrfEncryptionMetadata",
+      "dwrfEncryptionMetadata");
+}
+
+void from_json(const json& j, EncryptionInformation& p) {
+  from_json_key(
+      j,
+      "dwrfEncryptionMetadata",
+      p.dwrfEncryptionMetadata,
+      "EncryptionInformation",
+      "DwrfEncryptionMetadata",
+      "dwrfEncryptionMetadata");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+FilterNode::FilterNode() noexcept {
+  _type = ".FilterNode";
+}
+
+void to_json(json& j, const FilterNode& p) {
+  j = json::object();
+  j["@type"] = ".FilterNode";
+  to_json_key(j, "id", p.id, "FilterNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "FilterNode", "PlanNode", "source");
+  to_json_key(
+      j, "predicate", p.predicate, "FilterNode", "RowExpression", "predicate");
+}
+
+void from_json(const json& j, FilterNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "FilterNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "FilterNode", "PlanNode", "source");
+  from_json_key(
+      j, "predicate", p.predicate, "FilterNode", "RowExpression", "predicate");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -5450,6 +1481,42 @@ void from_json(const json& j, WriteMode& e) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<TableType, json> TableType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {TableType::NEW, "NEW"},
+        {TableType::EXISTING, "EXISTING"},
+        {TableType::TEMPORARY, "TEMPORARY"}};
+void to_json(json& j, const TableType& e) {
+  static_assert(std::is_enum<TableType>::value, "TableType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(TableType_enum_table),
+      std::end(TableType_enum_table),
+      [e](const std::pair<TableType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(TableType_enum_table))
+           ? it
+           : std::begin(TableType_enum_table))
+          ->second;
+}
+void from_json(const json& j, TableType& e) {
+  static_assert(std::is_enum<TableType>::value, "TableType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(TableType_enum_table),
+      std::end(TableType_enum_table),
+      [&j](const std::pair<TableType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(TableType_enum_table))
+           ? it
+           : std::begin(TableType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 
 void to_json(json& j, const LocationHandle& p) {
   j = json::object();
@@ -5476,6 +1543,159 @@ void from_json(const json& j, LocationHandle& p) {
       j, "tableType", p.tableType, "LocationHandle", "TableType", "tableType");
   from_json_key(
       j, "writeMode", p.writeMode, "LocationHandle", "WriteMode", "writeMode");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<BucketFunctionType, json>
+    BucketFunctionType_enum_table[] = { // NOLINT: cert-err58-cpp
+        {BucketFunctionType::HIVE_COMPATIBLE, "HIVE_COMPATIBLE"},
+        {BucketFunctionType::PRESTO_NATIVE, "PRESTO_NATIVE"}};
+void to_json(json& j, const BucketFunctionType& e) {
+  static_assert(
+      std::is_enum<BucketFunctionType>::value,
+      "BucketFunctionType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BucketFunctionType_enum_table),
+      std::end(BucketFunctionType_enum_table),
+      [e](const std::pair<BucketFunctionType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(BucketFunctionType_enum_table))
+           ? it
+           : std::begin(BucketFunctionType_enum_table))
+          ->second;
+}
+void from_json(const json& j, BucketFunctionType& e) {
+  static_assert(
+      std::is_enum<BucketFunctionType>::value,
+      "BucketFunctionType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BucketFunctionType_enum_table),
+      std::end(BucketFunctionType_enum_table),
+      [&j](const std::pair<BucketFunctionType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(BucketFunctionType_enum_table))
+           ? it
+           : std::begin(BucketFunctionType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Order, json> Order_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {Order::ASCENDING, "ASCENDING"},
+        {Order::DESCENDING, "DESCENDING"}};
+void to_json(json& j, const Order& e) {
+  static_assert(std::is_enum<Order>::value, "Order must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Order_enum_table),
+      std::end(Order_enum_table),
+      [e](const std::pair<Order, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Order_enum_table)) ? it : std::begin(Order_enum_table))
+          ->second;
+}
+void from_json(const json& j, Order& e) {
+  static_assert(std::is_enum<Order>::value, "Order must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Order_enum_table),
+      std::end(Order_enum_table),
+      [&j](const std::pair<Order, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Order_enum_table)) ? it : std::begin(Order_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SortingColumn& p) {
+  j = json::object();
+  to_json_key(
+      j, "columnName", p.columnName, "SortingColumn", "String", "columnName");
+  to_json_key(j, "order", p.order, "SortingColumn", "Order", "order");
+}
+
+void from_json(const json& j, SortingColumn& p) {
+  from_json_key(
+      j, "columnName", p.columnName, "SortingColumn", "String", "columnName");
+  from_json_key(j, "order", p.order, "SortingColumn", "Order", "order");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const HiveBucketProperty& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "bucketedBy",
+      p.bucketedBy,
+      "HiveBucketProperty",
+      "List<String>",
+      "bucketedBy");
+  to_json_key(
+      j,
+      "bucketCount",
+      p.bucketCount,
+      "HiveBucketProperty",
+      "int",
+      "bucketCount");
+  to_json_key(
+      j,
+      "sortedBy",
+      p.sortedBy,
+      "HiveBucketProperty",
+      "List<SortingColumn>",
+      "sortedBy");
+  to_json_key(
+      j,
+      "bucketFunctionType",
+      p.bucketFunctionType,
+      "HiveBucketProperty",
+      "BucketFunctionType",
+      "bucketFunctionType");
+  to_json_key(j, "types", p.types, "HiveBucketProperty", "List<Type>", "types");
+}
+
+void from_json(const json& j, HiveBucketProperty& p) {
+  from_json_key(
+      j,
+      "bucketedBy",
+      p.bucketedBy,
+      "HiveBucketProperty",
+      "List<String>",
+      "bucketedBy");
+  from_json_key(
+      j,
+      "bucketCount",
+      p.bucketCount,
+      "HiveBucketProperty",
+      "int",
+      "bucketCount");
+  from_json_key(
+      j,
+      "sortedBy",
+      p.sortedBy,
+      "HiveBucketProperty",
+      "List<SortingColumn>",
+      "sortedBy");
+  from_json_key(
+      j,
+      "bucketFunctionType",
+      p.bucketFunctionType,
+      "HiveBucketProperty",
+      "BucketFunctionType",
+      "bucketFunctionType");
+  from_json_key(
+      j, "types", p.types, "HiveBucketProperty", "List<Type>", "types");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -5559,6 +1779,114 @@ void from_json(const json& j, PrestoTableType& e) {
            ? it
            : std::begin(PrestoTableType_enum_table))
           ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const StorageFormat& p) {
+  j = json::object();
+  to_json_key(j, "serDe", p.serDe, "StorageFormat", "String", "serDe");
+  to_json_key(
+      j,
+      "inputFormat",
+      p.inputFormat,
+      "StorageFormat",
+      "String",
+      "inputFormat");
+  to_json_key(
+      j,
+      "outputFormat",
+      p.outputFormat,
+      "StorageFormat",
+      "String",
+      "outputFormat");
+}
+
+void from_json(const json& j, StorageFormat& p) {
+  from_json_key(j, "serDe", p.serDe, "StorageFormat", "String", "serDe");
+  from_json_key(
+      j,
+      "inputFormat",
+      p.inputFormat,
+      "StorageFormat",
+      "String",
+      "inputFormat");
+  from_json_key(
+      j,
+      "outputFormat",
+      p.outputFormat,
+      "StorageFormat",
+      "String",
+      "outputFormat");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Storage& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "storageFormat",
+      p.storageFormat,
+      "Storage",
+      "StorageFormat",
+      "storageFormat");
+  to_json_key(j, "location", p.location, "Storage", "String", "location");
+  to_json_key(
+      j,
+      "bucketProperty",
+      p.bucketProperty,
+      "Storage",
+      "HiveBucketProperty",
+      "bucketProperty");
+  to_json_key(j, "skewed", p.skewed, "Storage", "bool", "skewed");
+  to_json_key(
+      j,
+      "serdeParameters",
+      p.serdeParameters,
+      "Storage",
+      "Map<String, String>",
+      "serdeParameters");
+  to_json_key(
+      j,
+      "parameters",
+      p.parameters,
+      "Storage",
+      "Map<String, String>",
+      "parameters");
+}
+
+void from_json(const json& j, Storage& p) {
+  from_json_key(
+      j,
+      "storageFormat",
+      p.storageFormat,
+      "Storage",
+      "StorageFormat",
+      "storageFormat");
+  from_json_key(j, "location", p.location, "Storage", "String", "location");
+  from_json_key(
+      j,
+      "bucketProperty",
+      p.bucketProperty,
+      "Storage",
+      "HiveBucketProperty",
+      "bucketProperty");
+  from_json_key(j, "skewed", p.skewed, "Storage", "bool", "skewed");
+  from_json_key(
+      j,
+      "serdeParameters",
+      p.serdeParameters,
+      "Storage",
+      "Map<String, String>",
+      "serdeParameters");
+  from_json_key(
+      j,
+      "parameters",
+      p.parameters,
+      "Storage",
+      "Map<String, String>",
+      "parameters");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -5667,6 +1995,42 @@ void from_json(const json& j, HivePageSinkMetadata& p) {
       "SchemaTableName",
       "schemaTableName");
   from_json_key(j, "table", p.table, "HivePageSinkMetadata", "Table", "table");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const HiveStorageFormat& p) {
+  throw ParseError("Not implemented");
+}
+
+static const std::pair<HiveStorageFormat, json> HiveStorageFormat_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {HiveStorageFormat::ORC, "ORC"},
+        {HiveStorageFormat::DWRF, "DWRF"},
+        {HiveStorageFormat::PARQUET, "PARQUET"},
+        {HiveStorageFormat::AVRO, "AVRO"},
+        {HiveStorageFormat::RCBINARY, "RCBINARY"},
+        {HiveStorageFormat::RCTEXT, "RCTEXT"},
+        {HiveStorageFormat::SEQUENCEFILE, "SEQUENCEFILE"},
+        {HiveStorageFormat::JSON, "JSON"},
+        {HiveStorageFormat::TEXTFILE, "TEXTFILE"},
+        {HiveStorageFormat::CSV, "CSV"},
+        {HiveStorageFormat::PAGEFILE, "PAGEFILE"}};
+
+void from_json(const json& j, HiveStorageFormat& e) {
+  static_assert(
+      std::is_enum<HiveStorageFormat>::value,
+      "HiveStorageFormat must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(HiveStorageFormat_enum_table),
+      std::end(HiveStorageFormat_enum_table),
+      [&j](const std::pair<HiveStorageFormat, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(HiveStorageFormat_enum_table))
+           ? it
+           : std::begin(HiveStorageFormat_enum_table))
+          ->first;
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -5852,51 +2216,225 @@ void from_json(const json& j, HiveInsertTableHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
 
-void to_json(json& j, const ValueEntry& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "ValueEntry", "Type", "type");
-  to_json_key(j, "block", p.block, "ValueEntry", "Block", "block");
+  if (type == "$remote") {
+    j = *std::static_pointer_cast<SystemPartitioningHandle>(p);
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HivePartitioningHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorPartitioningHandle");
 }
 
-void from_json(const json& j, ValueEntry& p) {
-  from_json_key(j, "type", p.type, "ValueEntry", "Type", "type");
-  from_json_key(j, "block", p.block, "ValueEntry", "Block", "block");
+void from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(std::string(e.what()) + " ConnectorPartitioningHandle");
+  }
+
+  if (type == "$remote") {
+    auto k = std::make_shared<SystemPartitioningHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HivePartitioningHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorPartitioningHandle");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-EquatableValueSet::EquatableValueSet() noexcept {
-  _type = "equatable";
+void to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == "$remote") {
+    j = *std::static_pointer_cast<RemoteTransactionHandle>(p);
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveTransactionHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTransactionHandle");
 }
 
-void to_json(json& j, const EquatableValueSet& p) {
+void from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorTransactionHandle  ConnectorTransactionHandle");
+  }
+
+  if (type == "$remote") {
+    auto k = std::make_shared<RemoteTransactionHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HiveTransactionHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTransactionHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PartitioningHandle& p) {
   j = json::object();
-  j["@type"] = "equatable";
-  to_json_key(j, "type", p.type, "EquatableValueSet", "Type", "type");
-  to_json_key(
-      j, "whiteList", p.whiteList, "EquatableValueSet", "bool", "whiteList");
   to_json_key(
       j,
-      "entries",
-      p.entries,
-      "EquatableValueSet",
-      "List<ValueEntry>",
-      "entries");
+      "connectorId",
+      p.connectorId,
+      "PartitioningHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "PartitioningHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "PartitioningHandle",
+      "ConnectorPartitioningHandle",
+      "connectorHandle");
 }
 
-void from_json(const json& j, EquatableValueSet& p) {
-  p._type = j["@type"];
-  from_json_key(j, "type", p.type, "EquatableValueSet", "Type", "type");
-  from_json_key(
-      j, "whiteList", p.whiteList, "EquatableValueSet", "bool", "whiteList");
+void from_json(const json& j, PartitioningHandle& p) {
   from_json_key(
       j,
-      "entries",
-      p.entries,
-      "EquatableValueSet",
-      "List<ValueEntry>",
-      "entries");
+      "connectorId",
+      p.connectorId,
+      "PartitioningHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "PartitioningHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "PartitioningHandle",
+      "ConnectorPartitioningHandle",
+      "connectorHandle");
 }
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const DistributionSnapshot& p) {
+  j = json::object();
+  to_json_key(
+      j, "maxError", p.maxError, "DistributionSnapshot", "double", "maxError");
+  to_json_key(j, "count", p.count, "DistributionSnapshot", "double", "count");
+  to_json_key(j, "total", p.total, "DistributionSnapshot", "double", "total");
+  to_json_key(j, "p01", p.p01, "DistributionSnapshot", "int64_t", "p01");
+  to_json_key(j, "p05", p.p05, "DistributionSnapshot", "int64_t", "p05");
+  to_json_key(j, "p10", p.p10, "DistributionSnapshot", "int64_t", "p10");
+  to_json_key(j, "p25", p.p25, "DistributionSnapshot", "int64_t", "p25");
+  to_json_key(j, "p50", p.p50, "DistributionSnapshot", "int64_t", "p50");
+  to_json_key(j, "p75", p.p75, "DistributionSnapshot", "int64_t", "p75");
+  to_json_key(j, "p90", p.p90, "DistributionSnapshot", "int64_t", "p90");
+  to_json_key(j, "p95", p.p95, "DistributionSnapshot", "int64_t", "p95");
+  to_json_key(j, "p99", p.p99, "DistributionSnapshot", "int64_t", "p99");
+  to_json_key(j, "min", p.min, "DistributionSnapshot", "int64_t", "min");
+  to_json_key(j, "max", p.max, "DistributionSnapshot", "int64_t", "max");
+  to_json_key(j, "avg", p.avg, "DistributionSnapshot", "double", "avg");
+}
+
+void from_json(const json& j, DistributionSnapshot& p) {
+  from_json_key(
+      j, "maxError", p.maxError, "DistributionSnapshot", "double", "maxError");
+  from_json_key(j, "count", p.count, "DistributionSnapshot", "double", "count");
+  from_json_key(j, "total", p.total, "DistributionSnapshot", "double", "total");
+  from_json_key(j, "p01", p.p01, "DistributionSnapshot", "int64_t", "p01");
+  from_json_key(j, "p05", p.p05, "DistributionSnapshot", "int64_t", "p05");
+  from_json_key(j, "p10", p.p10, "DistributionSnapshot", "int64_t", "p10");
+  from_json_key(j, "p25", p.p25, "DistributionSnapshot", "int64_t", "p25");
+  from_json_key(j, "p50", p.p50, "DistributionSnapshot", "int64_t", "p50");
+  from_json_key(j, "p75", p.p75, "DistributionSnapshot", "int64_t", "p75");
+  from_json_key(j, "p90", p.p90, "DistributionSnapshot", "int64_t", "p90");
+  from_json_key(j, "p95", p.p95, "DistributionSnapshot", "int64_t", "p95");
+  from_json_key(j, "p99", p.p99, "DistributionSnapshot", "int64_t", "p99");
+  from_json_key(j, "min", p.min, "DistributionSnapshot", "int64_t", "min");
+  from_json_key(j, "max", p.max, "DistributionSnapshot", "int64_t", "max");
+  from_json_key(j, "avg", p.avg, "DistributionSnapshot", "double", "avg");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Lifespan& p) {
+  if (p.isgroup) {
+    j = "Group" + std::to_string(p.groupid);
+  } else {
+    j = "TaskWide";
+  }
+}
+
+void from_json(const json& j, Lifespan& p) {
+  String lifespan = j;
+
+  if (lifespan == "TaskWide") {
+    p.isgroup = false;
+    p.groupid = 0;
+  } else {
+    if (lifespan != "Group") {
+      // fail...
+    }
+    p.isgroup = true;
+    p.groupid = std::stoi(lifespan.substr(strlen("Group")));
+  }
+}
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Duration& p) {
+  j = p.toString();
+}
+
+void from_json(const json& j, Duration& p) {
+  p = Duration(std::string(j));
+}
+
+std::ostream& operator<<(std::ostream& os, const Duration& d) {
+  return os << d.toString();
+}
+
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
@@ -5937,6 +2475,21 @@ void from_json(const json& j, BlockedReason& e) {
 namespace facebook::presto::protocol {
 void to_json(json& j, const OperatorInfo& p) {}
 void from_json(const json& j, OperatorInfo& p) {}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(nlohmann::json& j, const DataSize& p) {
+  j = p.toString();
+}
+
+void from_json(const nlohmann::json& j, DataSize& p) {
+  p = DataSize(std::string(j));
+}
+
+std::ostream& operator<<(std::ostream& os, const DataSize& d) {
+  return os << d.toString();
+}
+
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
@@ -6713,47 +3266,6 @@ void from_json(const json& j, DriverStats& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const DistributionSnapshot& p) {
-  j = json::object();
-  to_json_key(
-      j, "maxError", p.maxError, "DistributionSnapshot", "double", "maxError");
-  to_json_key(j, "count", p.count, "DistributionSnapshot", "double", "count");
-  to_json_key(j, "total", p.total, "DistributionSnapshot", "double", "total");
-  to_json_key(j, "p01", p.p01, "DistributionSnapshot", "int64_t", "p01");
-  to_json_key(j, "p05", p.p05, "DistributionSnapshot", "int64_t", "p05");
-  to_json_key(j, "p10", p.p10, "DistributionSnapshot", "int64_t", "p10");
-  to_json_key(j, "p25", p.p25, "DistributionSnapshot", "int64_t", "p25");
-  to_json_key(j, "p50", p.p50, "DistributionSnapshot", "int64_t", "p50");
-  to_json_key(j, "p75", p.p75, "DistributionSnapshot", "int64_t", "p75");
-  to_json_key(j, "p90", p.p90, "DistributionSnapshot", "int64_t", "p90");
-  to_json_key(j, "p95", p.p95, "DistributionSnapshot", "int64_t", "p95");
-  to_json_key(j, "p99", p.p99, "DistributionSnapshot", "int64_t", "p99");
-  to_json_key(j, "min", p.min, "DistributionSnapshot", "int64_t", "min");
-  to_json_key(j, "max", p.max, "DistributionSnapshot", "int64_t", "max");
-  to_json_key(j, "avg", p.avg, "DistributionSnapshot", "double", "avg");
-}
-
-void from_json(const json& j, DistributionSnapshot& p) {
-  from_json_key(
-      j, "maxError", p.maxError, "DistributionSnapshot", "double", "maxError");
-  from_json_key(j, "count", p.count, "DistributionSnapshot", "double", "count");
-  from_json_key(j, "total", p.total, "DistributionSnapshot", "double", "total");
-  from_json_key(j, "p01", p.p01, "DistributionSnapshot", "int64_t", "p01");
-  from_json_key(j, "p05", p.p05, "DistributionSnapshot", "int64_t", "p05");
-  from_json_key(j, "p10", p.p10, "DistributionSnapshot", "int64_t", "p10");
-  from_json_key(j, "p25", p.p25, "DistributionSnapshot", "int64_t", "p25");
-  from_json_key(j, "p50", p.p50, "DistributionSnapshot", "int64_t", "p50");
-  from_json_key(j, "p75", p.p75, "DistributionSnapshot", "int64_t", "p75");
-  from_json_key(j, "p90", p.p90, "DistributionSnapshot", "int64_t", "p90");
-  from_json_key(j, "p95", p.p95, "DistributionSnapshot", "int64_t", "p95");
-  from_json_key(j, "p99", p.p99, "DistributionSnapshot", "int64_t", "p99");
-  from_json_key(j, "min", p.min, "DistributionSnapshot", "int64_t", "min");
-  from_json_key(j, "max", p.max, "DistributionSnapshot", "int64_t", "max");
-  from_json_key(j, "avg", p.avg, "DistributionSnapshot", "double", "avg");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
 void to_json(json& j, const PipelineStats& p) {
   j = json::object();
   to_json_key(
@@ -7229,257 +3741,6 @@ void from_json(const json& j, PipelineStats& p) {
       "operatorSummaries");
   from_json_key(
       j, "drivers", p.drivers, "PipelineStats", "List<DriverStats>", "drivers");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Location& p) {
-  j = json::object();
-  to_json_key(j, "location", p.location, "Location", "String", "location");
-}
-
-void from_json(const json& j, Location& p) {
-  from_json_key(j, "location", p.location, "Location", "String", "location");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-UnnestNode::UnnestNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.UnnestNode";
-}
-
-void to_json(json& j, const UnnestNode& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.UnnestNode";
-  to_json_key(j, "id", p.id, "UnnestNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "UnnestNode", "PlanNode", "source");
-  to_json_key(
-      j,
-      "replicateVariables",
-      p.replicateVariables,
-      "UnnestNode",
-      "List<VariableReferenceExpression>",
-      "replicateVariables");
-  to_json_key(
-      j,
-      "unnestVariables",
-      p.unnestVariables,
-      "UnnestNode",
-      "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
-      "unnestVariables");
-  to_json_key(
-      j,
-      "ordinalityVariable",
-      p.ordinalityVariable,
-      "UnnestNode",
-      "VariableReferenceExpression",
-      "ordinalityVariable");
-}
-
-void from_json(const json& j, UnnestNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "UnnestNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "UnnestNode", "PlanNode", "source");
-  from_json_key(
-      j,
-      "replicateVariables",
-      p.replicateVariables,
-      "UnnestNode",
-      "List<VariableReferenceExpression>",
-      "replicateVariables");
-  from_json_key(
-      j,
-      "unnestVariables",
-      p.unnestVariables,
-      "UnnestNode",
-      "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
-      "unnestVariables");
-  from_json_key(
-      j,
-      "ordinalityVariable",
-      p.ordinalityVariable,
-      "UnnestNode",
-      "VariableReferenceExpression",
-      "ordinalityVariable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (getConnectorKey(type) == "hive") {
-    j = *std::static_pointer_cast<HiveMetadataUpdateHandle>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorMetadataUpdateHandle");
-}
-
-void from_json(
-    const json& j,
-    std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " ConnectorMetadataUpdateHandle");
-  }
-
-  if (getConnectorKey(type) == "hive") {
-    auto k = std::make_shared<HiveMetadataUpdateHandle>();
-    j.get_to(*k);
-    p = k;
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ConnectorMetadataUpdateHandle");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const MetadataUpdates& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "MetadataUpdates",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "metadataUpdates",
-      p.metadataUpdates,
-      "MetadataUpdates",
-      "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
-      "metadataUpdates");
-}
-
-void from_json(const json& j, MetadataUpdates& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "MetadataUpdates",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "metadataUpdates",
-      p.metadataUpdates,
-      "MetadataUpdates",
-      "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
-      "metadataUpdates");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-SortNode::SortNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.SortNode";
-}
-
-void to_json(json& j, const SortNode& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.SortNode";
-  to_json_key(j, "id", p.id, "SortNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "SortNode", "PlanNode", "source");
-  to_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "SortNode",
-      "OrderingScheme",
-      "orderingScheme");
-  to_json_key(j, "isPartial", p.isPartial, "SortNode", "bool", "isPartial");
-}
-
-void from_json(const json& j, SortNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "SortNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "SortNode", "PlanNode", "source");
-  from_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "SortNode",
-      "OrderingScheme",
-      "orderingScheme");
-  from_json_key(j, "isPartial", p.isPartial, "SortNode", "bool", "isPartial");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-DistinctLimitNode::DistinctLimitNode() noexcept {
-  _type = ".DistinctLimitNode";
-}
-
-void to_json(json& j, const DistinctLimitNode& p) {
-  j = json::object();
-  j["@type"] = ".DistinctLimitNode";
-  to_json_key(j, "id", p.id, "DistinctLimitNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "DistinctLimitNode", "PlanNode", "source");
-  to_json_key(j, "limit", p.limit, "DistinctLimitNode", "int64_t", "limit");
-  to_json_key(j, "partial", p.partial, "DistinctLimitNode", "bool", "partial");
-  to_json_key(
-      j,
-      "distinctVariables",
-      p.distinctVariables,
-      "DistinctLimitNode",
-      "List<VariableReferenceExpression>",
-      "distinctVariables");
-  to_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "DistinctLimitNode",
-      "VariableReferenceExpression",
-      "hashVariable");
-}
-
-void from_json(const json& j, DistinctLimitNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "DistinctLimitNode", "PlanNodeId", "id");
-  from_json_key(
-      j, "source", p.source, "DistinctLimitNode", "PlanNode", "source");
-  from_json_key(j, "limit", p.limit, "DistinctLimitNode", "int64_t", "limit");
-  from_json_key(
-      j, "partial", p.partial, "DistinctLimitNode", "bool", "partial");
-  from_json_key(
-      j,
-      "distinctVariables",
-      p.distinctVariables,
-      "DistinctLimitNode",
-      "List<VariableReferenceExpression>",
-      "distinctVariables");
-  from_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "DistinctLimitNode",
-      "VariableReferenceExpression",
-      "hashVariable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-FilterNode::FilterNode() noexcept {
-  _type = ".FilterNode";
-}
-
-void to_json(json& j, const FilterNode& p) {
-  j = json::object();
-  j["@type"] = ".FilterNode";
-  to_json_key(j, "id", p.id, "FilterNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "FilterNode", "PlanNode", "source");
-  to_json_key(
-      j, "predicate", p.predicate, "FilterNode", "RowExpression", "predicate");
-}
-
-void from_json(const json& j, FilterNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "FilterNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "FilterNode", "PlanNode", "source");
-  from_json_key(
-      j, "predicate", p.predicate, "FilterNode", "RowExpression", "predicate");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -7994,6 +4255,2480 @@ void from_json(const json& j, TaskStats& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Form, json> Form_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {Form::IF, "IF"},
+        {Form::NULL_IF, "NULL_IF"},
+        {Form::SWITCH, "SWITCH"},
+        {Form::WHEN, "WHEN"},
+        {Form::IS_NULL, "IS_NULL"},
+        {Form::COALESCE, "COALESCE"},
+        {Form::IN, "IN"},
+        {Form::AND, "AND"},
+        {Form::OR, "OR"},
+        {Form::DEREFERENCE, "DEREFERENCE"},
+        {Form::ROW_CONSTRUCTOR, "ROW_CONSTRUCTOR"},
+        {Form::BIND, "BIND"}};
+void to_json(json& j, const Form& e) {
+  static_assert(std::is_enum<Form>::value, "Form must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Form_enum_table),
+      std::end(Form_enum_table),
+      [e](const std::pair<Form, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Form_enum_table)) ? it : std::begin(Form_enum_table))
+          ->second;
+}
+void from_json(const json& j, Form& e) {
+  static_assert(std::is_enum<Form>::value, "Form must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Form_enum_table),
+      std::end(Form_enum_table),
+      [&j](const std::pair<Form, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Form_enum_table)) ? it : std::begin(Form_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+SpecialFormExpression::SpecialFormExpression() noexcept {
+  _type = "special";
+}
+
+void to_json(json& j, const SpecialFormExpression& p) {
+  j = json::object();
+  j["@type"] = "special";
+  to_json_key(
+      j,
+      "sourceLocation",
+      p.sourceLocation,
+      "SpecialFormExpression",
+      "SourceLocation",
+      "sourceLocation");
+  to_json_key(j, "form", p.form, "SpecialFormExpression", "Form", "form");
+  to_json_key(
+      j,
+      "returnType",
+      p.returnType,
+      "SpecialFormExpression",
+      "Type",
+      "returnType");
+  to_json_key(
+      j,
+      "arguments",
+      p.arguments,
+      "SpecialFormExpression",
+      "List<std::shared_ptr<RowExpression>>",
+      "arguments");
+}
+
+void from_json(const json& j, SpecialFormExpression& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "sourceLocation",
+      p.sourceLocation,
+      "SpecialFormExpression",
+      "SourceLocation",
+      "sourceLocation");
+  from_json_key(j, "form", p.form, "SpecialFormExpression", "Form", "form");
+  from_json_key(
+      j,
+      "returnType",
+      p.returnType,
+      "SpecialFormExpression",
+      "Type",
+      "returnType");
+  from_json_key(
+      j,
+      "arguments",
+      p.arguments,
+      "SpecialFormExpression",
+      "List<std::shared_ptr<RowExpression>>",
+      "arguments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+AssignUniqueId::AssignUniqueId() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.AssignUniqueId";
+}
+
+void to_json(json& j, const AssignUniqueId& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.AssignUniqueId";
+  to_json_key(j, "id", p.id, "AssignUniqueId", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "AssignUniqueId", "PlanNode", "source");
+  to_json_key(
+      j,
+      "idVariable",
+      p.idVariable,
+      "AssignUniqueId",
+      "VariableReferenceExpression",
+      "idVariable");
+}
+
+void from_json(const json& j, AssignUniqueId& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "AssignUniqueId", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "AssignUniqueId", "PlanNode", "source");
+  from_json_key(
+      j,
+      "idVariable",
+      p.idVariable,
+      "AssignUniqueId",
+      "VariableReferenceExpression",
+      "idVariable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Location& p) {
+  j = json::object();
+  to_json_key(j, "location", p.location, "Location", "String", "location");
+}
+
+void from_json(const json& j, Location& p) {
+  from_json_key(j, "location", p.location, "Location", "String", "location");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveOutputTableHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorOutputTableHandle ");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorOutputTableHandle  ConnectorOutputTableHandle");
+  }
+
+  if (getConnectorKey(type) == "hive") {
+    std::shared_ptr<HiveOutputTableHandle> k =
+        std::make_shared<HiveOutputTableHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ConnectorOutputTableHandle>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorOutputTableHandle ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const OutputTableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "OutputTableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "OutputTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "OutputTableHandle",
+      "ConnectorOutputTableHandle",
+      "connectorHandle");
+}
+
+void from_json(const json& j, OutputTableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "OutputTableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "OutputTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "OutputTableHandle",
+      "ConnectorOutputTableHandle",
+      "connectorHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<BufferType, json> BufferType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {BufferType::PARTITIONED, "PARTITIONED"},
+        {BufferType::BROADCAST, "BROADCAST"},
+        {BufferType::ARBITRARY, "ARBITRARY"},
+        {BufferType::DISCARDING, "DISCARDING"},
+        {BufferType::SPOOLING, "SPOOLING"}};
+void to_json(json& j, const BufferType& e) {
+  static_assert(std::is_enum<BufferType>::value, "BufferType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BufferType_enum_table),
+      std::end(BufferType_enum_table),
+      [e](const std::pair<BufferType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(BufferType_enum_table))
+           ? it
+           : std::begin(BufferType_enum_table))
+          ->second;
+}
+void from_json(const json& j, BufferType& e) {
+  static_assert(std::is_enum<BufferType>::value, "BufferType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BufferType_enum_table),
+      std::end(BufferType_enum_table),
+      [&j](const std::pair<BufferType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(BufferType_enum_table))
+           ? it
+           : std::begin(BufferType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const OutputBuffers& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "OutputBuffers", "BufferType", "type");
+  to_json_key(j, "version", p.version, "OutputBuffers", "int64_t", "version");
+  to_json_key(
+      j,
+      "noMoreBufferIds",
+      p.noMoreBufferIds,
+      "OutputBuffers",
+      "bool",
+      "noMoreBufferIds");
+  to_json_key(
+      j,
+      "buffers",
+      p.buffers,
+      "OutputBuffers",
+      "Map<OutputBufferId, Integer>",
+      "buffers");
+}
+
+void from_json(const json& j, OutputBuffers& p) {
+  from_json_key(j, "type", p.type, "OutputBuffers", "BufferType", "type");
+  from_json_key(j, "version", p.version, "OutputBuffers", "int64_t", "version");
+  from_json_key(
+      j,
+      "noMoreBufferIds",
+      p.noMoreBufferIds,
+      "OutputBuffers",
+      "bool",
+      "noMoreBufferIds");
+  from_json_key(
+      j,
+      "buffers",
+      p.buffers,
+      "OutputBuffers",
+      "Map<OutputBufferId, Integer>",
+      "buffers");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == "CreateHandle") {
+    j = *std::static_pointer_cast<CreateHandle>(p);
+    return;
+  }
+  if (type == "InsertHandle") {
+    j = *std::static_pointer_cast<InsertHandle>(p);
+    return;
+  }
+  if (type == "DeleteHandle") {
+    j = *std::static_pointer_cast<DeleteHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ExecutionWriterTarget ");
+}
+
+void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ExecutionWriterTarget  ExecutionWriterTarget");
+  }
+
+  if (type == "CreateHandle") {
+    std::shared_ptr<CreateHandle> k = std::make_shared<CreateHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
+    return;
+  }
+  if (type == "InsertHandle") {
+    std::shared_ptr<InsertHandle> k = std::make_shared<InsertHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
+    return;
+  }
+  if (type == "DeleteHandle") {
+    std::shared_ptr<DeleteHandle> k = std::make_shared<DeleteHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ExecutionWriterTarget ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveTableLayoutHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTableLayoutHandle");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorTableLayoutHandle  ConnectorTableLayoutHandle");
+  }
+
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HiveTableLayoutHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTableLayoutHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveTableHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTableHandle");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) + " ConnectorTableHandle  ConnectorTableHandle");
+  }
+
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HiveTableHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorTableHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "TableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "TableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+  to_json_key(
+      j,
+      "transaction",
+      p.transaction,
+      "TableHandle",
+      "ConnectorTransactionHandle",
+      "transaction");
+  to_json_key(
+      j,
+      "connectorTableLayout",
+      p.connectorTableLayout,
+      "TableHandle",
+      "ConnectorTableLayoutHandle",
+      "connectorTableLayout");
+}
+
+void from_json(const json& j, TableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "TableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "TableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+  from_json_key(
+      j,
+      "transaction",
+      p.transaction,
+      "TableHandle",
+      "ConnectorTransactionHandle",
+      "transaction");
+  from_json_key(
+      j,
+      "connectorTableLayout",
+      p.connectorTableLayout,
+      "TableHandle",
+      "ConnectorTableLayoutHandle",
+      "connectorTableLayout");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const DeleteScanInfo& p) {
+  j = json::object();
+  to_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
+  to_json_key(
+      j,
+      "tableHandle",
+      p.tableHandle,
+      "DeleteScanInfo",
+      "TableHandle",
+      "tableHandle");
+}
+
+void from_json(const json& j, DeleteScanInfo& p) {
+  from_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
+  from_json_key(
+      j,
+      "tableHandle",
+      p.tableHandle,
+      "DeleteScanInfo",
+      "TableHandle",
+      "tableHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const AnalyzeTableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "AnalyzeTableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "AnalyzeTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "AnalyzeTableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+}
+
+void from_json(const json& j, AnalyzeTableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "AnalyzeTableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "AnalyzeTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "AnalyzeTableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TableWriteInfo& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "writerTarget",
+      p.writerTarget,
+      "TableWriteInfo",
+      "ExecutionWriterTarget",
+      "writerTarget");
+  to_json_key(
+      j,
+      "analyzeTableHandle",
+      p.analyzeTableHandle,
+      "TableWriteInfo",
+      "AnalyzeTableHandle",
+      "analyzeTableHandle");
+  to_json_key(
+      j,
+      "deleteScanInfo",
+      p.deleteScanInfo,
+      "TableWriteInfo",
+      "DeleteScanInfo",
+      "deleteScanInfo");
+}
+
+void from_json(const json& j, TableWriteInfo& p) {
+  from_json_key(
+      j,
+      "writerTarget",
+      p.writerTarget,
+      "TableWriteInfo",
+      "ExecutionWriterTarget",
+      "writerTarget");
+  from_json_key(
+      j,
+      "analyzeTableHandle",
+      p.analyzeTableHandle,
+      "TableWriteInfo",
+      "AnalyzeTableHandle",
+      "analyzeTableHandle");
+  from_json_key(
+      j,
+      "deleteScanInfo",
+      p.deleteScanInfo,
+      "TableWriteInfo",
+      "DeleteScanInfo",
+      "deleteScanInfo");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SplitContext& p) {
+  j = json::object();
+  to_json_key(j, "cacheable", p.cacheable, "SplitContext", "bool", "cacheable");
+}
+
+void from_json(const json& j, SplitContext& p) {
+  from_json_key(
+      j, "cacheable", p.cacheable, "SplitContext", "bool", "cacheable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorSplit>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == "$remote") {
+    j = *std::static_pointer_cast<RemoteSplit>(p);
+    return;
+  }
+  if (type == "$empty") {
+    j = *std::static_pointer_cast<EmptySplit>(p);
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveSplit>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorSplit");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorSplit>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(std::string(e.what()) + " ConnectorSplit");
+  }
+
+  if (type == "$remote") {
+    auto k = std::make_shared<RemoteSplit>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+  if (type == "$empty") {
+    auto k = std::make_shared<EmptySplit>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HiveSplit>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorSplit");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Split& p) {
+  j = json::object();
+  to_json_key(
+      j, "connectorId", p.connectorId, "Split", "ConnectorId", "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "Split",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorSplit",
+      p.connectorSplit,
+      "Split",
+      "ConnectorSplit",
+      "connectorSplit");
+  to_json_key(j, "lifespan", p.lifespan, "Split", "Lifespan", "lifespan");
+  to_json_key(
+      j,
+      "splitContext",
+      p.splitContext,
+      "Split",
+      "SplitContext",
+      "splitContext");
+}
+
+void from_json(const json& j, Split& p) {
+  from_json_key(
+      j, "connectorId", p.connectorId, "Split", "ConnectorId", "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "Split",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorSplit",
+      p.connectorSplit,
+      "Split",
+      "ConnectorSplit",
+      "connectorSplit");
+  from_json_key(j, "lifespan", p.lifespan, "Split", "Lifespan", "lifespan");
+  from_json_key(
+      j,
+      "splitContext",
+      p.splitContext,
+      "Split",
+      "SplitContext",
+      "splitContext");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ScheduledSplit& p) {
+  j = json::object();
+  to_json_key(
+      j, "sequenceId", p.sequenceId, "ScheduledSplit", "int64_t", "sequenceId");
+  to_json_key(
+      j,
+      "planNodeId",
+      p.planNodeId,
+      "ScheduledSplit",
+      "PlanNodeId",
+      "planNodeId");
+  to_json_key(j, "split", p.split, "ScheduledSplit", "Split", "split");
+}
+
+void from_json(const json& j, ScheduledSplit& p) {
+  from_json_key(
+      j, "sequenceId", p.sequenceId, "ScheduledSplit", "int64_t", "sequenceId");
+  from_json_key(
+      j,
+      "planNodeId",
+      p.planNodeId,
+      "ScheduledSplit",
+      "PlanNodeId",
+      "planNodeId");
+  from_json_key(j, "split", p.split, "ScheduledSplit", "Split", "split");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TaskSource& p) {
+  j = json::object();
+  to_json_key(
+      j, "planNodeId", p.planNodeId, "TaskSource", "PlanNodeId", "planNodeId");
+  to_json_key(
+      j, "splits", p.splits, "TaskSource", "List<ScheduledSplit>", "splits");
+  to_json_key(
+      j,
+      "noMoreSplitsForLifespan",
+      p.noMoreSplitsForLifespan,
+      "TaskSource",
+      "List<Lifespan>",
+      "noMoreSplitsForLifespan");
+  to_json_key(
+      j, "noMoreSplits", p.noMoreSplits, "TaskSource", "bool", "noMoreSplits");
+}
+
+void from_json(const json& j, TaskSource& p) {
+  from_json_key(
+      j, "planNodeId", p.planNodeId, "TaskSource", "PlanNodeId", "planNodeId");
+  from_json_key(
+      j, "splits", p.splits, "TaskSource", "List<ScheduledSplit>", "splits");
+  from_json_key(
+      j,
+      "noMoreSplitsForLifespan",
+      p.noMoreSplitsForLifespan,
+      "TaskSource",
+      "List<Lifespan>",
+      "noMoreSplitsForLifespan");
+  from_json_key(
+      j, "noMoreSplits", p.noMoreSplits, "TaskSource", "bool", "noMoreSplits");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ResourceEstimates& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "executionTime",
+      p.executionTime,
+      "ResourceEstimates",
+      "Duration",
+      "executionTime");
+  to_json_key(
+      j, "cpuTime", p.cpuTime, "ResourceEstimates", "Duration", "cpuTime");
+  to_json_key(
+      j,
+      "peakMemory",
+      p.peakMemory,
+      "ResourceEstimates",
+      "DataSize",
+      "peakMemory");
+  to_json_key(
+      j,
+      "peakTaskMemory",
+      p.peakTaskMemory,
+      "ResourceEstimates",
+      "DataSize",
+      "peakTaskMemory");
+}
+
+void from_json(const json& j, ResourceEstimates& p) {
+  from_json_key(
+      j,
+      "executionTime",
+      p.executionTime,
+      "ResourceEstimates",
+      "Duration",
+      "executionTime");
+  from_json_key(
+      j, "cpuTime", p.cpuTime, "ResourceEstimates", "Duration", "cpuTime");
+  from_json_key(
+      j,
+      "peakMemory",
+      p.peakMemory,
+      "ResourceEstimates",
+      "DataSize",
+      "peakMemory");
+  from_json_key(
+      j,
+      "peakTaskMemory",
+      p.peakTaskMemory,
+      "ResourceEstimates",
+      "DataSize",
+      "peakTaskMemory");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<SelectedRoleType, json> SelectedRoleType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {SelectedRoleType::ROLE, "ROLE"},
+        {SelectedRoleType::ALL, "ALL"},
+        {SelectedRoleType::NONE, "NONE"}};
+void to_json(json& j, const SelectedRoleType& e) {
+  static_assert(
+      std::is_enum<SelectedRoleType>::value,
+      "SelectedRoleType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SelectedRoleType_enum_table),
+      std::end(SelectedRoleType_enum_table),
+      [e](const std::pair<SelectedRoleType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(SelectedRoleType_enum_table))
+           ? it
+           : std::begin(SelectedRoleType_enum_table))
+          ->second;
+}
+void from_json(const json& j, SelectedRoleType& e) {
+  static_assert(
+      std::is_enum<SelectedRoleType>::value,
+      "SelectedRoleType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SelectedRoleType_enum_table),
+      std::end(SelectedRoleType_enum_table),
+      [&j](const std::pair<SelectedRoleType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(SelectedRoleType_enum_table))
+           ? it
+           : std::begin(SelectedRoleType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SelectedRole& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "SelectedRole", "SelectedRoleType", "type");
+  to_json_key(j, "role", p.role, "SelectedRole", "String", "role");
+}
+
+void from_json(const json& j, SelectedRole& p) {
+  from_json_key(j, "type", p.type, "SelectedRole", "SelectedRoleType", "type");
+  from_json_key(j, "role", p.role, "SelectedRole", "String", "role");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Parameter& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "Parameter", "String", "name");
+  to_json_key(j, "type", p.type, "Parameter", "TypeSignature", "type");
+}
+
+void from_json(const json& j, Parameter& p) {
+  from_json_key(j, "name", p.name, "Parameter", "String", "name");
+  from_json_key(j, "type", p.type, "Parameter", "TypeSignature", "type");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Language& p) {
+  j = json::object();
+  to_json_key(j, "language", p.language, "Language", "String", "language");
+}
+
+void from_json(const json& j, Language& p) {
+  from_json_key(j, "language", p.language, "Language", "String", "language");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<NullCallClause, json> NullCallClause_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {NullCallClause::RETURNS_NULL_ON_NULL_INPUT,
+         "RETURNS_NULL_ON_NULL_INPUT"},
+        {NullCallClause::CALLED_ON_NULL_INPUT, "CALLED_ON_NULL_INPUT"}};
+void to_json(json& j, const NullCallClause& e) {
+  static_assert(
+      std::is_enum<NullCallClause>::value, "NullCallClause must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NullCallClause_enum_table),
+      std::end(NullCallClause_enum_table),
+      [e](const std::pair<NullCallClause, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(NullCallClause_enum_table))
+           ? it
+           : std::begin(NullCallClause_enum_table))
+          ->second;
+}
+void from_json(const json& j, NullCallClause& e) {
+  static_assert(
+      std::is_enum<NullCallClause>::value, "NullCallClause must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NullCallClause_enum_table),
+      std::end(NullCallClause_enum_table),
+      [&j](const std::pair<NullCallClause, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(NullCallClause_enum_table))
+           ? it
+           : std::begin(NullCallClause_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Determinism, json> Determinism_enum_table[] = {
+    // NOLINT: cert-err58-cpp
+    {Determinism::DETERMINISTIC, "DETERMINISTIC"},
+    {Determinism::NOT_DETERMINISTIC, "NOT_DETERMINISTIC"},
+};
+void to_json(json& j, const Determinism& e) {
+  static_assert(
+      std::is_enum<Determinism>::value, "Determinism must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Determinism_enum_table),
+      std::end(Determinism_enum_table),
+      [e](const std::pair<Determinism, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Determinism_enum_table))
+           ? it
+           : std::begin(Determinism_enum_table))
+          ->second;
+}
+void from_json(const json& j, Determinism& e) {
+  static_assert(
+      std::is_enum<Determinism>::value, "Determinism must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Determinism_enum_table),
+      std::end(Determinism_enum_table),
+      [&j](const std::pair<Determinism, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Determinism_enum_table))
+           ? it
+           : std::begin(Determinism_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const RoutineCharacteristics& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "language",
+      p.language,
+      "RoutineCharacteristics",
+      "Language",
+      "language");
+  to_json_key(
+      j,
+      "determinism",
+      p.determinism,
+      "RoutineCharacteristics",
+      "Determinism",
+      "determinism");
+  to_json_key(
+      j,
+      "nullCallClause",
+      p.nullCallClause,
+      "RoutineCharacteristics",
+      "NullCallClause",
+      "nullCallClause");
+}
+
+void from_json(const json& j, RoutineCharacteristics& p) {
+  from_json_key(
+      j,
+      "language",
+      p.language,
+      "RoutineCharacteristics",
+      "Language",
+      "language");
+  from_json_key(
+      j,
+      "determinism",
+      p.determinism,
+      "RoutineCharacteristics",
+      "Determinism",
+      "determinism");
+  from_json_key(
+      j,
+      "nullCallClause",
+      p.nullCallClause,
+      "RoutineCharacteristics",
+      "NullCallClause",
+      "nullCallClause");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const LongVariableConstraint& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "LongVariableConstraint", "String", "name");
+  to_json_key(
+      j,
+      "expression",
+      p.expression,
+      "LongVariableConstraint",
+      "String",
+      "expression");
+}
+
+void from_json(const json& j, LongVariableConstraint& p) {
+  from_json_key(j, "name", p.name, "LongVariableConstraint", "String", "name");
+  from_json_key(
+      j,
+      "expression",
+      p.expression,
+      "LongVariableConstraint",
+      "String",
+      "expression");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TypeVariableConstraint& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "TypeVariableConstraint", "String", "name");
+  to_json_key(
+      j,
+      "comparableRequired",
+      p.comparableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "comparableRequired");
+  to_json_key(
+      j,
+      "orderableRequired",
+      p.orderableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "orderableRequired");
+  to_json_key(
+      j,
+      "variadicBound",
+      p.variadicBound,
+      "TypeVariableConstraint",
+      "String",
+      "variadicBound");
+  to_json_key(
+      j,
+      "nonDecimalNumericRequired",
+      p.nonDecimalNumericRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "nonDecimalNumericRequired");
+}
+
+void from_json(const json& j, TypeVariableConstraint& p) {
+  from_json_key(j, "name", p.name, "TypeVariableConstraint", "String", "name");
+  from_json_key(
+      j,
+      "comparableRequired",
+      p.comparableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "comparableRequired");
+  from_json_key(
+      j,
+      "orderableRequired",
+      p.orderableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "orderableRequired");
+  from_json_key(
+      j,
+      "variadicBound",
+      p.variadicBound,
+      "TypeVariableConstraint",
+      "String",
+      "variadicBound");
+  from_json_key(
+      j,
+      "nonDecimalNumericRequired",
+      p.nonDecimalNumericRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "nonDecimalNumericRequired");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<FunctionKind, json> FunctionKind_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {FunctionKind::SCALAR, "SCALAR"},
+        {FunctionKind::AGGREGATE, "AGGREGATE"},
+        {FunctionKind::WINDOW, "WINDOW"}};
+void to_json(json& j, const FunctionKind& e) {
+  static_assert(
+      std::is_enum<FunctionKind>::value, "FunctionKind must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(FunctionKind_enum_table),
+      std::end(FunctionKind_enum_table),
+      [e](const std::pair<FunctionKind, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(FunctionKind_enum_table))
+           ? it
+           : std::begin(FunctionKind_enum_table))
+          ->second;
+}
+void from_json(const json& j, FunctionKind& e) {
+  static_assert(
+      std::is_enum<FunctionKind>::value, "FunctionKind must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(FunctionKind_enum_table),
+      std::end(FunctionKind_enum_table),
+      [&j](const std::pair<FunctionKind, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(FunctionKind_enum_table))
+           ? it
+           : std::begin(FunctionKind_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Signature& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "Signature", "QualifiedObjectName", "name");
+  to_json_key(j, "kind", p.kind, "Signature", "FunctionKind", "kind");
+  to_json_key(
+      j,
+      "typeVariableConstraints",
+      p.typeVariableConstraints,
+      "Signature",
+      "List<TypeVariableConstraint>",
+      "typeVariableConstraints");
+  to_json_key(
+      j,
+      "longVariableConstraints",
+      p.longVariableConstraints,
+      "Signature",
+      "List<LongVariableConstraint>",
+      "longVariableConstraints");
+  to_json_key(
+      j,
+      "returnType",
+      p.returnType,
+      "Signature",
+      "TypeSignature",
+      "returnType");
+  to_json_key(
+      j,
+      "argumentTypes",
+      p.argumentTypes,
+      "Signature",
+      "List<TypeSignature>",
+      "argumentTypes");
+  to_json_key(
+      j,
+      "variableArity",
+      p.variableArity,
+      "Signature",
+      "bool",
+      "variableArity");
+}
+
+void from_json(const json& j, Signature& p) {
+  from_json_key(j, "name", p.name, "Signature", "QualifiedObjectName", "name");
+  from_json_key(j, "kind", p.kind, "Signature", "FunctionKind", "kind");
+  from_json_key(
+      j,
+      "typeVariableConstraints",
+      p.typeVariableConstraints,
+      "Signature",
+      "List<TypeVariableConstraint>",
+      "typeVariableConstraints");
+  from_json_key(
+      j,
+      "longVariableConstraints",
+      p.longVariableConstraints,
+      "Signature",
+      "List<LongVariableConstraint>",
+      "longVariableConstraints");
+  from_json_key(
+      j,
+      "returnType",
+      p.returnType,
+      "Signature",
+      "TypeSignature",
+      "returnType");
+  from_json_key(
+      j,
+      "argumentTypes",
+      p.argumentTypes,
+      "Signature",
+      "List<TypeSignature>",
+      "argumentTypes");
+  from_json_key(
+      j,
+      "variableArity",
+      p.variableArity,
+      "Signature",
+      "bool",
+      "variableArity");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SqlInvokedFunction& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "parameters",
+      p.parameters,
+      "SqlInvokedFunction",
+      "List<Parameter>",
+      "parameters");
+  to_json_key(
+      j,
+      "description",
+      p.description,
+      "SqlInvokedFunction",
+      "String",
+      "description");
+  to_json_key(
+      j,
+      "routineCharacteristics",
+      p.routineCharacteristics,
+      "SqlInvokedFunction",
+      "RoutineCharacteristics",
+      "routineCharacteristics");
+  to_json_key(j, "body", p.body, "SqlInvokedFunction", "String", "body");
+  to_json_key(
+      j,
+      "signature",
+      p.signature,
+      "SqlInvokedFunction",
+      "Signature",
+      "signature");
+  to_json_key(
+      j,
+      "functionId",
+      p.functionId,
+      "SqlInvokedFunction",
+      "SqlFunctionId",
+      "functionId");
+}
+
+void from_json(const json& j, SqlInvokedFunction& p) {
+  from_json_key(
+      j,
+      "parameters",
+      p.parameters,
+      "SqlInvokedFunction",
+      "List<Parameter>",
+      "parameters");
+  from_json_key(
+      j,
+      "description",
+      p.description,
+      "SqlInvokedFunction",
+      "String",
+      "description");
+  from_json_key(
+      j,
+      "routineCharacteristics",
+      p.routineCharacteristics,
+      "SqlInvokedFunction",
+      "RoutineCharacteristics",
+      "routineCharacteristics");
+  from_json_key(j, "body", p.body, "SqlInvokedFunction", "String", "body");
+  from_json_key(
+      j,
+      "signature",
+      p.signature,
+      "SqlInvokedFunction",
+      "Signature",
+      "signature");
+  from_json_key(
+      j,
+      "functionId",
+      p.functionId,
+      "SqlInvokedFunction",
+      "SqlFunctionId",
+      "functionId");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SessionRepresentation& p) {
+  j = json::object();
+  to_json_key(
+      j, "queryId", p.queryId, "SessionRepresentation", "String", "queryId");
+  to_json_key(
+      j,
+      "transactionId",
+      p.transactionId,
+      "SessionRepresentation",
+      "TransactionId",
+      "transactionId");
+  to_json_key(
+      j,
+      "clientTransactionSupport",
+      p.clientTransactionSupport,
+      "SessionRepresentation",
+      "bool",
+      "clientTransactionSupport");
+  to_json_key(j, "user", p.user, "SessionRepresentation", "String", "user");
+  to_json_key(
+      j,
+      "principal",
+      p.principal,
+      "SessionRepresentation",
+      "String",
+      "principal");
+  to_json_key(
+      j, "source", p.source, "SessionRepresentation", "String", "source");
+  to_json_key(
+      j, "catalog", p.catalog, "SessionRepresentation", "String", "catalog");
+  to_json_key(
+      j, "schema", p.schema, "SessionRepresentation", "String", "schema");
+  to_json_key(
+      j,
+      "traceToken",
+      p.traceToken,
+      "SessionRepresentation",
+      "String",
+      "traceToken");
+  to_json_key(
+      j,
+      "timeZoneKey",
+      p.timeZoneKey,
+      "SessionRepresentation",
+      "TimeZoneKey",
+      "timeZoneKey");
+  to_json_key(
+      j, "locale", p.locale, "SessionRepresentation", "Locale", "locale");
+  to_json_key(
+      j,
+      "remoteUserAddress",
+      p.remoteUserAddress,
+      "SessionRepresentation",
+      "String",
+      "remoteUserAddress");
+  to_json_key(
+      j,
+      "userAgent",
+      p.userAgent,
+      "SessionRepresentation",
+      "String",
+      "userAgent");
+  to_json_key(
+      j,
+      "clientInfo",
+      p.clientInfo,
+      "SessionRepresentation",
+      "String",
+      "clientInfo");
+  to_json_key(
+      j,
+      "clientTags",
+      p.clientTags,
+      "SessionRepresentation",
+      "List<String>",
+      "clientTags");
+  to_json_key(
+      j,
+      "resourceEstimates",
+      p.resourceEstimates,
+      "SessionRepresentation",
+      "ResourceEstimates",
+      "resourceEstimates");
+  to_json_key(
+      j,
+      "startTime",
+      p.startTime,
+      "SessionRepresentation",
+      "int64_t",
+      "startTime");
+  to_json_key(
+      j,
+      "systemProperties",
+      p.systemProperties,
+      "SessionRepresentation",
+      "Map<String, String>",
+      "systemProperties");
+  to_json_key(
+      j,
+      "catalogProperties",
+      p.catalogProperties,
+      "SessionRepresentation",
+      "Map<ConnectorId, Map<String, String>>",
+      "catalogProperties");
+  to_json_key(
+      j,
+      "unprocessedCatalogProperties",
+      p.unprocessedCatalogProperties,
+      "SessionRepresentation",
+      "Map<String, Map<String, String>>",
+      "unprocessedCatalogProperties");
+  to_json_key(
+      j,
+      "roles",
+      p.roles,
+      "SessionRepresentation",
+      "Map<String, SelectedRole>",
+      "roles");
+  to_json_key(
+      j,
+      "preparedStatements",
+      p.preparedStatements,
+      "SessionRepresentation",
+      "Map<String, String>",
+      "preparedStatements");
+  to_json_key(
+      j,
+      "sessionFunctions",
+      p.sessionFunctions,
+      "SessionRepresentation",
+      "Map<SqlFunctionId, SqlInvokedFunction>",
+      "sessionFunctions");
+}
+
+void from_json(const json& j, SessionRepresentation& p) {
+  from_json_key(
+      j, "queryId", p.queryId, "SessionRepresentation", "String", "queryId");
+  from_json_key(
+      j,
+      "transactionId",
+      p.transactionId,
+      "SessionRepresentation",
+      "TransactionId",
+      "transactionId");
+  from_json_key(
+      j,
+      "clientTransactionSupport",
+      p.clientTransactionSupport,
+      "SessionRepresentation",
+      "bool",
+      "clientTransactionSupport");
+  from_json_key(j, "user", p.user, "SessionRepresentation", "String", "user");
+  from_json_key(
+      j,
+      "principal",
+      p.principal,
+      "SessionRepresentation",
+      "String",
+      "principal");
+  from_json_key(
+      j, "source", p.source, "SessionRepresentation", "String", "source");
+  from_json_key(
+      j, "catalog", p.catalog, "SessionRepresentation", "String", "catalog");
+  from_json_key(
+      j, "schema", p.schema, "SessionRepresentation", "String", "schema");
+  from_json_key(
+      j,
+      "traceToken",
+      p.traceToken,
+      "SessionRepresentation",
+      "String",
+      "traceToken");
+  from_json_key(
+      j,
+      "timeZoneKey",
+      p.timeZoneKey,
+      "SessionRepresentation",
+      "TimeZoneKey",
+      "timeZoneKey");
+  from_json_key(
+      j, "locale", p.locale, "SessionRepresentation", "Locale", "locale");
+  from_json_key(
+      j,
+      "remoteUserAddress",
+      p.remoteUserAddress,
+      "SessionRepresentation",
+      "String",
+      "remoteUserAddress");
+  from_json_key(
+      j,
+      "userAgent",
+      p.userAgent,
+      "SessionRepresentation",
+      "String",
+      "userAgent");
+  from_json_key(
+      j,
+      "clientInfo",
+      p.clientInfo,
+      "SessionRepresentation",
+      "String",
+      "clientInfo");
+  from_json_key(
+      j,
+      "clientTags",
+      p.clientTags,
+      "SessionRepresentation",
+      "List<String>",
+      "clientTags");
+  from_json_key(
+      j,
+      "resourceEstimates",
+      p.resourceEstimates,
+      "SessionRepresentation",
+      "ResourceEstimates",
+      "resourceEstimates");
+  from_json_key(
+      j,
+      "startTime",
+      p.startTime,
+      "SessionRepresentation",
+      "int64_t",
+      "startTime");
+  from_json_key(
+      j,
+      "systemProperties",
+      p.systemProperties,
+      "SessionRepresentation",
+      "Map<String, String>",
+      "systemProperties");
+  from_json_key(
+      j,
+      "catalogProperties",
+      p.catalogProperties,
+      "SessionRepresentation",
+      "Map<ConnectorId, Map<String, String>>",
+      "catalogProperties");
+  from_json_key(
+      j,
+      "unprocessedCatalogProperties",
+      p.unprocessedCatalogProperties,
+      "SessionRepresentation",
+      "Map<String, Map<String, String>>",
+      "unprocessedCatalogProperties");
+  from_json_key(
+      j,
+      "roles",
+      p.roles,
+      "SessionRepresentation",
+      "Map<String, SelectedRole>",
+      "roles");
+  from_json_key(
+      j,
+      "preparedStatements",
+      p.preparedStatements,
+      "SessionRepresentation",
+      "Map<String, String>",
+      "preparedStatements");
+  from_json_key(
+      j,
+      "sessionFunctions",
+      p.sessionFunctions,
+      "SessionRepresentation",
+      "Map<SqlFunctionId, SqlInvokedFunction>",
+      "sessionFunctions");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TaskUpdateRequest& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "session",
+      p.session,
+      "TaskUpdateRequest",
+      "SessionRepresentation",
+      "session");
+  to_json_key(
+      j,
+      "extraCredentials",
+      p.extraCredentials,
+      "TaskUpdateRequest",
+      "Map<String, String>",
+      "extraCredentials");
+  to_json_key(
+      j, "fragment", p.fragment, "TaskUpdateRequest", "String", "fragment");
+  to_json_key(
+      j,
+      "sources",
+      p.sources,
+      "TaskUpdateRequest",
+      "List<TaskSource>",
+      "sources");
+  to_json_key(
+      j,
+      "outputIds",
+      p.outputIds,
+      "TaskUpdateRequest",
+      "OutputBuffers",
+      "outputIds");
+  to_json_key(
+      j,
+      "tableWriteInfo",
+      p.tableWriteInfo,
+      "TaskUpdateRequest",
+      "TableWriteInfo",
+      "tableWriteInfo");
+}
+
+void from_json(const json& j, TaskUpdateRequest& p) {
+  from_json_key(
+      j,
+      "session",
+      p.session,
+      "TaskUpdateRequest",
+      "SessionRepresentation",
+      "session");
+  from_json_key(
+      j,
+      "extraCredentials",
+      p.extraCredentials,
+      "TaskUpdateRequest",
+      "Map<String, String>",
+      "extraCredentials");
+  from_json_key(
+      j, "fragment", p.fragment, "TaskUpdateRequest", "String", "fragment");
+  from_json_key(
+      j,
+      "sources",
+      p.sources,
+      "TaskUpdateRequest",
+      "List<TaskSource>",
+      "sources");
+  from_json_key(
+      j,
+      "outputIds",
+      p.outputIds,
+      "TaskUpdateRequest",
+      "OutputBuffers",
+      "outputIds");
+  from_json_key(
+      j,
+      "tableWriteInfo",
+      p.tableWriteInfo,
+      "TaskUpdateRequest",
+      "TableWriteInfo",
+      "tableWriteInfo");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Specification& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "Specification",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "Specification",
+      "OrderingScheme",
+      "orderingScheme");
+}
+
+void from_json(const json& j, Specification& p) {
+  from_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "Specification",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  from_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "Specification",
+      "OrderingScheme",
+      "orderingScheme");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<WindowType, json> WindowType_enum_table[] = {
+    // NOLINT: cert-err58-cpp
+    {WindowType::RANGE, "RANGE"},
+    {WindowType::ROWS, "ROWS"},
+};
+void to_json(json& j, const WindowType& e) {
+  static_assert(std::is_enum<WindowType>::value, "WindowType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(WindowType_enum_table),
+      std::end(WindowType_enum_table),
+      [e](const std::pair<WindowType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(WindowType_enum_table))
+           ? it
+           : std::begin(WindowType_enum_table))
+          ->second;
+}
+void from_json(const json& j, WindowType& e) {
+  static_assert(std::is_enum<WindowType>::value, "WindowType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(WindowType_enum_table),
+      std::end(WindowType_enum_table),
+      [&j](const std::pair<WindowType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(WindowType_enum_table))
+           ? it
+           : std::begin(WindowType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<BoundType, json> BoundType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {BoundType::UNBOUNDED_PRECEDING, "UNBOUNDED_PRECEDING"},
+        {BoundType::PRECEDING, "PRECEDING"},
+        {BoundType::CURRENT_ROW, "CURRENT_ROW"},
+        {BoundType::FOLLOWING, "FOLLOWING"},
+        {BoundType::UNBOUNDED_FOLLOWING, "UNBOUNDED_FOLLOWING"}};
+void to_json(json& j, const BoundType& e) {
+  static_assert(std::is_enum<BoundType>::value, "BoundType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BoundType_enum_table),
+      std::end(BoundType_enum_table),
+      [e](const std::pair<BoundType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(BoundType_enum_table))
+           ? it
+           : std::begin(BoundType_enum_table))
+          ->second;
+}
+void from_json(const json& j, BoundType& e) {
+  static_assert(std::is_enum<BoundType>::value, "BoundType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BoundType_enum_table),
+      std::end(BoundType_enum_table),
+      [&j](const std::pair<BoundType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(BoundType_enum_table))
+           ? it
+           : std::begin(BoundType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Frame& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "Frame", "WindowType", "type");
+  to_json_key(j, "startType", p.startType, "Frame", "BoundType", "startType");
+  to_json_key(
+      j,
+      "startValue",
+      p.startValue,
+      "Frame",
+      "VariableReferenceExpression",
+      "startValue");
+  to_json_key(j, "endType", p.endType, "Frame", "BoundType", "endType");
+  to_json_key(
+      j,
+      "endValue",
+      p.endValue,
+      "Frame",
+      "VariableReferenceExpression",
+      "endValue");
+  to_json_key(
+      j,
+      "originalStartValue",
+      p.originalStartValue,
+      "Frame",
+      "String",
+      "originalStartValue");
+  to_json_key(
+      j,
+      "originalEndValue",
+      p.originalEndValue,
+      "Frame",
+      "String",
+      "originalEndValue");
+}
+
+void from_json(const json& j, Frame& p) {
+  from_json_key(j, "type", p.type, "Frame", "WindowType", "type");
+  from_json_key(j, "startType", p.startType, "Frame", "BoundType", "startType");
+  from_json_key(
+      j,
+      "startValue",
+      p.startValue,
+      "Frame",
+      "VariableReferenceExpression",
+      "startValue");
+  from_json_key(j, "endType", p.endType, "Frame", "BoundType", "endType");
+  from_json_key(
+      j,
+      "endValue",
+      p.endValue,
+      "Frame",
+      "VariableReferenceExpression",
+      "endValue");
+  from_json_key(
+      j,
+      "originalStartValue",
+      p.originalStartValue,
+      "Frame",
+      "String",
+      "originalStartValue");
+  from_json_key(
+      j,
+      "originalEndValue",
+      p.originalEndValue,
+      "Frame",
+      "String",
+      "originalEndValue");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Function& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "functionCall",
+      p.functionCall,
+      "Function",
+      "CallExpression",
+      "functionCall");
+  to_json_key(j, "frame", p.frame, "Function", "Frame", "frame");
+  to_json_key(
+      j, "ignoreNulls", p.ignoreNulls, "Function", "bool", "ignoreNulls");
+}
+
+void from_json(const json& j, Function& p) {
+  from_json_key(
+      j,
+      "functionCall",
+      p.functionCall,
+      "Function",
+      "CallExpression",
+      "functionCall");
+  from_json_key(j, "frame", p.frame, "Function", "Frame", "frame");
+  from_json_key(
+      j, "ignoreNulls", p.ignoreNulls, "Function", "bool", "ignoreNulls");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+WindowNode::WindowNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.WindowNode";
+}
+
+void to_json(json& j, const WindowNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.WindowNode";
+  to_json_key(j, "id", p.id, "WindowNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "WindowNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "specification",
+      p.specification,
+      "WindowNode",
+      "Specification",
+      "specification");
+  to_json_key(
+      j,
+      "windowFunctions",
+      p.windowFunctions,
+      "WindowNode",
+      "Map<VariableReferenceExpression, Function>",
+      "windowFunctions");
+  to_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "WindowNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+  to_json_key(
+      j,
+      "prePartitionedInputs",
+      p.prePartitionedInputs,
+      "WindowNode",
+      "List<VariableReferenceExpression>",
+      "prePartitionedInputs");
+  to_json_key(
+      j,
+      "preSortedOrderPrefix",
+      p.preSortedOrderPrefix,
+      "WindowNode",
+      "int",
+      "preSortedOrderPrefix");
+}
+
+void from_json(const json& j, WindowNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "WindowNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "WindowNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "specification",
+      p.specification,
+      "WindowNode",
+      "Specification",
+      "specification");
+  from_json_key(
+      j,
+      "windowFunctions",
+      p.windowFunctions,
+      "WindowNode",
+      "Map<VariableReferenceExpression, Function>",
+      "windowFunctions");
+  from_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "WindowNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+  from_json_key(
+      j,
+      "prePartitionedInputs",
+      p.prePartitionedInputs,
+      "WindowNode",
+      "List<VariableReferenceExpression>",
+      "prePartitionedInputs");
+  from_json_key(
+      j,
+      "preSortedOrderPrefix",
+      p.preSortedOrderPrefix,
+      "WindowNode",
+      "int",
+      "preSortedOrderPrefix");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+DeleteHandle::DeleteHandle() noexcept {
+  _type = "DeleteHandle";
+}
+
+void to_json(json& j, const DeleteHandle& p) {
+  j = json::object();
+  j["@type"] = "DeleteHandle";
+  to_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  to_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "DeleteHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+
+void from_json(const json& j, DeleteHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  from_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "DeleteHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+ValuesNode::ValuesNode() noexcept {
+  _type = ".ValuesNode";
+}
+
+void to_json(json& j, const ValuesNode& p) {
+  j = json::object();
+  j["@type"] = ".ValuesNode";
+  to_json_key(j, "id", p.id, "ValuesNode", "PlanNodeId", "id");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "ValuesNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  to_json_key(
+      j,
+      "rows",
+      p.rows,
+      "ValuesNode",
+      "List<List<std::shared_ptr<RowExpression>>>",
+      "rows");
+}
+
+void from_json(const json& j, ValuesNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "ValuesNode", "PlanNodeId", "id");
+  from_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "ValuesNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  from_json_key(
+      j,
+      "rows",
+      p.rows,
+      "ValuesNode",
+      "List<List<std::shared_ptr<RowExpression>>>",
+      "rows");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorInsertTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == "hive") {
+    j = *std::static_pointer_cast<HiveInsertTableHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorInsertTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorInsertTableHandle  ConnectorInsertTableHandle");
+  }
+
+  if (type == "hive") {
+    std::shared_ptr<HiveInsertTableHandle> k =
+        std::make_shared<HiveInsertTableHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ConnectorInsertTableHandle>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const InsertTableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "InsertTableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "InsertTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "InsertTableHandle",
+      "ConnectorInsertTableHandle",
+      "connectorHandle");
+}
+
+void from_json(const json& j, InsertTableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "InsertTableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "InsertTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "InsertTableHandle",
+      "ConnectorInsertTableHandle",
+      "connectorHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const RefreshMaterializedViewHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "handle",
+      p.handle,
+      "RefreshMaterializedViewHandle",
+      "InsertTableHandle",
+      "handle");
+  to_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "RefreshMaterializedViewHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+
+void from_json(const json& j, RefreshMaterializedViewHandle& p) {
+  from_json_key(
+      j,
+      "handle",
+      p.handle,
+      "RefreshMaterializedViewHandle",
+      "InsertTableHandle",
+      "handle");
+  from_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "RefreshMaterializedViewHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Locality, json> Locality_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {Locality::UNKNOWN, "UNKNOWN"},
+        {Locality::LOCAL, "LOCAL"},
+        {Locality::REMOTE, "REMOTE"}};
+void to_json(json& j, const Locality& e) {
+  static_assert(std::is_enum<Locality>::value, "Locality must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Locality_enum_table),
+      std::end(Locality_enum_table),
+      [e](const std::pair<Locality, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Locality_enum_table)) ? it
+                                             : std::begin(Locality_enum_table))
+          ->second;
+}
+void from_json(const json& j, Locality& e) {
+  static_assert(std::is_enum<Locality>::value, "Locality must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Locality_enum_table),
+      std::end(Locality_enum_table),
+      [&j](const std::pair<Locality, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Locality_enum_table)) ? it
+                                             : std::begin(Locality_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Assignments& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "assignments",
+      p.assignments,
+      "Assignments",
+      "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
+      "assignments");
+}
+
+void from_json(const json& j, Assignments& p) {
+  from_json_key(
+      j,
+      "assignments",
+      p.assignments,
+      "Assignments",
+      "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
+      "assignments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+ProjectNode::ProjectNode() noexcept {
+  _type = ".ProjectNode";
+}
+
+void to_json(json& j, const ProjectNode& p) {
+  j = json::object();
+  j["@type"] = ".ProjectNode";
+  to_json_key(j, "id", p.id, "ProjectNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "ProjectNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "assignments",
+      p.assignments,
+      "ProjectNode",
+      "Assignments",
+      "assignments");
+  to_json_key(j, "locality", p.locality, "ProjectNode", "Locality", "locality");
+}
+
+void from_json(const json& j, ProjectNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "ProjectNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "ProjectNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "assignments",
+      p.assignments,
+      "ProjectNode",
+      "Assignments",
+      "assignments");
+  from_json_key(
+      j, "locality", p.locality, "ProjectNode", "Locality", "locality");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<ErrorType, json> ErrorType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {ErrorType::USER_ERROR, "USER_ERROR"},
+        {ErrorType::INTERNAL_ERROR, "INTERNAL_ERROR"},
+        {ErrorType::INSUFFICIENT_RESOURCES, "INSUFFICIENT_RESOURCES"},
+        {ErrorType::EXTERNAL, "EXTERNAL"}};
+void to_json(json& j, const ErrorType& e) {
+  static_assert(std::is_enum<ErrorType>::value, "ErrorType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ErrorType_enum_table),
+      std::end(ErrorType_enum_table),
+      [e](const std::pair<ErrorType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(ErrorType_enum_table))
+           ? it
+           : std::begin(ErrorType_enum_table))
+          ->second;
+}
+void from_json(const json& j, ErrorType& e) {
+  static_assert(std::is_enum<ErrorType>::value, "ErrorType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ErrorType_enum_table),
+      std::end(ErrorType_enum_table),
+      [&j](const std::pair<ErrorType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(ErrorType_enum_table))
+           ? it
+           : std::begin(ErrorType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ErrorCode& p) {
+  j = json::object();
+  to_json_key(j, "code", p.code, "ErrorCode", "int", "code");
+  to_json_key(j, "name", p.name, "ErrorCode", "String", "name");
+  to_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
+  to_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
+}
+
+void from_json(const json& j, ErrorCode& p) {
+  from_json_key(j, "code", p.code, "ErrorCode", "int", "code");
+  from_json_key(j, "name", p.name, "ErrorCode", "String", "name");
+  from_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
+  from_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ErrorLocation& p) {
+  j = json::object();
+  to_json_key(
+      j, "lineNumber", p.lineNumber, "ErrorLocation", "int", "lineNumber");
+  to_json_key(
+      j,
+      "columnNumber",
+      p.columnNumber,
+      "ErrorLocation",
+      "int",
+      "columnNumber");
+}
+
+void from_json(const json& j, ErrorLocation& p) {
+  from_json_key(
+      j, "lineNumber", p.lineNumber, "ErrorLocation", "int", "lineNumber");
+  from_json_key(
+      j,
+      "columnNumber",
+      p.columnNumber,
+      "ErrorLocation",
+      "int",
+      "columnNumber");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ExecutionFailureInfo& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "ExecutionFailureInfo", "String", "type");
+  to_json_key(
+      j, "message", p.message, "ExecutionFailureInfo", "String", "message");
+  to_json_key(
+      j,
+      "cause",
+      p.cause,
+      "ExecutionFailureInfo",
+      "ExecutionFailureInfo",
+      "cause");
+  to_json_key(
+      j,
+      "suppressed",
+      p.suppressed,
+      "ExecutionFailureInfo",
+      "List<ExecutionFailureInfo>",
+      "suppressed");
+  to_json_key(
+      j, "stack", p.stack, "ExecutionFailureInfo", "List<String>", "stack");
+  to_json_key(
+      j,
+      "errorLocation",
+      p.errorLocation,
+      "ExecutionFailureInfo",
+      "ErrorLocation",
+      "errorLocation");
+  to_json_key(
+      j,
+      "errorCode",
+      p.errorCode,
+      "ExecutionFailureInfo",
+      "ErrorCode",
+      "errorCode");
+  to_json_key(
+      j,
+      "remoteHost",
+      p.remoteHost,
+      "ExecutionFailureInfo",
+      "HostAddress",
+      "remoteHost");
+}
+
+void from_json(const json& j, ExecutionFailureInfo& p) {
+  from_json_key(j, "type", p.type, "ExecutionFailureInfo", "String", "type");
+  from_json_key(
+      j, "message", p.message, "ExecutionFailureInfo", "String", "message");
+  from_json_key(
+      j,
+      "cause",
+      p.cause,
+      "ExecutionFailureInfo",
+      "ExecutionFailureInfo",
+      "cause");
+  from_json_key(
+      j,
+      "suppressed",
+      p.suppressed,
+      "ExecutionFailureInfo",
+      "List<ExecutionFailureInfo>",
+      "suppressed");
+  from_json_key(
+      j, "stack", p.stack, "ExecutionFailureInfo", "List<String>", "stack");
+  from_json_key(
+      j,
+      "errorLocation",
+      p.errorLocation,
+      "ExecutionFailureInfo",
+      "ErrorLocation",
+      "errorLocation");
+  from_json_key(
+      j,
+      "errorCode",
+      p.errorCode,
+      "ExecutionFailureInfo",
+      "ErrorCode",
+      "errorCode");
+  from_json_key(
+      j,
+      "remoteHost",
+      p.remoteHost,
+      "ExecutionFailureInfo",
+      "HostAddress",
+      "remoteHost");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 
 void to_json(json& j, const PageBufferInfo& p) {
   j = json::object();
@@ -8090,156 +6825,679 @@ void from_json(const json& j, BufferInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+
+void to_json(json& j, const Partitioning& p) {
+  j = json::object();
+  to_json_key(
+      j, "handle", p.handle, "Partitioning", "PartitioningHandle", "handle");
+  to_json_key(
+      j,
+      "arguments",
+      p.arguments,
+      "Partitioning",
+      "List<std::shared_ptr<RowExpression>>",
+      "arguments");
+}
+
+void from_json(const json& j, Partitioning& p) {
+  from_json_key(
+      j, "handle", p.handle, "Partitioning", "PartitioningHandle", "handle");
+  from_json_key(
+      j,
+      "arguments",
+      p.arguments,
+      "Partitioning",
+      "List<std::shared_ptr<RowExpression>>",
+      "arguments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PartitioningScheme& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "partitioning",
+      p.partitioning,
+      "PartitioningScheme",
+      "Partitioning",
+      "partitioning");
+  to_json_key(
+      j,
+      "outputLayout",
+      p.outputLayout,
+      "PartitioningScheme",
+      "List<VariableReferenceExpression>",
+      "outputLayout");
+  to_json_key(
+      j,
+      "hashColumn",
+      p.hashColumn,
+      "PartitioningScheme",
+      "VariableReferenceExpression",
+      "hashColumn");
+  to_json_key(
+      j,
+      "replicateNullsAndAny",
+      p.replicateNullsAndAny,
+      "PartitioningScheme",
+      "bool",
+      "replicateNullsAndAny");
+  to_json_key(
+      j,
+      "bucketToPartition",
+      p.bucketToPartition,
+      "PartitioningScheme",
+      "List<int>",
+      "bucketToPartition");
+}
+
+void from_json(const json& j, PartitioningScheme& p) {
+  from_json_key(
+      j,
+      "partitioning",
+      p.partitioning,
+      "PartitioningScheme",
+      "Partitioning",
+      "partitioning");
+  from_json_key(
+      j,
+      "outputLayout",
+      p.outputLayout,
+      "PartitioningScheme",
+      "List<VariableReferenceExpression>",
+      "outputLayout");
+  from_json_key(
+      j,
+      "hashColumn",
+      p.hashColumn,
+      "PartitioningScheme",
+      "VariableReferenceExpression",
+      "hashColumn");
+  from_json_key(
+      j,
+      "replicateNullsAndAny",
+      p.replicateNullsAndAny,
+      "PartitioningScheme",
+      "bool",
+      "replicateNullsAndAny");
+  from_json_key(
+      j,
+      "bucketToPartition",
+      p.bucketToPartition,
+      "PartitioningScheme",
+      "List<int>",
+      "bucketToPartition");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+TableWriterNode::TableWriterNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.TableWriterNode";
+}
+
+void to_json(json& j, const TableWriterNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.TableWriterNode";
+  to_json_key(j, "id", p.id, "TableWriterNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "TableWriterNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "rowCountVariable",
+      p.rowCountVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "rowCountVariable");
+  to_json_key(
+      j,
+      "fragmentVariable",
+      p.fragmentVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "fragmentVariable");
+  to_json_key(
+      j,
+      "tableCommitContextVariable",
+      p.tableCommitContextVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "tableCommitContextVariable");
+  to_json_key(
+      j,
+      "columns",
+      p.columns,
+      "TableWriterNode",
+      "List<VariableReferenceExpression>",
+      "columns");
+  to_json_key(
+      j,
+      "columnNames",
+      p.columnNames,
+      "TableWriterNode",
+      "List<String>",
+      "columnNames");
+  to_json_key(
+      j,
+      "notNullColumnVariables",
+      p.notNullColumnVariables,
+      "TableWriterNode",
+      "List<VariableReferenceExpression>",
+      "notNullColumnVariables");
+  to_json_key(
+      j,
+      "partitioningScheme",
+      p.partitioningScheme,
+      "TableWriterNode",
+      "PartitioningScheme",
+      "partitioningScheme");
+  to_json_key(
+      j,
+      "preferredShufflePartitioningScheme",
+      p.preferredShufflePartitioningScheme,
+      "TableWriterNode",
+      "PartitioningScheme",
+      "preferredShufflePartitioningScheme");
+}
+
+void from_json(const json& j, TableWriterNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "TableWriterNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "TableWriterNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "rowCountVariable",
+      p.rowCountVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "rowCountVariable");
+  from_json_key(
+      j,
+      "fragmentVariable",
+      p.fragmentVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "fragmentVariable");
+  from_json_key(
+      j,
+      "tableCommitContextVariable",
+      p.tableCommitContextVariable,
+      "TableWriterNode",
+      "VariableReferenceExpression",
+      "tableCommitContextVariable");
+  from_json_key(
+      j,
+      "columns",
+      p.columns,
+      "TableWriterNode",
+      "List<VariableReferenceExpression>",
+      "columns");
+  from_json_key(
+      j,
+      "columnNames",
+      p.columnNames,
+      "TableWriterNode",
+      "List<String>",
+      "columnNames");
+  from_json_key(
+      j,
+      "notNullColumnVariables",
+      p.notNullColumnVariables,
+      "TableWriterNode",
+      "List<VariableReferenceExpression>",
+      "notNullColumnVariables");
+  from_json_key(
+      j,
+      "partitioningScheme",
+      p.partitioningScheme,
+      "TableWriterNode",
+      "PartitioningScheme",
+      "partitioningScheme");
+  from_json_key(
+      j,
+      "preferredShufflePartitioningScheme",
+      p.preferredShufflePartitioningScheme,
+      "TableWriterNode",
+      "PartitioningScheme",
+      "preferredShufflePartitioningScheme");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+GroupIdNode::GroupIdNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.GroupIdNode";
+}
+
+void to_json(json& j, const GroupIdNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.GroupIdNode";
+  to_json_key(j, "id", p.id, "GroupIdNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "GroupIdNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "groupingSets",
+      p.groupingSets,
+      "GroupIdNode",
+      "List<List<VariableReferenceExpression>>",
+      "groupingSets");
+  to_json_key(
+      j,
+      "groupingColumns",
+      p.groupingColumns,
+      "GroupIdNode",
+      "Map<VariableReferenceExpression, VariableReferenceExpression>",
+      "groupingColumns");
+  to_json_key(
+      j,
+      "aggregationArguments",
+      p.aggregationArguments,
+      "GroupIdNode",
+      "List<VariableReferenceExpression>",
+      "aggregationArguments");
+  to_json_key(
+      j,
+      "groupIdVariable",
+      p.groupIdVariable,
+      "GroupIdNode",
+      "VariableReferenceExpression",
+      "groupIdVariable");
+}
+
+void from_json(const json& j, GroupIdNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "GroupIdNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "GroupIdNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "groupingSets",
+      p.groupingSets,
+      "GroupIdNode",
+      "List<List<VariableReferenceExpression>>",
+      "groupingSets");
+  from_json_key(
+      j,
+      "groupingColumns",
+      p.groupingColumns,
+      "GroupIdNode",
+      "Map<VariableReferenceExpression, VariableReferenceExpression>",
+      "groupingColumns");
+  from_json_key(
+      j,
+      "aggregationArguments",
+      p.aggregationArguments,
+      "GroupIdNode",
+      "List<VariableReferenceExpression>",
+      "aggregationArguments");
+  from_json_key(
+      j,
+      "groupIdVariable",
+      p.groupIdVariable,
+      "GroupIdNode",
+      "VariableReferenceExpression",
+      "groupIdVariable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+HiveMetadataUpdateHandle::HiveMetadataUpdateHandle() noexcept {
+  _type = "hive";
+}
+
+void to_json(json& j, const HiveMetadataUpdateHandle& p) {
+  j = json::object();
+  j["@type"] = "hive";
+  to_json_key(
+      j,
+      "requestId",
+      p.requestId,
+      "HiveMetadataUpdateHandle",
+      "UUID",
+      "requestId");
+  to_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "HiveMetadataUpdateHandle",
+      "SchemaTableName",
+      "schemaTableName");
+  to_json_key(
+      j,
+      "partitionName",
+      p.partitionName,
+      "HiveMetadataUpdateHandle",
+      "String",
+      "partitionName");
+  to_json_key(
+      j,
+      "fileName",
+      p.fileName,
+      "HiveMetadataUpdateHandle",
+      "String",
+      "fileName");
+}
+
+void from_json(const json& j, HiveMetadataUpdateHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "requestId",
+      p.requestId,
+      "HiveMetadataUpdateHandle",
+      "UUID",
+      "requestId");
+  from_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "HiveMetadataUpdateHandle",
+      "SchemaTableName",
+      "schemaTableName");
+  from_json_key(
+      j,
+      "partitionName",
+      p.partitionName,
+      "HiveMetadataUpdateHandle",
+      "String",
+      "partitionName");
+  from_json_key(
+      j,
+      "fileName",
+      p.fileName,
+      "HiveMetadataUpdateHandle",
+      "String",
+      "fileName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const VariableStatsEstimate& p) {
+  j = json::object();
+  to_json_key(
+      j, "lowValue", p.lowValue, "VariableStatsEstimate", "double", "lowValue");
+  to_json_key(
+      j,
+      "highValue",
+      p.highValue,
+      "VariableStatsEstimate",
+      "double",
+      "highValue");
+  to_json_key(
+      j,
+      "nullsFraction",
+      p.nullsFraction,
+      "VariableStatsEstimate",
+      "double",
+      "nullsFraction");
+  to_json_key(
+      j,
+      "averageRowSize",
+      p.averageRowSize,
+      "VariableStatsEstimate",
+      "double",
+      "averageRowSize");
+  to_json_key(
+      j,
+      "distinctValuesCount",
+      p.distinctValuesCount,
+      "VariableStatsEstimate",
+      "double",
+      "distinctValuesCount");
+}
+
+void from_json(const json& j, VariableStatsEstimate& p) {
+  from_json_key(
+      j, "lowValue", p.lowValue, "VariableStatsEstimate", "double", "lowValue");
+  from_json_key(
+      j,
+      "highValue",
+      p.highValue,
+      "VariableStatsEstimate",
+      "double",
+      "highValue");
+  from_json_key(
+      j,
+      "nullsFraction",
+      p.nullsFraction,
+      "VariableStatsEstimate",
+      "double",
+      "nullsFraction");
+  from_json_key(
+      j,
+      "averageRowSize",
+      p.averageRowSize,
+      "VariableStatsEstimate",
+      "double",
+      "averageRowSize");
+  from_json_key(
+      j,
+      "distinctValuesCount",
+      p.distinctValuesCount,
+      "VariableStatsEstimate",
+      "double",
+      "distinctValuesCount");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PlanNodeStatsEstimate& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "outputRowCount",
+      p.outputRowCount,
+      "PlanNodeStatsEstimate",
+      "double",
+      "outputRowCount");
+  to_json_key(
+      j,
+      "totalSize",
+      p.totalSize,
+      "PlanNodeStatsEstimate",
+      "double",
+      "totalSize");
+  to_json_key(
+      j,
+      "confident",
+      p.confident,
+      "PlanNodeStatsEstimate",
+      "bool",
+      "confident");
+  to_json_key(
+      j,
+      "variableStatistics",
+      p.variableStatistics,
+      "PlanNodeStatsEstimate",
+      "Map<VariableReferenceExpression, VariableStatsEstimate>",
+      "variableStatistics");
+}
+
+void from_json(const json& j, PlanNodeStatsEstimate& p) {
+  from_json_key(
+      j,
+      "outputRowCount",
+      p.outputRowCount,
+      "PlanNodeStatsEstimate",
+      "double",
+      "outputRowCount");
+  from_json_key(
+      j,
+      "totalSize",
+      p.totalSize,
+      "PlanNodeStatsEstimate",
+      "double",
+      "totalSize");
+  from_json_key(
+      j,
+      "confident",
+      p.confident,
+      "PlanNodeStatsEstimate",
+      "bool",
+      "confident");
+  from_json_key(
+      j,
+      "variableStatistics",
+      p.variableStatistics,
+      "PlanNodeStatsEstimate",
+      "Map<VariableReferenceExpression, VariableStatsEstimate>",
+      "variableStatistics");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+EmptySplit::EmptySplit() noexcept {
+  _type = "$empty";
+}
+
+void to_json(json& j, const EmptySplit& p) {
+  j = json::object();
+  j["@type"] = "$empty";
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "EmptySplit",
+      "ConnectorId",
+      "connectorId");
+}
+
+void from_json(const json& j, EmptySplit& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "EmptySplit",
+      "ConnectorId",
+      "connectorId");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+RemoteTransactionHandle::RemoteTransactionHandle() noexcept {
+  _type = "$remote";
+}
+
+void to_json(json& j, const RemoteTransactionHandle& p) {
+  j = json::object();
+  j["@type"] = "$remote";
+  to_json_key(
+      j, "dummy", p.dummy, "RemoteTransactionHandle", "String", "dummy");
+}
+
+void from_json(const json& j, RemoteTransactionHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j, "dummy", p.dummy, "RemoteTransactionHandle", "String", "dummy");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<BufferState, json> BufferState_enum_table[] =
+static const std::pair<RuntimeUnit, json> RuntimeUnit_enum_table[] =
     { // NOLINT: cert-err58-cpp
-        {BufferState::OPEN, "OPEN"},
-        {BufferState::NO_MORE_BUFFERS, "NO_MORE_BUFFERS"},
-        {BufferState::NO_MORE_PAGES, "NO_MORE_PAGES"},
-        {BufferState::FLUSHING, "FLUSHING"},
-        {BufferState::FINISHED, "FINISHED"},
-        {BufferState::FAILED, "FAILED"}};
-void to_json(json& j, const BufferState& e) {
+        {RuntimeUnit::NONE, "NONE"},
+        {RuntimeUnit::NANO, "NANO"},
+        {RuntimeUnit::BYTE, "BYTE"}};
+void to_json(json& j, const RuntimeUnit& e) {
   static_assert(
-      std::is_enum<BufferState>::value, "BufferState must be an enum!");
+      std::is_enum<RuntimeUnit>::value, "RuntimeUnit must be an enum!");
   const auto* it = std::find_if(
-      std::begin(BufferState_enum_table),
-      std::end(BufferState_enum_table),
-      [e](const std::pair<BufferState, json>& ej_pair) -> bool {
+      std::begin(RuntimeUnit_enum_table),
+      std::end(RuntimeUnit_enum_table),
+      [e](const std::pair<RuntimeUnit, json>& ej_pair) -> bool {
         return ej_pair.first == e;
       });
-  j = ((it != std::end(BufferState_enum_table))
+  j = ((it != std::end(RuntimeUnit_enum_table))
            ? it
-           : std::begin(BufferState_enum_table))
+           : std::begin(RuntimeUnit_enum_table))
           ->second;
 }
-void from_json(const json& j, BufferState& e) {
+void from_json(const json& j, RuntimeUnit& e) {
   static_assert(
-      std::is_enum<BufferState>::value, "BufferState must be an enum!");
+      std::is_enum<RuntimeUnit>::value, "RuntimeUnit must be an enum!");
   const auto* it = std::find_if(
-      std::begin(BufferState_enum_table),
-      std::end(BufferState_enum_table),
-      [&j](const std::pair<BufferState, json>& ej_pair) -> bool {
+      std::begin(RuntimeUnit_enum_table),
+      std::end(RuntimeUnit_enum_table),
+      [&j](const std::pair<RuntimeUnit, json>& ej_pair) -> bool {
         return ej_pair.second == j;
       });
-  e = ((it != std::end(BufferState_enum_table))
+  e = ((it != std::end(RuntimeUnit_enum_table))
            ? it
-           : std::begin(BufferState_enum_table))
+           : std::begin(RuntimeUnit_enum_table))
           ->first;
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const OutputBufferInfo& p) {
+void to_json(json& j, const RuntimeMetric& p) {
   j = json::object();
-  to_json_key(j, "type", p.type, "OutputBufferInfo", "String", "type");
-  to_json_key(j, "state", p.state, "OutputBufferInfo", "BufferState", "state");
-  to_json_key(
-      j,
-      "canAddBuffers",
-      p.canAddBuffers,
-      "OutputBufferInfo",
-      "bool",
-      "canAddBuffers");
-  to_json_key(
-      j,
-      "canAddPages",
-      p.canAddPages,
-      "OutputBufferInfo",
-      "bool",
-      "canAddPages");
-  to_json_key(
-      j,
-      "totalBufferedBytes",
-      p.totalBufferedBytes,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalBufferedBytes");
-  to_json_key(
-      j,
-      "totalBufferedPages",
-      p.totalBufferedPages,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalBufferedPages");
-  to_json_key(
-      j,
-      "totalRowsSent",
-      p.totalRowsSent,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalRowsSent");
-  to_json_key(
-      j,
-      "totalPagesSent",
-      p.totalPagesSent,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalPagesSent");
-  to_json_key(
-      j,
-      "buffers",
-      p.buffers,
-      "OutputBufferInfo",
-      "List<BufferInfo>",
-      "buffers");
+  to_json_key(j, "name", p.name, "RuntimeMetric", "String", "name");
+  to_json_key(j, "unit", p.unit, "RuntimeMetric", "RuntimeUnit", "unit");
+  to_json_key(j, "sum", p.sum, "RuntimeMetric", "int64_t", "sum");
+  to_json_key(j, "count", p.count, "RuntimeMetric", "int64_t", "count");
+  to_json_key(j, "max", p.max, "RuntimeMetric", "int64_t", "max");
+  to_json_key(j, "min", p.min, "RuntimeMetric", "int64_t", "min");
 }
 
-void from_json(const json& j, OutputBufferInfo& p) {
-  from_json_key(j, "type", p.type, "OutputBufferInfo", "String", "type");
+void from_json(const json& j, RuntimeMetric& p) {
+  from_json_key(j, "name", p.name, "RuntimeMetric", "String", "name");
+  from_json_key(j, "unit", p.unit, "RuntimeMetric", "RuntimeUnit", "unit");
+  from_json_key(j, "sum", p.sum, "RuntimeMetric", "int64_t", "sum");
+  from_json_key(j, "count", p.count, "RuntimeMetric", "int64_t", "count");
+  from_json_key(j, "max", p.max, "RuntimeMetric", "int64_t", "max");
+  from_json_key(j, "min", p.min, "RuntimeMetric", "int64_t", "min");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const Block& p) {
+  j = p.data;
+}
+
+void from_json(const json& j, Block& p) {
+  p.data = std::string(j);
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const ValueEntry& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "ValueEntry", "Type", "type");
+  to_json_key(j, "block", p.block, "ValueEntry", "Block", "block");
+}
+
+void from_json(const json& j, ValueEntry& p) {
+  from_json_key(j, "type", p.type, "ValueEntry", "Type", "type");
+  from_json_key(j, "block", p.block, "ValueEntry", "Block", "block");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+EquatableValueSet::EquatableValueSet() noexcept {
+  _type = "equatable";
+}
+
+void to_json(json& j, const EquatableValueSet& p) {
+  j = json::object();
+  j["@type"] = "equatable";
+  to_json_key(j, "type", p.type, "EquatableValueSet", "Type", "type");
+  to_json_key(
+      j, "whiteList", p.whiteList, "EquatableValueSet", "bool", "whiteList");
+  to_json_key(
+      j,
+      "entries",
+      p.entries,
+      "EquatableValueSet",
+      "List<ValueEntry>",
+      "entries");
+}
+
+void from_json(const json& j, EquatableValueSet& p) {
+  p._type = j["@type"];
+  from_json_key(j, "type", p.type, "EquatableValueSet", "Type", "type");
   from_json_key(
-      j, "state", p.state, "OutputBufferInfo", "BufferState", "state");
+      j, "whiteList", p.whiteList, "EquatableValueSet", "bool", "whiteList");
   from_json_key(
       j,
-      "canAddBuffers",
-      p.canAddBuffers,
-      "OutputBufferInfo",
-      "bool",
-      "canAddBuffers");
-  from_json_key(
-      j,
-      "canAddPages",
-      p.canAddPages,
-      "OutputBufferInfo",
-      "bool",
-      "canAddPages");
-  from_json_key(
-      j,
-      "totalBufferedBytes",
-      p.totalBufferedBytes,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalBufferedBytes");
-  from_json_key(
-      j,
-      "totalBufferedPages",
-      p.totalBufferedPages,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalBufferedPages");
-  from_json_key(
-      j,
-      "totalRowsSent",
-      p.totalRowsSent,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalRowsSent");
-  from_json_key(
-      j,
-      "totalPagesSent",
-      p.totalPagesSent,
-      "OutputBufferInfo",
-      "int64_t",
-      "totalPagesSent");
-  from_json_key(
-      j,
-      "buffers",
-      p.buffers,
-      "OutputBufferInfo",
-      "List<BufferInfo>",
-      "buffers");
+      "entries",
+      p.entries,
+      "EquatableValueSet",
+      "List<ValueEntry>",
+      "entries");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -8539,6 +7797,231 @@ void from_json(const json& j, TaskStatus& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<BufferState, json> BufferState_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {BufferState::OPEN, "OPEN"},
+        {BufferState::NO_MORE_BUFFERS, "NO_MORE_BUFFERS"},
+        {BufferState::NO_MORE_PAGES, "NO_MORE_PAGES"},
+        {BufferState::FLUSHING, "FLUSHING"},
+        {BufferState::FINISHED, "FINISHED"},
+        {BufferState::FAILED, "FAILED"}};
+void to_json(json& j, const BufferState& e) {
+  static_assert(
+      std::is_enum<BufferState>::value, "BufferState must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BufferState_enum_table),
+      std::end(BufferState_enum_table),
+      [e](const std::pair<BufferState, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(BufferState_enum_table))
+           ? it
+           : std::begin(BufferState_enum_table))
+          ->second;
+}
+void from_json(const json& j, BufferState& e) {
+  static_assert(
+      std::is_enum<BufferState>::value, "BufferState must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(BufferState_enum_table),
+      std::end(BufferState_enum_table),
+      [&j](const std::pair<BufferState, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(BufferState_enum_table))
+           ? it
+           : std::begin(BufferState_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const OutputBufferInfo& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "OutputBufferInfo", "String", "type");
+  to_json_key(j, "state", p.state, "OutputBufferInfo", "BufferState", "state");
+  to_json_key(
+      j,
+      "canAddBuffers",
+      p.canAddBuffers,
+      "OutputBufferInfo",
+      "bool",
+      "canAddBuffers");
+  to_json_key(
+      j,
+      "canAddPages",
+      p.canAddPages,
+      "OutputBufferInfo",
+      "bool",
+      "canAddPages");
+  to_json_key(
+      j,
+      "totalBufferedBytes",
+      p.totalBufferedBytes,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalBufferedBytes");
+  to_json_key(
+      j,
+      "totalBufferedPages",
+      p.totalBufferedPages,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalBufferedPages");
+  to_json_key(
+      j,
+      "totalRowsSent",
+      p.totalRowsSent,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalRowsSent");
+  to_json_key(
+      j,
+      "totalPagesSent",
+      p.totalPagesSent,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalPagesSent");
+  to_json_key(
+      j,
+      "buffers",
+      p.buffers,
+      "OutputBufferInfo",
+      "List<BufferInfo>",
+      "buffers");
+}
+
+void from_json(const json& j, OutputBufferInfo& p) {
+  from_json_key(j, "type", p.type, "OutputBufferInfo", "String", "type");
+  from_json_key(
+      j, "state", p.state, "OutputBufferInfo", "BufferState", "state");
+  from_json_key(
+      j,
+      "canAddBuffers",
+      p.canAddBuffers,
+      "OutputBufferInfo",
+      "bool",
+      "canAddBuffers");
+  from_json_key(
+      j,
+      "canAddPages",
+      p.canAddPages,
+      "OutputBufferInfo",
+      "bool",
+      "canAddPages");
+  from_json_key(
+      j,
+      "totalBufferedBytes",
+      p.totalBufferedBytes,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalBufferedBytes");
+  from_json_key(
+      j,
+      "totalBufferedPages",
+      p.totalBufferedPages,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalBufferedPages");
+  from_json_key(
+      j,
+      "totalRowsSent",
+      p.totalRowsSent,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalRowsSent");
+  from_json_key(
+      j,
+      "totalPagesSent",
+      p.totalPagesSent,
+      "OutputBufferInfo",
+      "int64_t",
+      "totalPagesSent");
+  from_json_key(
+      j,
+      "buffers",
+      p.buffers,
+      "OutputBufferInfo",
+      "List<BufferInfo>",
+      "buffers");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveMetadataUpdateHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorMetadataUpdateHandle");
+}
+
+void from_json(
+    const json& j,
+    std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(std::string(e.what()) + " ConnectorMetadataUpdateHandle");
+  }
+
+  if (getConnectorKey(type) == "hive") {
+    auto k = std::make_shared<HiveMetadataUpdateHandle>();
+    j.get_to(*k);
+    p = k;
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorMetadataUpdateHandle");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const MetadataUpdates& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "MetadataUpdates",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "metadataUpdates",
+      p.metadataUpdates,
+      "MetadataUpdates",
+      "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
+      "metadataUpdates");
+}
+
+void from_json(const json& j, MetadataUpdates& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "MetadataUpdates",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "metadataUpdates",
+      p.metadataUpdates,
+      "MetadataUpdates",
+      "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
+      "metadataUpdates");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 
 void to_json(json& j, const TaskInfo& p) {
   j = json::object();
@@ -8616,490 +8099,491 @@ void from_json(const json& j, TaskInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-TableWriterNode::TableWriterNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.TableWriterNode";
-}
 
-void to_json(json& j, const TableWriterNode& p) {
+void to_json(json& j, const MemoryAllocation& p) {
   j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.TableWriterNode";
-  to_json_key(j, "id", p.id, "TableWriterNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "TableWriterNode", "PlanNode", "source");
+  to_json_key(j, "tag", p.tag, "MemoryAllocation", "String", "tag");
   to_json_key(
       j,
-      "rowCountVariable",
-      p.rowCountVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "rowCountVariable");
-  to_json_key(
-      j,
-      "fragmentVariable",
-      p.fragmentVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "fragmentVariable");
-  to_json_key(
-      j,
-      "tableCommitContextVariable",
-      p.tableCommitContextVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "tableCommitContextVariable");
-  to_json_key(
-      j,
-      "columns",
-      p.columns,
-      "TableWriterNode",
-      "List<VariableReferenceExpression>",
-      "columns");
-  to_json_key(
-      j,
-      "columnNames",
-      p.columnNames,
-      "TableWriterNode",
-      "List<String>",
-      "columnNames");
-  to_json_key(
-      j,
-      "notNullColumnVariables",
-      p.notNullColumnVariables,
-      "TableWriterNode",
-      "List<VariableReferenceExpression>",
-      "notNullColumnVariables");
-  to_json_key(
-      j,
-      "partitioningScheme",
-      p.partitioningScheme,
-      "TableWriterNode",
-      "PartitioningScheme",
-      "partitioningScheme");
-  to_json_key(
-      j,
-      "preferredShufflePartitioningScheme",
-      p.preferredShufflePartitioningScheme,
-      "TableWriterNode",
-      "PartitioningScheme",
-      "preferredShufflePartitioningScheme");
+      "allocation",
+      p.allocation,
+      "MemoryAllocation",
+      "int64_t",
+      "allocation");
 }
 
-void from_json(const json& j, TableWriterNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "TableWriterNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "TableWriterNode", "PlanNode", "source");
+void from_json(const json& j, MemoryAllocation& p) {
+  from_json_key(j, "tag", p.tag, "MemoryAllocation", "String", "tag");
   from_json_key(
       j,
-      "rowCountVariable",
-      p.rowCountVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "rowCountVariable");
-  from_json_key(
-      j,
-      "fragmentVariable",
-      p.fragmentVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "fragmentVariable");
-  from_json_key(
-      j,
-      "tableCommitContextVariable",
-      p.tableCommitContextVariable,
-      "TableWriterNode",
-      "VariableReferenceExpression",
-      "tableCommitContextVariable");
-  from_json_key(
-      j,
-      "columns",
-      p.columns,
-      "TableWriterNode",
-      "List<VariableReferenceExpression>",
-      "columns");
-  from_json_key(
-      j,
-      "columnNames",
-      p.columnNames,
-      "TableWriterNode",
-      "List<String>",
-      "columnNames");
-  from_json_key(
-      j,
-      "notNullColumnVariables",
-      p.notNullColumnVariables,
-      "TableWriterNode",
-      "List<VariableReferenceExpression>",
-      "notNullColumnVariables");
-  from_json_key(
-      j,
-      "partitioningScheme",
-      p.partitioningScheme,
-      "TableWriterNode",
-      "PartitioningScheme",
-      "partitioningScheme");
-  from_json_key(
-      j,
-      "preferredShufflePartitioningScheme",
-      p.preferredShufflePartitioningScheme,
-      "TableWriterNode",
-      "PartitioningScheme",
-      "preferredShufflePartitioningScheme");
+      "allocation",
+      p.allocation,
+      "MemoryAllocation",
+      "int64_t",
+      "allocation");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-TableScanNode::TableScanNode() noexcept {
-  _type = ".TableScanNode";
-}
 
-void to_json(json& j, const TableScanNode& p) {
+void to_json(json& j, const MemoryPoolInfo& p) {
   j = json::object();
-  j["@type"] = ".TableScanNode";
-  to_json_key(j, "id", p.id, "TableScanNode", "PlanNodeId", "id");
-  to_json_key(j, "table", p.table, "TableScanNode", "TableHandle", "table");
+  to_json_key(
+      j, "maxBytes", p.maxBytes, "MemoryPoolInfo", "int64_t", "maxBytes");
   to_json_key(
       j,
-      "outputVariables",
-      p.outputVariables,
-      "TableScanNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
+      "reservedBytes",
+      p.reservedBytes,
+      "MemoryPoolInfo",
+      "int64_t",
+      "reservedBytes");
   to_json_key(
       j,
-      "assignments",
-      p.assignments,
-      "TableScanNode",
-      "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
-      "assignments");
+      "reservedRevocableBytes",
+      p.reservedRevocableBytes,
+      "MemoryPoolInfo",
+      "int64_t",
+      "reservedRevocableBytes");
+  to_json_key(
+      j,
+      "queryMemoryReservations",
+      p.queryMemoryReservations,
+      "MemoryPoolInfo",
+      "Map<QueryId, Long>",
+      "queryMemoryReservations");
+  to_json_key(
+      j,
+      "queryMemoryAllocations",
+      p.queryMemoryAllocations,
+      "MemoryPoolInfo",
+      "Map<QueryId, List<MemoryAllocation>>",
+      "queryMemoryAllocations");
+  to_json_key(
+      j,
+      "queryMemoryRevocableReservations",
+      p.queryMemoryRevocableReservations,
+      "MemoryPoolInfo",
+      "Map<QueryId, Long>",
+      "queryMemoryRevocableReservations");
 }
 
-void from_json(const json& j, TableScanNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "TableScanNode", "PlanNodeId", "id");
-  from_json_key(j, "table", p.table, "TableScanNode", "TableHandle", "table");
+void from_json(const json& j, MemoryPoolInfo& p) {
+  from_json_key(
+      j, "maxBytes", p.maxBytes, "MemoryPoolInfo", "int64_t", "maxBytes");
   from_json_key(
       j,
-      "outputVariables",
-      p.outputVariables,
-      "TableScanNode",
-      "List<VariableReferenceExpression>",
-      "outputVariables");
+      "reservedBytes",
+      p.reservedBytes,
+      "MemoryPoolInfo",
+      "int64_t",
+      "reservedBytes");
   from_json_key(
       j,
-      "assignments",
-      p.assignments,
-      "TableScanNode",
-      "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
-      "assignments");
+      "reservedRevocableBytes",
+      p.reservedRevocableBytes,
+      "MemoryPoolInfo",
+      "int64_t",
+      "reservedRevocableBytes");
+  from_json_key(
+      j,
+      "queryMemoryReservations",
+      p.queryMemoryReservations,
+      "MemoryPoolInfo",
+      "Map<QueryId, Long>",
+      "queryMemoryReservations");
+  from_json_key(
+      j,
+      "queryMemoryAllocations",
+      p.queryMemoryAllocations,
+      "MemoryPoolInfo",
+      "Map<QueryId, List<MemoryAllocation>>",
+      "queryMemoryAllocations");
+  from_json_key(
+      j,
+      "queryMemoryRevocableReservations",
+      p.queryMemoryRevocableReservations,
+      "MemoryPoolInfo",
+      "Map<QueryId, Long>",
+      "queryMemoryRevocableReservations");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-AllOrNoneValueSet::AllOrNoneValueSet() noexcept {
-  _type = "allOrNone";
-}
 
-void to_json(json& j, const AllOrNoneValueSet& p) {
+void to_json(json& j, const MemoryInfo& p) {
   j = json::object();
-  j["@type"] = "allOrNone";
-  to_json_key(j, "type", p.type, "AllOrNoneValueSet", "Type", "type");
-  to_json_key(j, "all", p.all, "AllOrNoneValueSet", "bool", "all");
+  to_json_key(
+      j,
+      "totalNodeMemory",
+      p.totalNodeMemory,
+      "MemoryInfo",
+      "DataSize",
+      "totalNodeMemory");
+  to_json_key(
+      j,
+      "pools",
+      p.pools,
+      "MemoryInfo",
+      "Map<MemoryPoolId, MemoryPoolInfo>",
+      "pools");
 }
 
-void from_json(const json& j, AllOrNoneValueSet& p) {
-  p._type = j["@type"];
-  from_json_key(j, "type", p.type, "AllOrNoneValueSet", "Type", "type");
-  from_json_key(j, "all", p.all, "AllOrNoneValueSet", "bool", "all");
+void from_json(const json& j, MemoryInfo& p) {
+  from_json_key(
+      j,
+      "totalNodeMemory",
+      p.totalNodeMemory,
+      "MemoryInfo",
+      "DataSize",
+      "totalNodeMemory");
+  from_json_key(
+      j,
+      "pools",
+      p.pools,
+      "MemoryInfo",
+      "Map<MemoryPoolId, MemoryPoolInfo>",
+      "pools");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const NodeVersion& p) {
+  j = json::object();
+  to_json_key(j, "version", p.version, "NodeVersion", "String", "version");
+}
+
+void from_json(const json& j, NodeVersion& p) {
+  from_json_key(j, "version", p.version, "NodeVersion", "String", "version");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const NodeStatus& p) {
+  j = json::object();
+  to_json_key(j, "nodeId", p.nodeId, "NodeStatus", "String", "nodeId");
+  to_json_key(
+      j,
+      "nodeVersion",
+      p.nodeVersion,
+      "NodeStatus",
+      "NodeVersion",
+      "nodeVersion");
+  to_json_key(
+      j, "environment", p.environment, "NodeStatus", "String", "environment");
+  to_json_key(
+      j, "coordinator", p.coordinator, "NodeStatus", "bool", "coordinator");
+  to_json_key(j, "uptime", p.uptime, "NodeStatus", "Duration", "uptime");
+  to_json_key(
+      j,
+      "externalAddress",
+      p.externalAddress,
+      "NodeStatus",
+      "String",
+      "externalAddress");
+  to_json_key(
+      j,
+      "internalAddress",
+      p.internalAddress,
+      "NodeStatus",
+      "String",
+      "internalAddress");
+  to_json_key(
+      j, "memoryInfo", p.memoryInfo, "NodeStatus", "MemoryInfo", "memoryInfo");
+  to_json_key(j, "processors", p.processors, "NodeStatus", "int", "processors");
+  to_json_key(
+      j,
+      "processCpuLoad",
+      p.processCpuLoad,
+      "NodeStatus",
+      "double",
+      "processCpuLoad");
+  to_json_key(
+      j,
+      "systemCpuLoad",
+      p.systemCpuLoad,
+      "NodeStatus",
+      "double",
+      "systemCpuLoad");
+  to_json_key(j, "heapUsed", p.heapUsed, "NodeStatus", "int64_t", "heapUsed");
+  to_json_key(
+      j,
+      "heapAvailable",
+      p.heapAvailable,
+      "NodeStatus",
+      "int64_t",
+      "heapAvailable");
+  to_json_key(
+      j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+}
+
+void from_json(const json& j, NodeStatus& p) {
+  from_json_key(j, "nodeId", p.nodeId, "NodeStatus", "String", "nodeId");
+  from_json_key(
+      j,
+      "nodeVersion",
+      p.nodeVersion,
+      "NodeStatus",
+      "NodeVersion",
+      "nodeVersion");
+  from_json_key(
+      j, "environment", p.environment, "NodeStatus", "String", "environment");
+  from_json_key(
+      j, "coordinator", p.coordinator, "NodeStatus", "bool", "coordinator");
+  from_json_key(j, "uptime", p.uptime, "NodeStatus", "Duration", "uptime");
+  from_json_key(
+      j,
+      "externalAddress",
+      p.externalAddress,
+      "NodeStatus",
+      "String",
+      "externalAddress");
+  from_json_key(
+      j,
+      "internalAddress",
+      p.internalAddress,
+      "NodeStatus",
+      "String",
+      "internalAddress");
+  from_json_key(
+      j, "memoryInfo", p.memoryInfo, "NodeStatus", "MemoryInfo", "memoryInfo");
+  from_json_key(
+      j, "processors", p.processors, "NodeStatus", "int", "processors");
+  from_json_key(
+      j,
+      "processCpuLoad",
+      p.processCpuLoad,
+      "NodeStatus",
+      "double",
+      "processCpuLoad");
+  from_json_key(
+      j,
+      "systemCpuLoad",
+      p.systemCpuLoad,
+      "NodeStatus",
+      "double",
+      "systemCpuLoad");
+  from_json_key(j, "heapUsed", p.heapUsed, "NodeStatus", "int64_t", "heapUsed");
+  from_json_key(
+      j,
+      "heapAvailable",
+      p.heapAvailable,
+      "NodeStatus",
+      "int64_t",
+      "heapAvailable");
+  from_json_key(
+      j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PlanCostEstimate& p) {
+  j = json::object();
+  to_json_key(j, "cpuCost", p.cpuCost, "PlanCostEstimate", "double", "cpuCost");
+  to_json_key(
+      j, "maxMemory", p.maxMemory, "PlanCostEstimate", "double", "maxMemory");
+  to_json_key(
+      j,
+      "maxMemoryWhenOutputting",
+      p.maxMemoryWhenOutputting,
+      "PlanCostEstimate",
+      "double",
+      "maxMemoryWhenOutputting");
+  to_json_key(
+      j,
+      "networkCost",
+      p.networkCost,
+      "PlanCostEstimate",
+      "double",
+      "networkCost");
+}
+
+void from_json(const json& j, PlanCostEstimate& p) {
+  from_json_key(
+      j, "cpuCost", p.cpuCost, "PlanCostEstimate", "double", "cpuCost");
+  from_json_key(
+      j, "maxMemory", p.maxMemory, "PlanCostEstimate", "double", "maxMemory");
+  from_json_key(
+      j,
+      "maxMemoryWhenOutputting",
+      p.maxMemoryWhenOutputting,
+      "PlanCostEstimate",
+      "double",
+      "maxMemoryWhenOutputting");
+  from_json_key(
+      j,
+      "networkCost",
+      p.networkCost,
+      "PlanCostEstimate",
+      "double",
+      "networkCost");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const StatsAndCosts& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "stats",
+      p.stats,
+      "StatsAndCosts",
+      "Map<PlanNodeId, PlanNodeStatsEstimate>",
+      "stats");
+  to_json_key(
+      j,
+      "costs",
+      p.costs,
+      "StatsAndCosts",
+      "Map<PlanNodeId, PlanCostEstimate>",
+      "costs");
+}
+
+void from_json(const json& j, StatsAndCosts& p) {
+  from_json_key(
+      j,
+      "stats",
+      p.stats,
+      "StatsAndCosts",
+      "Map<PlanNodeId, PlanNodeStatsEstimate>",
+      "stats");
+  from_json_key(
+      j,
+      "costs",
+      p.costs,
+      "StatsAndCosts",
+      "Map<PlanNodeId, PlanCostEstimate>",
+      "costs");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<AggregationNodeStep, json>
-    AggregationNodeStep_enum_table[] = { // NOLINT: cert-err58-cpp
-        {AggregationNodeStep::PARTIAL, "PARTIAL"},
-        {AggregationNodeStep::FINAL, "FINAL"},
-        {AggregationNodeStep::INTERMEDIATE, "INTERMEDIATE"},
-        {AggregationNodeStep::SINGLE, "SINGLE"}};
-void to_json(json& j, const AggregationNodeStep& e) {
-  static_assert(
-      std::is_enum<AggregationNodeStep>::value,
-      "AggregationNodeStep must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(AggregationNodeStep_enum_table),
-      std::end(AggregationNodeStep_enum_table),
-      [e](const std::pair<AggregationNodeStep, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(AggregationNodeStep_enum_table))
-           ? it
-           : std::begin(AggregationNodeStep_enum_table))
-          ->second;
-}
-void from_json(const json& j, AggregationNodeStep& e) {
-  static_assert(
-      std::is_enum<AggregationNodeStep>::value,
-      "AggregationNodeStep must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(AggregationNodeStep_enum_table),
-      std::end(AggregationNodeStep_enum_table),
-      [&j](const std::pair<AggregationNodeStep, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(AggregationNodeStep_enum_table))
-           ? it
-           : std::begin(AggregationNodeStep_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const GroupingSetDescriptor& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "groupingKeys",
-      p.groupingKeys,
-      "GroupingSetDescriptor",
-      "List<VariableReferenceExpression>",
-      "groupingKeys");
-  to_json_key(
-      j,
-      "groupingSetCount",
-      p.groupingSetCount,
-      "GroupingSetDescriptor",
-      "int",
-      "groupingSetCount");
-  to_json_key(
-      j,
-      "globalGroupingSets",
-      p.globalGroupingSets,
-      "GroupingSetDescriptor",
-      "List<Integer>",
-      "globalGroupingSets");
-}
-
-void from_json(const json& j, GroupingSetDescriptor& p) {
-  from_json_key(
-      j,
-      "groupingKeys",
-      p.groupingKeys,
-      "GroupingSetDescriptor",
-      "List<VariableReferenceExpression>",
-      "groupingKeys");
-  from_json_key(
-      j,
-      "groupingSetCount",
-      p.groupingSetCount,
-      "GroupingSetDescriptor",
-      "int",
-      "groupingSetCount");
-  from_json_key(
-      j,
-      "globalGroupingSets",
-      p.globalGroupingSets,
-      "GroupingSetDescriptor",
-      "List<Integer>",
-      "globalGroupingSets");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-AggregationNode::AggregationNode() noexcept {
-  _type = ".AggregationNode";
-}
-
-void to_json(json& j, const AggregationNode& p) {
-  j = json::object();
-  j["@type"] = ".AggregationNode";
-  to_json_key(j, "id", p.id, "AggregationNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "AggregationNode", "PlanNode", "source");
-  to_json_key(
-      j,
-      "aggregations",
-      p.aggregations,
-      "AggregationNode",
-      "Map<VariableReferenceExpression, Aggregation>",
-      "aggregations");
-  to_json_key(
-      j,
-      "groupingSets",
-      p.groupingSets,
-      "AggregationNode",
-      "GroupingSetDescriptor",
-      "groupingSets");
-  to_json_key(
-      j,
-      "preGroupedVariables",
-      p.preGroupedVariables,
-      "AggregationNode",
-      "List<VariableReferenceExpression>",
-      "preGroupedVariables");
-  to_json_key(
-      j, "step", p.step, "AggregationNode", "AggregationNodeStep", "step");
-  to_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "AggregationNode",
-      "VariableReferenceExpression",
-      "hashVariable");
-  to_json_key(
-      j,
-      "groupIdVariable",
-      p.groupIdVariable,
-      "AggregationNode",
-      "VariableReferenceExpression",
-      "groupIdVariable");
-}
-
-void from_json(const json& j, AggregationNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "AggregationNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "AggregationNode", "PlanNode", "source");
-  from_json_key(
-      j,
-      "aggregations",
-      p.aggregations,
-      "AggregationNode",
-      "Map<VariableReferenceExpression, Aggregation>",
-      "aggregations");
-  from_json_key(
-      j,
-      "groupingSets",
-      p.groupingSets,
-      "AggregationNode",
-      "GroupingSetDescriptor",
-      "groupingSets");
-  from_json_key(
-      j,
-      "preGroupedVariables",
-      p.preGroupedVariables,
-      "AggregationNode",
-      "List<VariableReferenceExpression>",
-      "preGroupedVariables");
-  from_json_key(
-      j, "step", p.step, "AggregationNode", "AggregationNodeStep", "step");
-  from_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "AggregationNode",
-      "VariableReferenceExpression",
-      "hashVariable");
-  from_json_key(
-      j,
-      "groupIdVariable",
-      p.groupIdVariable,
-      "AggregationNode",
-      "VariableReferenceExpression",
-      "groupIdVariable");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ValueSet>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-
-  if (type == "equatable") {
-    j = *std::static_pointer_cast<EquatableValueSet>(p);
-    return;
-  }
-  if (type == "sortable") {
-    j = *std::static_pointer_cast<SortedRangeSet>(p);
-    return;
-  }
-  if (type == "allOrNone") {
-    j = *std::static_pointer_cast<AllOrNoneValueSet>(p);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ValueSet ");
-}
-
-void from_json(const json& j, std::shared_ptr<ValueSet>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(std::string(e.what()) + " ValueSet  ValueSet");
-  }
-
-  if (type == "equatable") {
-    std::shared_ptr<EquatableValueSet> k =
-        std::make_shared<EquatableValueSet>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ValueSet>(k);
-    return;
-  }
-  if (type == "sortable") {
-    std::shared_ptr<SortedRangeSet> k = std::make_shared<SortedRangeSet>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ValueSet>(k);
-    return;
-  }
-  if (type == "allOrNone") {
-    std::shared_ptr<AllOrNoneValueSet> k =
-        std::make_shared<AllOrNoneValueSet>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ValueSet>(k);
-    return;
-  }
-
-  throw TypeError(type + " no abstract type ValueSet ");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const Domain& p) {
-  j = json::object();
-  to_json_key(j, "values", p.values, "Domain", "ValueSet", "values");
-  to_json_key(j, "nullAllowed", p.nullAllowed, "Domain", "bool", "nullAllowed");
-}
-
-void from_json(const json& j, Domain& p) {
-  from_json_key(j, "values", p.values, "Domain", "ValueSet", "values");
-  from_json_key(
-      j, "nullAllowed", p.nullAllowed, "Domain", "bool", "nullAllowed");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<ExchangeNodeScope, json> ExchangeNodeScope_enum_table[] =
+static const std::pair<LimitNodeStep, json> LimitNodeStep_enum_table[] =
     { // NOLINT: cert-err58-cpp
-        {ExchangeNodeScope::LOCAL, "LOCAL"},
-        {ExchangeNodeScope::REMOTE_STREAMING, "REMOTE_STREAMING"},
-        {ExchangeNodeScope::REMOTE_MATERIALIZED, "REMOTE_MATERIALIZED"}};
-void to_json(json& j, const ExchangeNodeScope& e) {
+        {LimitNodeStep::PARTIAL, "PARTIAL"},
+        {LimitNodeStep::FINAL, "FINAL"}};
+void to_json(json& j, const LimitNodeStep& e) {
   static_assert(
-      std::is_enum<ExchangeNodeScope>::value,
-      "ExchangeNodeScope must be an enum!");
+      std::is_enum<LimitNodeStep>::value, "LimitNodeStep must be an enum!");
   const auto* it = std::find_if(
-      std::begin(ExchangeNodeScope_enum_table),
-      std::end(ExchangeNodeScope_enum_table),
-      [e](const std::pair<ExchangeNodeScope, json>& ej_pair) -> bool {
+      std::begin(LimitNodeStep_enum_table),
+      std::end(LimitNodeStep_enum_table),
+      [e](const std::pair<LimitNodeStep, json>& ej_pair) -> bool {
         return ej_pair.first == e;
       });
-  j = ((it != std::end(ExchangeNodeScope_enum_table))
+  j = ((it != std::end(LimitNodeStep_enum_table))
            ? it
-           : std::begin(ExchangeNodeScope_enum_table))
+           : std::begin(LimitNodeStep_enum_table))
           ->second;
 }
-void from_json(const json& j, ExchangeNodeScope& e) {
+void from_json(const json& j, LimitNodeStep& e) {
   static_assert(
-      std::is_enum<ExchangeNodeScope>::value,
-      "ExchangeNodeScope must be an enum!");
+      std::is_enum<LimitNodeStep>::value, "LimitNodeStep must be an enum!");
   const auto* it = std::find_if(
-      std::begin(ExchangeNodeScope_enum_table),
-      std::end(ExchangeNodeScope_enum_table),
-      [&j](const std::pair<ExchangeNodeScope, json>& ej_pair) -> bool {
+      std::begin(LimitNodeStep_enum_table),
+      std::end(LimitNodeStep_enum_table),
+      [&j](const std::pair<LimitNodeStep, json>& ej_pair) -> bool {
         return ej_pair.second == j;
       });
-  e = ((it != std::end(ExchangeNodeScope_enum_table))
+  e = ((it != std::end(LimitNodeStep_enum_table))
            ? it
-           : std::begin(ExchangeNodeScope_enum_table))
+           : std::begin(LimitNodeStep_enum_table))
           ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+LimitNode::LimitNode() noexcept {
+  _type = ".LimitNode";
+}
+
+void to_json(json& j, const LimitNode& p) {
+  j = json::object();
+  j["@type"] = ".LimitNode";
+  to_json_key(j, "id", p.id, "LimitNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "LimitNode", "PlanNode", "source");
+  to_json_key(j, "count", p.count, "LimitNode", "int64_t", "count");
+  to_json_key(j, "step", p.step, "LimitNode", "LimitNodeStep", "step");
+}
+
+void from_json(const json& j, LimitNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "LimitNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "LimitNode", "PlanNode", "source");
+  from_json_key(j, "count", p.count, "LimitNode", "int64_t", "count");
+  from_json_key(j, "step", p.step, "LimitNode", "LimitNodeStep", "step");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+HivePartitioningHandle::HivePartitioningHandle() noexcept {
+  _type = "hive";
+}
+
+void to_json(json& j, const HivePartitioningHandle& p) {
+  j = json::object();
+  j["@type"] = "hive";
+  to_json_key(
+      j,
+      "bucketCount",
+      p.bucketCount,
+      "HivePartitioningHandle",
+      "int",
+      "bucketCount");
+  to_json_key(
+      j,
+      "maxCompatibleBucketCount",
+      p.maxCompatibleBucketCount,
+      "HivePartitioningHandle",
+      "int",
+      "maxCompatibleBucketCount");
+  to_json_key(
+      j,
+      "bucketFunctionType",
+      p.bucketFunctionType,
+      "HivePartitioningHandle",
+      "BucketFunctionType",
+      "bucketFunctionType");
+  to_json_key(
+      j,
+      "hiveTypes",
+      p.hiveTypes,
+      "HivePartitioningHandle",
+      "List<HiveType>",
+      "hiveTypes");
+  to_json_key(
+      j, "types", p.types, "HivePartitioningHandle", "List<Type>", "types");
+}
+
+void from_json(const json& j, HivePartitioningHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "bucketCount",
+      p.bucketCount,
+      "HivePartitioningHandle",
+      "int",
+      "bucketCount");
+  from_json_key(
+      j,
+      "maxCompatibleBucketCount",
+      p.maxCompatibleBucketCount,
+      "HivePartitioningHandle",
+      "int",
+      "maxCompatibleBucketCount");
+  from_json_key(
+      j,
+      "bucketFunctionType",
+      p.bucketFunctionType,
+      "HivePartitioningHandle",
+      "BucketFunctionType",
+      "bucketFunctionType");
+  from_json_key(
+      j,
+      "hiveTypes",
+      p.hiveTypes,
+      "HivePartitioningHandle",
+      "List<HiveType>",
+      "hiveTypes");
+  from_json_key(
+      j, "types", p.types, "HivePartitioningHandle", "List<Type>", "types");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -9140,6 +8624,46 @@ void from_json(const json& j, ExchangeNodeType& e) {
   e = ((it != std::end(ExchangeNodeType_enum_table))
            ? it
            : std::begin(ExchangeNodeType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<ExchangeNodeScope, json> ExchangeNodeScope_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {ExchangeNodeScope::LOCAL, "LOCAL"},
+        {ExchangeNodeScope::REMOTE_STREAMING, "REMOTE_STREAMING"},
+        {ExchangeNodeScope::REMOTE_MATERIALIZED, "REMOTE_MATERIALIZED"}};
+void to_json(json& j, const ExchangeNodeScope& e) {
+  static_assert(
+      std::is_enum<ExchangeNodeScope>::value,
+      "ExchangeNodeScope must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ExchangeNodeScope_enum_table),
+      std::end(ExchangeNodeScope_enum_table),
+      [e](const std::pair<ExchangeNodeScope, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(ExchangeNodeScope_enum_table))
+           ? it
+           : std::begin(ExchangeNodeScope_enum_table))
+          ->second;
+}
+void from_json(const json& j, ExchangeNodeScope& e) {
+  static_assert(
+      std::is_enum<ExchangeNodeScope>::value,
+      "ExchangeNodeScope must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ExchangeNodeScope_enum_table),
+      std::end(ExchangeNodeScope_enum_table),
+      [&j](const std::pair<ExchangeNodeScope, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(ExchangeNodeScope_enum_table))
+           ? it
+           : std::begin(ExchangeNodeScope_enum_table))
           ->first;
 }
 } // namespace facebook::presto::protocol
@@ -9236,21 +8760,89 @@ void from_json(const json& j, ExchangeNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-RemoteTransactionHandle::RemoteTransactionHandle() noexcept {
-  _type = "$remote";
+RemoteSourceNode::RemoteSourceNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.RemoteSourceNode";
 }
 
-void to_json(json& j, const RemoteTransactionHandle& p) {
+void to_json(json& j, const RemoteSourceNode& p) {
   j = json::object();
-  j["@type"] = "$remote";
+  j["@type"] = "com.facebook.presto.sql.planner.plan.RemoteSourceNode";
+  to_json_key(j, "id", p.id, "RemoteSourceNode", "PlanNodeId", "id");
   to_json_key(
-      j, "dummy", p.dummy, "RemoteTransactionHandle", "String", "dummy");
+      j,
+      "sourceFragmentIds",
+      p.sourceFragmentIds,
+      "RemoteSourceNode",
+      "List<PlanFragmentId>",
+      "sourceFragmentIds");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "RemoteSourceNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  to_json_key(
+      j,
+      "ensureSourceOrdering",
+      p.ensureSourceOrdering,
+      "RemoteSourceNode",
+      "bool",
+      "ensureSourceOrdering");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "RemoteSourceNode",
+      "OrderingScheme",
+      "orderingScheme");
+  to_json_key(
+      j,
+      "exchangeType",
+      p.exchangeType,
+      "RemoteSourceNode",
+      "ExchangeNodeType",
+      "exchangeType");
 }
 
-void from_json(const json& j, RemoteTransactionHandle& p) {
+void from_json(const json& j, RemoteSourceNode& p) {
   p._type = j["@type"];
+  from_json_key(j, "id", p.id, "RemoteSourceNode", "PlanNodeId", "id");
   from_json_key(
-      j, "dummy", p.dummy, "RemoteTransactionHandle", "String", "dummy");
+      j,
+      "sourceFragmentIds",
+      p.sourceFragmentIds,
+      "RemoteSourceNode",
+      "List<PlanFragmentId>",
+      "sourceFragmentIds");
+  from_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "RemoteSourceNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  from_json_key(
+      j,
+      "ensureSourceOrdering",
+      p.ensureSourceOrdering,
+      "RemoteSourceNode",
+      "bool",
+      "ensureSourceOrdering");
+  from_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "RemoteSourceNode",
+      "OrderingScheme",
+      "orderingScheme");
+  from_json_key(
+      j,
+      "exchangeType",
+      p.exchangeType,
+      "RemoteSourceNode",
+      "ExchangeNodeType",
+      "exchangeType");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -9289,531 +8881,298 @@ void from_json(const json& j, ServerInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+CreateHandle::CreateHandle() noexcept {
+  _type = "CreateHandle";
+}
 
-void to_json(json& j, const HiveBucketFilter& p) {
+void to_json(json& j, const CreateHandle& p) {
   j = json::object();
+  j["@type"] = "CreateHandle";
   to_json_key(
-      j,
-      "bucketsToKeep",
-      p.bucketsToKeep,
-      "HiveBucketFilter",
-      "List<Integer>",
-      "bucketsToKeep");
-}
-
-void from_json(const json& j, HiveBucketFilter& p) {
-  from_json_key(
-      j,
-      "bucketsToKeep",
-      p.bucketsToKeep,
-      "HiveBucketFilter",
-      "List<Integer>",
-      "bucketsToKeep");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const HiveBucketHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "columns",
-      p.columns,
-      "HiveBucketHandle",
-      "List<HiveColumnHandle>",
-      "columns");
-  to_json_key(
-      j,
-      "tableBucketCount",
-      p.tableBucketCount,
-      "HiveBucketHandle",
-      "int",
-      "tableBucketCount");
-  to_json_key(
-      j,
-      "readBucketCount",
-      p.readBucketCount,
-      "HiveBucketHandle",
-      "int",
-      "readBucketCount");
-}
-
-void from_json(const json& j, HiveBucketHandle& p) {
-  from_json_key(
-      j,
-      "columns",
-      p.columns,
-      "HiveBucketHandle",
-      "List<HiveColumnHandle>",
-      "columns");
-  from_json_key(
-      j,
-      "tableBucketCount",
-      p.tableBucketCount,
-      "HiveBucketHandle",
-      "int",
-      "tableBucketCount");
-  from_json_key(
-      j,
-      "readBucketCount",
-      p.readBucketCount,
-      "HiveBucketHandle",
-      "int",
-      "readBucketCount");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-HiveTableLayoutHandle::HiveTableLayoutHandle() noexcept {
-  _type = "hive";
-}
-
-void to_json(json& j, const HiveTableLayoutHandle& p) {
-  j = json::object();
-  j["@type"] = "hive";
+      j, "handle", p.handle, "CreateHandle", "OutputTableHandle", "handle");
   to_json_key(
       j,
       "schemaTableName",
       p.schemaTableName,
-      "HiveTableLayoutHandle",
+      "CreateHandle",
       "SchemaTableName",
       "schemaTableName");
-  to_json_key(
-      j,
-      "tablePath",
-      p.tablePath,
-      "HiveTableLayoutHandle",
-      "String",
-      "tablePath");
-  to_json_key(
-      j,
-      "partitionColumns",
-      p.partitionColumns,
-      "HiveTableLayoutHandle",
-      "List<HiveColumnHandle>",
-      "partitionColumns");
-  to_json_key(
-      j,
-      "dataColumns",
-      p.dataColumns,
-      "HiveTableLayoutHandle",
-      "List<Column>",
-      "dataColumns");
-  to_json_key(
-      j,
-      "tableParameters",
-      p.tableParameters,
-      "HiveTableLayoutHandle",
-      "Map<String, String>",
-      "tableParameters");
-  to_json_key(
-      j,
-      "domainPredicate",
-      p.domainPredicate,
-      "HiveTableLayoutHandle",
-      "TupleDomain<Subfield>",
-      "domainPredicate");
-  to_json_key(
-      j,
-      "remainingPredicate",
-      p.remainingPredicate,
-      "HiveTableLayoutHandle",
-      "RowExpression",
-      "remainingPredicate");
-  to_json_key(
-      j,
-      "predicateColumns",
-      p.predicateColumns,
-      "HiveTableLayoutHandle",
-      "Map<String, HiveColumnHandle>",
-      "predicateColumns");
-  to_json_key(
-      j,
-      "partitionColumnPredicate",
-      p.partitionColumnPredicate,
-      "HiveTableLayoutHandle",
-      "TupleDomain<std::shared_ptr<ColumnHandle>>",
-      "partitionColumnPredicate");
-  to_json_key(
-      j,
-      "bucketHandle",
-      p.bucketHandle,
-      "HiveTableLayoutHandle",
-      "HiveBucketHandle",
-      "bucketHandle");
-  to_json_key(
-      j,
-      "bucketFilter",
-      p.bucketFilter,
-      "HiveTableLayoutHandle",
-      "HiveBucketFilter",
-      "bucketFilter");
-  to_json_key(
-      j,
-      "pushdownFilterEnabled",
-      p.pushdownFilterEnabled,
-      "HiveTableLayoutHandle",
-      "bool",
-      "pushdownFilterEnabled");
-  to_json_key(
-      j,
-      "layoutString",
-      p.layoutString,
-      "HiveTableLayoutHandle",
-      "String",
-      "layoutString");
-  to_json_key(
-      j,
-      "requestedColumns",
-      p.requestedColumns,
-      "HiveTableLayoutHandle",
-      "List<HiveColumnHandle>",
-      "requestedColumns");
-  to_json_key(
-      j,
-      "partialAggregationsPushedDown",
-      p.partialAggregationsPushedDown,
-      "HiveTableLayoutHandle",
-      "bool",
-      "partialAggregationsPushedDown");
-  to_json_key(
-      j,
-      "appendRowNumber",
-      p.appendRowNumber,
-      "HiveTableLayoutHandle",
-      "bool",
-      "appendRowNumber");
 }
 
-void from_json(const json& j, HiveTableLayoutHandle& p) {
+void from_json(const json& j, CreateHandle& p) {
   p._type = j["@type"];
+  from_json_key(
+      j, "handle", p.handle, "CreateHandle", "OutputTableHandle", "handle");
   from_json_key(
       j,
       "schemaTableName",
       p.schemaTableName,
-      "HiveTableLayoutHandle",
+      "CreateHandle",
       "SchemaTableName",
       "schemaTableName");
-  from_json_key(
-      j,
-      "tablePath",
-      p.tablePath,
-      "HiveTableLayoutHandle",
-      "String",
-      "tablePath");
-  from_json_key(
-      j,
-      "partitionColumns",
-      p.partitionColumns,
-      "HiveTableLayoutHandle",
-      "List<HiveColumnHandle>",
-      "partitionColumns");
-  from_json_key(
-      j,
-      "dataColumns",
-      p.dataColumns,
-      "HiveTableLayoutHandle",
-      "List<Column>",
-      "dataColumns");
-  from_json_key(
-      j,
-      "tableParameters",
-      p.tableParameters,
-      "HiveTableLayoutHandle",
-      "Map<String, String>",
-      "tableParameters");
-  from_json_key(
-      j,
-      "domainPredicate",
-      p.domainPredicate,
-      "HiveTableLayoutHandle",
-      "TupleDomain<Subfield>",
-      "domainPredicate");
-  from_json_key(
-      j,
-      "remainingPredicate",
-      p.remainingPredicate,
-      "HiveTableLayoutHandle",
-      "RowExpression",
-      "remainingPredicate");
-  from_json_key(
-      j,
-      "predicateColumns",
-      p.predicateColumns,
-      "HiveTableLayoutHandle",
-      "Map<String, HiveColumnHandle>",
-      "predicateColumns");
-  from_json_key(
-      j,
-      "partitionColumnPredicate",
-      p.partitionColumnPredicate,
-      "HiveTableLayoutHandle",
-      "TupleDomain<std::shared_ptr<ColumnHandle>>",
-      "partitionColumnPredicate");
-  from_json_key(
-      j,
-      "bucketHandle",
-      p.bucketHandle,
-      "HiveTableLayoutHandle",
-      "HiveBucketHandle",
-      "bucketHandle");
-  from_json_key(
-      j,
-      "bucketFilter",
-      p.bucketFilter,
-      "HiveTableLayoutHandle",
-      "HiveBucketFilter",
-      "bucketFilter");
-  from_json_key(
-      j,
-      "pushdownFilterEnabled",
-      p.pushdownFilterEnabled,
-      "HiveTableLayoutHandle",
-      "bool",
-      "pushdownFilterEnabled");
-  from_json_key(
-      j,
-      "layoutString",
-      p.layoutString,
-      "HiveTableLayoutHandle",
-      "String",
-      "layoutString");
-  from_json_key(
-      j,
-      "requestedColumns",
-      p.requestedColumns,
-      "HiveTableLayoutHandle",
-      "List<HiveColumnHandle>",
-      "requestedColumns");
-  from_json_key(
-      j,
-      "partialAggregationsPushedDown",
-      p.partialAggregationsPushedDown,
-      "HiveTableLayoutHandle",
-      "bool",
-      "partialAggregationsPushedDown");
-  from_json_key(
-      j,
-      "appendRowNumber",
-      p.appendRowNumber,
-      "HiveTableLayoutHandle",
-      "bool",
-      "appendRowNumber");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+BuiltInFunctionHandle::BuiltInFunctionHandle() noexcept {
+  _type = "$static";
+}
 
-void to_json(json& j, const PlanFragment& p) {
+void to_json(json& j, const BuiltInFunctionHandle& p) {
   j = json::object();
-  to_json_key(j, "id", p.id, "PlanFragment", "PlanFragmentId", "id");
-  to_json_key(j, "root", p.root, "PlanFragment", "PlanNode", "root");
+  j["@type"] = "$static";
   to_json_key(
       j,
-      "variables",
-      p.variables,
-      "PlanFragment",
-      "List<VariableReferenceExpression>",
-      "variables");
-  to_json_key(
-      j,
-      "partitioning",
-      p.partitioning,
-      "PlanFragment",
-      "PartitioningHandle",
-      "partitioning");
-  to_json_key(
-      j,
-      "tableScanSchedulingOrder",
-      p.tableScanSchedulingOrder,
-      "PlanFragment",
-      "List<PlanNodeId>",
-      "tableScanSchedulingOrder");
-  to_json_key(
-      j,
-      "partitioningScheme",
-      p.partitioningScheme,
-      "PlanFragment",
-      "PartitioningScheme",
-      "partitioningScheme");
-  to_json_key(
-      j,
-      "stageExecutionDescriptor",
-      p.stageExecutionDescriptor,
-      "PlanFragment",
-      "StageExecutionDescriptor",
-      "stageExecutionDescriptor");
-  to_json_key(
-      j,
-      "outputTableWriterFragment",
-      p.outputTableWriterFragment,
-      "PlanFragment",
-      "bool",
-      "outputTableWriterFragment");
-  to_json_key(
-      j,
-      "jsonRepresentation",
-      p.jsonRepresentation,
-      "PlanFragment",
-      "String",
-      "jsonRepresentation");
+      "signature",
+      p.signature,
+      "BuiltInFunctionHandle",
+      "Signature",
+      "signature");
 }
 
-void from_json(const json& j, PlanFragment& p) {
-  from_json_key(j, "id", p.id, "PlanFragment", "PlanFragmentId", "id");
-  from_json_key(j, "root", p.root, "PlanFragment", "PlanNode", "root");
-  from_json_key(
-      j,
-      "variables",
-      p.variables,
-      "PlanFragment",
-      "List<VariableReferenceExpression>",
-      "variables");
-  from_json_key(
-      j,
-      "partitioning",
-      p.partitioning,
-      "PlanFragment",
-      "PartitioningHandle",
-      "partitioning");
-  from_json_key(
-      j,
-      "tableScanSchedulingOrder",
-      p.tableScanSchedulingOrder,
-      "PlanFragment",
-      "List<PlanNodeId>",
-      "tableScanSchedulingOrder");
-  from_json_key(
-      j,
-      "partitioningScheme",
-      p.partitioningScheme,
-      "PlanFragment",
-      "PartitioningScheme",
-      "partitioningScheme");
-  from_json_key(
-      j,
-      "stageExecutionDescriptor",
-      p.stageExecutionDescriptor,
-      "PlanFragment",
-      "StageExecutionDescriptor",
-      "stageExecutionDescriptor");
-  from_json_key(
-      j,
-      "outputTableWriterFragment",
-      p.outputTableWriterFragment,
-      "PlanFragment",
-      "bool",
-      "outputTableWriterFragment");
-  from_json_key(
-      j,
-      "jsonRepresentation",
-      p.jsonRepresentation,
-      "PlanFragment",
-      "String",
-      "jsonRepresentation");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-RemoteSplit::RemoteSplit() noexcept {
-  _type = "$remote";
-}
-
-void to_json(json& j, const RemoteSplit& p) {
-  j = json::object();
-  j["@type"] = "$remote";
-  to_json_key(j, "location", p.location, "RemoteSplit", "Location", "location");
-  to_json_key(
-      j,
-      "remoteSourceTaskId",
-      p.remoteSourceTaskId,
-      "RemoteSplit",
-      "TaskId",
-      "remoteSourceTaskId");
-}
-
-void from_json(const json& j, RemoteSplit& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j, "location", p.location, "RemoteSplit", "Location", "location");
-  from_json_key(
-      j,
-      "remoteSourceTaskId",
-      p.remoteSourceTaskId,
-      "RemoteSplit",
-      "TaskId",
-      "remoteSourceTaskId");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-HivePartitioningHandle::HivePartitioningHandle() noexcept {
-  _type = "hive";
-}
-
-void to_json(json& j, const HivePartitioningHandle& p) {
-  j = json::object();
-  j["@type"] = "hive";
-  to_json_key(
-      j,
-      "bucketCount",
-      p.bucketCount,
-      "HivePartitioningHandle",
-      "int",
-      "bucketCount");
-  to_json_key(
-      j,
-      "maxCompatibleBucketCount",
-      p.maxCompatibleBucketCount,
-      "HivePartitioningHandle",
-      "int",
-      "maxCompatibleBucketCount");
-  to_json_key(
-      j,
-      "bucketFunctionType",
-      p.bucketFunctionType,
-      "HivePartitioningHandle",
-      "BucketFunctionType",
-      "bucketFunctionType");
-  to_json_key(
-      j,
-      "hiveTypes",
-      p.hiveTypes,
-      "HivePartitioningHandle",
-      "List<HiveType>",
-      "hiveTypes");
-  to_json_key(
-      j, "types", p.types, "HivePartitioningHandle", "List<Type>", "types");
-}
-
-void from_json(const json& j, HivePartitioningHandle& p) {
+void from_json(const json& j, BuiltInFunctionHandle& p) {
   p._type = j["@type"];
   from_json_key(
       j,
-      "bucketCount",
-      p.bucketCount,
-      "HivePartitioningHandle",
-      "int",
-      "bucketCount");
+      "signature",
+      p.signature,
+      "BuiltInFunctionHandle",
+      "Signature",
+      "signature");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<DistributionType, json> DistributionType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {DistributionType::PARTITIONED, "PARTITIONED"},
+        {DistributionType::REPLICATED, "REPLICATED"}};
+void to_json(json& j, const DistributionType& e) {
+  static_assert(
+      std::is_enum<DistributionType>::value,
+      "DistributionType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(DistributionType_enum_table),
+      std::end(DistributionType_enum_table),
+      [e](const std::pair<DistributionType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(DistributionType_enum_table))
+           ? it
+           : std::begin(DistributionType_enum_table))
+          ->second;
+}
+void from_json(const json& j, DistributionType& e) {
+  static_assert(
+      std::is_enum<DistributionType>::value,
+      "DistributionType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(DistributionType_enum_table),
+      std::end(DistributionType_enum_table),
+      [&j](const std::pair<DistributionType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(DistributionType_enum_table))
+           ? it
+           : std::begin(DistributionType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const EquiJoinClause& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "left",
+      p.left,
+      "EquiJoinClause",
+      "VariableReferenceExpression",
+      "left");
+  to_json_key(
+      j,
+      "right",
+      p.right,
+      "EquiJoinClause",
+      "VariableReferenceExpression",
+      "right");
+}
+
+void from_json(const json& j, EquiJoinClause& p) {
   from_json_key(
       j,
-      "maxCompatibleBucketCount",
-      p.maxCompatibleBucketCount,
-      "HivePartitioningHandle",
-      "int",
-      "maxCompatibleBucketCount");
+      "left",
+      p.left,
+      "EquiJoinClause",
+      "VariableReferenceExpression",
+      "left");
   from_json_key(
       j,
-      "bucketFunctionType",
-      p.bucketFunctionType,
-      "HivePartitioningHandle",
-      "BucketFunctionType",
-      "bucketFunctionType");
+      "right",
+      p.right,
+      "EquiJoinClause",
+      "VariableReferenceExpression",
+      "right");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<JoinNodeType, json> JoinNodeType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {JoinNodeType::INNER, "INNER"},
+        {JoinNodeType::LEFT, "LEFT"},
+        {JoinNodeType::RIGHT, "RIGHT"},
+        {JoinNodeType::FULL, "FULL"}};
+void to_json(json& j, const JoinNodeType& e) {
+  static_assert(
+      std::is_enum<JoinNodeType>::value, "JoinNodeType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(JoinNodeType_enum_table),
+      std::end(JoinNodeType_enum_table),
+      [e](const std::pair<JoinNodeType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(JoinNodeType_enum_table))
+           ? it
+           : std::begin(JoinNodeType_enum_table))
+          ->second;
+}
+void from_json(const json& j, JoinNodeType& e) {
+  static_assert(
+      std::is_enum<JoinNodeType>::value, "JoinNodeType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(JoinNodeType_enum_table),
+      std::end(JoinNodeType_enum_table),
+      [&j](const std::pair<JoinNodeType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(JoinNodeType_enum_table))
+           ? it
+           : std::begin(JoinNodeType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+JoinNode::JoinNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.JoinNode";
+}
+
+void to_json(json& j, const JoinNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.JoinNode";
+  to_json_key(j, "id", p.id, "JoinNode", "PlanNodeId", "id");
+  to_json_key(j, "type", p.type, "JoinNode", "JoinNodeType", "type");
+  to_json_key(j, "left", p.left, "JoinNode", "PlanNode", "left");
+  to_json_key(j, "right", p.right, "JoinNode", "PlanNode", "right");
+  to_json_key(
+      j,
+      "criteria",
+      p.criteria,
+      "JoinNode",
+      "List<EquiJoinClause>",
+      "criteria");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "JoinNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  to_json_key(
+      j,
+      "filter",
+      p.filter,
+      "JoinNode",
+      "std::shared_ptr<RowExpression>",
+      "filter");
+  to_json_key(
+      j,
+      "leftHashVariable",
+      p.leftHashVariable,
+      "JoinNode",
+      "VariableReferenceExpression",
+      "leftHashVariable");
+  to_json_key(
+      j,
+      "rightHashVariable",
+      p.rightHashVariable,
+      "JoinNode",
+      "VariableReferenceExpression",
+      "rightHashVariable");
+  to_json_key(
+      j,
+      "distributionType",
+      p.distributionType,
+      "JoinNode",
+      "DistributionType",
+      "distributionType");
+  to_json_key(
+      j,
+      "dynamicFilters",
+      p.dynamicFilters,
+      "JoinNode",
+      "Map<String, VariableReferenceExpression>",
+      "dynamicFilters");
+}
+
+void from_json(const json& j, JoinNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "JoinNode", "PlanNodeId", "id");
+  from_json_key(j, "type", p.type, "JoinNode", "JoinNodeType", "type");
+  from_json_key(j, "left", p.left, "JoinNode", "PlanNode", "left");
+  from_json_key(j, "right", p.right, "JoinNode", "PlanNode", "right");
   from_json_key(
       j,
-      "hiveTypes",
-      p.hiveTypes,
-      "HivePartitioningHandle",
-      "List<HiveType>",
-      "hiveTypes");
+      "criteria",
+      p.criteria,
+      "JoinNode",
+      "List<EquiJoinClause>",
+      "criteria");
   from_json_key(
-      j, "types", p.types, "HivePartitioningHandle", "List<Type>", "types");
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "JoinNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  from_json_key(
+      j,
+      "filter",
+      p.filter,
+      "JoinNode",
+      "std::shared_ptr<RowExpression>",
+      "filter");
+  from_json_key(
+      j,
+      "leftHashVariable",
+      p.leftHashVariable,
+      "JoinNode",
+      "VariableReferenceExpression",
+      "leftHashVariable");
+  from_json_key(
+      j,
+      "rightHashVariable",
+      p.rightHashVariable,
+      "JoinNode",
+      "VariableReferenceExpression",
+      "rightHashVariable");
+  from_json_key(
+      j,
+      "distributionType",
+      p.distributionType,
+      "JoinNode",
+      "DistributionType",
+      "distributionType");
+  from_json_key(
+      j,
+      "dynamicFilters",
+      p.dynamicFilters,
+      "JoinNode",
+      "Map<String, VariableReferenceExpression>",
+      "dynamicFilters");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -9947,406 +9306,1011 @@ namespace facebook::presto::protocol {
 // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<LimitNodeStep, json> LimitNodeStep_enum_table[] =
+static const std::pair<Bound, json> Bound_enum_table[] =
     { // NOLINT: cert-err58-cpp
-        {LimitNodeStep::PARTIAL, "PARTIAL"},
-        {LimitNodeStep::FINAL, "FINAL"}};
-void to_json(json& j, const LimitNodeStep& e) {
-  static_assert(
-      std::is_enum<LimitNodeStep>::value, "LimitNodeStep must be an enum!");
+        {Bound::BELOW, "BELOW"},
+        {Bound::EXACTLY, "EXACTLY"},
+        {Bound::ABOVE, "ABOVE"}};
+void to_json(json& j, const Bound& e) {
+  static_assert(std::is_enum<Bound>::value, "Bound must be an enum!");
   const auto* it = std::find_if(
-      std::begin(LimitNodeStep_enum_table),
-      std::end(LimitNodeStep_enum_table),
-      [e](const std::pair<LimitNodeStep, json>& ej_pair) -> bool {
+      std::begin(Bound_enum_table),
+      std::end(Bound_enum_table),
+      [e](const std::pair<Bound, json>& ej_pair) -> bool {
         return ej_pair.first == e;
       });
-  j = ((it != std::end(LimitNodeStep_enum_table))
-           ? it
-           : std::begin(LimitNodeStep_enum_table))
+  j = ((it != std::end(Bound_enum_table)) ? it : std::begin(Bound_enum_table))
           ->second;
 }
-void from_json(const json& j, LimitNodeStep& e) {
-  static_assert(
-      std::is_enum<LimitNodeStep>::value, "LimitNodeStep must be an enum!");
+void from_json(const json& j, Bound& e) {
+  static_assert(std::is_enum<Bound>::value, "Bound must be an enum!");
   const auto* it = std::find_if(
-      std::begin(LimitNodeStep_enum_table),
-      std::end(LimitNodeStep_enum_table),
-      [&j](const std::pair<LimitNodeStep, json>& ej_pair) -> bool {
+      std::begin(Bound_enum_table),
+      std::end(Bound_enum_table),
+      [&j](const std::pair<Bound, json>& ej_pair) -> bool {
         return ej_pair.second == j;
       });
-  e = ((it != std::end(LimitNodeStep_enum_table))
-           ? it
-           : std::begin(LimitNodeStep_enum_table))
+  e = ((it != std::end(Bound_enum_table)) ? it : std::begin(Bound_enum_table))
           ->first;
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-LimitNode::LimitNode() noexcept {
-  _type = ".LimitNode";
-}
 
-void to_json(json& j, const LimitNode& p) {
+void to_json(json& j, const Marker& p) {
   j = json::object();
-  j["@type"] = ".LimitNode";
-  to_json_key(j, "id", p.id, "LimitNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "LimitNode", "PlanNode", "source");
-  to_json_key(j, "count", p.count, "LimitNode", "int64_t", "count");
-  to_json_key(j, "step", p.step, "LimitNode", "LimitNodeStep", "step");
+  to_json_key(j, "type", p.type, "Marker", "Type", "type");
+  to_json_key(j, "valueBlock", p.valueBlock, "Marker", "Block", "valueBlock");
+  to_json_key(j, "bound", p.bound, "Marker", "Bound", "bound");
 }
 
-void from_json(const json& j, LimitNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "LimitNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "LimitNode", "PlanNode", "source");
-  from_json_key(j, "count", p.count, "LimitNode", "int64_t", "count");
-  from_json_key(j, "step", p.step, "LimitNode", "LimitNodeStep", "step");
+void from_json(const json& j, Marker& p) {
+  from_json_key(j, "type", p.type, "Marker", "Type", "type");
+  from_json_key(j, "valueBlock", p.valueBlock, "Marker", "Block", "valueBlock");
+  from_json_key(j, "bound", p.bound, "Marker", "Bound", "bound");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-GroupIdNode::GroupIdNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.GroupIdNode";
-}
 
-void to_json(json& j, const GroupIdNode& p) {
+void to_json(json& j, const Range& p) {
   j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.GroupIdNode";
-  to_json_key(j, "id", p.id, "GroupIdNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "GroupIdNode", "PlanNode", "source");
-  to_json_key(
-      j,
-      "groupingSets",
-      p.groupingSets,
-      "GroupIdNode",
-      "List<List<VariableReferenceExpression>>",
-      "groupingSets");
-  to_json_key(
-      j,
-      "groupingColumns",
-      p.groupingColumns,
-      "GroupIdNode",
-      "Map<VariableReferenceExpression, VariableReferenceExpression>",
-      "groupingColumns");
-  to_json_key(
-      j,
-      "aggregationArguments",
-      p.aggregationArguments,
-      "GroupIdNode",
-      "List<VariableReferenceExpression>",
-      "aggregationArguments");
-  to_json_key(
-      j,
-      "groupIdVariable",
-      p.groupIdVariable,
-      "GroupIdNode",
-      "VariableReferenceExpression",
-      "groupIdVariable");
+  to_json_key(j, "low", p.low, "Range", "Marker", "low");
+  to_json_key(j, "high", p.high, "Range", "Marker", "high");
 }
 
-void from_json(const json& j, GroupIdNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "GroupIdNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "GroupIdNode", "PlanNode", "source");
-  from_json_key(
-      j,
-      "groupingSets",
-      p.groupingSets,
-      "GroupIdNode",
-      "List<List<VariableReferenceExpression>>",
-      "groupingSets");
-  from_json_key(
-      j,
-      "groupingColumns",
-      p.groupingColumns,
-      "GroupIdNode",
-      "Map<VariableReferenceExpression, VariableReferenceExpression>",
-      "groupingColumns");
-  from_json_key(
-      j,
-      "aggregationArguments",
-      p.aggregationArguments,
-      "GroupIdNode",
-      "List<VariableReferenceExpression>",
-      "aggregationArguments");
-  from_json_key(
-      j,
-      "groupIdVariable",
-      p.groupIdVariable,
-      "GroupIdNode",
-      "VariableReferenceExpression",
-      "groupIdVariable");
+void from_json(const json& j, Range& p) {
+  from_json_key(j, "low", p.low, "Range", "Marker", "low");
+  from_json_key(j, "high", p.high, "Range", "Marker", "high");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-RemoteSourceNode::RemoteSourceNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.RemoteSourceNode";
+SortedRangeSet::SortedRangeSet() noexcept {
+  _type = "sortable";
 }
 
-void to_json(json& j, const RemoteSourceNode& p) {
+void to_json(json& j, const SortedRangeSet& p) {
   j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.RemoteSourceNode";
-  to_json_key(j, "id", p.id, "RemoteSourceNode", "PlanNodeId", "id");
-  to_json_key(
-      j,
-      "sourceFragmentIds",
-      p.sourceFragmentIds,
-      "RemoteSourceNode",
-      "List<PlanFragmentId>",
-      "sourceFragmentIds");
+  j["@type"] = "sortable";
+  to_json_key(j, "type", p.type, "SortedRangeSet", "Type", "type");
+  to_json_key(j, "ranges", p.ranges, "SortedRangeSet", "List<Range>", "ranges");
+}
+
+void from_json(const json& j, SortedRangeSet& p) {
+  p._type = j["@type"];
+  from_json_key(j, "type", p.type, "SortedRangeSet", "Type", "type");
+  from_json_key(
+      j, "ranges", p.ranges, "SortedRangeSet", "List<Range>", "ranges");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+TableScanNode::TableScanNode() noexcept {
+  _type = ".TableScanNode";
+}
+
+void to_json(json& j, const TableScanNode& p) {
+  j = json::object();
+  j["@type"] = ".TableScanNode";
+  to_json_key(j, "id", p.id, "TableScanNode", "PlanNodeId", "id");
+  to_json_key(j, "table", p.table, "TableScanNode", "TableHandle", "table");
   to_json_key(
       j,
       "outputVariables",
       p.outputVariables,
-      "RemoteSourceNode",
+      "TableScanNode",
       "List<VariableReferenceExpression>",
       "outputVariables");
   to_json_key(
       j,
-      "ensureSourceOrdering",
-      p.ensureSourceOrdering,
-      "RemoteSourceNode",
-      "bool",
-      "ensureSourceOrdering");
-  to_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "RemoteSourceNode",
-      "OrderingScheme",
-      "orderingScheme");
-  to_json_key(
-      j,
-      "exchangeType",
-      p.exchangeType,
-      "RemoteSourceNode",
-      "ExchangeNodeType",
-      "exchangeType");
+      "assignments",
+      p.assignments,
+      "TableScanNode",
+      "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
+      "assignments");
 }
 
-void from_json(const json& j, RemoteSourceNode& p) {
+void from_json(const json& j, TableScanNode& p) {
   p._type = j["@type"];
-  from_json_key(j, "id", p.id, "RemoteSourceNode", "PlanNodeId", "id");
-  from_json_key(
-      j,
-      "sourceFragmentIds",
-      p.sourceFragmentIds,
-      "RemoteSourceNode",
-      "List<PlanFragmentId>",
-      "sourceFragmentIds");
+  from_json_key(j, "id", p.id, "TableScanNode", "PlanNodeId", "id");
+  from_json_key(j, "table", p.table, "TableScanNode", "TableHandle", "table");
   from_json_key(
       j,
       "outputVariables",
       p.outputVariables,
-      "RemoteSourceNode",
+      "TableScanNode",
       "List<VariableReferenceExpression>",
       "outputVariables");
   from_json_key(
       j,
-      "ensureSourceOrdering",
-      p.ensureSourceOrdering,
-      "RemoteSourceNode",
+      "assignments",
+      p.assignments,
+      "TableScanNode",
+      "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
+      "assignments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<StageExecutionStrategy, json>
+    StageExecutionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
+        {StageExecutionStrategy::UNGROUPED_EXECUTION, "UNGROUPED_EXECUTION"},
+        {StageExecutionStrategy::FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+         "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
+        {StageExecutionStrategy::DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+         "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
+        {StageExecutionStrategy::RECOVERABLE_GROUPED_EXECUTION,
+         "RECOVERABLE_GROUPED_EXECUTION"}};
+void to_json(json& j, const StageExecutionStrategy& e) {
+  static_assert(
+      std::is_enum<StageExecutionStrategy>::value,
+      "StageExecutionStrategy must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(StageExecutionStrategy_enum_table),
+      std::end(StageExecutionStrategy_enum_table),
+      [e](const std::pair<StageExecutionStrategy, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(StageExecutionStrategy_enum_table))
+           ? it
+           : std::begin(StageExecutionStrategy_enum_table))
+          ->second;
+}
+void from_json(const json& j, StageExecutionStrategy& e) {
+  static_assert(
+      std::is_enum<StageExecutionStrategy>::value,
+      "StageExecutionStrategy must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(StageExecutionStrategy_enum_table),
+      std::end(StageExecutionStrategy_enum_table),
+      [&j](const std::pair<StageExecutionStrategy, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(StageExecutionStrategy_enum_table))
+           ? it
+           : std::begin(StageExecutionStrategy_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const StageExecutionDescriptor& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "stageExecutionStrategy",
+      p.stageExecutionStrategy,
+      "StageExecutionDescriptor",
+      "StageExecutionStrategy",
+      "stageExecutionStrategy");
+  to_json_key(
+      j,
+      "groupedExecutionScanNodes",
+      p.groupedExecutionScanNodes,
+      "StageExecutionDescriptor",
+      "List<PlanNodeId>",
+      "groupedExecutionScanNodes");
+  to_json_key(
+      j,
+      "totalLifespans",
+      p.totalLifespans,
+      "StageExecutionDescriptor",
+      "int",
+      "totalLifespans");
+}
+
+void from_json(const json& j, StageExecutionDescriptor& p) {
+  from_json_key(
+      j,
+      "stageExecutionStrategy",
+      p.stageExecutionStrategy,
+      "StageExecutionDescriptor",
+      "StageExecutionStrategy",
+      "stageExecutionStrategy");
+  from_json_key(
+      j,
+      "groupedExecutionScanNodes",
+      p.groupedExecutionScanNodes,
+      "StageExecutionDescriptor",
+      "List<PlanNodeId>",
+      "groupedExecutionScanNodes");
+  from_json_key(
+      j,
+      "totalLifespans",
+      p.totalLifespans,
+      "StageExecutionDescriptor",
+      "int",
+      "totalLifespans");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PlanFragment& p) {
+  j = json::object();
+  to_json_key(j, "id", p.id, "PlanFragment", "PlanFragmentId", "id");
+  to_json_key(j, "root", p.root, "PlanFragment", "PlanNode", "root");
+  to_json_key(
+      j,
+      "variables",
+      p.variables,
+      "PlanFragment",
+      "List<VariableReferenceExpression>",
+      "variables");
+  to_json_key(
+      j,
+      "partitioning",
+      p.partitioning,
+      "PlanFragment",
+      "PartitioningHandle",
+      "partitioning");
+  to_json_key(
+      j,
+      "tableScanSchedulingOrder",
+      p.tableScanSchedulingOrder,
+      "PlanFragment",
+      "List<PlanNodeId>",
+      "tableScanSchedulingOrder");
+  to_json_key(
+      j,
+      "partitioningScheme",
+      p.partitioningScheme,
+      "PlanFragment",
+      "PartitioningScheme",
+      "partitioningScheme");
+  to_json_key(
+      j,
+      "stageExecutionDescriptor",
+      p.stageExecutionDescriptor,
+      "PlanFragment",
+      "StageExecutionDescriptor",
+      "stageExecutionDescriptor");
+  to_json_key(
+      j,
+      "outputTableWriterFragment",
+      p.outputTableWriterFragment,
+      "PlanFragment",
       "bool",
-      "ensureSourceOrdering");
+      "outputTableWriterFragment");
+  to_json_key(
+      j,
+      "jsonRepresentation",
+      p.jsonRepresentation,
+      "PlanFragment",
+      "String",
+      "jsonRepresentation");
+}
+
+void from_json(const json& j, PlanFragment& p) {
+  from_json_key(j, "id", p.id, "PlanFragment", "PlanFragmentId", "id");
+  from_json_key(j, "root", p.root, "PlanFragment", "PlanNode", "root");
+  from_json_key(
+      j,
+      "variables",
+      p.variables,
+      "PlanFragment",
+      "List<VariableReferenceExpression>",
+      "variables");
+  from_json_key(
+      j,
+      "partitioning",
+      p.partitioning,
+      "PlanFragment",
+      "PartitioningHandle",
+      "partitioning");
+  from_json_key(
+      j,
+      "tableScanSchedulingOrder",
+      p.tableScanSchedulingOrder,
+      "PlanFragment",
+      "List<PlanNodeId>",
+      "tableScanSchedulingOrder");
+  from_json_key(
+      j,
+      "partitioningScheme",
+      p.partitioningScheme,
+      "PlanFragment",
+      "PartitioningScheme",
+      "partitioningScheme");
+  from_json_key(
+      j,
+      "stageExecutionDescriptor",
+      p.stageExecutionDescriptor,
+      "PlanFragment",
+      "StageExecutionDescriptor",
+      "stageExecutionDescriptor");
+  from_json_key(
+      j,
+      "outputTableWriterFragment",
+      p.outputTableWriterFragment,
+      "PlanFragment",
+      "bool",
+      "outputTableWriterFragment");
+  from_json_key(
+      j,
+      "jsonRepresentation",
+      p.jsonRepresentation,
+      "PlanFragment",
+      "String",
+      "jsonRepresentation");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const GroupingSetDescriptor& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "groupingKeys",
+      p.groupingKeys,
+      "GroupingSetDescriptor",
+      "List<VariableReferenceExpression>",
+      "groupingKeys");
+  to_json_key(
+      j,
+      "groupingSetCount",
+      p.groupingSetCount,
+      "GroupingSetDescriptor",
+      "int",
+      "groupingSetCount");
+  to_json_key(
+      j,
+      "globalGroupingSets",
+      p.globalGroupingSets,
+      "GroupingSetDescriptor",
+      "List<Integer>",
+      "globalGroupingSets");
+}
+
+void from_json(const json& j, GroupingSetDescriptor& p) {
+  from_json_key(
+      j,
+      "groupingKeys",
+      p.groupingKeys,
+      "GroupingSetDescriptor",
+      "List<VariableReferenceExpression>",
+      "groupingKeys");
+  from_json_key(
+      j,
+      "groupingSetCount",
+      p.groupingSetCount,
+      "GroupingSetDescriptor",
+      "int",
+      "groupingSetCount");
+  from_json_key(
+      j,
+      "globalGroupingSets",
+      p.globalGroupingSets,
+      "GroupingSetDescriptor",
+      "List<Integer>",
+      "globalGroupingSets");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<AggregationNodeStep, json>
+    AggregationNodeStep_enum_table[] = { // NOLINT: cert-err58-cpp
+        {AggregationNodeStep::PARTIAL, "PARTIAL"},
+        {AggregationNodeStep::FINAL, "FINAL"},
+        {AggregationNodeStep::INTERMEDIATE, "INTERMEDIATE"},
+        {AggregationNodeStep::SINGLE, "SINGLE"}};
+void to_json(json& j, const AggregationNodeStep& e) {
+  static_assert(
+      std::is_enum<AggregationNodeStep>::value,
+      "AggregationNodeStep must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(AggregationNodeStep_enum_table),
+      std::end(AggregationNodeStep_enum_table),
+      [e](const std::pair<AggregationNodeStep, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(AggregationNodeStep_enum_table))
+           ? it
+           : std::begin(AggregationNodeStep_enum_table))
+          ->second;
+}
+void from_json(const json& j, AggregationNodeStep& e) {
+  static_assert(
+      std::is_enum<AggregationNodeStep>::value,
+      "AggregationNodeStep must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(AggregationNodeStep_enum_table),
+      std::end(AggregationNodeStep_enum_table),
+      [&j](const std::pair<AggregationNodeStep, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(AggregationNodeStep_enum_table))
+           ? it
+           : std::begin(AggregationNodeStep_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+AggregationNode::AggregationNode() noexcept {
+  _type = ".AggregationNode";
+}
+
+void to_json(json& j, const AggregationNode& p) {
+  j = json::object();
+  j["@type"] = ".AggregationNode";
+  to_json_key(j, "id", p.id, "AggregationNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "AggregationNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "aggregations",
+      p.aggregations,
+      "AggregationNode",
+      "Map<VariableReferenceExpression, Aggregation>",
+      "aggregations");
+  to_json_key(
+      j,
+      "groupingSets",
+      p.groupingSets,
+      "AggregationNode",
+      "GroupingSetDescriptor",
+      "groupingSets");
+  to_json_key(
+      j,
+      "preGroupedVariables",
+      p.preGroupedVariables,
+      "AggregationNode",
+      "List<VariableReferenceExpression>",
+      "preGroupedVariables");
+  to_json_key(
+      j, "step", p.step, "AggregationNode", "AggregationNodeStep", "step");
+  to_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "AggregationNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+  to_json_key(
+      j,
+      "groupIdVariable",
+      p.groupIdVariable,
+      "AggregationNode",
+      "VariableReferenceExpression",
+      "groupIdVariable");
+}
+
+void from_json(const json& j, AggregationNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "AggregationNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "AggregationNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "aggregations",
+      p.aggregations,
+      "AggregationNode",
+      "Map<VariableReferenceExpression, Aggregation>",
+      "aggregations");
+  from_json_key(
+      j,
+      "groupingSets",
+      p.groupingSets,
+      "AggregationNode",
+      "GroupingSetDescriptor",
+      "groupingSets");
+  from_json_key(
+      j,
+      "preGroupedVariables",
+      p.preGroupedVariables,
+      "AggregationNode",
+      "List<VariableReferenceExpression>",
+      "preGroupedVariables");
+  from_json_key(
+      j, "step", p.step, "AggregationNode", "AggregationNodeStep", "step");
+  from_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "AggregationNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+  from_json_key(
+      j,
+      "groupIdVariable",
+      p.groupIdVariable,
+      "AggregationNode",
+      "VariableReferenceExpression",
+      "groupIdVariable");
+}
+} // namespace facebook::presto::protocol
+// dependency KeyedSubclass
+
+namespace facebook::presto::protocol {
+
+std::string JsonEncodedSubclass::getSubclassKey(nlohmann::json j) {
+  return j["@type"];
+}
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+RowNumberNode::RowNumberNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.RowNumberNode";
+}
+
+void to_json(json& j, const RowNumberNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.RowNumberNode";
+  to_json_key(j, "id", p.id, "RowNumberNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "RowNumberNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "RowNumberNode",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  to_json_key(
+      j,
+      "rowNumberVariable",
+      p.rowNumberVariable,
+      "RowNumberNode",
+      "VariableReferenceExpression",
+      "rowNumberVariable");
+  to_json_key(
+      j,
+      "maxRowCountPerPartition",
+      p.maxRowCountPerPartition,
+      "RowNumberNode",
+      "Integer",
+      "maxRowCountPerPartition");
+  to_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "RowNumberNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+}
+
+void from_json(const json& j, RowNumberNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "RowNumberNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "RowNumberNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "RowNumberNode",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  from_json_key(
+      j,
+      "rowNumberVariable",
+      p.rowNumberVariable,
+      "RowNumberNode",
+      "VariableReferenceExpression",
+      "rowNumberVariable");
+  from_json_key(
+      j,
+      "maxRowCountPerPartition",
+      p.maxRowCountPerPartition,
+      "RowNumberNode",
+      "Integer",
+      "maxRowCountPerPartition");
+  from_json_key(
+      j,
+      "hashVariable",
+      p.hashVariable,
+      "RowNumberNode",
+      "VariableReferenceExpression",
+      "hashVariable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+UnnestNode::UnnestNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.UnnestNode";
+}
+
+void to_json(json& j, const UnnestNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.UnnestNode";
+  to_json_key(j, "id", p.id, "UnnestNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "UnnestNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "replicateVariables",
+      p.replicateVariables,
+      "UnnestNode",
+      "List<VariableReferenceExpression>",
+      "replicateVariables");
+  to_json_key(
+      j,
+      "unnestVariables",
+      p.unnestVariables,
+      "UnnestNode",
+      "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
+      "unnestVariables");
+  to_json_key(
+      j,
+      "ordinalityVariable",
+      p.ordinalityVariable,
+      "UnnestNode",
+      "VariableReferenceExpression",
+      "ordinalityVariable");
+}
+
+void from_json(const json& j, UnnestNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "UnnestNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "UnnestNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "replicateVariables",
+      p.replicateVariables,
+      "UnnestNode",
+      "List<VariableReferenceExpression>",
+      "replicateVariables");
+  from_json_key(
+      j,
+      "unnestVariables",
+      p.unnestVariables,
+      "UnnestNode",
+      "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
+      "unnestVariables");
+  from_json_key(
+      j,
+      "ordinalityVariable",
+      p.ordinalityVariable,
+      "UnnestNode",
+      "VariableReferenceExpression",
+      "ordinalityVariable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+InsertHandle::InsertHandle() noexcept {
+  _type = "InsertHandle";
+}
+
+void to_json(json& j, const InsertHandle& p) {
+  j = json::object();
+  j["@type"] = "InsertHandle";
+  to_json_key(
+      j, "handle", p.handle, "InsertHandle", "InsertTableHandle", "handle");
+  to_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "InsertHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+
+void from_json(const json& j, InsertHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j, "handle", p.handle, "InsertHandle", "InsertTableHandle", "handle");
+  from_json_key(
+      j,
+      "schemaTableName",
+      p.schemaTableName,
+      "InsertHandle",
+      "SchemaTableName",
+      "schemaTableName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+AllOrNoneValueSet::AllOrNoneValueSet() noexcept {
+  _type = "allOrNone";
+}
+
+void to_json(json& j, const AllOrNoneValueSet& p) {
+  j = json::object();
+  j["@type"] = "allOrNone";
+  to_json_key(j, "type", p.type, "AllOrNoneValueSet", "Type", "type");
+  to_json_key(j, "all", p.all, "AllOrNoneValueSet", "bool", "all");
+}
+
+void from_json(const json& j, AllOrNoneValueSet& p) {
+  p._type = j["@type"];
+  from_json_key(j, "type", p.type, "AllOrNoneValueSet", "Type", "type");
+  from_json_key(j, "all", p.all, "AllOrNoneValueSet", "bool", "all");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+MergeJoinNode::MergeJoinNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.MergeJoinNode";
+}
+
+void to_json(json& j, const MergeJoinNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.MergeJoinNode";
+  to_json_key(j, "id", p.id, "MergeJoinNode", "PlanNodeId", "id");
+  to_json_key(j, "type", p.type, "MergeJoinNode", "JoinNode.Type", "type");
+  to_json_key(j, "left", p.left, "MergeJoinNode", "PlanNode", "left");
+  to_json_key(j, "right", p.right, "MergeJoinNode", "PlanNode", "right");
+  to_json_key(
+      j,
+      "criteria",
+      p.criteria,
+      "MergeJoinNode",
+      "List<JoinNode.EquiJoinClause>",
+      "criteria");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "MergeJoinNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  to_json_key(
+      j,
+      "filter",
+      p.filter,
+      "MergeJoinNode",
+      "std::shared_ptr<RowExpression>",
+      "filter");
+  to_json_key(
+      j,
+      "leftHashVariable",
+      p.leftHashVariable,
+      "MergeJoinNode",
+      "VariableReferenceExpression",
+      "leftHashVariable");
+  to_json_key(
+      j,
+      "rightHashVariable",
+      p.rightHashVariable,
+      "MergeJoinNode",
+      "VariableReferenceExpression",
+      "rightHashVariable");
+}
+
+void from_json(const json& j, MergeJoinNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "MergeJoinNode", "PlanNodeId", "id");
+  from_json_key(j, "type", p.type, "MergeJoinNode", "JoinNode.Type", "type");
+  from_json_key(j, "left", p.left, "MergeJoinNode", "PlanNode", "left");
+  from_json_key(j, "right", p.right, "MergeJoinNode", "PlanNode", "right");
+  from_json_key(
+      j,
+      "criteria",
+      p.criteria,
+      "MergeJoinNode",
+      "List<JoinNode.EquiJoinClause>",
+      "criteria");
+  from_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "MergeJoinNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  from_json_key(
+      j,
+      "filter",
+      p.filter,
+      "MergeJoinNode",
+      "std::shared_ptr<RowExpression>",
+      "filter");
+  from_json_key(
+      j,
+      "leftHashVariable",
+      p.leftHashVariable,
+      "MergeJoinNode",
+      "VariableReferenceExpression",
+      "leftHashVariable");
+  from_json_key(
+      j,
+      "rightHashVariable",
+      p.rightHashVariable,
+      "MergeJoinNode",
+      "VariableReferenceExpression",
+      "rightHashVariable");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+HiveTableHandle::HiveTableHandle() noexcept {
+  _type = "hive";
+}
+
+void to_json(json& j, const HiveTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive";
+  to_json_key(
+      j, "schemaName", p.schemaName, "HiveTableHandle", "String", "schemaName");
+  to_json_key(
+      j, "tableName", p.tableName, "HiveTableHandle", "String", "tableName");
+  to_json_key(
+      j,
+      "analyzePartitionValues",
+      p.analyzePartitionValues,
+      "HiveTableHandle",
+      "List<List<String>>",
+      "analyzePartitionValues");
+}
+
+void from_json(const json& j, HiveTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j, "schemaName", p.schemaName, "HiveTableHandle", "String", "schemaName");
+  from_json_key(
+      j, "tableName", p.tableName, "HiveTableHandle", "String", "tableName");
+  from_json_key(
+      j,
+      "analyzePartitionValues",
+      p.analyzePartitionValues,
+      "HiveTableHandle",
+      "List<List<String>>",
+      "analyzePartitionValues");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Step, json> Step_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {Step::SINGLE, "SINGLE"},
+        {Step::PARTIAL, "PARTIAL"},
+        {Step::FINAL, "FINAL"}};
+void to_json(json& j, const Step& e) {
+  static_assert(std::is_enum<Step>::value, "Step must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Step_enum_table),
+      std::end(Step_enum_table),
+      [e](const std::pair<Step, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Step_enum_table)) ? it : std::begin(Step_enum_table))
+          ->second;
+}
+void from_json(const json& j, Step& e) {
+  static_assert(std::is_enum<Step>::value, "Step must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Step_enum_table),
+      std::end(Step_enum_table),
+      [&j](const std::pair<Step, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Step_enum_table)) ? it : std::begin(Step_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+TopNNode::TopNNode() noexcept {
+  _type = ".TopNNode";
+}
+
+void to_json(json& j, const TopNNode& p) {
+  j = json::object();
+  j["@type"] = ".TopNNode";
+  to_json_key(j, "id", p.id, "TopNNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "TopNNode", "PlanNode", "source");
+  to_json_key(j, "count", p.count, "TopNNode", "int64_t", "count");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "TopNNode",
+      "OrderingScheme",
+      "orderingScheme");
+  to_json_key(j, "step", p.step, "TopNNode", "Step", "step");
+}
+
+void from_json(const json& j, TopNNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "TopNNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "TopNNode", "PlanNode", "source");
+  from_json_key(j, "count", p.count, "TopNNode", "int64_t", "count");
   from_json_key(
       j,
       "orderingScheme",
       p.orderingScheme,
-      "RemoteSourceNode",
+      "TopNNode",
       "OrderingScheme",
       "orderingScheme");
-  from_json_key(
-      j,
-      "exchangeType",
-      p.exchangeType,
-      "RemoteSourceNode",
-      "ExchangeNodeType",
-      "exchangeType");
+  from_json_key(j, "step", p.step, "TopNNode", "Step", "step");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+HiveTransactionHandle::HiveTransactionHandle() noexcept {
+  _type = "hive";
+}
 
-void to_json(json& j, const RefreshMaterializedViewHandle& p) {
+void to_json(json& j, const HiveTransactionHandle& p) {
   j = json::object();
-  to_json_key(
-      j,
-      "handle",
-      p.handle,
-      "RefreshMaterializedViewHandle",
-      "InsertTableHandle",
-      "handle");
-  to_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "RefreshMaterializedViewHandle",
-      "SchemaTableName",
-      "schemaTableName");
+  j["@type"] = "hive";
+  to_json_key(j, "uuid", p.uuid, "HiveTransactionHandle", "UUID", "uuid");
 }
 
-void from_json(const json& j, RefreshMaterializedViewHandle& p) {
-  from_json_key(
-      j,
-      "handle",
-      p.handle,
-      "RefreshMaterializedViewHandle",
-      "InsertTableHandle",
-      "handle");
-  from_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "RefreshMaterializedViewHandle",
-      "SchemaTableName",
-      "schemaTableName");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-EnforceSingleRowNode::EnforceSingleRowNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode";
-}
-
-void to_json(json& j, const EnforceSingleRowNode& p) {
-  j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode";
-  to_json_key(j, "id", p.id, "EnforceSingleRowNode", "PlanNodeId", "id");
-  to_json_key(
-      j, "source", p.source, "EnforceSingleRowNode", "PlanNode", "source");
-}
-
-void from_json(const json& j, EnforceSingleRowNode& p) {
+void from_json(const json& j, HiveTransactionHandle& p) {
   p._type = j["@type"];
-  from_json_key(j, "id", p.id, "EnforceSingleRowNode", "PlanNodeId", "id");
-  from_json_key(
-      j, "source", p.source, "EnforceSingleRowNode", "PlanNode", "source");
+  from_json_key(j, "uuid", p.uuid, "HiveTransactionHandle", "UUID", "uuid");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-SemiJoinNode::SemiJoinNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.SemiJoinNode";
+LambdaDefinitionExpression::LambdaDefinitionExpression() noexcept {
+  _type = "lambda";
 }
 
-void to_json(json& j, const SemiJoinNode& p) {
+void to_json(json& j, const LambdaDefinitionExpression& p) {
   j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.SemiJoinNode";
-  to_json_key(j, "id", p.id, "SemiJoinNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "SemiJoinNode", "PlanNode", "source");
+  j["@type"] = "lambda";
   to_json_key(
       j,
-      "filteringSource",
-      p.filteringSource,
-      "SemiJoinNode",
-      "PlanNode",
-      "filteringSource");
+      "sourceLocation",
+      p.sourceLocation,
+      "LambdaDefinitionExpression",
+      "SourceLocation",
+      "sourceLocation");
   to_json_key(
       j,
-      "sourceJoinVariable",
-      p.sourceJoinVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "sourceJoinVariable");
+      "argumentTypes",
+      p.argumentTypes,
+      "LambdaDefinitionExpression",
+      "List<Type>",
+      "argumentTypes");
   to_json_key(
       j,
-      "filteringSourceJoinVariable",
-      p.filteringSourceJoinVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "filteringSourceJoinVariable");
+      "arguments",
+      p.arguments,
+      "LambdaDefinitionExpression",
+      "List<String>",
+      "arguments");
   to_json_key(
-      j,
-      "semiJoinOutput",
-      p.semiJoinOutput,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "semiJoinOutput");
-  to_json_key(
-      j,
-      "sourceHashVariable",
-      p.sourceHashVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "sourceHashVariable");
-  to_json_key(
-      j,
-      "filteringSourceHashVariable",
-      p.filteringSourceHashVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "filteringSourceHashVariable");
-  to_json_key(
-      j,
-      "distributionType",
-      p.distributionType,
-      "SemiJoinNode",
-      "DistributionType",
-      "distributionType");
-  to_json_key(
-      j,
-      "dynamicFilters",
-      p.dynamicFilters,
-      "SemiJoinNode",
-      "Map<String, VariableReferenceExpression>",
-      "dynamicFilters");
+      j, "body", p.body, "LambdaDefinitionExpression", "RowExpression", "body");
 }
 
-void from_json(const json& j, SemiJoinNode& p) {
+void from_json(const json& j, LambdaDefinitionExpression& p) {
   p._type = j["@type"];
-  from_json_key(j, "id", p.id, "SemiJoinNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "SemiJoinNode", "PlanNode", "source");
   from_json_key(
       j,
-      "filteringSource",
-      p.filteringSource,
-      "SemiJoinNode",
-      "PlanNode",
-      "filteringSource");
+      "sourceLocation",
+      p.sourceLocation,
+      "LambdaDefinitionExpression",
+      "SourceLocation",
+      "sourceLocation");
   from_json_key(
       j,
-      "sourceJoinVariable",
-      p.sourceJoinVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "sourceJoinVariable");
+      "argumentTypes",
+      p.argumentTypes,
+      "LambdaDefinitionExpression",
+      "List<Type>",
+      "argumentTypes");
   from_json_key(
       j,
-      "filteringSourceJoinVariable",
-      p.filteringSourceJoinVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "filteringSourceJoinVariable");
+      "arguments",
+      p.arguments,
+      "LambdaDefinitionExpression",
+      "List<String>",
+      "arguments");
+  from_json_key(
+      j, "body", p.body, "LambdaDefinitionExpression", "RowExpression", "body");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+RemoteSplit::RemoteSplit() noexcept {
+  _type = "$remote";
+}
+
+void to_json(json& j, const RemoteSplit& p) {
+  j = json::object();
+  j["@type"] = "$remote";
+  to_json_key(j, "location", p.location, "RemoteSplit", "Location", "location");
+  to_json_key(
+      j,
+      "remoteSourceTaskId",
+      p.remoteSourceTaskId,
+      "RemoteSplit",
+      "TaskId",
+      "remoteSourceTaskId");
+}
+
+void from_json(const json& j, RemoteSplit& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j, "location", p.location, "RemoteSplit", "Location", "location");
   from_json_key(
       j,
-      "semiJoinOutput",
-      p.semiJoinOutput,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "semiJoinOutput");
-  from_json_key(
-      j,
-      "sourceHashVariable",
-      p.sourceHashVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "sourceHashVariable");
-  from_json_key(
-      j,
-      "filteringSourceHashVariable",
-      p.filteringSourceHashVariable,
-      "SemiJoinNode",
-      "VariableReferenceExpression",
-      "filteringSourceHashVariable");
-  from_json_key(
-      j,
-      "distributionType",
-      p.distributionType,
-      "SemiJoinNode",
-      "DistributionType",
-      "distributionType");
-  from_json_key(
-      j,
-      "dynamicFilters",
-      p.dynamicFilters,
-      "SemiJoinNode",
-      "Map<String, VariableReferenceExpression>",
-      "dynamicFilters");
+      "remoteSourceTaskId",
+      p.remoteSourceTaskId,
+      "RemoteSplit",
+      "TaskId",
+      "remoteSourceTaskId");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -10574,209 +10538,503 @@ void from_json(const json& j, HiveOutputTableHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-InsertHandle::InsertHandle() noexcept {
-  _type = "InsertHandle";
-}
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
-void to_json(json& j, const InsertHandle& p) {
-  j = json::object();
-  j["@type"] = "InsertHandle";
-  to_json_key(
-      j, "handle", p.handle, "InsertHandle", "InsertTableHandle", "handle");
-  to_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "InsertHandle",
-      "SchemaTableName",
-      "schemaTableName");
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<CacheQuotaScope, json> CacheQuotaScope_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {CacheQuotaScope::GLOBAL, "GLOBAL"},
+        {CacheQuotaScope::SCHEMA, "SCHEMA"},
+        {CacheQuotaScope::TABLE, "TABLE"},
+        {CacheQuotaScope::PARTITION, "PARTITION"}};
+void to_json(json& j, const CacheQuotaScope& e) {
+  static_assert(
+      std::is_enum<CacheQuotaScope>::value, "CacheQuotaScope must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(CacheQuotaScope_enum_table),
+      std::end(CacheQuotaScope_enum_table),
+      [e](const std::pair<CacheQuotaScope, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(CacheQuotaScope_enum_table))
+           ? it
+           : std::begin(CacheQuotaScope_enum_table))
+          ->second;
 }
-
-void from_json(const json& j, InsertHandle& p) {
-  p._type = j["@type"];
-  from_json_key(
-      j, "handle", p.handle, "InsertHandle", "InsertTableHandle", "handle");
-  from_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "InsertHandle",
-      "SchemaTableName",
-      "schemaTableName");
+void from_json(const json& j, CacheQuotaScope& e) {
+  static_assert(
+      std::is_enum<CacheQuotaScope>::value, "CacheQuotaScope must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(CacheQuotaScope_enum_table),
+      std::end(CacheQuotaScope_enum_table),
+      [&j](const std::pair<CacheQuotaScope, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(CacheQuotaScope_enum_table))
+           ? it
+           : std::begin(CacheQuotaScope_enum_table))
+          ->first;
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-RowNumberNode::RowNumberNode() noexcept {
-  _type = "com.facebook.presto.sql.planner.plan.RowNumberNode";
-}
 
-void to_json(json& j, const RowNumberNode& p) {
+void to_json(json& j, const CacheQuotaRequirement& p) {
   j = json::object();
-  j["@type"] = "com.facebook.presto.sql.planner.plan.RowNumberNode";
-  to_json_key(j, "id", p.id, "RowNumberNode", "PlanNodeId", "id");
-  to_json_key(j, "source", p.source, "RowNumberNode", "PlanNode", "source");
   to_json_key(
       j,
-      "partitionBy",
-      p.partitionBy,
-      "RowNumberNode",
-      "List<VariableReferenceExpression>",
-      "partitionBy");
+      "cacheQuotaScope",
+      p.cacheQuotaScope,
+      "CacheQuotaRequirement",
+      "CacheQuotaScope",
+      "cacheQuotaScope");
   to_json_key(
-      j,
-      "rowNumberVariable",
-      p.rowNumberVariable,
-      "RowNumberNode",
-      "VariableReferenceExpression",
-      "rowNumberVariable");
-  to_json_key(
-      j,
-      "maxRowCountPerPartition",
-      p.maxRowCountPerPartition,
-      "RowNumberNode",
-      "Integer",
-      "maxRowCountPerPartition");
-  to_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "RowNumberNode",
-      "VariableReferenceExpression",
-      "hashVariable");
+      j, "quota", p.quota, "CacheQuotaRequirement", "DataSize", "quota");
 }
 
-void from_json(const json& j, RowNumberNode& p) {
-  p._type = j["@type"];
-  from_json_key(j, "id", p.id, "RowNumberNode", "PlanNodeId", "id");
-  from_json_key(j, "source", p.source, "RowNumberNode", "PlanNode", "source");
+void from_json(const json& j, CacheQuotaRequirement& p) {
   from_json_key(
       j,
-      "partitionBy",
-      p.partitionBy,
-      "RowNumberNode",
-      "List<VariableReferenceExpression>",
-      "partitionBy");
+      "cacheQuotaScope",
+      p.cacheQuotaScope,
+      "CacheQuotaRequirement",
+      "CacheQuotaScope",
+      "cacheQuotaScope");
   from_json_key(
-      j,
-      "rowNumberVariable",
-      p.rowNumberVariable,
-      "RowNumberNode",
-      "VariableReferenceExpression",
-      "rowNumberVariable");
-  from_json_key(
-      j,
-      "maxRowCountPerPartition",
-      p.maxRowCountPerPartition,
-      "RowNumberNode",
-      "Integer",
-      "maxRowCountPerPartition");
-  from_json_key(
-      j,
-      "hashVariable",
-      p.hashVariable,
-      "RowNumberNode",
-      "VariableReferenceExpression",
-      "hashVariable");
+      j, "quota", p.quota, "CacheQuotaRequirement", "DataSize", "quota");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-HiveMetadataUpdateHandle::HiveMetadataUpdateHandle() noexcept {
+SortNode::SortNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.SortNode";
+}
+
+void to_json(json& j, const SortNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.SortNode";
+  to_json_key(j, "id", p.id, "SortNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "SortNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "SortNode",
+      "OrderingScheme",
+      "orderingScheme");
+  to_json_key(j, "isPartial", p.isPartial, "SortNode", "bool", "isPartial");
+}
+
+void from_json(const json& j, SortNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "SortNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "SortNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "SortNode",
+      "OrderingScheme",
+      "orderingScheme");
+  from_json_key(j, "isPartial", p.isPartial, "SortNode", "bool", "isPartial");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const HivePartitionKey& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "HivePartitionKey", "String", "name");
+  to_json_key(j, "value", p.value, "HivePartitionKey", "String", "value");
+}
+
+void from_json(const json& j, HivePartitionKey& p) {
+  from_json_key(j, "name", p.name, "HivePartitionKey", "String", "name");
+  from_json_key(j, "value", p.value, "HivePartitionKey", "String", "value");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+ConstantExpression::ConstantExpression() noexcept {
+  _type = "constant";
+}
+
+void to_json(json& j, const ConstantExpression& p) {
+  j = json::object();
+  j["@type"] = "constant";
+  to_json_key(
+      j,
+      "valueBlock",
+      p.valueBlock,
+      "ConstantExpression",
+      "Block",
+      "valueBlock");
+  to_json_key(j, "type", p.type, "ConstantExpression", "Type", "type");
+}
+
+void from_json(const json& j, ConstantExpression& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "valueBlock",
+      p.valueBlock,
+      "ConstantExpression",
+      "Block",
+      "valueBlock");
+  from_json_key(j, "type", p.type, "ConstantExpression", "Type", "type");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const BucketConversion& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "tableBucketCount",
+      p.tableBucketCount,
+      "BucketConversion",
+      "int",
+      "tableBucketCount");
+  to_json_key(
+      j,
+      "partitionBucketCount",
+      p.partitionBucketCount,
+      "BucketConversion",
+      "int",
+      "partitionBucketCount");
+  to_json_key(
+      j,
+      "bucketColumnHandles",
+      p.bucketColumnHandles,
+      "BucketConversion",
+      "List<HiveColumnHandle>",
+      "bucketColumnHandles");
+}
+
+void from_json(const json& j, BucketConversion& p) {
+  from_json_key(
+      j,
+      "tableBucketCount",
+      p.tableBucketCount,
+      "BucketConversion",
+      "int",
+      "tableBucketCount");
+  from_json_key(
+      j,
+      "partitionBucketCount",
+      p.partitionBucketCount,
+      "BucketConversion",
+      "int",
+      "partitionBucketCount");
+  from_json_key(
+      j,
+      "bucketColumnHandles",
+      p.bucketColumnHandles,
+      "BucketConversion",
+      "List<HiveColumnHandle>",
+      "bucketColumnHandles");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<NodeSelectionStrategy, json>
+    NodeSelectionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
+        {NodeSelectionStrategy::HARD_AFFINITY, "HARD_AFFINITY"},
+        {NodeSelectionStrategy::SOFT_AFFINITY, "SOFT_AFFINITY"},
+        {NodeSelectionStrategy::NO_PREFERENCE, "NO_PREFERENCE"}};
+void to_json(json& j, const NodeSelectionStrategy& e) {
+  static_assert(
+      std::is_enum<NodeSelectionStrategy>::value,
+      "NodeSelectionStrategy must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NodeSelectionStrategy_enum_table),
+      std::end(NodeSelectionStrategy_enum_table),
+      [e](const std::pair<NodeSelectionStrategy, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(NodeSelectionStrategy_enum_table))
+           ? it
+           : std::begin(NodeSelectionStrategy_enum_table))
+          ->second;
+}
+void from_json(const json& j, NodeSelectionStrategy& e) {
+  static_assert(
+      std::is_enum<NodeSelectionStrategy>::value,
+      "NodeSelectionStrategy must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NodeSelectionStrategy_enum_table),
+      std::end(NodeSelectionStrategy_enum_table),
+      [&j](const std::pair<NodeSelectionStrategy, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(NodeSelectionStrategy_enum_table))
+           ? it
+           : std::begin(NodeSelectionStrategy_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+HiveSplit::HiveSplit() noexcept {
   _type = "hive";
 }
 
-void to_json(json& j, const HiveMetadataUpdateHandle& p) {
+void to_json(json& j, const HiveSplit& p) {
   j = json::object();
   j["@type"] = "hive";
-  to_json_key(
-      j,
-      "requestId",
-      p.requestId,
-      "HiveMetadataUpdateHandle",
-      "UUID",
-      "requestId");
-  to_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "HiveMetadataUpdateHandle",
-      "SchemaTableName",
-      "schemaTableName");
+  to_json_key(j, "database", p.database, "HiveSplit", "String", "database");
+  to_json_key(j, "table", p.table, "HiveSplit", "String", "table");
   to_json_key(
       j,
       "partitionName",
       p.partitionName,
-      "HiveMetadataUpdateHandle",
+      "HiveSplit",
       "String",
       "partitionName");
+  to_json_key(j, "path", p.path, "HiveSplit", "String", "path");
+  to_json_key(j, "start", p.start, "HiveSplit", "int64_t", "start");
+  to_json_key(j, "length", p.length, "HiveSplit", "int64_t", "length");
+  to_json_key(j, "fileSize", p.fileSize, "HiveSplit", "int64_t", "fileSize");
   to_json_key(
       j,
-      "fileName",
-      p.fileName,
-      "HiveMetadataUpdateHandle",
+      "fileModifiedTime",
+      p.fileModifiedTime,
+      "HiveSplit",
+      "int64_t",
+      "fileModifiedTime");
+  to_json_key(j, "storage", p.storage, "HiveSplit", "Storage", "storage");
+  to_json_key(
+      j,
+      "partitionKeys",
+      p.partitionKeys,
+      "HiveSplit",
+      "List<HivePartitionKey>",
+      "partitionKeys");
+  to_json_key(
+      j,
+      "addresses",
+      p.addresses,
+      "HiveSplit",
+      "List<HostAddress>",
+      "addresses");
+  to_json_key(
+      j,
+      "readBucketNumber",
+      p.readBucketNumber,
+      "HiveSplit",
+      "int",
+      "readBucketNumber");
+  to_json_key(
+      j,
+      "tableBucketNumber",
+      p.tableBucketNumber,
+      "HiveSplit",
+      "int",
+      "tableBucketNumber");
+  to_json_key(
+      j,
+      "nodeSelectionStrategy",
+      p.nodeSelectionStrategy,
+      "HiveSplit",
+      "NodeSelectionStrategy",
+      "nodeSelectionStrategy");
+  to_json_key(
+      j,
+      "partitionDataColumnCount",
+      p.partitionDataColumnCount,
+      "HiveSplit",
+      "int",
+      "partitionDataColumnCount");
+  to_json_key(
+      j,
+      "tableToPartitionMapping",
+      p.tableToPartitionMapping,
+      "HiveSplit",
+      "TableToPartitionMapping",
+      "tableToPartitionMapping");
+  to_json_key(
+      j,
+      "bucketConversion",
+      p.bucketConversion,
+      "HiveSplit",
+      "BucketConversion",
+      "bucketConversion");
+  to_json_key(
+      j,
+      "s3SelectPushdownEnabled",
+      p.s3SelectPushdownEnabled,
+      "HiveSplit",
+      "bool",
+      "s3SelectPushdownEnabled");
+  to_json_key(
+      j,
+      "extraFileInfo",
+      p.extraFileInfo,
+      "HiveSplit",
       "String",
-      "fileName");
+      "extraFileInfo");
+  to_json_key(
+      j,
+      "cacheQuota",
+      p.cacheQuota,
+      "HiveSplit",
+      "CacheQuotaRequirement",
+      "cacheQuota");
+  to_json_key(
+      j,
+      "encryptionMetadata",
+      p.encryptionMetadata,
+      "HiveSplit",
+      "EncryptionInformation",
+      "encryptionMetadata");
+  to_json_key(
+      j,
+      "customSplitInfo",
+      p.customSplitInfo,
+      "HiveSplit",
+      "Map<String, String>",
+      "customSplitInfo");
+  to_json_key(
+      j,
+      "redundantColumnDomains",
+      p.redundantColumnDomains,
+      "HiveSplit",
+      "List<std::shared_ptr<ColumnHandle>>",
+      "redundantColumnDomains");
+  to_json_key(
+      j,
+      "splitWeight",
+      p.splitWeight,
+      "HiveSplit",
+      "SplitWeight",
+      "splitWeight");
 }
 
-void from_json(const json& j, HiveMetadataUpdateHandle& p) {
+void from_json(const json& j, HiveSplit& p) {
   p._type = j["@type"];
-  from_json_key(
-      j,
-      "requestId",
-      p.requestId,
-      "HiveMetadataUpdateHandle",
-      "UUID",
-      "requestId");
-  from_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "HiveMetadataUpdateHandle",
-      "SchemaTableName",
-      "schemaTableName");
+  from_json_key(j, "database", p.database, "HiveSplit", "String", "database");
+  from_json_key(j, "table", p.table, "HiveSplit", "String", "table");
   from_json_key(
       j,
       "partitionName",
       p.partitionName,
-      "HiveMetadataUpdateHandle",
+      "HiveSplit",
       "String",
       "partitionName");
+  from_json_key(j, "path", p.path, "HiveSplit", "String", "path");
+  from_json_key(j, "start", p.start, "HiveSplit", "int64_t", "start");
+  from_json_key(j, "length", p.length, "HiveSplit", "int64_t", "length");
+  from_json_key(j, "fileSize", p.fileSize, "HiveSplit", "int64_t", "fileSize");
   from_json_key(
       j,
-      "fileName",
-      p.fileName,
-      "HiveMetadataUpdateHandle",
+      "fileModifiedTime",
+      p.fileModifiedTime,
+      "HiveSplit",
+      "int64_t",
+      "fileModifiedTime");
+  from_json_key(j, "storage", p.storage, "HiveSplit", "Storage", "storage");
+  from_json_key(
+      j,
+      "partitionKeys",
+      p.partitionKeys,
+      "HiveSplit",
+      "List<HivePartitionKey>",
+      "partitionKeys");
+  from_json_key(
+      j,
+      "addresses",
+      p.addresses,
+      "HiveSplit",
+      "List<HostAddress>",
+      "addresses");
+  from_json_key(
+      j,
+      "readBucketNumber",
+      p.readBucketNumber,
+      "HiveSplit",
+      "int",
+      "readBucketNumber");
+  from_json_key(
+      j,
+      "tableBucketNumber",
+      p.tableBucketNumber,
+      "HiveSplit",
+      "int",
+      "tableBucketNumber");
+  from_json_key(
+      j,
+      "nodeSelectionStrategy",
+      p.nodeSelectionStrategy,
+      "HiveSplit",
+      "NodeSelectionStrategy",
+      "nodeSelectionStrategy");
+  from_json_key(
+      j,
+      "partitionDataColumnCount",
+      p.partitionDataColumnCount,
+      "HiveSplit",
+      "int",
+      "partitionDataColumnCount");
+  from_json_key(
+      j,
+      "tableToPartitionMapping",
+      p.tableToPartitionMapping,
+      "HiveSplit",
+      "TableToPartitionMapping",
+      "tableToPartitionMapping");
+  from_json_key(
+      j,
+      "bucketConversion",
+      p.bucketConversion,
+      "HiveSplit",
+      "BucketConversion",
+      "bucketConversion");
+  from_json_key(
+      j,
+      "s3SelectPushdownEnabled",
+      p.s3SelectPushdownEnabled,
+      "HiveSplit",
+      "bool",
+      "s3SelectPushdownEnabled");
+  from_json_key(
+      j,
+      "extraFileInfo",
+      p.extraFileInfo,
+      "HiveSplit",
       "String",
-      "fileName");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-DeleteHandle::DeleteHandle() noexcept {
-  _type = "DeleteHandle";
-}
-
-void to_json(json& j, const DeleteHandle& p) {
-  j = json::object();
-  j["@type"] = "DeleteHandle";
-  to_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
-  to_json_key(
-      j,
-      "schemaTableName",
-      p.schemaTableName,
-      "DeleteHandle",
-      "SchemaTableName",
-      "schemaTableName");
-}
-
-void from_json(const json& j, DeleteHandle& p) {
-  p._type = j["@type"];
-  from_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+      "extraFileInfo");
   from_json_key(
       j,
-      "schemaTableName",
-      p.schemaTableName,
-      "DeleteHandle",
-      "SchemaTableName",
-      "schemaTableName");
+      "cacheQuota",
+      p.cacheQuota,
+      "HiveSplit",
+      "CacheQuotaRequirement",
+      "cacheQuota");
+  from_json_key(
+      j,
+      "encryptionMetadata",
+      p.encryptionMetadata,
+      "HiveSplit",
+      "EncryptionInformation",
+      "encryptionMetadata");
+  from_json_key(
+      j,
+      "customSplitInfo",
+      p.customSplitInfo,
+      "HiveSplit",
+      "Map<String, String>",
+      "customSplitInfo");
+  from_json_key(
+      j,
+      "redundantColumnDomains",
+      p.redundantColumnDomains,
+      "HiveSplit",
+      "List<std::shared_ptr<ColumnHandle>>",
+      "redundantColumnDomains");
+  from_json_key(
+      j,
+      "splitWeight",
+      p.splitWeight,
+      "HiveSplit",
+      "SplitWeight",
+      "splitWeight");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -10826,102 +11084,153 @@ void from_json(const json& j, OutputNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Form, json> Form_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Form::IF, "IF"},
-        {Form::NULL_IF, "NULL_IF"},
-        {Form::SWITCH, "SWITCH"},
-        {Form::WHEN, "WHEN"},
-        {Form::IS_NULL, "IS_NULL"},
-        {Form::COALESCE, "COALESCE"},
-        {Form::IN, "IN"},
-        {Form::AND, "AND"},
-        {Form::OR, "OR"},
-        {Form::DEREFERENCE, "DEREFERENCE"},
-        {Form::ROW_CONSTRUCTOR, "ROW_CONSTRUCTOR"},
-        {Form::BIND, "BIND"}};
-void to_json(json& j, const Form& e) {
-  static_assert(std::is_enum<Form>::value, "Form must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Form_enum_table),
-      std::end(Form_enum_table),
-      [e](const std::pair<Form, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Form_enum_table)) ? it : std::begin(Form_enum_table))
-          ->second;
+EnforceSingleRowNode::EnforceSingleRowNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode";
 }
-void from_json(const json& j, Form& e) {
-  static_assert(std::is_enum<Form>::value, "Form must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Form_enum_table),
-      std::end(Form_enum_table),
-      [&j](const std::pair<Form, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Form_enum_table)) ? it : std::begin(Form_enum_table))
-          ->first;
+
+void to_json(json& j, const EnforceSingleRowNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode";
+  to_json_key(j, "id", p.id, "EnforceSingleRowNode", "PlanNodeId", "id");
+  to_json_key(
+      j, "source", p.source, "EnforceSingleRowNode", "PlanNode", "source");
+}
+
+void from_json(const json& j, EnforceSingleRowNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "EnforceSingleRowNode", "PlanNodeId", "id");
+  from_json_key(
+      j, "source", p.source, "EnforceSingleRowNode", "PlanNode", "source");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-SpecialFormExpression::SpecialFormExpression() noexcept {
-  _type = "special";
+SemiJoinNode::SemiJoinNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.SemiJoinNode";
 }
 
-void to_json(json& j, const SpecialFormExpression& p) {
+void to_json(json& j, const SemiJoinNode& p) {
   j = json::object();
-  j["@type"] = "special";
+  j["@type"] = "com.facebook.presto.sql.planner.plan.SemiJoinNode";
+  to_json_key(j, "id", p.id, "SemiJoinNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "SemiJoinNode", "PlanNode", "source");
   to_json_key(
       j,
-      "sourceLocation",
-      p.sourceLocation,
-      "SpecialFormExpression",
-      "SourceLocation",
-      "sourceLocation");
-  to_json_key(j, "form", p.form, "SpecialFormExpression", "Form", "form");
+      "filteringSource",
+      p.filteringSource,
+      "SemiJoinNode",
+      "PlanNode",
+      "filteringSource");
   to_json_key(
       j,
-      "returnType",
-      p.returnType,
-      "SpecialFormExpression",
-      "Type",
-      "returnType");
+      "sourceJoinVariable",
+      p.sourceJoinVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "sourceJoinVariable");
   to_json_key(
       j,
-      "arguments",
-      p.arguments,
-      "SpecialFormExpression",
-      "List<std::shared_ptr<RowExpression>>",
-      "arguments");
+      "filteringSourceJoinVariable",
+      p.filteringSourceJoinVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "filteringSourceJoinVariable");
+  to_json_key(
+      j,
+      "semiJoinOutput",
+      p.semiJoinOutput,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "semiJoinOutput");
+  to_json_key(
+      j,
+      "sourceHashVariable",
+      p.sourceHashVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "sourceHashVariable");
+  to_json_key(
+      j,
+      "filteringSourceHashVariable",
+      p.filteringSourceHashVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "filteringSourceHashVariable");
+  to_json_key(
+      j,
+      "distributionType",
+      p.distributionType,
+      "SemiJoinNode",
+      "DistributionType",
+      "distributionType");
+  to_json_key(
+      j,
+      "dynamicFilters",
+      p.dynamicFilters,
+      "SemiJoinNode",
+      "Map<String, VariableReferenceExpression>",
+      "dynamicFilters");
 }
 
-void from_json(const json& j, SpecialFormExpression& p) {
+void from_json(const json& j, SemiJoinNode& p) {
   p._type = j["@type"];
+  from_json_key(j, "id", p.id, "SemiJoinNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "SemiJoinNode", "PlanNode", "source");
   from_json_key(
       j,
-      "sourceLocation",
-      p.sourceLocation,
-      "SpecialFormExpression",
-      "SourceLocation",
-      "sourceLocation");
-  from_json_key(j, "form", p.form, "SpecialFormExpression", "Form", "form");
+      "filteringSource",
+      p.filteringSource,
+      "SemiJoinNode",
+      "PlanNode",
+      "filteringSource");
   from_json_key(
       j,
-      "returnType",
-      p.returnType,
-      "SpecialFormExpression",
-      "Type",
-      "returnType");
+      "sourceJoinVariable",
+      p.sourceJoinVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "sourceJoinVariable");
   from_json_key(
       j,
-      "arguments",
-      p.arguments,
-      "SpecialFormExpression",
-      "List<std::shared_ptr<RowExpression>>",
-      "arguments");
+      "filteringSourceJoinVariable",
+      p.filteringSourceJoinVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "filteringSourceJoinVariable");
+  from_json_key(
+      j,
+      "semiJoinOutput",
+      p.semiJoinOutput,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "semiJoinOutput");
+  from_json_key(
+      j,
+      "sourceHashVariable",
+      p.sourceHashVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "sourceHashVariable");
+  from_json_key(
+      j,
+      "filteringSourceHashVariable",
+      p.filteringSourceHashVariable,
+      "SemiJoinNode",
+      "VariableReferenceExpression",
+      "filteringSourceHashVariable");
+  from_json_key(
+      j,
+      "distributionType",
+      p.distributionType,
+      "SemiJoinNode",
+      "DistributionType",
+      "distributionType");
+  from_json_key(
+      j,
+      "dynamicFilters",
+      p.dynamicFilters,
+      "SemiJoinNode",
+      "Map<String, VariableReferenceExpression>",
+      "dynamicFilters");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
@@ -252,16 +252,6 @@ struct adl_serializer<facebook::presto::protocol::Map<K, V>> {
 // Forward declaration of all abstract types
 //
 namespace facebook::presto::protocol {
-struct ConnectorPartitioningHandle : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p);
-void from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ConnectorTransactionHandle : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p);
-void from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct RowExpression : public JsonEncodedSubclass {
   std::shared_ptr<SourceLocation> sourceLocation = {};
 };
@@ -269,11 +259,9 @@ void to_json(json& j, const std::shared_ptr<RowExpression>& p);
 void from_json(const json& j, std::shared_ptr<RowExpression>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct PlanNode : public JsonEncodedSubclass {
-  PlanNodeId id = {};
-};
-void to_json(json& j, const std::shared_ptr<PlanNode>& p);
-void from_json(const json& j, std::shared_ptr<PlanNode>& p);
+struct FunctionHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<FunctionHandle>& p);
+void from_json(const json& j, std::shared_ptr<FunctionHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct ColumnHandle : public JsonEncodedSubclass {
@@ -285,9 +273,36 @@ void to_json(json& j, const std::shared_ptr<ColumnHandle>& p);
 void from_json(const json& j, std::shared_ptr<ColumnHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct FunctionHandle : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<FunctionHandle>& p);
-void from_json(const json& j, std::shared_ptr<FunctionHandle>& p);
+struct ValueSet : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ValueSet>& p);
+void from_json(const json& j, std::shared_ptr<ValueSet>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PlanNode : public JsonEncodedSubclass {
+  PlanNodeId id = {};
+};
+void to_json(json& j, const std::shared_ptr<PlanNode>& p);
+void from_json(const json& j, std::shared_ptr<PlanNode>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ConnectorPartitioningHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p);
+void from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ConnectorTransactionHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p);
+void from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ConnectorOutputTableHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p);
+void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ExecutionWriterTarget : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p);
+void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct ConnectorTableLayoutHandle : public JsonEncodedSubclass {};
@@ -300,19 +315,9 @@ void to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p);
 void from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct ExecutionWriterTarget : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p);
-void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct ConnectorSplit : public JsonEncodedSubclass {};
 void to_json(json& j, const std::shared_ptr<ConnectorSplit>& p);
 void from_json(const json& j, std::shared_ptr<ConnectorSplit>& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ConnectorOutputTableHandle : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p);
-void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct ConnectorInsertTableHandle : public JsonEncodedSubclass {};
@@ -326,30 +331,11 @@ void from_json(
     const json& j,
     std::shared_ptr<ConnectorMetadataUpdateHandle>& p);
 } // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ValueSet : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ValueSet>& p);
-void from_json(const json& j, std::shared_ptr<ValueSet>& p);
-} // namespace facebook::presto::protocol
 
 namespace facebook::presto::protocol {
-enum class StageExecutionStrategy {
-  UNGROUPED_EXECUTION,
-  FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-  DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-  RECOVERABLE_GROUPED_EXECUTION
-};
-extern void to_json(json& j, const StageExecutionStrategy& e);
-extern void from_json(const json& j, StageExecutionStrategy& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct StageExecutionDescriptor {
-  StageExecutionStrategy stageExecutionStrategy = {};
-  List<PlanNodeId> groupedExecutionScanNodes = {};
-  int totalLifespans = {};
-};
-void to_json(json& j, const StageExecutionDescriptor& p);
-void from_json(const json& j, StageExecutionDescriptor& p);
+enum class ColumnType { PARTITION_KEY, REGULAR, SYNTHESIZED, AGGREGATED };
+extern void to_json(json& j, const ColumnType& e);
+extern void from_json(const json& j, ColumnType& e);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct SourceLocation {
@@ -358,6 +344,18 @@ struct SourceLocation {
 };
 void to_json(json& j, const SourceLocation& p);
 void from_json(const json& j, SourceLocation& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct CallExpression : public RowExpression {
+  String displayName = {};
+  std::shared_ptr<FunctionHandle> functionHandle = {};
+  Type returnType = {};
+  List<std::shared_ptr<RowExpression>> arguments = {};
+
+  CallExpression() noexcept;
+};
+void to_json(json& j, const CallExpression& p);
+void from_json(const json& j, CallExpression& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
@@ -393,164 +391,6 @@ std::string json_map_key(
 
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct EquiJoinClause {
-  VariableReferenceExpression left = {};
-  VariableReferenceExpression right = {};
-};
-void to_json(json& j, const EquiJoinClause& p);
-void from_json(const json& j, EquiJoinClause& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct LongVariableConstraint {
-  String name = {};
-  String expression = {};
-};
-void to_json(json& j, const LongVariableConstraint& p);
-void from_json(const json& j, LongVariableConstraint& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class FunctionKind { SCALAR, AGGREGATE, WINDOW };
-extern void to_json(json& j, const FunctionKind& e);
-extern void from_json(const json& j, FunctionKind& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-struct TypeVariableConstraint {
-  String name = {};
-  bool comparableRequired = {};
-  bool orderableRequired = {};
-  String variadicBound = {};
-  bool nonDecimalNumericRequired = {};
-  String boundedBy = {};
-};
-void to_json(json& j, const TypeVariableConstraint& p);
-void from_json(const json& j, TypeVariableConstraint& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Signature {
-  QualifiedObjectName name = {};
-  FunctionKind kind = {};
-  List<TypeVariableConstraint> typeVariableConstraints = {};
-  List<LongVariableConstraint> longVariableConstraints = {};
-  TypeSignature returnType = {};
-  List<TypeSignature> argumentTypes = {};
-  bool variableArity = {};
-};
-void to_json(json& j, const Signature& p);
-void from_json(const json& j, Signature& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Determinism {
-  DETERMINISTIC,
-  NOT_DETERMINISTIC,
-};
-extern void to_json(json& j, const Determinism& e);
-extern void from_json(const json& j, Determinism& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Language {
-  String language = {};
-};
-void to_json(json& j, const Language& p);
-void from_json(const json& j, Language& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class NullCallClause { RETURNS_NULL_ON_NULL_INPUT, CALLED_ON_NULL_INPUT };
-extern void to_json(json& j, const NullCallClause& e);
-extern void from_json(const json& j, NullCallClause& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct RoutineCharacteristics {
-  std::shared_ptr<Language> language = {};
-  std::shared_ptr<Determinism> determinism = {};
-  std::shared_ptr<NullCallClause> nullCallClause = {};
-};
-void to_json(json& j, const RoutineCharacteristics& p);
-void from_json(const json& j, RoutineCharacteristics& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Parameter {
-  String name = {};
-  TypeSignature type = {};
-};
-void to_json(json& j, const Parameter& p);
-void from_json(const json& j, Parameter& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SqlInvokedFunction {
-  List<Parameter> parameters = {};
-  String description = {};
-  RoutineCharacteristics routineCharacteristics = {};
-  String body = {};
-  Signature signature = {};
-  SqlFunctionId functionId = {};
-};
-void to_json(json& j, const SqlInvokedFunction& p);
-void from_json(const json& j, SqlInvokedFunction& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveTableHandle : public ConnectorTableHandle {
-  String schemaName = {};
-  String tableName = {};
-  std::shared_ptr<List<List<String>>> analyzePartitionValues = {};
-
-  HiveTableHandle() noexcept;
-};
-void to_json(json& j, const HiveTableHandle& p);
-void from_json(const json& j, HiveTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct BuiltInFunctionHandle : public FunctionHandle {
-  Signature signature = {};
-
-  BuiltInFunctionHandle() noexcept;
-};
-void to_json(json& j, const BuiltInFunctionHandle& p);
-void from_json(const json& j, BuiltInFunctionHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PartitioningHandle {
-  std::shared_ptr<ConnectorId> connectorId = {};
-  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
-  std::shared_ptr<ConnectorPartitioningHandle> connectorHandle = {};
-};
-void to_json(json& j, const PartitioningHandle& p);
-void from_json(const json& j, PartitioningHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Partitioning {
-  PartitioningHandle handle = {};
-  List<std::shared_ptr<RowExpression>> arguments = {};
-};
-void to_json(json& j, const Partitioning& p);
-void from_json(const json& j, Partitioning& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PartitioningScheme {
-  Partitioning partitioning = {};
-  List<VariableReferenceExpression> outputLayout = {};
-  std::shared_ptr<VariableReferenceExpression> hashColumn = {};
-  bool replicateNullsAndAny = {};
-  std::shared_ptr<List<int>> bucketToPartition = {};
-};
-void to_json(json& j, const PartitioningScheme& p);
-void from_json(const json& j, PartitioningScheme& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Assignments {
-  Map<VariableReferenceExpression, std::shared_ptr<RowExpression>> assignments =
-      {};
-};
-void to_json(json& j, const Assignments& p);
-void from_json(const json& j, Assignments& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Step { SINGLE, PARTIAL, FINAL };
-extern void to_json(json& j, const Step& e);
-extern void from_json(const json& j, Step& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 enum class SortOrder {
   ASC_NULLS_FIRST,
   ASC_NULLS_LAST,
@@ -574,200 +414,6 @@ struct OrderingScheme {
 };
 void to_json(json& j, const OrderingScheme& p);
 void from_json(const json& j, OrderingScheme& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TopNNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  int64_t count = {};
-  OrderingScheme orderingScheme = {};
-  Step step = {};
-
-  TopNNode() noexcept;
-};
-void to_json(json& j, const TopNNode& p);
-void from_json(const json& j, TopNNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-struct Column {
-  String name;
-  String type;
-
-  Column() = default;
-  explicit Column(const String& str) {
-    name = str;
-  }
-};
-
-void to_json(json& j, const Column& p);
-void from_json(const json& j, Column& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-struct Block {
-  std::string data;
-};
-
-void to_json(json& j, const Block& p);
-
-void from_json(const json& j, Block& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ConstantExpression : public RowExpression {
-  Block valueBlock = {};
-  Type type = {};
-
-  ConstantExpression() noexcept;
-};
-void to_json(json& j, const ConstantExpression& p);
-void from_json(const json& j, ConstantExpression& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct EmptySplit : public ConnectorSplit {
-  ConnectorId connectorId = {};
-
-  EmptySplit() noexcept;
-};
-void to_json(json& j, const EmptySplit& p);
-void from_json(const json& j, EmptySplit& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Bound { BELOW, EXACTLY, ABOVE };
-extern void to_json(json& j, const Bound& e);
-extern void from_json(const json& j, Bound& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Marker {
-  Type type = {};
-  std::shared_ptr<Block> valueBlock = {};
-  Bound bound = {};
-};
-void to_json(json& j, const Marker& p);
-void from_json(const json& j, Marker& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Range {
-  Marker low = {};
-  Marker high = {};
-};
-void to_json(json& j, const Range& p);
-void from_json(const json& j, Range& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TableToPartitionMapping {
-  std::shared_ptr<Map<Integer, Integer>> tableToPartitionColumns = {};
-  Map<Integer, Column> partitionSchemaDifference = {};
-};
-void to_json(json& j, const TableToPartitionMapping& p);
-void from_json(const json& j, TableToPartitionMapping& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DwrfEncryptionMetadata {
-  Map<String, String> fieldToKeyData = {};
-  Map<String, String> extraMetadata = {};
-  String encryptionAlgorithm = {};
-  String encryptionProvider = {};
-};
-void to_json(json& j, const DwrfEncryptionMetadata& p);
-void from_json(const json& j, DwrfEncryptionMetadata& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct EncryptionInformation {
-  std::shared_ptr<DwrfEncryptionMetadata> dwrfEncryptionMetadata = {};
-};
-void to_json(json& j, const EncryptionInformation& p);
-void from_json(const json& j, EncryptionInformation& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class BucketFunctionType { HIVE_COMPATIBLE, PRESTO_NATIVE };
-extern void to_json(json& j, const BucketFunctionType& e);
-extern void from_json(const json& j, BucketFunctionType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Order { ASCENDING, DESCENDING };
-extern void to_json(json& j, const Order& e);
-extern void from_json(const json& j, Order& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SortingColumn {
-  String columnName = {};
-  Order order = {};
-};
-void to_json(json& j, const SortingColumn& p);
-void from_json(const json& j, SortingColumn& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveBucketProperty {
-  List<String> bucketedBy = {};
-  int bucketCount = {};
-  List<SortingColumn> sortedBy = {};
-  BucketFunctionType bucketFunctionType = {};
-  std::shared_ptr<List<Type>> types = {};
-};
-void to_json(json& j, const HiveBucketProperty& p);
-void from_json(const json& j, HiveBucketProperty& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct StorageFormat {
-  String serDe = {};
-  String inputFormat = {};
-  String outputFormat = {};
-};
-void to_json(json& j, const StorageFormat& p);
-void from_json(const json& j, StorageFormat& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Storage {
-  StorageFormat storageFormat = {};
-  String location = {};
-  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
-  bool skewed = {};
-  Map<String, String> serdeParameters = {};
-  Map<String, String> parameters = {};
-};
-void to_json(json& j, const Storage& p);
-void from_json(const json& j, Storage& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class NodeSelectionStrategy {
-  HARD_AFFINITY,
-  SOFT_AFFINITY,
-  NO_PREFERENCE
-};
-extern void to_json(json& j, const NodeSelectionStrategy& e);
-extern void from_json(const json& j, NodeSelectionStrategy& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-using HostAddress = std::string;
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HivePartitionKey {
-  String name = {};
-  std::shared_ptr<String> value = {};
-};
-void to_json(json& j, const HivePartitionKey& p);
-void from_json(const json& j, HivePartitionKey& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class ColumnType { PARTITION_KEY, REGULAR, SYNTHESIZED, AGGREGATED };
-extern void to_json(json& j, const ColumnType& e);
-extern void from_json(const json& j, ColumnType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct CallExpression : public RowExpression {
-  String displayName = {};
-  std::shared_ptr<FunctionHandle> functionHandle = {};
-  Type returnType = {};
-  List<std::shared_ptr<RowExpression>> arguments = {};
-
-  CallExpression() noexcept;
-};
-void to_json(json& j, const CallExpression& p);
-void from_json(const json& j, CallExpression& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct Aggregation {
@@ -806,275 +452,6 @@ void from_json(const json& j, HiveColumnHandle& p);
 
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct BucketConversion {
-  int tableBucketCount = {};
-  int partitionBucketCount = {};
-  List<HiveColumnHandle> bucketColumnHandles = {};
-};
-void to_json(json& j, const BucketConversion& p);
-void from_json(const json& j, BucketConversion& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class CacheQuotaScope { GLOBAL, SCHEMA, TABLE, PARTITION };
-extern void to_json(json& j, const CacheQuotaScope& e);
-extern void from_json(const json& j, CacheQuotaScope& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-std::ostream& operator<<(std::ostream& os, const DataSize& d);
-
-void to_json(nlohmann::json& j, const DataSize& p);
-void from_json(const nlohmann::json& j, DataSize& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct CacheQuotaRequirement {
-  CacheQuotaScope cacheQuotaScope = {};
-  std::shared_ptr<DataSize> quota = {};
-};
-void to_json(json& j, const CacheQuotaRequirement& p);
-void from_json(const json& j, CacheQuotaRequirement& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveSplit : public ConnectorSplit {
-  String database = {};
-  String table = {};
-  String partitionName = {};
-  String path = {};
-  int64_t start = {};
-  int64_t length = {};
-  int64_t fileSize = {};
-  int64_t fileModifiedTime = {};
-  Storage storage = {};
-  List<HivePartitionKey> partitionKeys = {};
-  List<HostAddress> addresses = {};
-  std::shared_ptr<int> readBucketNumber = {};
-  std::shared_ptr<int> tableBucketNumber = {};
-  NodeSelectionStrategy nodeSelectionStrategy = {};
-  int partitionDataColumnCount = {};
-  TableToPartitionMapping tableToPartitionMapping = {};
-  std::shared_ptr<BucketConversion> bucketConversion = {};
-  bool s3SelectPushdownEnabled = {};
-  std::shared_ptr<String> extraFileInfo = {};
-  CacheQuotaRequirement cacheQuota = {};
-  std::shared_ptr<EncryptionInformation> encryptionMetadata = {};
-  Map<String, String> customSplitInfo = {};
-  List<std::shared_ptr<ColumnHandle>> redundantColumnDomains = {};
-  SplitWeight splitWeight = {};
-
-  HiveSplit() noexcept;
-};
-void to_json(json& j, const HiveSplit& p);
-void from_json(const json& j, HiveSplit& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class BufferType {
-  PARTITIONED,
-  BROADCAST,
-  ARBITRARY,
-  DISCARDING,
-  SPOOLING
-};
-extern void to_json(json& j, const BufferType& e);
-extern void from_json(const json& j, BufferType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OutputBuffers {
-  BufferType type = {};
-  int64_t version = {};
-  bool noMoreBufferIds = {};
-  Map<OutputBufferId, Integer> buffers = {};
-};
-void to_json(json& j, const OutputBuffers& p);
-void from_json(const json& j, OutputBuffers& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class SelectedRoleType { ROLE, ALL, NONE };
-extern void to_json(json& j, const SelectedRoleType& e);
-extern void from_json(const json& j, SelectedRoleType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SelectedRole {
-  SelectedRoleType type = {};
-  std::shared_ptr<String> role = {};
-};
-void to_json(json& j, const SelectedRole& p);
-void from_json(const json& j, SelectedRole& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-std::ostream& operator<<(std::ostream& os, const Duration& d);
-
-void to_json(json& j, const Duration& p);
-void from_json(const json& j, Duration& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ResourceEstimates {
-  std::shared_ptr<Duration> executionTime = {};
-  std::shared_ptr<Duration> cpuTime = {};
-  std::shared_ptr<DataSize> peakMemory = {};
-  std::shared_ptr<DataSize> peakTaskMemory = {};
-};
-void to_json(json& j, const ResourceEstimates& p);
-void from_json(const json& j, ResourceEstimates& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SessionRepresentation {
-  String queryId = {};
-  std::shared_ptr<TransactionId> transactionId = {};
-  bool clientTransactionSupport = {};
-  String user = {};
-  std::shared_ptr<String> principal = {};
-  std::shared_ptr<String> source = {};
-  std::shared_ptr<String> catalog = {};
-  std::shared_ptr<String> schema = {};
-  std::shared_ptr<String> traceToken = {};
-  TimeZoneKey timeZoneKey = {};
-  Locale locale = {};
-  std::shared_ptr<String> remoteUserAddress = {};
-  std::shared_ptr<String> userAgent = {};
-  std::shared_ptr<String> clientInfo = {};
-  List<String> clientTags = {};
-  ResourceEstimates resourceEstimates = {};
-  int64_t startTime = {};
-  Map<String, String> systemProperties = {};
-  Map<ConnectorId, Map<String, String>> catalogProperties = {};
-  Map<String, Map<String, String>> unprocessedCatalogProperties = {};
-  Map<String, SelectedRole> roles = {};
-  Map<String, String> preparedStatements = {};
-  Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions = {};
-};
-void to_json(json& j, const SessionRepresentation& p);
-void from_json(const json& j, SessionRepresentation& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TableHandle {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
-  std::shared_ptr<ConnectorTransactionHandle> transaction = {};
-  std::shared_ptr<ConnectorTableLayoutHandle> connectorTableLayout = {};
-};
-void to_json(json& j, const TableHandle& p);
-void from_json(const json& j, TableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DeleteScanInfo {
-  PlanNodeId id = {};
-  TableHandle tableHandle = {};
-};
-void to_json(json& j, const DeleteScanInfo& p);
-void from_json(const json& j, DeleteScanInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct AnalyzeTableHandle {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
-  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
-};
-void to_json(json& j, const AnalyzeTableHandle& p);
-void from_json(const json& j, AnalyzeTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TableWriteInfo {
-  std::shared_ptr<ExecutionWriterTarget> writerTarget = {};
-  std::shared_ptr<AnalyzeTableHandle> analyzeTableHandle = {};
-  std::shared_ptr<DeleteScanInfo> deleteScanInfo = {};
-};
-void to_json(json& j, const TableWriteInfo& p);
-void from_json(const json& j, TableWriteInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SplitContext {
-  bool cacheable = {};
-};
-void to_json(json& j, const SplitContext& p);
-void from_json(const json& j, SplitContext& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-struct Lifespan {
-  bool isgroup = false;
-  long groupid = 0;
-
-  bool operator<(const Lifespan& o) const {
-    return groupid < o.groupid;
-  }
-};
-
-void to_json(json& j, const Lifespan& p);
-void from_json(const json& j, Lifespan& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Split {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
-  std::shared_ptr<ConnectorSplit> connectorSplit = {};
-  Lifespan lifespan = {};
-  SplitContext splitContext = {};
-};
-void to_json(json& j, const Split& p);
-void from_json(const json& j, Split& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-struct ScheduledSplit {
-  long sequenceId = {};
-  PlanNodeId planNodeId = {}; // dependency
-  Split split = {};
-
-  bool operator<(const ScheduledSplit& o) const {
-    return sequenceId < o.sequenceId;
-  }
-};
-
-void to_json(json& j, const ScheduledSplit& p);
-void from_json(const json& j, ScheduledSplit& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TaskSource {
-  PlanNodeId planNodeId = {};
-  List<ScheduledSplit> splits = {};
-  List<Lifespan> noMoreSplitsForLifespan = {};
-  bool noMoreSplits = {};
-};
-void to_json(json& j, const TaskSource& p);
-void from_json(const json& j, TaskSource& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TaskUpdateRequest {
-  SessionRepresentation session = {};
-  Map<String, String> extraCredentials = {};
-  std::shared_ptr<String> fragment = {};
-  List<TaskSource> sources = {};
-  OutputBuffers outputIds = {};
-  std::shared_ptr<TableWriteInfo> tableWriteInfo = {};
-};
-void to_json(json& j, const TaskUpdateRequest& p);
-void from_json(const json& j, TaskUpdateRequest& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct AssignUniqueId : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  VariableReferenceExpression idVariable = {};
-
-  AssignUniqueId() noexcept;
-};
-void to_json(json& j, const AssignUniqueId& p);
-void from_json(const json& j, AssignUniqueId& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OutputTableHandle {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
-  std::shared_ptr<ConnectorOutputTableHandle> connectorHandle = {};
-};
-void to_json(json& j, const OutputTableHandle& p);
-void from_json(const json& j, OutputTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct SchemaTableName {
   String schema = {};
   String table = {};
@@ -1083,838 +460,20 @@ void to_json(json& j, const SchemaTableName& p);
 void from_json(const json& j, SchemaTableName& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct CreateHandle : public ExecutionWriterTarget {
-  OutputTableHandle handle = {};
-  SchemaTableName schemaTableName = {};
 
-  CreateHandle() noexcept;
-};
-void to_json(json& j, const CreateHandle& p);
-void from_json(const json& j, CreateHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class ErrorType {
-  USER_ERROR,
-  INTERNAL_ERROR,
-  INSUFFICIENT_RESOURCES,
-  EXTERNAL
-};
-extern void to_json(json& j, const ErrorType& e);
-extern void from_json(const json& j, ErrorType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ErrorCode {
-  int code = {};
-  String name = {};
-  ErrorType type = {};
-  bool retriable = {};
-};
-void to_json(json& j, const ErrorCode& p);
-void from_json(const json& j, ErrorCode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ErrorLocation {
-  int lineNumber = {};
-  int columnNumber = {};
-};
-void to_json(json& j, const ErrorLocation& p);
-void from_json(const json& j, ErrorLocation& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ExecutionFailureInfo {
-  String type = {};
-  String message = {};
-  std::shared_ptr<ExecutionFailureInfo> cause = {};
-  List<ExecutionFailureInfo> suppressed = {};
-  List<String> stack = {};
-  ErrorLocation errorLocation = {};
-  ErrorCode errorCode = {};
-  HostAddress remoteHost = {};
-};
-void to_json(json& j, const ExecutionFailureInfo& p);
-void from_json(const json& j, ExecutionFailureInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SortedRangeSet : public ValueSet {
-  Type type = {};
-  List<Range> ranges = {};
+struct Column {
+  String name;
+  String type;
 
-  SortedRangeSet() noexcept;
-};
-void to_json(json& j, const SortedRangeSet& p);
-void from_json(const json& j, SortedRangeSet& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ValuesNode : public PlanNode {
-  List<VariableReferenceExpression> outputVariables = {};
-  List<List<std::shared_ptr<RowExpression>>> rows = {};
-
-  ValuesNode() noexcept;
-};
-void to_json(json& j, const ValuesNode& p);
-void from_json(const json& j, ValuesNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Locality { UNKNOWN, LOCAL, REMOTE };
-extern void to_json(json& j, const Locality& e);
-extern void from_json(const json& j, Locality& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ProjectNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  Assignments assignments = {};
-  Locality locality = {};
-
-  ProjectNode() noexcept;
-};
-void to_json(json& j, const ProjectNode& p);
-void from_json(const json& j, ProjectNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct InsertTableHandle {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
-  std::shared_ptr<ConnectorInsertTableHandle> connectorHandle = {};
-};
-void to_json(json& j, const InsertTableHandle& p);
-void from_json(const json& j, InsertTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class RuntimeUnit { NONE, NANO, BYTE };
-extern void to_json(json& j, const RuntimeUnit& e);
-extern void from_json(const json& j, RuntimeUnit& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct RuntimeMetric {
-  String name = {};
-  RuntimeUnit unit = {};
-  int64_t sum = {};
-  int64_t count = {};
-  int64_t max = {};
-  int64_t min = {};
-};
-void to_json(json& j, const RuntimeMetric& p);
-void from_json(const json& j, RuntimeMetric& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveTransactionHandle : public ConnectorTransactionHandle {
-  UUID uuid = {};
-
-  HiveTransactionHandle() noexcept;
-};
-void to_json(json& j, const HiveTransactionHandle& p);
-void from_json(const json& j, HiveTransactionHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class JoinNodeType { INNER, LEFT, RIGHT, FULL };
-extern void to_json(json& j, const JoinNodeType& e);
-extern void from_json(const json& j, JoinNodeType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class DistributionType { PARTITIONED, REPLICATED };
-extern void to_json(json& j, const DistributionType& e);
-extern void from_json(const json& j, DistributionType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct JoinNode : public PlanNode {
-  JoinNodeType type = {};
-  std::shared_ptr<PlanNode> left = {};
-  std::shared_ptr<PlanNode> right = {};
-  List<EquiJoinClause> criteria = {};
-  List<VariableReferenceExpression> outputVariables = {};
-  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};
-  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};
-  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};
-  std::shared_ptr<DistributionType> distributionType = {};
-  Map<String, VariableReferenceExpression> dynamicFilters = {};
-
-  JoinNode() noexcept;
-};
-void to_json(json& j, const JoinNode& p);
-void from_json(const json& j, JoinNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct MergeJoinNode : public PlanNode {
-  MergeJoinNode() noexcept;
-  PlanNodeId id = {};
-  // JoinNodeType is referenced as JoinNode.Type in Presto
-  // Since presto_cpp codegen can't nicely handle inner class references
-  // So a special hard-coded template is required here
-  JoinNodeType type = {};
-  std::shared_ptr<PlanNode> left = {};
-  std::shared_ptr<PlanNode> right = {};
-  // EquiJoinClause is referenced as JoinNode.EquiJoinClause in Presto
-  List<EquiJoinClause> criteria = {};
-  List<VariableReferenceExpression> outputVariables = {};
-  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};
-  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};
-  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};
-};
-void to_json(json& j, const MergeJoinNode& p);
-void from_json(const json& j, MergeJoinNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct NodeVersion {
-  String version = {};
-};
-void to_json(json& j, const NodeVersion& p);
-void from_json(const json& j, NodeVersion& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct MemoryAllocation {
-  String tag = {};
-  int64_t allocation = {};
-};
-void to_json(json& j, const MemoryAllocation& p);
-void from_json(const json& j, MemoryAllocation& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct MemoryPoolInfo {
-  int64_t maxBytes = {};
-  int64_t reservedBytes = {};
-  int64_t reservedRevocableBytes = {};
-  Map<QueryId, Long> queryMemoryReservations = {};
-  Map<QueryId, List<MemoryAllocation>> queryMemoryAllocations = {};
-  Map<QueryId, Long> queryMemoryRevocableReservations = {};
-};
-void to_json(json& j, const MemoryPoolInfo& p);
-void from_json(const json& j, MemoryPoolInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct MemoryInfo {
-  DataSize totalNodeMemory = {};
-  Map<MemoryPoolId, MemoryPoolInfo> pools = {};
-};
-void to_json(json& j, const MemoryInfo& p);
-void from_json(const json& j, MemoryInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct NodeStatus {
-  String nodeId = {};
-  NodeVersion nodeVersion = {};
-  String environment = {};
-  bool coordinator = {};
-  Duration uptime = {};
-  String externalAddress = {};
-  String internalAddress = {};
-  MemoryInfo memoryInfo = {};
-  int processors = {};
-  double processCpuLoad = {};
-  double systemCpuLoad = {};
-  int64_t heapUsed = {};
-  int64_t heapAvailable = {};
-  int64_t nonHeapUsed = {};
-};
-void to_json(json& j, const NodeStatus& p);
-void from_json(const json& j, NodeStatus& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PlanCostEstimate {
-  double cpuCost = {};
-  double maxMemory = {};
-  double maxMemoryWhenOutputting = {};
-  double networkCost = {};
-};
-void to_json(json& j, const PlanCostEstimate& p);
-void from_json(const json& j, PlanCostEstimate& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct VariableStatsEstimate {
-  double lowValue = {};
-  double highValue = {};
-  double nullsFraction = {};
-  double averageRowSize = {};
-  double distinctValuesCount = {};
-};
-void to_json(json& j, const VariableStatsEstimate& p);
-void from_json(const json& j, VariableStatsEstimate& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PlanNodeStatsEstimate {
-  double outputRowCount = {};
-  double totalSize = {};
-  bool confident = {};
-  Map<VariableReferenceExpression, VariableStatsEstimate> variableStatistics =
-      {};
-};
-void to_json(json& j, const PlanNodeStatsEstimate& p);
-void from_json(const json& j, PlanNodeStatsEstimate& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct StatsAndCosts {
-  Map<PlanNodeId, PlanNodeStatsEstimate> stats = {};
-  Map<PlanNodeId, PlanCostEstimate> costs = {};
-};
-void to_json(json& j, const StatsAndCosts& p);
-void from_json(const json& j, StatsAndCosts& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct LambdaDefinitionExpression : public RowExpression {
-  List<Type> argumentTypes = {};
-  List<String> arguments = {};
-  std::shared_ptr<RowExpression> body = {};
-
-  LambdaDefinitionExpression() noexcept;
-};
-void to_json(json& j, const LambdaDefinitionExpression& p);
-void from_json(const json& j, LambdaDefinitionExpression& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-enum class HiveStorageFormat {
-  ORC,
-  DWRF,
-  PARQUET,
-  AVRO,
-  RCBINARY,
-  RCTEXT,
-  SEQUENCEFILE,
-  JSON,
-  TEXTFILE,
-  CSV,
-  PAGEFILE
+  Column() = default;
+  explicit Column(const String& str) {
+    name = str;
+  }
 };
 
-void to_json(json& j, const HiveStorageFormat& p);
-void from_json(const json& j, HiveStorageFormat& p);
+void to_json(json& j, const Column& p);
+void from_json(const json& j, Column& p);
 
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class TableType { NEW, EXISTING, TEMPORARY };
-extern void to_json(json& j, const TableType& e);
-extern void from_json(const json& j, TableType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class WriteMode {
-  STAGE_AND_MOVE_TO_TARGET_DIRECTORY,
-  DIRECT_TO_TARGET_NEW_DIRECTORY,
-  DIRECT_TO_TARGET_EXISTING_DIRECTORY
-};
-extern void to_json(json& j, const WriteMode& e);
-extern void from_json(const json& j, WriteMode& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct LocationHandle {
-  String targetPath = {};
-  String writePath = {};
-  std::shared_ptr<String> tempPath = {};
-  TableType tableType = {};
-  WriteMode writeMode = {};
-};
-void to_json(json& j, const LocationHandle& p);
-void from_json(const json& j, LocationHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class HiveCompressionCodec { NONE, SNAPPY, GZIP, LZ4, ZSTD };
-extern void to_json(json& j, const HiveCompressionCodec& e);
-extern void from_json(const json& j, HiveCompressionCodec& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class PrestoTableType {
-  MANAGED_TABLE,
-  EXTERNAL_TABLE,
-  VIRTUAL_VIEW,
-  MATERIALIZED_VIEW,
-  TEMPORARY_TABLE,
-  OTHER
-};
-extern void to_json(json& j, const PrestoTableType& e);
-extern void from_json(const json& j, PrestoTableType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Table {
-  String databaseName = {};
-  String tableName = {};
-  String owner = {};
-  PrestoTableType tableType = {};
-  Storage storage = {};
-  List<Column> dataColumns = {};
-  List<Column> partitionColumns = {};
-  Map<String, String> parameters = {};
-  std::shared_ptr<String> viewOriginalText = {};
-  std::shared_ptr<String> viewExpandedText = {};
-};
-void to_json(json& j, const Table& p);
-void from_json(const json& j, Table& p);
-} // namespace facebook::presto::protocol
-// dependency Table
-// dependency SchemaTableName
-
-namespace facebook::presto::protocol {
-
-struct HivePageSinkMetadata {
-  SchemaTableName schemaTableName = {};
-  std::shared_ptr<Table> table = {};
-  // TODO Add modifiedPartitions
-};
-void to_json(json& j, const HivePageSinkMetadata& p);
-void from_json(const json& j, HivePageSinkMetadata& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveInsertTableHandle : public ConnectorInsertTableHandle {
-  String schemaName = {};
-  String tableName = {};
-  List<HiveColumnHandle> inputColumns = {};
-  HivePageSinkMetadata pageSinkMetadata = {};
-  LocationHandle locationHandle = {};
-  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
-  List<SortingColumn> preferredOrderingColumns = {};
-  HiveStorageFormat tableStorageFormat = {};
-  HiveStorageFormat partitionStorageFormat = {};
-  HiveStorageFormat actualStorageFormat = {};
-  HiveCompressionCodec compressionCodec = {};
-  std::shared_ptr<EncryptionInformation> encryptionInformation = {};
-
-  HiveInsertTableHandle() noexcept;
-};
-void to_json(json& j, const HiveInsertTableHandle& p);
-void from_json(const json& j, HiveInsertTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-class ValueEntry {
- public:
-  Type type;
-  std::shared_ptr<Block> block;
-};
-
-void to_json(json& j, const ValueEntry& p);
-void from_json(const json& j, ValueEntry& p);
-
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct EquatableValueSet : public ValueSet {
-  Type type = {};
-  bool whiteList = {};
-  List<ValueEntry> entries = {};
-
-  EquatableValueSet() noexcept;
-};
-void to_json(json& j, const EquatableValueSet& p);
-void from_json(const json& j, EquatableValueSet& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class BlockedReason { WAITING_FOR_MEMORY };
-extern void to_json(json& j, const BlockedReason& e);
-extern void from_json(const json& j, BlockedReason& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OperatorInfo {};
-void to_json(json& j, const OperatorInfo& p);
-void from_json(const json& j, OperatorInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OperatorStats {
-  int stageId = {};
-  int stageExecutionId = {};
-  int pipelineId = {};
-  int operatorId = {};
-  PlanNodeId planNodeId = {};
-  String operatorType = {};
-  int64_t totalDrivers = {};
-  int64_t addInputCalls = {};
-  Duration addInputWall = {};
-  Duration addInputCpu = {};
-  DataSize addInputAllocation = {};
-  DataSize rawInputDataSize = {};
-  int64_t rawInputPositions = {};
-  DataSize inputDataSize = {};
-  int64_t inputPositions = {};
-  double sumSquaredInputPositions = {};
-  int64_t getOutputCalls = {};
-  Duration getOutputWall = {};
-  Duration getOutputCpu = {};
-  DataSize getOutputAllocation = {};
-  DataSize outputDataSize = {};
-  int64_t outputPositions = {};
-  DataSize physicalWrittenDataSize = {};
-  Duration additionalCpu = {};
-  Duration blockedWall = {};
-  int64_t finishCalls = {};
-  Duration finishWall = {};
-  Duration finishCpu = {};
-  DataSize finishAllocation = {};
-  DataSize userMemoryReservation = {};
-  DataSize revocableMemoryReservation = {};
-  DataSize systemMemoryReservation = {};
-  DataSize peakUserMemoryReservation = {};
-  DataSize peakSystemMemoryReservation = {};
-  DataSize peakTotalMemoryReservation = {};
-  DataSize spilledDataSize = {};
-  std::shared_ptr<BlockedReason> blockedReason = {};
-  OperatorInfo info = {};
-  RuntimeStats runtimeStats = {};
-};
-void to_json(json& j, const OperatorStats& p);
-void from_json(const json& j, OperatorStats& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DriverStats {
-  Lifespan lifespan = {};
-  DateTime createTime = {};
-  DateTime startTime = {};
-  DateTime endTime = {};
-  Duration queuedTime = {};
-  Duration elapsedTime = {};
-  DataSize userMemoryReservation = {};
-  DataSize revocableMemoryReservation = {};
-  DataSize systemMemoryReservation = {};
-  Duration totalScheduledTime = {};
-  Duration totalCpuTime = {};
-  Duration totalBlockedTime = {};
-  bool fullyBlocked = {};
-  List<BlockedReason> blockedReasons = {};
-  DataSize totalAllocation = {};
-  DataSize rawInputDataSize = {};
-  int64_t rawInputPositions = {};
-  Duration rawInputReadTime = {};
-  DataSize processedInputDataSize = {};
-  int64_t processedInputPositions = {};
-  DataSize outputDataSize = {};
-  int64_t outputPositions = {};
-  DataSize physicalWrittenDataSize = {};
-  List<OperatorStats> operatorStats = {};
-};
-void to_json(json& j, const DriverStats& p);
-void from_json(const json& j, DriverStats& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DistributionSnapshot {
-  double maxError = {};
-  double count = {};
-  double total = {};
-  int64_t p01 = {};
-  int64_t p05 = {};
-  int64_t p10 = {};
-  int64_t p25 = {};
-  int64_t p50 = {};
-  int64_t p75 = {};
-  int64_t p90 = {};
-  int64_t p95 = {};
-  int64_t p99 = {};
-  int64_t min = {};
-  int64_t max = {};
-  double avg = {};
-};
-void to_json(json& j, const DistributionSnapshot& p);
-void from_json(const json& j, DistributionSnapshot& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PipelineStats {
-  int pipelineId = {};
-  DateTime firstStartTime = {};
-  DateTime lastStartTime = {};
-  DateTime lastEndTime = {};
-  bool inputPipeline = {};
-  bool outputPipeline = {};
-  int totalDrivers = {};
-  int queuedDrivers = {};
-  int queuedPartitionedDrivers = {};
-  int64_t queuedPartitionedSplitsWeight = {};
-  int runningDrivers = {};
-  int runningPartitionedDrivers = {};
-  int64_t runningPartitionedSplitsWeight = {};
-  int blockedDrivers = {};
-  int completedDrivers = {};
-  int64_t userMemoryReservationInBytes = {};
-  int64_t revocableMemoryReservationInBytes = {};
-  int64_t systemMemoryReservationInBytes = {};
-  DistributionSnapshot queuedTime = {};
-  DistributionSnapshot elapsedTime = {};
-  int64_t totalScheduledTimeInNanos = {};
-  int64_t totalCpuTimeInNanos = {};
-  int64_t totalBlockedTimeInNanos = {};
-  bool fullyBlocked = {};
-  List<BlockedReason> blockedReasons = {};
-  int64_t totalAllocationInBytes = {};
-  int64_t rawInputDataSizeInBytes = {};
-  int64_t rawInputPositions = {};
-  int64_t processedInputDataSizeInBytes = {};
-  int64_t processedInputPositions = {};
-  int64_t outputDataSizeInBytes = {};
-  int64_t outputPositions = {};
-  int64_t physicalWrittenDataSizeInBytes = {};
-  List<OperatorStats> operatorSummaries = {};
-  List<DriverStats> drivers = {};
-};
-void to_json(json& j, const PipelineStats& p);
-void from_json(const json& j, PipelineStats& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct Location {
-  String location = {};
-};
-void to_json(json& j, const Location& p);
-void from_json(const json& j, Location& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct UnnestNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  List<VariableReferenceExpression> replicateVariables = {};
-  Map<VariableReferenceExpression, List<VariableReferenceExpression>>
-      unnestVariables = {};
-  std::shared_ptr<VariableReferenceExpression> ordinalityVariable = {};
-
-  UnnestNode() noexcept;
-};
-void to_json(json& j, const UnnestNode& p);
-void from_json(const json& j, UnnestNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct MetadataUpdates {
-  ConnectorId connectorId = {};
-  List<std::shared_ptr<ConnectorMetadataUpdateHandle>> metadataUpdates = {};
-};
-void to_json(json& j, const MetadataUpdates& p);
-void from_json(const json& j, MetadataUpdates& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SortNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  OrderingScheme orderingScheme = {};
-  bool isPartial = {};
-
-  SortNode() noexcept;
-};
-void to_json(json& j, const SortNode& p);
-void from_json(const json& j, SortNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DistinctLimitNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  int64_t limit = {};
-  bool partial = {};
-  List<VariableReferenceExpression> distinctVariables = {};
-  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
-
-  DistinctLimitNode() noexcept;
-};
-void to_json(json& j, const DistinctLimitNode& p);
-void from_json(const json& j, DistinctLimitNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct FilterNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  std::shared_ptr<RowExpression> predicate = {};
-
-  FilterNode() noexcept;
-};
-void to_json(json& j, const FilterNode& p);
-void from_json(const json& j, FilterNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TaskStats {
-  DateTime createTime = {};
-  DateTime firstStartTime = {};
-  DateTime lastStartTime = {};
-  DateTime lastEndTime = {};
-  DateTime endTime = {};
-  int64_t elapsedTimeInNanos = {};
-  int64_t queuedTimeInNanos = {};
-  int totalDrivers = {};
-  int queuedDrivers = {};
-  int queuedPartitionedDrivers = {};
-  int64_t queuedPartitionedSplitsWeight = {};
-  int runningDrivers = {};
-  int runningPartitionedDrivers = {};
-  int64_t runningPartitionedSplitsWeight = {};
-  int blockedDrivers = {};
-  int completedDrivers = {};
-  double cumulativeUserMemory = {};
-  double cumulativeTotalMemory = {};
-  int64_t userMemoryReservation = {};
-  int64_t revocableMemoryReservationInBytes = {};
-  int64_t systemMemoryReservationInBytes = {};
-  int64_t peakTotalMemoryInBytes = {};
-  int64_t peakUserMemoryInBytes = {};
-  int64_t peakNodeTotalMemoryInbytes = {};
-  int64_t totalScheduledTimeInNanos = {};
-  int64_t totalCpuTimeInNanos = {};
-  int64_t totalBlockedTimeInNanos = {};
-  bool fullyBlocked = {};
-  List<BlockedReason> blockedReasons = {};
-  int64_t totalAllocationInBytes = {};
-  int64_t rawInputDataSizeInBytes = {};
-  int64_t rawInputPositions = {};
-  int64_t processedInputDataSizeInBytes = {};
-  int64_t processedInputPositions = {};
-  int64_t outputDataSizeInBytes = {};
-  int64_t outputPositions = {};
-  int64_t physicalWrittenDataSizeInBytes = {};
-  int fullGcCount = {};
-  int64_t fullGcTimeInMillis = {};
-  List<PipelineStats> pipelines = {};
-  RuntimeStats runtimeStats = {};
-};
-void to_json(json& j, const TaskStats& p);
-void from_json(const json& j, TaskStats& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct PageBufferInfo {
-  int partition = {};
-  int64_t bufferedPages = {};
-  int64_t bufferedBytes = {};
-  int64_t rowsAdded = {};
-  int64_t pagesAdded = {};
-};
-void to_json(json& j, const PageBufferInfo& p);
-void from_json(const json& j, PageBufferInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct BufferInfo {
-  OutputBufferId bufferId = {};
-  bool finished = {};
-  int bufferedPages = {};
-  int64_t pagesSent = {};
-  PageBufferInfo pageBufferInfo = {};
-};
-void to_json(json& j, const BufferInfo& p);
-void from_json(const json& j, BufferInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class BufferState {
-  OPEN,
-  NO_MORE_BUFFERS,
-  NO_MORE_PAGES,
-  FLUSHING,
-  FINISHED,
-  FAILED
-};
-extern void to_json(json& j, const BufferState& e);
-extern void from_json(const json& j, BufferState& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OutputBufferInfo {
-  String type = {};
-  BufferState state = {};
-  bool canAddBuffers = {};
-  bool canAddPages = {};
-  int64_t totalBufferedBytes = {};
-  int64_t totalBufferedPages = {};
-  int64_t totalRowsSent = {};
-  int64_t totalPagesSent = {};
-  List<BufferInfo> buffers = {};
-};
-void to_json(json& j, const OutputBufferInfo& p);
-void from_json(const json& j, OutputBufferInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class TaskState { PLANNED, RUNNING, FINISHED, CANCELED, ABORTED, FAILED };
-extern void to_json(json& j, const TaskState& e);
-extern void from_json(const json& j, TaskState& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TaskStatus {
-  int64_t taskInstanceIdLeastSignificantBits = {};
-  int64_t taskInstanceIdMostSignificantBits = {};
-  int64_t version = {};
-  TaskState state = {};
-  URI self = {};
-  List<Lifespan> completedDriverGroups = {};
-  List<ExecutionFailureInfo> failures = {};
-  int queuedPartitionedDrivers = {};
-  int runningPartitionedDrivers = {};
-  double outputBufferUtilization = {};
-  bool outputBufferOverutilized = {};
-  int64_t physicalWrittenDataSizeInBytes = {};
-  int64_t memoryReservationInBytes = {};
-  int64_t systemMemoryReservationInBytes = {};
-  int64_t peakNodeTotalMemoryReservationInBytes = {};
-  int64_t fullGcCount = {};
-  int64_t fullGcTimeInMillis = {};
-  int64_t totalCpuTimeInNanos = {};
-  int64_t taskAgeInMillis = {};
-  int64_t queuedPartitionedSplitsWeight = {};
-  int64_t runningPartitionedSplitsWeight = {};
-};
-void to_json(json& j, const TaskStatus& p);
-void from_json(const json& j, TaskStatus& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TaskInfo {
-  TaskId taskId = {};
-  TaskStatus taskStatus = {};
-  DateTime lastHeartbeat = {};
-  OutputBufferInfo outputBuffers = {};
-  List<PlanNodeId> noMoreSplits = {};
-  TaskStats stats = {};
-  bool needsPlan = {};
-  MetadataUpdates metadataUpdates = {};
-  String nodeId = {};
-};
-void to_json(json& j, const TaskInfo& p);
-void from_json(const json& j, TaskInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TableWriterNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  // TODO Add target
-  VariableReferenceExpression rowCountVariable = {};
-  VariableReferenceExpression fragmentVariable = {};
-  VariableReferenceExpression tableCommitContextVariable = {};
-  List<VariableReferenceExpression> columns = {};
-  List<String> columnNames = {};
-  List<VariableReferenceExpression> notNullColumnVariables = {};
-  std::shared_ptr<PartitioningScheme> partitioningScheme = {};
-  std::shared_ptr<PartitioningScheme> preferredShufflePartitioningScheme = {};
-  // TODO Add statisticsAggregation
-
-  TableWriterNode() noexcept;
-};
-void to_json(json& j, const TableWriterNode& p);
-void from_json(const json& j, TableWriterNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct TableScanNode : public PlanNode {
-  TableHandle table = {};
-  List<VariableReferenceExpression> outputVariables = {};
-  Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>> assignments =
-      {};
-
-  TableScanNode() noexcept;
-};
-void to_json(json& j, const TableScanNode& p);
-void from_json(const json& j, TableScanNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct AllOrNoneValueSet : public ValueSet {
-  Type type = {};
-  bool all = {};
-
-  AllOrNoneValueSet() noexcept;
-};
-void to_json(json& j, const AllOrNoneValueSet& p);
-void from_json(const json& j, AllOrNoneValueSet& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class AggregationNodeStep { PARTIAL, FINAL, INTERMEDIATE, SINGLE };
-extern void to_json(json& j, const AggregationNodeStep& e);
-extern void from_json(const json& j, AggregationNodeStep& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct GroupingSetDescriptor {
-  List<VariableReferenceExpression> groupingKeys = {};
-  int groupingSetCount = {};
-  List<Integer> globalGroupingSets = {};
-};
-void to_json(json& j, const GroupingSetDescriptor& p);
-void from_json(const json& j, GroupingSetDescriptor& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct AggregationNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  Map<VariableReferenceExpression, Aggregation> aggregations = {};
-  GroupingSetDescriptor groupingSets = {};
-  List<VariableReferenceExpression> preGroupedVariables = {};
-  AggregationNodeStep step = {};
-  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
-  std::shared_ptr<VariableReferenceExpression> groupIdVariable = {};
-
-  AggregationNode() noexcept;
-};
-void to_json(json& j, const AggregationNode& p);
-void from_json(const json& j, AggregationNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct Domain {
@@ -1923,55 +482,6 @@ struct Domain {
 };
 void to_json(json& j, const Domain& p);
 void from_json(const json& j, Domain& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class ExchangeNodeScope { LOCAL, REMOTE_STREAMING, REMOTE_MATERIALIZED };
-extern void to_json(json& j, const ExchangeNodeScope& e);
-extern void from_json(const json& j, ExchangeNodeScope& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class ExchangeNodeType {
-  GATHER,
-  REPARTITION,
-  REPLICATE,
-};
-extern void to_json(json& j, const ExchangeNodeType& e);
-extern void from_json(const json& j, ExchangeNodeType& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ExchangeNode : public PlanNode {
-  ExchangeNodeType type = {};
-  ExchangeNodeScope scope = {};
-  PartitioningScheme partitioningScheme = {};
-  List<std::shared_ptr<PlanNode>> sources = {};
-  List<List<VariableReferenceExpression>> inputs = {};
-  bool ensureSourceOrdering = {};
-  std::shared_ptr<OrderingScheme> orderingScheme = {};
-
-  ExchangeNode() noexcept;
-};
-void to_json(json& j, const ExchangeNode& p);
-void from_json(const json& j, ExchangeNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct RemoteTransactionHandle : public ConnectorTransactionHandle {
-  std::shared_ptr<String> dummy = {};
-
-  RemoteTransactionHandle() noexcept;
-};
-void to_json(json& j, const RemoteTransactionHandle& p);
-void from_json(const json& j, RemoteTransactionHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct ServerInfo {
-  NodeVersion nodeVersion = {};
-  String environment = {};
-  bool coordinator = {};
-  bool starting = {};
-  std::shared_ptr<Duration> uptime = {};
-};
-void to_json(json& j, const ServerInfo& p);
-void from_json(const json& j, ServerInfo& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
@@ -2150,29 +660,1276 @@ void to_json(json& j, const HiveTableLayoutHandle& p);
 void from_json(const json& j, HiveTableLayoutHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct PlanFragment {
-  PlanFragmentId id = {};
-  std::shared_ptr<PlanNode> root = {};
-  List<VariableReferenceExpression> variables = {};
-  PartitioningHandle partitioning = {};
-  List<PlanNodeId> tableScanSchedulingOrder = {};
-  PartitioningScheme partitioningScheme = {};
-  StageExecutionDescriptor stageExecutionDescriptor = {};
-  bool outputTableWriterFragment = {};
-  std::shared_ptr<String> jsonRepresentation = {};
+struct DistinctLimitNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  int64_t limit = {};
+  bool partial = {};
+  List<VariableReferenceExpression> distinctVariables = {};
+  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
+
+  DistinctLimitNode() noexcept;
 };
-void to_json(json& j, const PlanFragment& p);
-void from_json(const json& j, PlanFragment& p);
+void to_json(json& j, const DistinctLimitNode& p);
+void from_json(const json& j, DistinctLimitNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct RemoteSplit : public ConnectorSplit {
-  Location location = {};
-  TaskId remoteSourceTaskId = {};
-
-  RemoteSplit() noexcept;
+struct TableToPartitionMapping {
+  std::shared_ptr<Map<Integer, Integer>> tableToPartitionColumns = {};
+  Map<Integer, Column> partitionSchemaDifference = {};
 };
-void to_json(json& j, const RemoteSplit& p);
-void from_json(const json& j, RemoteSplit& p);
+void to_json(json& j, const TableToPartitionMapping& p);
+void from_json(const json& j, TableToPartitionMapping& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DwrfEncryptionMetadata {
+  Map<String, String> fieldToKeyData = {};
+  Map<String, String> extraMetadata = {};
+  String encryptionAlgorithm = {};
+  String encryptionProvider = {};
+};
+void to_json(json& j, const DwrfEncryptionMetadata& p);
+void from_json(const json& j, DwrfEncryptionMetadata& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct EncryptionInformation {
+  std::shared_ptr<DwrfEncryptionMetadata> dwrfEncryptionMetadata = {};
+};
+void to_json(json& j, const EncryptionInformation& p);
+void from_json(const json& j, EncryptionInformation& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct FilterNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  std::shared_ptr<RowExpression> predicate = {};
+
+  FilterNode() noexcept;
+};
+void to_json(json& j, const FilterNode& p);
+void from_json(const json& j, FilterNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class WriteMode {
+  STAGE_AND_MOVE_TO_TARGET_DIRECTORY,
+  DIRECT_TO_TARGET_NEW_DIRECTORY,
+  DIRECT_TO_TARGET_EXISTING_DIRECTORY
+};
+extern void to_json(json& j, const WriteMode& e);
+extern void from_json(const json& j, WriteMode& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class TableType { NEW, EXISTING, TEMPORARY };
+extern void to_json(json& j, const TableType& e);
+extern void from_json(const json& j, TableType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct LocationHandle {
+  String targetPath = {};
+  String writePath = {};
+  std::shared_ptr<String> tempPath = {};
+  TableType tableType = {};
+  WriteMode writeMode = {};
+};
+void to_json(json& j, const LocationHandle& p);
+void from_json(const json& j, LocationHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class BucketFunctionType { HIVE_COMPATIBLE, PRESTO_NATIVE };
+extern void to_json(json& j, const BucketFunctionType& e);
+extern void from_json(const json& j, BucketFunctionType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class Order { ASCENDING, DESCENDING };
+extern void to_json(json& j, const Order& e);
+extern void from_json(const json& j, Order& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SortingColumn {
+  String columnName = {};
+  Order order = {};
+};
+void to_json(json& j, const SortingColumn& p);
+void from_json(const json& j, SortingColumn& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveBucketProperty {
+  List<String> bucketedBy = {};
+  int bucketCount = {};
+  List<SortingColumn> sortedBy = {};
+  BucketFunctionType bucketFunctionType = {};
+  std::shared_ptr<List<Type>> types = {};
+};
+void to_json(json& j, const HiveBucketProperty& p);
+void from_json(const json& j, HiveBucketProperty& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class HiveCompressionCodec { NONE, SNAPPY, GZIP, LZ4, ZSTD };
+extern void to_json(json& j, const HiveCompressionCodec& e);
+extern void from_json(const json& j, HiveCompressionCodec& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class PrestoTableType {
+  MANAGED_TABLE,
+  EXTERNAL_TABLE,
+  VIRTUAL_VIEW,
+  MATERIALIZED_VIEW,
+  TEMPORARY_TABLE,
+  OTHER
+};
+extern void to_json(json& j, const PrestoTableType& e);
+extern void from_json(const json& j, PrestoTableType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct StorageFormat {
+  String serDe = {};
+  String inputFormat = {};
+  String outputFormat = {};
+};
+void to_json(json& j, const StorageFormat& p);
+void from_json(const json& j, StorageFormat& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Storage {
+  StorageFormat storageFormat = {};
+  String location = {};
+  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
+  bool skewed = {};
+  Map<String, String> serdeParameters = {};
+  Map<String, String> parameters = {};
+};
+void to_json(json& j, const Storage& p);
+void from_json(const json& j, Storage& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Table {
+  String databaseName = {};
+  String tableName = {};
+  String owner = {};
+  PrestoTableType tableType = {};
+  Storage storage = {};
+  List<Column> dataColumns = {};
+  List<Column> partitionColumns = {};
+  Map<String, String> parameters = {};
+  std::shared_ptr<String> viewOriginalText = {};
+  std::shared_ptr<String> viewExpandedText = {};
+};
+void to_json(json& j, const Table& p);
+void from_json(const json& j, Table& p);
+} // namespace facebook::presto::protocol
+// dependency Table
+// dependency SchemaTableName
+
+namespace facebook::presto::protocol {
+
+struct HivePageSinkMetadata {
+  SchemaTableName schemaTableName = {};
+  std::shared_ptr<Table> table = {};
+  // TODO Add modifiedPartitions
+};
+void to_json(json& j, const HivePageSinkMetadata& p);
+void from_json(const json& j, HivePageSinkMetadata& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+enum class HiveStorageFormat {
+  ORC,
+  DWRF,
+  PARQUET,
+  AVRO,
+  RCBINARY,
+  RCTEXT,
+  SEQUENCEFILE,
+  JSON,
+  TEXTFILE,
+  CSV,
+  PAGEFILE
+};
+
+void to_json(json& j, const HiveStorageFormat& p);
+void from_json(const json& j, HiveStorageFormat& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveInsertTableHandle : public ConnectorInsertTableHandle {
+  String schemaName = {};
+  String tableName = {};
+  List<HiveColumnHandle> inputColumns = {};
+  HivePageSinkMetadata pageSinkMetadata = {};
+  LocationHandle locationHandle = {};
+  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
+  List<SortingColumn> preferredOrderingColumns = {};
+  HiveStorageFormat tableStorageFormat = {};
+  HiveStorageFormat partitionStorageFormat = {};
+  HiveStorageFormat actualStorageFormat = {};
+  HiveCompressionCodec compressionCodec = {};
+  std::shared_ptr<EncryptionInformation> encryptionInformation = {};
+
+  HiveInsertTableHandle() noexcept;
+};
+void to_json(json& j, const HiveInsertTableHandle& p);
+void from_json(const json& j, HiveInsertTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PartitioningHandle {
+  std::shared_ptr<ConnectorId> connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorPartitioningHandle> connectorHandle = {};
+};
+void to_json(json& j, const PartitioningHandle& p);
+void from_json(const json& j, PartitioningHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DistributionSnapshot {
+  double maxError = {};
+  double count = {};
+  double total = {};
+  int64_t p01 = {};
+  int64_t p05 = {};
+  int64_t p10 = {};
+  int64_t p25 = {};
+  int64_t p50 = {};
+  int64_t p75 = {};
+  int64_t p90 = {};
+  int64_t p95 = {};
+  int64_t p99 = {};
+  int64_t min = {};
+  int64_t max = {};
+  double avg = {};
+};
+void to_json(json& j, const DistributionSnapshot& p);
+void from_json(const json& j, DistributionSnapshot& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+struct Lifespan {
+  bool isgroup = false;
+  long groupid = 0;
+
+  bool operator<(const Lifespan& o) const {
+    return groupid < o.groupid;
+  }
+};
+
+void to_json(json& j, const Lifespan& p);
+void from_json(const json& j, Lifespan& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+std::ostream& operator<<(std::ostream& os, const Duration& d);
+
+void to_json(json& j, const Duration& p);
+void from_json(const json& j, Duration& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class BlockedReason { WAITING_FOR_MEMORY };
+extern void to_json(json& j, const BlockedReason& e);
+extern void from_json(const json& j, BlockedReason& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OperatorInfo {};
+void to_json(json& j, const OperatorInfo& p);
+void from_json(const json& j, OperatorInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+std::ostream& operator<<(std::ostream& os, const DataSize& d);
+
+void to_json(nlohmann::json& j, const DataSize& p);
+void from_json(const nlohmann::json& j, DataSize& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OperatorStats {
+  int stageId = {};
+  int stageExecutionId = {};
+  int pipelineId = {};
+  int operatorId = {};
+  PlanNodeId planNodeId = {};
+  String operatorType = {};
+  int64_t totalDrivers = {};
+  int64_t addInputCalls = {};
+  Duration addInputWall = {};
+  Duration addInputCpu = {};
+  DataSize addInputAllocation = {};
+  DataSize rawInputDataSize = {};
+  int64_t rawInputPositions = {};
+  DataSize inputDataSize = {};
+  int64_t inputPositions = {};
+  double sumSquaredInputPositions = {};
+  int64_t getOutputCalls = {};
+  Duration getOutputWall = {};
+  Duration getOutputCpu = {};
+  DataSize getOutputAllocation = {};
+  DataSize outputDataSize = {};
+  int64_t outputPositions = {};
+  DataSize physicalWrittenDataSize = {};
+  Duration additionalCpu = {};
+  Duration blockedWall = {};
+  int64_t finishCalls = {};
+  Duration finishWall = {};
+  Duration finishCpu = {};
+  DataSize finishAllocation = {};
+  DataSize userMemoryReservation = {};
+  DataSize revocableMemoryReservation = {};
+  DataSize systemMemoryReservation = {};
+  DataSize peakUserMemoryReservation = {};
+  DataSize peakSystemMemoryReservation = {};
+  DataSize peakTotalMemoryReservation = {};
+  DataSize spilledDataSize = {};
+  std::shared_ptr<BlockedReason> blockedReason = {};
+  OperatorInfo info = {};
+  RuntimeStats runtimeStats = {};
+};
+void to_json(json& j, const OperatorStats& p);
+void from_json(const json& j, OperatorStats& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DriverStats {
+  Lifespan lifespan = {};
+  DateTime createTime = {};
+  DateTime startTime = {};
+  DateTime endTime = {};
+  Duration queuedTime = {};
+  Duration elapsedTime = {};
+  DataSize userMemoryReservation = {};
+  DataSize revocableMemoryReservation = {};
+  DataSize systemMemoryReservation = {};
+  Duration totalScheduledTime = {};
+  Duration totalCpuTime = {};
+  Duration totalBlockedTime = {};
+  bool fullyBlocked = {};
+  List<BlockedReason> blockedReasons = {};
+  DataSize totalAllocation = {};
+  DataSize rawInputDataSize = {};
+  int64_t rawInputPositions = {};
+  Duration rawInputReadTime = {};
+  DataSize processedInputDataSize = {};
+  int64_t processedInputPositions = {};
+  DataSize outputDataSize = {};
+  int64_t outputPositions = {};
+  DataSize physicalWrittenDataSize = {};
+  List<OperatorStats> operatorStats = {};
+};
+void to_json(json& j, const DriverStats& p);
+void from_json(const json& j, DriverStats& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PipelineStats {
+  int pipelineId = {};
+  DateTime firstStartTime = {};
+  DateTime lastStartTime = {};
+  DateTime lastEndTime = {};
+  bool inputPipeline = {};
+  bool outputPipeline = {};
+  int totalDrivers = {};
+  int queuedDrivers = {};
+  int queuedPartitionedDrivers = {};
+  int64_t queuedPartitionedSplitsWeight = {};
+  int runningDrivers = {};
+  int runningPartitionedDrivers = {};
+  int64_t runningPartitionedSplitsWeight = {};
+  int blockedDrivers = {};
+  int completedDrivers = {};
+  int64_t userMemoryReservationInBytes = {};
+  int64_t revocableMemoryReservationInBytes = {};
+  int64_t systemMemoryReservationInBytes = {};
+  DistributionSnapshot queuedTime = {};
+  DistributionSnapshot elapsedTime = {};
+  int64_t totalScheduledTimeInNanos = {};
+  int64_t totalCpuTimeInNanos = {};
+  int64_t totalBlockedTimeInNanos = {};
+  bool fullyBlocked = {};
+  List<BlockedReason> blockedReasons = {};
+  int64_t totalAllocationInBytes = {};
+  int64_t rawInputDataSizeInBytes = {};
+  int64_t rawInputPositions = {};
+  int64_t processedInputDataSizeInBytes = {};
+  int64_t processedInputPositions = {};
+  int64_t outputDataSizeInBytes = {};
+  int64_t outputPositions = {};
+  int64_t physicalWrittenDataSizeInBytes = {};
+  List<OperatorStats> operatorSummaries = {};
+  List<DriverStats> drivers = {};
+};
+void to_json(json& j, const PipelineStats& p);
+void from_json(const json& j, PipelineStats& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TaskStats {
+  DateTime createTime = {};
+  DateTime firstStartTime = {};
+  DateTime lastStartTime = {};
+  DateTime lastEndTime = {};
+  DateTime endTime = {};
+  int64_t elapsedTimeInNanos = {};
+  int64_t queuedTimeInNanos = {};
+  int totalDrivers = {};
+  int queuedDrivers = {};
+  int queuedPartitionedDrivers = {};
+  int64_t queuedPartitionedSplitsWeight = {};
+  int runningDrivers = {};
+  int runningPartitionedDrivers = {};
+  int64_t runningPartitionedSplitsWeight = {};
+  int blockedDrivers = {};
+  int completedDrivers = {};
+  double cumulativeUserMemory = {};
+  double cumulativeTotalMemory = {};
+  int64_t userMemoryReservation = {};
+  int64_t revocableMemoryReservationInBytes = {};
+  int64_t systemMemoryReservationInBytes = {};
+  int64_t peakTotalMemoryInBytes = {};
+  int64_t peakUserMemoryInBytes = {};
+  int64_t peakNodeTotalMemoryInbytes = {};
+  int64_t totalScheduledTimeInNanos = {};
+  int64_t totalCpuTimeInNanos = {};
+  int64_t totalBlockedTimeInNanos = {};
+  bool fullyBlocked = {};
+  List<BlockedReason> blockedReasons = {};
+  int64_t totalAllocationInBytes = {};
+  int64_t rawInputDataSizeInBytes = {};
+  int64_t rawInputPositions = {};
+  int64_t processedInputDataSizeInBytes = {};
+  int64_t processedInputPositions = {};
+  int64_t outputDataSizeInBytes = {};
+  int64_t outputPositions = {};
+  int64_t physicalWrittenDataSizeInBytes = {};
+  int fullGcCount = {};
+  int64_t fullGcTimeInMillis = {};
+  List<PipelineStats> pipelines = {};
+  RuntimeStats runtimeStats = {};
+};
+void to_json(json& j, const TaskStats& p);
+void from_json(const json& j, TaskStats& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class Form {
+  IF,
+  NULL_IF,
+  SWITCH,
+  WHEN,
+  IS_NULL,
+  COALESCE,
+  IN,
+  AND,
+  OR,
+  DEREFERENCE,
+  ROW_CONSTRUCTOR,
+  BIND
+};
+extern void to_json(json& j, const Form& e);
+extern void from_json(const json& j, Form& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SpecialFormExpression : public RowExpression {
+  Form form = {};
+  Type returnType = {};
+  List<std::shared_ptr<RowExpression>> arguments = {};
+
+  SpecialFormExpression() noexcept;
+};
+void to_json(json& j, const SpecialFormExpression& p);
+void from_json(const json& j, SpecialFormExpression& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct AssignUniqueId : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  VariableReferenceExpression idVariable = {};
+
+  AssignUniqueId() noexcept;
+};
+void to_json(json& j, const AssignUniqueId& p);
+void from_json(const json& j, AssignUniqueId& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Location {
+  String location = {};
+};
+void to_json(json& j, const Location& p);
+void from_json(const json& j, Location& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OutputTableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorOutputTableHandle> connectorHandle = {};
+};
+void to_json(json& j, const OutputTableHandle& p);
+void from_json(const json& j, OutputTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class BufferType {
+  PARTITIONED,
+  BROADCAST,
+  ARBITRARY,
+  DISCARDING,
+  SPOOLING
+};
+extern void to_json(json& j, const BufferType& e);
+extern void from_json(const json& j, BufferType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OutputBuffers {
+  BufferType type = {};
+  int64_t version = {};
+  bool noMoreBufferIds = {};
+  Map<OutputBufferId, Integer> buffers = {};
+};
+void to_json(json& j, const OutputBuffers& p);
+void from_json(const json& j, OutputBuffers& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
+  std::shared_ptr<ConnectorTransactionHandle> transaction = {};
+  std::shared_ptr<ConnectorTableLayoutHandle> connectorTableLayout = {};
+};
+void to_json(json& j, const TableHandle& p);
+void from_json(const json& j, TableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DeleteScanInfo {
+  PlanNodeId id = {};
+  TableHandle tableHandle = {};
+};
+void to_json(json& j, const DeleteScanInfo& p);
+void from_json(const json& j, DeleteScanInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct AnalyzeTableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
+};
+void to_json(json& j, const AnalyzeTableHandle& p);
+void from_json(const json& j, AnalyzeTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TableWriteInfo {
+  std::shared_ptr<ExecutionWriterTarget> writerTarget = {};
+  std::shared_ptr<AnalyzeTableHandle> analyzeTableHandle = {};
+  std::shared_ptr<DeleteScanInfo> deleteScanInfo = {};
+};
+void to_json(json& j, const TableWriteInfo& p);
+void from_json(const json& j, TableWriteInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SplitContext {
+  bool cacheable = {};
+};
+void to_json(json& j, const SplitContext& p);
+void from_json(const json& j, SplitContext& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Split {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorSplit> connectorSplit = {};
+  Lifespan lifespan = {};
+  SplitContext splitContext = {};
+};
+void to_json(json& j, const Split& p);
+void from_json(const json& j, Split& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+struct ScheduledSplit {
+  long sequenceId = {};
+  PlanNodeId planNodeId = {}; // dependency
+  Split split = {};
+
+  bool operator<(const ScheduledSplit& o) const {
+    return sequenceId < o.sequenceId;
+  }
+};
+
+void to_json(json& j, const ScheduledSplit& p);
+void from_json(const json& j, ScheduledSplit& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TaskSource {
+  PlanNodeId planNodeId = {};
+  List<ScheduledSplit> splits = {};
+  List<Lifespan> noMoreSplitsForLifespan = {};
+  bool noMoreSplits = {};
+};
+void to_json(json& j, const TaskSource& p);
+void from_json(const json& j, TaskSource& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ResourceEstimates {
+  std::shared_ptr<Duration> executionTime = {};
+  std::shared_ptr<Duration> cpuTime = {};
+  std::shared_ptr<DataSize> peakMemory = {};
+  std::shared_ptr<DataSize> peakTaskMemory = {};
+};
+void to_json(json& j, const ResourceEstimates& p);
+void from_json(const json& j, ResourceEstimates& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class SelectedRoleType { ROLE, ALL, NONE };
+extern void to_json(json& j, const SelectedRoleType& e);
+extern void from_json(const json& j, SelectedRoleType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SelectedRole {
+  SelectedRoleType type = {};
+  std::shared_ptr<String> role = {};
+};
+void to_json(json& j, const SelectedRole& p);
+void from_json(const json& j, SelectedRole& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Parameter {
+  String name = {};
+  TypeSignature type = {};
+};
+void to_json(json& j, const Parameter& p);
+void from_json(const json& j, Parameter& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Language {
+  String language = {};
+};
+void to_json(json& j, const Language& p);
+void from_json(const json& j, Language& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class NullCallClause { RETURNS_NULL_ON_NULL_INPUT, CALLED_ON_NULL_INPUT };
+extern void to_json(json& j, const NullCallClause& e);
+extern void from_json(const json& j, NullCallClause& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class Determinism {
+  DETERMINISTIC,
+  NOT_DETERMINISTIC,
+};
+extern void to_json(json& j, const Determinism& e);
+extern void from_json(const json& j, Determinism& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RoutineCharacteristics {
+  std::shared_ptr<Language> language = {};
+  std::shared_ptr<Determinism> determinism = {};
+  std::shared_ptr<NullCallClause> nullCallClause = {};
+};
+void to_json(json& j, const RoutineCharacteristics& p);
+void from_json(const json& j, RoutineCharacteristics& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct LongVariableConstraint {
+  String name = {};
+  String expression = {};
+};
+void to_json(json& j, const LongVariableConstraint& p);
+void from_json(const json& j, LongVariableConstraint& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+struct TypeVariableConstraint {
+  String name = {};
+  bool comparableRequired = {};
+  bool orderableRequired = {};
+  String variadicBound = {};
+  bool nonDecimalNumericRequired = {};
+  String boundedBy = {};
+};
+void to_json(json& j, const TypeVariableConstraint& p);
+void from_json(const json& j, TypeVariableConstraint& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class FunctionKind { SCALAR, AGGREGATE, WINDOW };
+extern void to_json(json& j, const FunctionKind& e);
+extern void from_json(const json& j, FunctionKind& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Signature {
+  QualifiedObjectName name = {};
+  FunctionKind kind = {};
+  List<TypeVariableConstraint> typeVariableConstraints = {};
+  List<LongVariableConstraint> longVariableConstraints = {};
+  TypeSignature returnType = {};
+  List<TypeSignature> argumentTypes = {};
+  bool variableArity = {};
+};
+void to_json(json& j, const Signature& p);
+void from_json(const json& j, Signature& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SqlInvokedFunction {
+  List<Parameter> parameters = {};
+  String description = {};
+  RoutineCharacteristics routineCharacteristics = {};
+  String body = {};
+  Signature signature = {};
+  SqlFunctionId functionId = {};
+};
+void to_json(json& j, const SqlInvokedFunction& p);
+void from_json(const json& j, SqlInvokedFunction& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SessionRepresentation {
+  String queryId = {};
+  std::shared_ptr<TransactionId> transactionId = {};
+  bool clientTransactionSupport = {};
+  String user = {};
+  std::shared_ptr<String> principal = {};
+  std::shared_ptr<String> source = {};
+  std::shared_ptr<String> catalog = {};
+  std::shared_ptr<String> schema = {};
+  std::shared_ptr<String> traceToken = {};
+  TimeZoneKey timeZoneKey = {};
+  Locale locale = {};
+  std::shared_ptr<String> remoteUserAddress = {};
+  std::shared_ptr<String> userAgent = {};
+  std::shared_ptr<String> clientInfo = {};
+  List<String> clientTags = {};
+  ResourceEstimates resourceEstimates = {};
+  int64_t startTime = {};
+  Map<String, String> systemProperties = {};
+  Map<ConnectorId, Map<String, String>> catalogProperties = {};
+  Map<String, Map<String, String>> unprocessedCatalogProperties = {};
+  Map<String, SelectedRole> roles = {};
+  Map<String, String> preparedStatements = {};
+  Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions = {};
+};
+void to_json(json& j, const SessionRepresentation& p);
+void from_json(const json& j, SessionRepresentation& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TaskUpdateRequest {
+  SessionRepresentation session = {};
+  Map<String, String> extraCredentials = {};
+  std::shared_ptr<String> fragment = {};
+  List<TaskSource> sources = {};
+  OutputBuffers outputIds = {};
+  std::shared_ptr<TableWriteInfo> tableWriteInfo = {};
+};
+void to_json(json& j, const TaskUpdateRequest& p);
+void from_json(const json& j, TaskUpdateRequest& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Specification {
+  List<VariableReferenceExpression> partitionBy = {};
+  std::shared_ptr<OrderingScheme> orderingScheme = {};
+};
+void to_json(json& j, const Specification& p);
+void from_json(const json& j, Specification& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class WindowType {
+  RANGE,
+  ROWS,
+};
+extern void to_json(json& j, const WindowType& e);
+extern void from_json(const json& j, WindowType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class BoundType {
+  UNBOUNDED_PRECEDING,
+  PRECEDING,
+  CURRENT_ROW,
+  FOLLOWING,
+  UNBOUNDED_FOLLOWING
+};
+extern void to_json(json& j, const BoundType& e);
+extern void from_json(const json& j, BoundType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Frame {
+  WindowType type = {};
+  BoundType startType = {};
+  std::shared_ptr<VariableReferenceExpression> startValue = {};
+  BoundType endType = {};
+  std::shared_ptr<VariableReferenceExpression> endValue = {};
+  std::shared_ptr<String> originalStartValue = {};
+  std::shared_ptr<String> originalEndValue = {};
+};
+void to_json(json& j, const Frame& p);
+void from_json(const json& j, Frame& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Function {
+  CallExpression functionCall = {};
+  Frame frame = {};
+  bool ignoreNulls = {};
+};
+void to_json(json& j, const Function& p);
+void from_json(const json& j, Function& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct WindowNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  Specification specification = {};
+  Map<VariableReferenceExpression, Function> windowFunctions = {};
+  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
+  List<VariableReferenceExpression> prePartitionedInputs = {};
+  int preSortedOrderPrefix = {};
+
+  WindowNode() noexcept;
+};
+void to_json(json& j, const WindowNode& p);
+void from_json(const json& j, WindowNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DeleteHandle : public ExecutionWriterTarget {
+  TableHandle handle = {};
+  SchemaTableName schemaTableName = {};
+
+  DeleteHandle() noexcept;
+};
+void to_json(json& j, const DeleteHandle& p);
+void from_json(const json& j, DeleteHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ValuesNode : public PlanNode {
+  List<VariableReferenceExpression> outputVariables = {};
+  List<List<std::shared_ptr<RowExpression>>> rows = {};
+
+  ValuesNode() noexcept;
+};
+void to_json(json& j, const ValuesNode& p);
+void from_json(const json& j, ValuesNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct InsertTableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorInsertTableHandle> connectorHandle = {};
+};
+void to_json(json& j, const InsertTableHandle& p);
+void from_json(const json& j, InsertTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RefreshMaterializedViewHandle {
+  InsertTableHandle handle = {};
+  SchemaTableName schemaTableName = {};
+};
+void to_json(json& j, const RefreshMaterializedViewHandle& p);
+void from_json(const json& j, RefreshMaterializedViewHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class Locality { UNKNOWN, LOCAL, REMOTE };
+extern void to_json(json& j, const Locality& e);
+extern void from_json(const json& j, Locality& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Assignments {
+  Map<VariableReferenceExpression, std::shared_ptr<RowExpression>> assignments =
+      {};
+};
+void to_json(json& j, const Assignments& p);
+void from_json(const json& j, Assignments& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ProjectNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  Assignments assignments = {};
+  Locality locality = {};
+
+  ProjectNode() noexcept;
+};
+void to_json(json& j, const ProjectNode& p);
+void from_json(const json& j, ProjectNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+using HostAddress = std::string;
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class ErrorType {
+  USER_ERROR,
+  INTERNAL_ERROR,
+  INSUFFICIENT_RESOURCES,
+  EXTERNAL
+};
+extern void to_json(json& j, const ErrorType& e);
+extern void from_json(const json& j, ErrorType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ErrorCode {
+  int code = {};
+  String name = {};
+  ErrorType type = {};
+  bool retriable = {};
+};
+void to_json(json& j, const ErrorCode& p);
+void from_json(const json& j, ErrorCode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ErrorLocation {
+  int lineNumber = {};
+  int columnNumber = {};
+};
+void to_json(json& j, const ErrorLocation& p);
+void from_json(const json& j, ErrorLocation& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ExecutionFailureInfo {
+  String type = {};
+  String message = {};
+  std::shared_ptr<ExecutionFailureInfo> cause = {};
+  List<ExecutionFailureInfo> suppressed = {};
+  List<String> stack = {};
+  ErrorLocation errorLocation = {};
+  ErrorCode errorCode = {};
+  HostAddress remoteHost = {};
+};
+void to_json(json& j, const ExecutionFailureInfo& p);
+void from_json(const json& j, ExecutionFailureInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PageBufferInfo {
+  int partition = {};
+  int64_t bufferedPages = {};
+  int64_t bufferedBytes = {};
+  int64_t rowsAdded = {};
+  int64_t pagesAdded = {};
+};
+void to_json(json& j, const PageBufferInfo& p);
+void from_json(const json& j, PageBufferInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct BufferInfo {
+  OutputBufferId bufferId = {};
+  bool finished = {};
+  int bufferedPages = {};
+  int64_t pagesSent = {};
+  PageBufferInfo pageBufferInfo = {};
+};
+void to_json(json& j, const BufferInfo& p);
+void from_json(const json& j, BufferInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct Partitioning {
+  PartitioningHandle handle = {};
+  List<std::shared_ptr<RowExpression>> arguments = {};
+};
+void to_json(json& j, const Partitioning& p);
+void from_json(const json& j, Partitioning& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PartitioningScheme {
+  Partitioning partitioning = {};
+  List<VariableReferenceExpression> outputLayout = {};
+  std::shared_ptr<VariableReferenceExpression> hashColumn = {};
+  bool replicateNullsAndAny = {};
+  std::shared_ptr<List<int>> bucketToPartition = {};
+};
+void to_json(json& j, const PartitioningScheme& p);
+void from_json(const json& j, PartitioningScheme& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TableWriterNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  // TODO Add target
+  VariableReferenceExpression rowCountVariable = {};
+  VariableReferenceExpression fragmentVariable = {};
+  VariableReferenceExpression tableCommitContextVariable = {};
+  List<VariableReferenceExpression> columns = {};
+  List<String> columnNames = {};
+  List<VariableReferenceExpression> notNullColumnVariables = {};
+  std::shared_ptr<PartitioningScheme> partitioningScheme = {};
+  std::shared_ptr<PartitioningScheme> preferredShufflePartitioningScheme = {};
+  // TODO Add statisticsAggregation
+
+  TableWriterNode() noexcept;
+};
+void to_json(json& j, const TableWriterNode& p);
+void from_json(const json& j, TableWriterNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct GroupIdNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  List<List<VariableReferenceExpression>> groupingSets = {};
+  Map<VariableReferenceExpression, VariableReferenceExpression>
+      groupingColumns = {};
+  List<VariableReferenceExpression> aggregationArguments = {};
+  VariableReferenceExpression groupIdVariable = {};
+
+  GroupIdNode() noexcept;
+};
+void to_json(json& j, const GroupIdNode& p);
+void from_json(const json& j, GroupIdNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveMetadataUpdateHandle : public ConnectorMetadataUpdateHandle {
+  UUID requestId = {};
+  SchemaTableName schemaTableName = {};
+  std::shared_ptr<String> partitionName = {};
+  std::shared_ptr<String> fileName = {};
+
+  HiveMetadataUpdateHandle() noexcept;
+};
+void to_json(json& j, const HiveMetadataUpdateHandle& p);
+void from_json(const json& j, HiveMetadataUpdateHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct VariableStatsEstimate {
+  double lowValue = {};
+  double highValue = {};
+  double nullsFraction = {};
+  double averageRowSize = {};
+  double distinctValuesCount = {};
+};
+void to_json(json& j, const VariableStatsEstimate& p);
+void from_json(const json& j, VariableStatsEstimate& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PlanNodeStatsEstimate {
+  double outputRowCount = {};
+  double totalSize = {};
+  bool confident = {};
+  Map<VariableReferenceExpression, VariableStatsEstimate> variableStatistics =
+      {};
+};
+void to_json(json& j, const PlanNodeStatsEstimate& p);
+void from_json(const json& j, PlanNodeStatsEstimate& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct EmptySplit : public ConnectorSplit {
+  ConnectorId connectorId = {};
+
+  EmptySplit() noexcept;
+};
+void to_json(json& j, const EmptySplit& p);
+void from_json(const json& j, EmptySplit& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RemoteTransactionHandle : public ConnectorTransactionHandle {
+  std::shared_ptr<String> dummy = {};
+
+  RemoteTransactionHandle() noexcept;
+};
+void to_json(json& j, const RemoteTransactionHandle& p);
+void from_json(const json& j, RemoteTransactionHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class RuntimeUnit { NONE, NANO, BYTE };
+extern void to_json(json& j, const RuntimeUnit& e);
+extern void from_json(const json& j, RuntimeUnit& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RuntimeMetric {
+  String name = {};
+  RuntimeUnit unit = {};
+  int64_t sum = {};
+  int64_t count = {};
+  int64_t max = {};
+  int64_t min = {};
+};
+void to_json(json& j, const RuntimeMetric& p);
+void from_json(const json& j, RuntimeMetric& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+struct Block {
+  std::string data;
+};
+
+void to_json(json& j, const Block& p);
+
+void from_json(const json& j, Block& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+class ValueEntry {
+ public:
+  Type type;
+  std::shared_ptr<Block> block;
+};
+
+void to_json(json& j, const ValueEntry& p);
+void from_json(const json& j, ValueEntry& p);
+
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct EquatableValueSet : public ValueSet {
+  Type type = {};
+  bool whiteList = {};
+  List<ValueEntry> entries = {};
+
+  EquatableValueSet() noexcept;
+};
+void to_json(json& j, const EquatableValueSet& p);
+void from_json(const json& j, EquatableValueSet& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class TaskState { PLANNED, RUNNING, FINISHED, CANCELED, ABORTED, FAILED };
+extern void to_json(json& j, const TaskState& e);
+extern void from_json(const json& j, TaskState& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TaskStatus {
+  int64_t taskInstanceIdLeastSignificantBits = {};
+  int64_t taskInstanceIdMostSignificantBits = {};
+  int64_t version = {};
+  TaskState state = {};
+  URI self = {};
+  List<Lifespan> completedDriverGroups = {};
+  List<ExecutionFailureInfo> failures = {};
+  int queuedPartitionedDrivers = {};
+  int runningPartitionedDrivers = {};
+  double outputBufferUtilization = {};
+  bool outputBufferOverutilized = {};
+  int64_t physicalWrittenDataSizeInBytes = {};
+  int64_t memoryReservationInBytes = {};
+  int64_t systemMemoryReservationInBytes = {};
+  int64_t peakNodeTotalMemoryReservationInBytes = {};
+  int64_t fullGcCount = {};
+  int64_t fullGcTimeInMillis = {};
+  int64_t totalCpuTimeInNanos = {};
+  int64_t taskAgeInMillis = {};
+  int64_t queuedPartitionedSplitsWeight = {};
+  int64_t runningPartitionedSplitsWeight = {};
+};
+void to_json(json& j, const TaskStatus& p);
+void from_json(const json& j, TaskStatus& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class BufferState {
+  OPEN,
+  NO_MORE_BUFFERS,
+  NO_MORE_PAGES,
+  FLUSHING,
+  FINISHED,
+  FAILED
+};
+extern void to_json(json& j, const BufferState& e);
+extern void from_json(const json& j, BufferState& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OutputBufferInfo {
+  String type = {};
+  BufferState state = {};
+  bool canAddBuffers = {};
+  bool canAddPages = {};
+  int64_t totalBufferedBytes = {};
+  int64_t totalBufferedPages = {};
+  int64_t totalRowsSent = {};
+  int64_t totalPagesSent = {};
+  List<BufferInfo> buffers = {};
+};
+void to_json(json& j, const OutputBufferInfo& p);
+void from_json(const json& j, OutputBufferInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MetadataUpdates {
+  ConnectorId connectorId = {};
+  List<std::shared_ptr<ConnectorMetadataUpdateHandle>> metadataUpdates = {};
+};
+void to_json(json& j, const MetadataUpdates& p);
+void from_json(const json& j, MetadataUpdates& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TaskInfo {
+  TaskId taskId = {};
+  TaskStatus taskStatus = {};
+  DateTime lastHeartbeat = {};
+  OutputBufferInfo outputBuffers = {};
+  List<PlanNodeId> noMoreSplits = {};
+  TaskStats stats = {};
+  bool needsPlan = {};
+  MetadataUpdates metadataUpdates = {};
+  String nodeId = {};
+};
+void to_json(json& j, const TaskInfo& p);
+void from_json(const json& j, TaskInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MemoryAllocation {
+  String tag = {};
+  int64_t allocation = {};
+};
+void to_json(json& j, const MemoryAllocation& p);
+void from_json(const json& j, MemoryAllocation& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MemoryPoolInfo {
+  int64_t maxBytes = {};
+  int64_t reservedBytes = {};
+  int64_t reservedRevocableBytes = {};
+  Map<QueryId, Long> queryMemoryReservations = {};
+  Map<QueryId, List<MemoryAllocation>> queryMemoryAllocations = {};
+  Map<QueryId, Long> queryMemoryRevocableReservations = {};
+};
+void to_json(json& j, const MemoryPoolInfo& p);
+void from_json(const json& j, MemoryPoolInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MemoryInfo {
+  DataSize totalNodeMemory = {};
+  Map<MemoryPoolId, MemoryPoolInfo> pools = {};
+};
+void to_json(json& j, const MemoryInfo& p);
+void from_json(const json& j, MemoryInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct NodeVersion {
+  String version = {};
+};
+void to_json(json& j, const NodeVersion& p);
+void from_json(const json& j, NodeVersion& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct NodeStatus {
+  String nodeId = {};
+  NodeVersion nodeVersion = {};
+  String environment = {};
+  bool coordinator = {};
+  Duration uptime = {};
+  String externalAddress = {};
+  String internalAddress = {};
+  MemoryInfo memoryInfo = {};
+  int processors = {};
+  double processCpuLoad = {};
+  double systemCpuLoad = {};
+  int64_t heapUsed = {};
+  int64_t heapAvailable = {};
+  int64_t nonHeapUsed = {};
+};
+void to_json(json& j, const NodeStatus& p);
+void from_json(const json& j, NodeStatus& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PlanCostEstimate {
+  double cpuCost = {};
+  double maxMemory = {};
+  double maxMemoryWhenOutputting = {};
+  double networkCost = {};
+};
+void to_json(json& j, const PlanCostEstimate& p);
+void from_json(const json& j, PlanCostEstimate& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct StatsAndCosts {
+  Map<PlanNodeId, PlanNodeStatsEstimate> stats = {};
+  Map<PlanNodeId, PlanCostEstimate> costs = {};
+};
+void to_json(json& j, const StatsAndCosts& p);
+void from_json(const json& j, StatsAndCosts& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class LimitNodeStep { PARTIAL, FINAL };
+extern void to_json(json& j, const LimitNodeStep& e);
+extern void from_json(const json& j, LimitNodeStep& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct LimitNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  int64_t count = {};
+  LimitNodeStep step = {};
+
+  LimitNode() noexcept;
+};
+void to_json(json& j, const LimitNode& p);
+void from_json(const json& j, LimitNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct HivePartitioningHandle : public ConnectorPartitioningHandle {
@@ -2186,6 +1943,114 @@ struct HivePartitioningHandle : public ConnectorPartitioningHandle {
 };
 void to_json(json& j, const HivePartitioningHandle& p);
 void from_json(const json& j, HivePartitioningHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class ExchangeNodeType {
+  GATHER,
+  REPARTITION,
+  REPLICATE,
+};
+extern void to_json(json& j, const ExchangeNodeType& e);
+extern void from_json(const json& j, ExchangeNodeType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class ExchangeNodeScope { LOCAL, REMOTE_STREAMING, REMOTE_MATERIALIZED };
+extern void to_json(json& j, const ExchangeNodeScope& e);
+extern void from_json(const json& j, ExchangeNodeScope& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ExchangeNode : public PlanNode {
+  ExchangeNodeType type = {};
+  ExchangeNodeScope scope = {};
+  PartitioningScheme partitioningScheme = {};
+  List<std::shared_ptr<PlanNode>> sources = {};
+  List<List<VariableReferenceExpression>> inputs = {};
+  bool ensureSourceOrdering = {};
+  std::shared_ptr<OrderingScheme> orderingScheme = {};
+
+  ExchangeNode() noexcept;
+};
+void to_json(json& j, const ExchangeNode& p);
+void from_json(const json& j, ExchangeNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RemoteSourceNode : public PlanNode {
+  List<PlanFragmentId> sourceFragmentIds = {};
+  List<VariableReferenceExpression> outputVariables = {};
+  bool ensureSourceOrdering = {};
+  std::shared_ptr<OrderingScheme> orderingScheme = {};
+  ExchangeNodeType exchangeType = {};
+
+  RemoteSourceNode() noexcept;
+};
+void to_json(json& j, const RemoteSourceNode& p);
+void from_json(const json& j, RemoteSourceNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ServerInfo {
+  NodeVersion nodeVersion = {};
+  String environment = {};
+  bool coordinator = {};
+  bool starting = {};
+  std::shared_ptr<Duration> uptime = {};
+};
+void to_json(json& j, const ServerInfo& p);
+void from_json(const json& j, ServerInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct CreateHandle : public ExecutionWriterTarget {
+  OutputTableHandle handle = {};
+  SchemaTableName schemaTableName = {};
+
+  CreateHandle() noexcept;
+};
+void to_json(json& j, const CreateHandle& p);
+void from_json(const json& j, CreateHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct BuiltInFunctionHandle : public FunctionHandle {
+  Signature signature = {};
+
+  BuiltInFunctionHandle() noexcept;
+};
+void to_json(json& j, const BuiltInFunctionHandle& p);
+void from_json(const json& j, BuiltInFunctionHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class DistributionType { PARTITIONED, REPLICATED };
+extern void to_json(json& j, const DistributionType& e);
+extern void from_json(const json& j, DistributionType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct EquiJoinClause {
+  VariableReferenceExpression left = {};
+  VariableReferenceExpression right = {};
+};
+void to_json(json& j, const EquiJoinClause& p);
+void from_json(const json& j, EquiJoinClause& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class JoinNodeType { INNER, LEFT, RIGHT, FULL };
+extern void to_json(json& j, const JoinNodeType& e);
+extern void from_json(const json& j, JoinNodeType& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct JoinNode : public PlanNode {
+  JoinNodeType type = {};
+  std::shared_ptr<PlanNode> left = {};
+  std::shared_ptr<PlanNode> right = {};
+  List<EquiJoinClause> criteria = {};
+  List<VariableReferenceExpression> outputVariables = {};
+  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};
+  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};
+  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};
+  std::shared_ptr<DistributionType> distributionType = {};
+  Map<String, VariableReferenceExpression> dynamicFilters = {};
+
+  JoinNode() noexcept;
+};
+void to_json(json& j, const JoinNode& p);
+void from_json(const json& j, JoinNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 enum class SystemPartitioning {
@@ -2221,55 +2086,361 @@ void to_json(json& j, const SystemPartitioningHandle& p);
 void from_json(const json& j, SystemPartitioningHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-enum class LimitNodeStep { PARTIAL, FINAL };
-extern void to_json(json& j, const LimitNodeStep& e);
-extern void from_json(const json& j, LimitNodeStep& e);
+enum class Bound { BELOW, EXACTLY, ABOVE };
+extern void to_json(json& j, const Bound& e);
+extern void from_json(const json& j, Bound& e);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct LimitNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  int64_t count = {};
-  LimitNodeStep step = {};
-
-  LimitNode() noexcept;
+struct Marker {
+  Type type = {};
+  std::shared_ptr<Block> valueBlock = {};
+  Bound bound = {};
 };
-void to_json(json& j, const LimitNode& p);
-void from_json(const json& j, LimitNode& p);
+void to_json(json& j, const Marker& p);
+void from_json(const json& j, Marker& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct GroupIdNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  List<List<VariableReferenceExpression>> groupingSets = {};
-  Map<VariableReferenceExpression, VariableReferenceExpression>
-      groupingColumns = {};
-  List<VariableReferenceExpression> aggregationArguments = {};
-  VariableReferenceExpression groupIdVariable = {};
-
-  GroupIdNode() noexcept;
+struct Range {
+  Marker low = {};
+  Marker high = {};
 };
-void to_json(json& j, const GroupIdNode& p);
-void from_json(const json& j, GroupIdNode& p);
+void to_json(json& j, const Range& p);
+void from_json(const json& j, Range& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct RemoteSourceNode : public PlanNode {
-  List<PlanFragmentId> sourceFragmentIds = {};
+struct SortedRangeSet : public ValueSet {
+  Type type = {};
+  List<Range> ranges = {};
+
+  SortedRangeSet() noexcept;
+};
+void to_json(json& j, const SortedRangeSet& p);
+void from_json(const json& j, SortedRangeSet& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TableScanNode : public PlanNode {
+  TableHandle table = {};
   List<VariableReferenceExpression> outputVariables = {};
-  bool ensureSourceOrdering = {};
-  std::shared_ptr<OrderingScheme> orderingScheme = {};
-  ExchangeNodeType exchangeType = {};
+  Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>> assignments =
+      {};
 
-  RemoteSourceNode() noexcept;
+  TableScanNode() noexcept;
 };
-void to_json(json& j, const RemoteSourceNode& p);
-void from_json(const json& j, RemoteSourceNode& p);
+void to_json(json& j, const TableScanNode& p);
+void from_json(const json& j, TableScanNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct RefreshMaterializedViewHandle {
+enum class StageExecutionStrategy {
+  UNGROUPED_EXECUTION,
+  FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+  DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+  RECOVERABLE_GROUPED_EXECUTION
+};
+extern void to_json(json& j, const StageExecutionStrategy& e);
+extern void from_json(const json& j, StageExecutionStrategy& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct StageExecutionDescriptor {
+  StageExecutionStrategy stageExecutionStrategy = {};
+  List<PlanNodeId> groupedExecutionScanNodes = {};
+  int totalLifespans = {};
+};
+void to_json(json& j, const StageExecutionDescriptor& p);
+void from_json(const json& j, StageExecutionDescriptor& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PlanFragment {
+  PlanFragmentId id = {};
+  std::shared_ptr<PlanNode> root = {};
+  List<VariableReferenceExpression> variables = {};
+  PartitioningHandle partitioning = {};
+  List<PlanNodeId> tableScanSchedulingOrder = {};
+  PartitioningScheme partitioningScheme = {};
+  StageExecutionDescriptor stageExecutionDescriptor = {};
+  bool outputTableWriterFragment = {};
+  std::shared_ptr<String> jsonRepresentation = {};
+};
+void to_json(json& j, const PlanFragment& p);
+void from_json(const json& j, PlanFragment& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct GroupingSetDescriptor {
+  List<VariableReferenceExpression> groupingKeys = {};
+  int groupingSetCount = {};
+  List<Integer> globalGroupingSets = {};
+};
+void to_json(json& j, const GroupingSetDescriptor& p);
+void from_json(const json& j, GroupingSetDescriptor& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class AggregationNodeStep { PARTIAL, FINAL, INTERMEDIATE, SINGLE };
+extern void to_json(json& j, const AggregationNodeStep& e);
+extern void from_json(const json& j, AggregationNodeStep& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct AggregationNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  Map<VariableReferenceExpression, Aggregation> aggregations = {};
+  GroupingSetDescriptor groupingSets = {};
+  List<VariableReferenceExpression> preGroupedVariables = {};
+  AggregationNodeStep step = {};
+  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
+  std::shared_ptr<VariableReferenceExpression> groupIdVariable = {};
+
+  AggregationNode() noexcept;
+};
+void to_json(json& j, const AggregationNode& p);
+void from_json(const json& j, AggregationNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RowNumberNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  List<VariableReferenceExpression> partitionBy = {};
+  VariableReferenceExpression rowNumberVariable = {};
+  std::shared_ptr<Integer> maxRowCountPerPartition = {};
+  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
+
+  RowNumberNode() noexcept;
+};
+void to_json(json& j, const RowNumberNode& p);
+void from_json(const json& j, RowNumberNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct UnnestNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  List<VariableReferenceExpression> replicateVariables = {};
+  Map<VariableReferenceExpression, List<VariableReferenceExpression>>
+      unnestVariables = {};
+  std::shared_ptr<VariableReferenceExpression> ordinalityVariable = {};
+
+  UnnestNode() noexcept;
+};
+void to_json(json& j, const UnnestNode& p);
+void from_json(const json& j, UnnestNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct InsertHandle : public ExecutionWriterTarget {
   InsertTableHandle handle = {};
   SchemaTableName schemaTableName = {};
+
+  InsertHandle() noexcept;
 };
-void to_json(json& j, const RefreshMaterializedViewHandle& p);
-void from_json(const json& j, RefreshMaterializedViewHandle& p);
+void to_json(json& j, const InsertHandle& p);
+void from_json(const json& j, InsertHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct AllOrNoneValueSet : public ValueSet {
+  Type type = {};
+  bool all = {};
+
+  AllOrNoneValueSet() noexcept;
+};
+void to_json(json& j, const AllOrNoneValueSet& p);
+void from_json(const json& j, AllOrNoneValueSet& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MergeJoinNode : public PlanNode {
+  MergeJoinNode() noexcept;
+  PlanNodeId id = {};
+  // JoinNodeType is referenced as JoinNode.Type in Presto
+  // Since presto_cpp codegen can't nicely handle inner class references
+  // So a special hard-coded template is required here
+  JoinNodeType type = {};
+  std::shared_ptr<PlanNode> left = {};
+  std::shared_ptr<PlanNode> right = {};
+  // EquiJoinClause is referenced as JoinNode.EquiJoinClause in Presto
+  List<EquiJoinClause> criteria = {};
+  List<VariableReferenceExpression> outputVariables = {};
+  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};
+  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};
+  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};
+};
+void to_json(json& j, const MergeJoinNode& p);
+void from_json(const json& j, MergeJoinNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveTableHandle : public ConnectorTableHandle {
+  String schemaName = {};
+  String tableName = {};
+  std::shared_ptr<List<List<String>>> analyzePartitionValues = {};
+
+  HiveTableHandle() noexcept;
+};
+void to_json(json& j, const HiveTableHandle& p);
+void from_json(const json& j, HiveTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class Step { SINGLE, PARTIAL, FINAL };
+extern void to_json(json& j, const Step& e);
+extern void from_json(const json& j, Step& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TopNNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  int64_t count = {};
+  OrderingScheme orderingScheme = {};
+  Step step = {};
+
+  TopNNode() noexcept;
+};
+void to_json(json& j, const TopNNode& p);
+void from_json(const json& j, TopNNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveTransactionHandle : public ConnectorTransactionHandle {
+  UUID uuid = {};
+
+  HiveTransactionHandle() noexcept;
+};
+void to_json(json& j, const HiveTransactionHandle& p);
+void from_json(const json& j, HiveTransactionHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct LambdaDefinitionExpression : public RowExpression {
+  List<Type> argumentTypes = {};
+  List<String> arguments = {};
+  std::shared_ptr<RowExpression> body = {};
+
+  LambdaDefinitionExpression() noexcept;
+};
+void to_json(json& j, const LambdaDefinitionExpression& p);
+void from_json(const json& j, LambdaDefinitionExpression& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct RemoteSplit : public ConnectorSplit {
+  Location location = {};
+  TaskId remoteSourceTaskId = {};
+
+  RemoteSplit() noexcept;
+};
+void to_json(json& j, const RemoteSplit& p);
+void from_json(const json& j, RemoteSplit& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveOutputTableHandle : public ConnectorOutputTableHandle {
+  String schemaName = {};
+  String tableName = {};
+  List<HiveColumnHandle> inputColumns = {};
+  HivePageSinkMetadata pageSinkMetadata = {};
+  LocationHandle locationHandle = {};
+  HiveStorageFormat tableStorageFormat = {};
+  HiveStorageFormat partitionStorageFormat = {};
+  HiveStorageFormat actualStorageFormat = {};
+  HiveCompressionCodec compressionCodec = {};
+  List<String> partitionedBy = {};
+  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
+  List<SortingColumn> preferredOrderingColumns = {};
+  String tableOwner = {};
+  Map<String, String> additionalTableParameters = {};
+  std::shared_ptr<EncryptionInformation> encryptionInformation = {};
+
+  HiveOutputTableHandle() noexcept;
+};
+void to_json(json& j, const HiveOutputTableHandle& p);
+void from_json(const json& j, HiveOutputTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class CacheQuotaScope { GLOBAL, SCHEMA, TABLE, PARTITION };
+extern void to_json(json& j, const CacheQuotaScope& e);
+extern void from_json(const json& j, CacheQuotaScope& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct CacheQuotaRequirement {
+  CacheQuotaScope cacheQuotaScope = {};
+  std::shared_ptr<DataSize> quota = {};
+};
+void to_json(json& j, const CacheQuotaRequirement& p);
+void from_json(const json& j, CacheQuotaRequirement& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SortNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  OrderingScheme orderingScheme = {};
+  bool isPartial = {};
+
+  SortNode() noexcept;
+};
+void to_json(json& j, const SortNode& p);
+void from_json(const json& j, SortNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HivePartitionKey {
+  String name = {};
+  std::shared_ptr<String> value = {};
+};
+void to_json(json& j, const HivePartitionKey& p);
+void from_json(const json& j, HivePartitionKey& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ConstantExpression : public RowExpression {
+  Block valueBlock = {};
+  Type type = {};
+
+  ConstantExpression() noexcept;
+};
+void to_json(json& j, const ConstantExpression& p);
+void from_json(const json& j, ConstantExpression& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct BucketConversion {
+  int tableBucketCount = {};
+  int partitionBucketCount = {};
+  List<HiveColumnHandle> bucketColumnHandles = {};
+};
+void to_json(json& j, const BucketConversion& p);
+void from_json(const json& j, BucketConversion& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class NodeSelectionStrategy {
+  HARD_AFFINITY,
+  SOFT_AFFINITY,
+  NO_PREFERENCE
+};
+extern void to_json(json& j, const NodeSelectionStrategy& e);
+extern void from_json(const json& j, NodeSelectionStrategy& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct HiveSplit : public ConnectorSplit {
+  String database = {};
+  String table = {};
+  String partitionName = {};
+  String path = {};
+  int64_t start = {};
+  int64_t length = {};
+  int64_t fileSize = {};
+  int64_t fileModifiedTime = {};
+  Storage storage = {};
+  List<HivePartitionKey> partitionKeys = {};
+  List<HostAddress> addresses = {};
+  std::shared_ptr<int> readBucketNumber = {};
+  std::shared_ptr<int> tableBucketNumber = {};
+  NodeSelectionStrategy nodeSelectionStrategy = {};
+  int partitionDataColumnCount = {};
+  TableToPartitionMapping tableToPartitionMapping = {};
+  std::shared_ptr<BucketConversion> bucketConversion = {};
+  bool s3SelectPushdownEnabled = {};
+  std::shared_ptr<String> extraFileInfo = {};
+  CacheQuotaRequirement cacheQuota = {};
+  std::shared_ptr<EncryptionInformation> encryptionMetadata = {};
+  Map<String, String> customSplitInfo = {};
+  List<std::shared_ptr<ColumnHandle>> redundantColumnDomains = {};
+  SplitWeight splitWeight = {};
+
+  HiveSplit() noexcept;
+};
+void to_json(json& j, const HiveSplit& p);
+void from_json(const json& j, HiveSplit& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct OutputNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  List<String> columnNames = {};
+  List<VariableReferenceExpression> outputVariables = {};
+
+  OutputNode() noexcept;
+};
+void to_json(json& j, const OutputNode& p);
+void from_json(const json& j, OutputNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct EnforceSingleRowNode : public PlanNode {
@@ -2296,114 +2467,6 @@ struct SemiJoinNode : public PlanNode {
 };
 void to_json(json& j, const SemiJoinNode& p);
 void from_json(const json& j, SemiJoinNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveOutputTableHandle : public ConnectorOutputTableHandle {
-  String schemaName = {};
-  String tableName = {};
-  List<HiveColumnHandle> inputColumns = {};
-  HivePageSinkMetadata pageSinkMetadata = {};
-  LocationHandle locationHandle = {};
-  HiveStorageFormat tableStorageFormat = {};
-  HiveStorageFormat partitionStorageFormat = {};
-  HiveStorageFormat actualStorageFormat = {};
-  HiveCompressionCodec compressionCodec = {};
-  List<String> partitionedBy = {};
-  std::shared_ptr<HiveBucketProperty> bucketProperty = {};
-  List<SortingColumn> preferredOrderingColumns = {};
-  String tableOwner = {};
-  Map<String, String> additionalTableParameters = {};
-  std::shared_ptr<EncryptionInformation> encryptionInformation = {};
-
-  HiveOutputTableHandle() noexcept;
-};
-void to_json(json& j, const HiveOutputTableHandle& p);
-void from_json(const json& j, HiveOutputTableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct InsertHandle : public ExecutionWriterTarget {
-  InsertTableHandle handle = {};
-  SchemaTableName schemaTableName = {};
-
-  InsertHandle() noexcept;
-};
-void to_json(json& j, const InsertHandle& p);
-void from_json(const json& j, InsertHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct RowNumberNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  List<VariableReferenceExpression> partitionBy = {};
-  VariableReferenceExpression rowNumberVariable = {};
-  std::shared_ptr<Integer> maxRowCountPerPartition = {};
-  std::shared_ptr<VariableReferenceExpression> hashVariable = {};
-
-  RowNumberNode() noexcept;
-};
-void to_json(json& j, const RowNumberNode& p);
-void from_json(const json& j, RowNumberNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct HiveMetadataUpdateHandle : public ConnectorMetadataUpdateHandle {
-  UUID requestId = {};
-  SchemaTableName schemaTableName = {};
-  std::shared_ptr<String> partitionName = {};
-  std::shared_ptr<String> fileName = {};
-
-  HiveMetadataUpdateHandle() noexcept;
-};
-void to_json(json& j, const HiveMetadataUpdateHandle& p);
-void from_json(const json& j, HiveMetadataUpdateHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DeleteHandle : public ExecutionWriterTarget {
-  TableHandle handle = {};
-  SchemaTableName schemaTableName = {};
-
-  DeleteHandle() noexcept;
-};
-void to_json(json& j, const DeleteHandle& p);
-void from_json(const json& j, DeleteHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct OutputNode : public PlanNode {
-  std::shared_ptr<PlanNode> source = {};
-  List<String> columnNames = {};
-  List<VariableReferenceExpression> outputVariables = {};
-
-  OutputNode() noexcept;
-};
-void to_json(json& j, const OutputNode& p);
-void from_json(const json& j, OutputNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class Form {
-  IF,
-  NULL_IF,
-  SWITCH,
-  WHEN,
-  IS_NULL,
-  COALESCE,
-  IN,
-  AND,
-  OR,
-  DEREFERENCE,
-  ROW_CONSTRUCTOR,
-  BIND
-};
-extern void to_json(json& j, const Form& e);
-extern void from_json(const json& j, Form& e);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct SpecialFormExpression : public RowExpression {
-  Form form = {};
-  Type returnType = {};
-  List<std::shared_ptr<RowExpression>> arguments = {};
-
-  SpecialFormExpression() noexcept;
-};
-void to_json(json& j, const SpecialFormExpression& p);
-void from_json(const json& j, SpecialFormExpression& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.json
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.json
@@ -3,52 +3,25 @@
     "comment": "// This file is generated DO NOT EDIT @generated"
   },
   {
-    "class_name": "StageExecutionStrategy",
+    "class_name": "ColumnType",
     "enum": true,
     "elements": [
       {
-        "element": "UNGROUPED_EXECUTION",
+        "element": "PARTITION_KEY",
         "_N": 1
       },
       {
-        "element": "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION",
+        "element": "REGULAR",
         "_N": 2
       },
       {
-        "element": "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION",
+        "element": "SYNTHESIZED",
         "_N": 3
       },
       {
-        "element": "RECOVERABLE_GROUPED_EXECUTION",
+        "element": "AGGREGATED",
         "_N": 4,
         "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "StageExecutionDescriptor",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "StageExecutionStrategy",
-        "field_name": "stageExecutionStrategy",
-        "field_text": "StageExecutionStrategy",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<PlanNodeId>",
-        "field_name": "groupedExecutionScanNodes",
-        "field_text": "List<PlanNodeId>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "totalLifespans",
-        "field_text": "int",
-        "_N": 3,
-        "field_local": true
       }
     ]
   },
@@ -69,457 +42,6 @@
         "field_text": "int",
         "_N": 2,
         "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "VariableReferenceExpression",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct VariableReferenceExpression : RowExpression {\n  String name;\n  Type type; // dependency\n\n  VariableReferenceExpression() noexcept;\n  explicit VariableReferenceExpression(const String& str) {\n    _type = \"variable\";\n\n    std::vector<std::string, std::allocator<std::string>> parts;\n\n    folly::split(\"<\", str, parts);\n    name = parts[0];\n    type = parts[1].substr(0, parts[1].length() - 1);\n  }\n\n  bool operator<(const VariableReferenceExpression& o) const {\n    if (name == o.name) {\n      return type < o.type;\n    }\n\n    return name < o.name;\n  }\n};\n\nvoid to_json(json& j, const VariableReferenceExpression& p);\nvoid from_json(const json& j, VariableReferenceExpression& p);\n\nstd::string json_map_key(\n    const facebook::presto::protocol::VariableReferenceExpression& p);\n\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<SourceLocation>",
-        "field_name": "sourceLocation",
-        "field_text": "SourceLocation",
-        "optional": true,
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
-        "_N": 3,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "RowExpression",
-    "json_key": "variable"
-  },
-  {
-    "class_name": "EquiJoinClause",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "left",
-        "field_text": "VariableReferenceExpression",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "right",
-        "field_text": "VariableReferenceExpression",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "LongVariableConstraint",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "expression",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "FunctionKind",
-    "enum": true,
-    "elements": [
-      {
-        "element": "SCALAR",
-        "_N": 1
-      },
-      {
-        "element": "AGGREGATE",
-        "_N": 2
-      },
-      {
-        "element": "WINDOW",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "TypeVariableConstraint",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct TypeVariableConstraint {\n  String name = {};\n  bool comparableRequired = {};\n  bool orderableRequired = {};\n  String variadicBound = {};\n  bool nonDecimalNumericRequired = {};\n  String boundedBy = {};\n};\nvoid to_json(json& j, const TypeVariableConstraint& p);\nvoid from_json(const json& j, TypeVariableConstraint& p);\n\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "comparableRequired",
-        "field_text": "bool",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "orderableRequired",
-        "field_text": "bool",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "variadicBound",
-        "field_text": "String",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "nonDecimalNumericRequired",
-        "field_text": "bool",
-        "_N": 5,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Signature",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "QualifiedObjectName",
-        "field_name": "name",
-        "field_text": "QualifiedObjectName",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "FunctionKind",
-        "field_name": "kind",
-        "field_text": "FunctionKind",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<TypeVariableConstraint>",
-        "field_name": "typeVariableConstraints",
-        "field_text": "List<TypeVariableConstraint>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "List<LongVariableConstraint>",
-        "field_name": "longVariableConstraints",
-        "field_text": "List<LongVariableConstraint>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "TypeSignature",
-        "field_name": "returnType",
-        "field_text": "TypeSignature",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "List<TypeSignature>",
-        "field_name": "argumentTypes",
-        "field_text": "List<TypeSignature>",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "variableArity",
-        "field_text": "bool",
-        "_N": 7,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Determinism",
-    "enum": true,
-    "elements": [
-      {
-        "element": "DETERMINISTIC",
-        "_N": 1
-      },
-      {
-        "element": "NOT_DETERMINISTIC",
-        "_N": 2
-      }
-    ]
-  },
-  {
-    "class_name": "Language",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "language",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "NullCallClause",
-    "enum": true,
-    "elements": [
-      {
-        "element": "RETURNS_NULL_ON_NULL_INPUT",
-        "_N": 1
-      },
-      {
-        "element": "CALLED_ON_NULL_INPUT",
-        "_N": 2,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "RoutineCharacteristics",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<Language>",
-        "field_name": "language",
-        "field_text": "Language",
-        "optional": true,
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Determinism>",
-        "field_name": "determinism",
-        "field_text": "Determinism",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<NullCallClause>",
-        "field_name": "nullCallClause",
-        "field_text": "NullCallClause",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Parameter",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "TypeSignature",
-        "field_name": "type",
-        "field_text": "TypeSignature",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "SqlInvokedFunction",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "List<Parameter>",
-        "field_name": "parameters",
-        "field_text": "List<Parameter>",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "description",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "RoutineCharacteristics",
-        "field_name": "routineCharacteristics",
-        "field_text": "RoutineCharacteristics",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "body",
-        "field_text": "String",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Signature",
-        "field_name": "signature",
-        "field_text": "Signature",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "SqlFunctionId",
-        "field_name": "functionId",
-        "field_text": "SqlFunctionId",
-        "_N": 6,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveTableHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "schemaName",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "tableName",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<List<List<String>>>",
-        "field_name": "analyzePartitionValues",
-        "field_text": "List<List<String>>",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorTableHandle",
-    "json_key": "hive"
-  },
-  {
-    "class_name": "BuiltInFunctionHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Signature",
-        "field_name": "signature",
-        "field_text": "Signature",
-        "_N": 1,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "FunctionHandle",
-    "json_key": "$static"
-  },
-  {
-    "class_name": "ConnectorPartitioningHandle",
-    "field_name": "connectorPartitioningHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "SystemPartitioningHandle",
-        "name": "systemPartitioningHandle",
-        "key": "$remote",
-        "_N": 1
-      },
-      {
-        "type": "HivePartitioningHandle",
-        "name": "hivePartitioningHandle",
-        "key": "hive",
-        "_N": 2,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<SystemPartitioningHandle>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HivePartitioningHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorPartitioningHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorPartitioningHandle\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<SystemPartitioningHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HivePartitioningHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorPartitioningHandle\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "ConnectorTransactionHandle",
-    "field_name": "connectorTransactionHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveTransactionHandle",
-        "name": "hiveTransactionHandle",
-        "key": "hive",
-        "_N": 1
-      },
-      {
-        "type": "RemoteTransactionHandle",
-        "name": "remoteTransactionHandle",
-        "key": "$remote",
-        "_N": 2,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<RemoteTransactionHandle>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTransactionHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTransactionHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorTransactionHandle  ConnectorTransactionHandle\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<RemoteTransactionHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTransactionHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTransactionHandle\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "PartitioningHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<ConnectorId>",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "optional": true,
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<ConnectorTransactionHandle>",
-        "field_name": "transactionHandle",
-        "field_text": "ConnectorTransactionHandle",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorPartitioningHandle",
-        "field_name": "connectorHandle",
-        "field_text": "ConnectorPartitioningHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
       }
     ]
   },
@@ -573,80 +95,559 @@
     ]
   },
   {
-    "class_name": "Partitioning",
+    "class_name": "FunctionHandle",
+    "field_name": "functionHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "BuiltInFunctionHandle",
+        "name": "builtInFunctionHandle",
+        "key": "$static",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": []
+  },
+  {
+    "class_name": "CallExpression",
     "struct": true,
     "fields": [
       {
-        "field_type": "PartitioningHandle",
-        "field_name": "handle",
-        "field_text": "PartitioningHandle",
+        "field_type": "Optional<SourceLocation>",
+        "field_name": "sourceLocation",
+        "field_text": "SourceLocation",
+        "optional": true,
         "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "String",
+        "field_name": "displayName",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "FunctionHandle",
+        "field_name": "functionHandle",
+        "field_text": "FunctionHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Type",
+        "field_name": "returnType",
+        "field_text": "Type",
+        "_N": 4,
         "field_local": true
       },
       {
         "field_type": "List<RowExpression>",
         "field_name": "arguments",
         "field_text": "List<std::shared_ptr<RowExpression>>",
+        "_N": 5,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "RowExpression",
+    "json_key": "call"
+  },
+  {
+    "class_name": "VariableReferenceExpression",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct VariableReferenceExpression : RowExpression {\n  String name;\n  Type type; // dependency\n\n  VariableReferenceExpression() noexcept;\n  explicit VariableReferenceExpression(const String& str) {\n    _type = \"variable\";\n\n    std::vector<std::string, std::allocator<std::string>> parts;\n\n    folly::split(\"<\", str, parts);\n    name = parts[0];\n    type = parts[1].substr(0, parts[1].length() - 1);\n  }\n\n  bool operator<(const VariableReferenceExpression& o) const {\n    if (name == o.name) {\n      return type < o.type;\n    }\n\n    return name < o.name;\n  }\n};\n\nvoid to_json(json& j, const VariableReferenceExpression& p);\nvoid from_json(const json& j, VariableReferenceExpression& p);\n\nstd::string json_map_key(\n    const facebook::presto::protocol::VariableReferenceExpression& p);\n\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<SourceLocation>",
+        "field_name": "sourceLocation",
+        "field_text": "SourceLocation",
+        "optional": true,
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 3,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "RowExpression",
+    "json_key": "variable"
+  },
+  {
+    "class_name": "SortOrder",
+    "enum": true,
+    "elements": [
+      {
+        "element": "ASC_NULLS_FIRST",
+        "_N": 1
+      },
+      {
+        "element": "ASC_NULLS_LAST",
+        "_N": 2
+      },
+      {
+        "element": "DESC_NULLS_FIRST",
+        "_N": 3
+      },
+      {
+        "element": "DESC_NULLS_LAST",
+        "_N": 4,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Ordering",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "variable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "SortOrder",
+        "field_name": "sortOrder",
+        "field_text": "SortOrder",
         "_N": 2,
         "field_local": true
       }
     ]
   },
   {
-    "class_name": "PartitioningScheme",
+    "class_name": "OrderingScheme",
     "struct": true,
     "fields": [
       {
-        "field_type": "Partitioning",
-        "field_name": "partitioning",
-        "field_text": "Partitioning",
+        "field_type": "List<Ordering>",
+        "field_name": "orderBy",
+        "field_text": "List<Ordering>",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Aggregation",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "CallExpression",
+        "field_name": "call",
+        "field_text": "CallExpression",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputLayout",
-        "field_text": "List<VariableReferenceExpression>",
+        "field_type": "Optional<RowExpression>",
+        "field_name": "filter",
+        "field_text": "std::shared_ptr<RowExpression>",
+        "optional": true,
         "_N": 2,
         "field_local": true
       },
       {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "hashColumn",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "Optional<OrderingScheme>",
+        "field_name": "orderBy",
+        "field_text": "OrderingScheme",
         "optional": true,
         "_N": 3,
         "field_local": true
       },
       {
         "field_type": "boolean",
-        "field_name": "replicateNullsAndAny",
+        "field_name": "distinct",
         "field_text": "bool",
         "_N": 4,
         "field_local": true
       },
       {
-        "field_type": "Optional<int[]>",
-        "field_name": "bucketToPartition",
-        "field_text": "List<int>",
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "mask",
+        "field_text": "VariableReferenceExpression",
         "optional": true,
         "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "FunctionHandle",
+        "field_name": "functionHandle",
+        "field_text": "FunctionHandle",
+        "_N": 6,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<RowExpression>",
+        "field_name": "arguments",
+        "field_text": "List<std::shared_ptr<RowExpression>>",
+        "_N": 7,
+        "field_local": true,
+        "last": true
+      }
+    ]
+  },
+  {
+    "class_name": "HiveColumnHandle",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct HiveColumnHandle : public ColumnHandle {\n  String name = {};\n  HiveType hiveType = {};\n  TypeSignature typeSignature = {};\n  int hiveColumnIndex = {};\n  ColumnType columnType = {};\n  std::shared_ptr<String> comment = {};\n  List<Subfield> requiredSubfields = {};\n  std::shared_ptr<Aggregation> partialAggregation = {};\n\n  HiveColumnHandle() noexcept;\n\n  bool operator<(const ColumnHandle& o) const override {\n    return name < dynamic_cast<const HiveColumnHandle&>(o).name;\n  }\n};\n\nvoid to_json(json& j, const HiveColumnHandle& p);\nvoid from_json(const json& j, HiveColumnHandle& p);\n\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "HiveType",
+        "field_name": "hiveType",
+        "field_text": "HiveType",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "TypeSignature",
+        "field_name": "typeSignature",
+        "field_text": "TypeSignature",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "hiveColumnIndex",
+        "field_text": "int",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "ColumnType",
+        "field_name": "columnType",
+        "field_text": "ColumnType",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "comment",
+        "field_text": "String",
+        "optional": true,
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "List<Subfield>",
+        "field_name": "requiredSubfields",
+        "field_text": "List<Subfield>",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Aggregation>",
+        "field_name": "partialAggregation",
+        "field_text": "Aggregation",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ColumnHandle",
+    "json_key": "hive"
+  },
+  {
+    "class_name": "SchemaTableName",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "schema",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "table",
+        "field_text": "String",
+        "_N": 2,
         "field_local": true
       }
     ]
   },
   {
-    "class_name": "Assignments",
+    "class_name": "ColumnHandle",
+    "field_name": "columnHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "comparable": true,
+    "subclasses": [
+      {
+        "type": "HiveColumnHandle",
+        "name": "hiveColumnHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ColumnHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveColumnHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ColumnHandle \");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ColumnHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ColumnHandle  ColumnHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    std::shared_ptr<HiveColumnHandle> k = std::make_shared<HiveColumnHandle>();\n    j.get_to(*k);\n    p = std::static_pointer_cast<ColumnHandle>(k);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ColumnHandle \");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "Column",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct Column {\n  String name;\n  String type;\n\n  Column() = default;\n  explicit Column(const String& str) {\n    name = str;\n  }\n};\n\nvoid to_json(json& j, const Column& p);\nvoid from_json(const json& j, Column& p);\n\n} // namespace facebook::presto::protocol",
     "struct": true,
     "fields": [
       {
-        "field_type": "Map<VariableReferenceExpression, RowExpression>",
-        "field_name": "assignments",
-        "field_text": "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "type",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ValueSet",
+    "field_name": "valueSet",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "EquatableValueSet",
+        "name": "equatableValueSet",
+        "key": "equatable",
+        "_N": 1
+      },
+      {
+        "type": "SortedRangeSet",
+        "name": "sortedRangeSet",
+        "key": "sortable",
+        "_N": 2
+      },
+      {
+        "type": "AllOrNoneValueSet",
+        "name": "allOrNoneValueSet",
+        "key": "allOrNone",
+        "_N": 3,
+        "_last": true
+      }
+    ],
+    "fields": []
+  },
+  {
+    "class_name": "Domain",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ValueSet",
+        "field_name": "values",
+        "field_text": "ValueSet",
+        "_N": 1,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "nullAllowed",
+        "field_text": "bool",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "TupleDomain",
+    "hinc": "namespace facebook::presto::protocol {\n\ntemplate <typename T>\nstruct pointerDerefCompare {\n  bool operator()(const std::shared_ptr<T>& a, const std::shared_ptr<T>& b)\n      const {\n    return *a < *b;\n  }\n};\n\ntemplate <typename T>\nstruct TupleDomain {\n  std::shared_ptr<Map<T, Domain>> domains;\n};\n\ntemplate <typename T>\nstruct TupleDomain<std::shared_ptr<T>> {\n  std::shared_ptr<std::map<std::shared_ptr<T>, Domain, pointerDerefCompare<T>>>\n      domains;\n};\n\ntemplate <class T>\nstruct ColumnDomain {\n  T column;\n  Domain domain; // dependency\n};\n\n} // namespace facebook::presto::protocol\n\nnamespace nlohmann {\n\ntemplate <typename T>\nstruct adl_serializer<facebook::presto::protocol::ColumnDomain<T>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::ColumnDomain<T>& p) {\n    facebook::presto::protocol::to_json_key(\n        j, \"column\", p.column, \"ColumnDomain\", \"T\", \"column\");\n    facebook::presto::protocol::to_json_key(\n        j, \"domain\", p.domain, \"ColumnDomain\", \"Domain\", \"domain\");\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::ColumnDomain<T>& p) {\n    facebook::presto::protocol::from_json_key(\n        j, \"column\", p.column, \"ColumnDomain\", \"T\", \"column\");\n    facebook::presto::protocol::from_json_key(\n        j, \"domain\", p.domain, \"ColumnDomain\", \"Domain\", \"domain\");\n  }\n};\n\ntemplate <typename T>\nstruct adl_serializer<facebook::presto::protocol::TupleDomain<T>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::TupleDomain<T>& tup) {\n    facebook::presto::protocol::List<\n        facebook::presto::protocol::ColumnDomain<T>>\n        list;\n    if (tup.domains != nullptr) {\n      for (auto& el : *tup.domains) {\n        facebook::presto::protocol::ColumnDomain<T> domain;\n        domain.column = el.first;\n        domain.domain = el.second;\n        list.push_back(domain);\n      }\n    }\n\n    j[\"columnDomains\"] = list;\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::TupleDomain<T>& tup) {\n    if (j.count(\"columnDomains\") != 0U) {\n      std::shared_ptr<facebook::presto::protocol::\n                          Map<T, facebook::presto::protocol::Domain>>\n          map = std::make_shared<\n              std::map<T, facebook::presto::protocol::Domain>>();\n\n      facebook::presto::protocol::List<\n          facebook::presto::protocol::ColumnDomain<T>>\n          list = j.at(\"columnDomains\");\n      for (const facebook::presto::protocol::ColumnDomain<T>& value : list) {\n        map->insert(std::make_pair(T(value.column), value.domain));\n      }\n      tup.domains = map;\n    }\n  }\n};\n\ntemplate <typename T>\nstruct adl_serializer<\n    facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>& tup) {\n    facebook::presto::protocol::List<\n        facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>>\n        list;\n    if (tup.domains != nullptr) {\n      for (auto& el : *tup.domains) {\n        facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>> domain;\n        domain.column = el.first;\n        domain.domain = el.second;\n        list.push_back(domain);\n      }\n    }\n\n    j[\"columnDomains\"] = list;\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>& tup) {\n    if (j.count(\"columnDomains\") != 0U) {\n      auto map = std::make_shared<std::map<\n          std::shared_ptr<T>,\n          facebook::presto::protocol::Domain,\n          facebook::presto::protocol::pointerDerefCompare<T>>>();\n\n      facebook::presto::protocol::List<\n          facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>>\n          list = j.at(\"columnDomains\");\n      for (const facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>&\n               value : list) {\n        map->insert(\n            std::make_pair(std::shared_ptr<T>(value.column), value.domain));\n      }\n      tup.domains = map;\n    }\n  }\n};\n\n} // namespace nlohmann"
+  },
+  {
+    "class_name": "HiveBucketFilter",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Set<Integer>",
+        "field_name": "bucketsToKeep",
+        "field_text": "List<Integer>",
         "_N": 1,
         "field_local": true
       }
     ]
+  },
+  {
+    "class_name": "HiveBucketHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "List<HiveColumnHandle>",
+        "field_name": "columns",
+        "field_text": "List<HiveColumnHandle>",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "tableBucketCount",
+        "field_text": "int",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "readBucketCount",
+        "field_text": "int",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "HiveTableLayoutHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "SchemaTableName",
+        "field_name": "schemaTableName",
+        "field_text": "SchemaTableName",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "tablePath",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<HiveColumnHandle>",
+        "field_name": "partitionColumns",
+        "field_text": "List<HiveColumnHandle>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "List<Column>",
+        "field_name": "dataColumns",
+        "field_text": "List<Column>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, String>",
+        "field_name": "tableParameters",
+        "field_text": "Map<String, String>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "TupleDomain<Subfield>",
+        "field_name": "domainPredicate",
+        "field_text": "TupleDomain<Subfield>",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "RowExpression",
+        "field_name": "remainingPredicate",
+        "field_text": "RowExpression",
+        "_N": 7,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Map<String, HiveColumnHandle>",
+        "field_name": "predicateColumns",
+        "field_text": "Map<String, HiveColumnHandle>",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "TupleDomain<ColumnHandle>",
+        "field_name": "partitionColumnPredicate",
+        "field_text": "TupleDomain<std::shared_ptr<ColumnHandle>>",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<HiveBucketHandle>",
+        "field_name": "bucketHandle",
+        "field_text": "HiveBucketHandle",
+        "optional": true,
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<HiveBucketFilter>",
+        "field_name": "bucketFilter",
+        "field_text": "HiveBucketFilter",
+        "optional": true,
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "pushdownFilterEnabled",
+        "field_text": "bool",
+        "_N": 12,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "layoutString",
+        "field_text": "String",
+        "_N": 13,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Set<HiveColumnHandle>>",
+        "field_name": "requestedColumns",
+        "field_text": "List<HiveColumnHandle>",
+        "optional": true,
+        "_N": 14,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "partialAggregationsPushedDown",
+        "field_text": "bool",
+        "_N": 15,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "appendRowNumber",
+        "field_text": "bool",
+        "_N": 16,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorTableLayoutHandle",
+    "json_key": "hive"
   },
   {
     "class_name": "PlanNode",
@@ -778,7 +779,13 @@
         "type": "MergeJoinNode",
         "name": "mergeJoinNode",
         "key": "com.facebook.presto.sql.planner.plan.MergeJoinNode",
-        "_N": 21,
+        "_N": 21
+      },
+      {
+        "type": "WindowNode",
+        "name": "windowNode",
+        "key": "com.facebook.presto.sql.planner.plan.WindowNode",
+        "_N": 22,
         "_last": true
       }
     ],
@@ -794,82 +801,7 @@
     ]
   },
   {
-    "class_name": "Step",
-    "enum": true,
-    "elements": [
-      {
-        "element": "SINGLE",
-        "_N": 1
-      },
-      {
-        "element": "PARTIAL",
-        "_N": 2
-      },
-      {
-        "element": "FINAL",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "SortOrder",
-    "enum": true,
-    "elements": [
-      {
-        "element": "ASC_NULLS_FIRST",
-        "_N": 1
-      },
-      {
-        "element": "ASC_NULLS_LAST",
-        "_N": 2
-      },
-      {
-        "element": "DESC_NULLS_FIRST",
-        "_N": 3
-      },
-      {
-        "element": "DESC_NULLS_LAST",
-        "_N": 4,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "Ordering",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "variable",
-        "field_text": "VariableReferenceExpression",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "SortOrder",
-        "field_name": "sortOrder",
-        "field_text": "SortOrder",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "OrderingScheme",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "List<Ordering>",
-        "field_name": "orderBy",
-        "field_text": "List<Ordering>",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "TopNNode",
+    "class_name": "DistinctLimitNode",
     "struct": true,
     "fields": [
       {
@@ -889,161 +821,37 @@
       },
       {
         "field_type": "long",
-        "field_name": "count",
+        "field_name": "limit",
         "field_text": "int64_t",
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "OrderingScheme",
-        "field_name": "orderingScheme",
-        "field_text": "OrderingScheme",
+        "field_type": "boolean",
+        "field_name": "partial",
+        "field_text": "bool",
         "_N": 4,
         "field_local": true
       },
       {
-        "field_type": "Step",
-        "field_name": "step",
-        "field_text": "Step",
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "distinctVariables",
+        "field_text": "List<VariableReferenceExpression>",
         "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "hashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 6,
         "field_local": true
       }
     ],
     "subclass": true,
     "super_class": "PlanNode",
-    "json_key": ".TopNNode"
-  },
-  {
-    "class_name": "Column",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct Column {\n  String name;\n  String type;\n\n  Column() = default;\n  explicit Column(const String& str) {\n    name = str;\n  }\n};\n\nvoid to_json(json& j, const Column& p);\nvoid from_json(const json& j, Column& p);\n\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "type",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Block",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Block& p) {\n  j = p.data;\n}\n\nvoid from_json(const json& j, Block& p) {\n  p.data = std::string(j);\n}\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct Block {\n  std::string data;\n};\n\nvoid to_json(json& j, const Block& p);\n\nvoid from_json(const json& j, Block& p);\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "ConstantExpression",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Block",
-        "field_name": "valueBlock",
-        "field_text": "Block",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
-        "_N": 2,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "RowExpression",
-    "json_key": "constant"
-  },
-  {
-    "class_name": "EmptySplit",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorSplit",
-    "json_key": "$empty"
-  },
-  {
-    "class_name": "Bound",
-    "enum": true,
-    "elements": [
-      {
-        "element": "BELOW",
-        "_N": 1
-      },
-      {
-        "element": "EXACTLY",
-        "_N": 2
-      },
-      {
-        "element": "ABOVE",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "Marker",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Block>",
-        "field_name": "valueBlock",
-        "field_text": "Block",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Bound",
-        "field_name": "bound",
-        "field_text": "Bound",
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Range",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Marker",
-        "field_name": "low",
-        "field_text": "Marker",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Marker",
-        "field_name": "high",
-        "field_text": "Marker",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
+    "json_key": ".DistinctLimitNode"
   },
   {
     "class_name": "TableToPartitionMapping",
@@ -1110,6 +918,118 @@
         "field_text": "DwrfEncryptionMetadata",
         "optional": true,
         "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "FilterNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "RowExpression",
+        "field_name": "predicate",
+        "field_text": "RowExpression",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": ".FilterNode"
+  },
+  {
+    "class_name": "WriteMode",
+    "enum": true,
+    "elements": [
+      {
+        "element": "STAGE_AND_MOVE_TO_TARGET_DIRECTORY",
+        "_N": 1
+      },
+      {
+        "element": "DIRECT_TO_TARGET_NEW_DIRECTORY",
+        "_N": 2
+      },
+      {
+        "element": "DIRECT_TO_TARGET_EXISTING_DIRECTORY",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "TableType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "NEW",
+        "_N": 1
+      },
+      {
+        "element": "EXISTING",
+        "_N": 2
+      },
+      {
+        "element": "TEMPORARY",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "LocationHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "targetPath",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "writePath",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "tempPath",
+        "field_text": "String",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "TableType",
+        "field_name": "tableType",
+        "field_text": "TableType",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "WriteMode",
+        "field_name": "writeMode",
+        "field_text": "WriteMode",
+        "_N": 5,
         "field_local": true
       }
     ]
@@ -1207,6 +1127,64 @@
     ]
   },
   {
+    "class_name": "HiveCompressionCodec",
+    "enum": true,
+    "elements": [
+      {
+        "element": "NONE",
+        "_N": 1
+      },
+      {
+        "element": "SNAPPY",
+        "_N": 2
+      },
+      {
+        "element": "GZIP",
+        "_N": 3
+      },
+      {
+        "element": "LZ4",
+        "_N": 4
+      },
+      {
+        "element": "ZSTD",
+        "_N": 5,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "PrestoTableType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "MANAGED_TABLE",
+        "_N": 1
+      },
+      {
+        "element": "EXTERNAL_TABLE",
+        "_N": 2
+      },
+      {
+        "element": "VIRTUAL_VIEW",
+        "_N": 3
+      },
+      {
+        "element": "MATERIALIZED_VIEW",
+        "_N": 4
+      },
+      {
+        "element": "TEMPORARY_TABLE",
+        "_N": 5
+      },
+      {
+        "element": "OTHER",
+        "_N": 6,
+        "_last": true
+      }
+    ]
+  },
+  {
     "class_name": "StorageFormat",
     "struct": true,
     "fields": [
@@ -1279,2465 +1257,6 @@
         "field_text": "Map<String, String>",
         "_N": 6,
         "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "NodeSelectionStrategy",
-    "enum": true,
-    "elements": [
-      {
-        "element": "HARD_AFFINITY",
-        "_N": 1
-      },
-      {
-        "element": "SOFT_AFFINITY",
-        "_N": 2
-      },
-      {
-        "element": "NO_PREFERENCE",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "ColumnHandle",
-    "field_name": "columnHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "comparable": true,
-    "subclasses": [
-      {
-        "type": "HiveColumnHandle",
-        "name": "hiveColumnHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ColumnHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveColumnHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ColumnHandle \");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ColumnHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ColumnHandle  ColumnHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    std::shared_ptr<HiveColumnHandle> k = std::make_shared<HiveColumnHandle>();\n    j.get_to(*k);\n    p = std::static_pointer_cast<ColumnHandle>(k);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ColumnHandle \");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "HostAddress",
-    "hinc": "namespace facebook::presto::protocol {\n\nusing HostAddress = std::string;\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "HivePartitionKey",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "value",
-        "field_text": "String",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ColumnType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "PARTITION_KEY",
-        "_N": 1
-      },
-      {
-        "element": "REGULAR",
-        "_N": 2
-      },
-      {
-        "element": "SYNTHESIZED",
-        "_N": 3
-      },
-      {
-        "element": "AGGREGATED",
-        "_N": 4,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "FunctionHandle",
-    "field_name": "functionHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "BuiltInFunctionHandle",
-        "name": "builtInFunctionHandle",
-        "key": "$static",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": []
-  },
-  {
-    "class_name": "CallExpression",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<SourceLocation>",
-        "field_name": "sourceLocation",
-        "field_text": "SourceLocation",
-        "optional": true,
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "String",
-        "field_name": "displayName",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "FunctionHandle",
-        "field_name": "functionHandle",
-        "field_text": "FunctionHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Type",
-        "field_name": "returnType",
-        "field_text": "Type",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<RowExpression>",
-        "field_name": "arguments",
-        "field_text": "List<std::shared_ptr<RowExpression>>",
-        "_N": 5,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "RowExpression",
-    "json_key": "call"
-  },
-  {
-    "class_name": "Aggregation",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "CallExpression",
-        "field_name": "call",
-        "field_text": "CallExpression",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<RowExpression>",
-        "field_name": "filter",
-        "field_text": "std::shared_ptr<RowExpression>",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<OrderingScheme>",
-        "field_name": "orderBy",
-        "field_text": "OrderingScheme",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "distinct",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "mask",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "FunctionHandle",
-        "field_name": "functionHandle",
-        "field_text": "FunctionHandle",
-        "_N": 6,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "List<RowExpression>",
-        "field_name": "arguments",
-        "field_text": "List<std::shared_ptr<RowExpression>>",
-        "_N": 7,
-        "field_local": true,
-        "last": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveColumnHandle",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct HiveColumnHandle : public ColumnHandle {\n  String name = {};\n  HiveType hiveType = {};\n  TypeSignature typeSignature = {};\n  int hiveColumnIndex = {};\n  ColumnType columnType = {};\n  std::shared_ptr<String> comment = {};\n  List<Subfield> requiredSubfields = {};\n  std::shared_ptr<Aggregation> partialAggregation = {};\n\n  HiveColumnHandle() noexcept;\n\n  bool operator<(const ColumnHandle& o) const override {\n    return name < dynamic_cast<const HiveColumnHandle&>(o).name;\n  }\n};\n\nvoid to_json(json& j, const HiveColumnHandle& p);\nvoid from_json(const json& j, HiveColumnHandle& p);\n\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "HiveType",
-        "field_name": "hiveType",
-        "field_text": "HiveType",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "TypeSignature",
-        "field_name": "typeSignature",
-        "field_text": "TypeSignature",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "hiveColumnIndex",
-        "field_text": "int",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "ColumnType",
-        "field_name": "columnType",
-        "field_text": "ColumnType",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "comment",
-        "field_text": "String",
-        "optional": true,
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "List<Subfield>",
-        "field_name": "requiredSubfields",
-        "field_text": "List<Subfield>",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Aggregation>",
-        "field_name": "partialAggregation",
-        "field_text": "Aggregation",
-        "optional": true,
-        "_N": 8,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ColumnHandle",
-    "json_key": "hive"
-  },
-  {
-    "class_name": "BucketConversion",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "int",
-        "field_name": "tableBucketCount",
-        "field_text": "int",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "partitionBucketCount",
-        "field_text": "int",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<HiveColumnHandle>",
-        "field_name": "bucketColumnHandles",
-        "field_text": "List<HiveColumnHandle>",
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "CacheQuotaScope",
-    "enum": true,
-    "elements": [
-      {
-        "element": "GLOBAL",
-        "_N": 1
-      },
-      {
-        "element": "SCHEMA",
-        "_N": 2
-      },
-      {
-        "element": "TABLE",
-        "_N": 3
-      },
-      {
-        "element": "PARTITION",
-        "_N": 4,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "DataSize",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(nlohmann::json& j, const DataSize& p) {\n  j = p.toString();\n}\n\nvoid from_json(const nlohmann::json& j, DataSize& p) {\n  p = DataSize(std::string(j));\n}\n\nstd::ostream& operator<<(std::ostream& os, const DataSize& d) {\n  return os << d.toString();\n}\n\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\n\nstd::ostream& operator<<(std::ostream& os, const DataSize& d);\n\nvoid to_json(nlohmann::json& j, const DataSize& p);\nvoid from_json(const nlohmann::json& j, DataSize& p);\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "CacheQuotaRequirement",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "CacheQuotaScope",
-        "field_name": "cacheQuotaScope",
-        "field_text": "CacheQuotaScope",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DataSize>",
-        "field_name": "quota",
-        "field_text": "DataSize",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveSplit",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "database",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "table",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "partitionName",
-        "field_text": "String",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "path",
-        "field_text": "String",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "start",
-        "field_text": "int64_t",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "length",
-        "field_text": "int64_t",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "fileSize",
-        "field_text": "int64_t",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "fileModifiedTime",
-        "field_text": "int64_t",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Storage",
-        "field_name": "storage",
-        "field_text": "Storage",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "List<HivePartitionKey>",
-        "field_name": "partitionKeys",
-        "field_text": "List<HivePartitionKey>",
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "List<HostAddress>",
-        "field_name": "addresses",
-        "field_text": "List<HostAddress>",
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "OptionalInt",
-        "field_name": "readBucketNumber",
-        "field_text": "int",
-        "optional": true,
-        "_N": 12,
-        "field_local": true
-      },
-      {
-        "field_type": "OptionalInt",
-        "field_name": "tableBucketNumber",
-        "field_text": "int",
-        "optional": true,
-        "_N": 13,
-        "field_local": true
-      },
-      {
-        "field_type": "NodeSelectionStrategy",
-        "field_name": "nodeSelectionStrategy",
-        "field_text": "NodeSelectionStrategy",
-        "_N": 14,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "partitionDataColumnCount",
-        "field_text": "int",
-        "_N": 15,
-        "field_local": true
-      },
-      {
-        "field_type": "TableToPartitionMapping",
-        "field_name": "tableToPartitionMapping",
-        "field_text": "TableToPartitionMapping",
-        "_N": 16,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<BucketConversion>",
-        "field_name": "bucketConversion",
-        "field_text": "BucketConversion",
-        "optional": true,
-        "_N": 17,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "s3SelectPushdownEnabled",
-        "field_text": "bool",
-        "_N": 18,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<byte[]>",
-        "field_name": "extraFileInfo",
-        "field_text": "String",
-        "optional": true,
-        "_N": 19,
-        "field_local": true
-      },
-      {
-        "field_type": "CacheQuotaRequirement",
-        "field_name": "cacheQuota",
-        "field_text": "CacheQuotaRequirement",
-        "_N": 20,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<EncryptionInformation>",
-        "field_name": "encryptionMetadata",
-        "field_text": "EncryptionInformation",
-        "optional": true,
-        "_N": 21,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, String>",
-        "field_name": "customSplitInfo",
-        "field_text": "Map<String, String>",
-        "_N": 22,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<ColumnHandle>",
-        "field_name": "redundantColumnDomains",
-        "field_text": "List<std::shared_ptr<ColumnHandle>>",
-        "_N": 23,
-        "field_local": true
-      },
-      {
-        "field_type": "SplitWeight",
-        "field_name": "splitWeight",
-        "field_text": "SplitWeight",
-        "_N": 24,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorSplit",
-    "json_key": "hive"
-  },
-  {
-    "class_name": "BufferType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "PARTITIONED",
-        "_N": 1
-      },
-      {
-        "element": "BROADCAST",
-        "_N": 2
-      },
-      {
-        "element": "ARBITRARY",
-        "_N": 3
-      },
-      {
-        "element": "DISCARDING",
-        "_N": 4
-      },
-      {
-        "element": "SPOOLING",
-        "_N": 5,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "OutputBuffers",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "BufferType",
-        "field_name": "type",
-        "field_text": "BufferType",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "version",
-        "field_text": "int64_t",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "noMoreBufferIds",
-        "field_text": "bool",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<OutputBufferId, Integer>",
-        "field_name": "buffers",
-        "field_text": "Map<OutputBufferId, Integer>",
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "SelectedRoleType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "ROLE",
-        "_N": 1
-      },
-      {
-        "element": "ALL",
-        "_N": 2
-      },
-      {
-        "element": "NONE",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "SelectedRole",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "SelectedRoleType",
-        "field_name": "type",
-        "field_text": "SelectedRoleType",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "role",
-        "field_text": "String",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Duration",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Duration& p) {\n  j = p.toString();\n}\n\nvoid from_json(const json& j, Duration& p) {\n  p = Duration(std::string(j));\n}\n\nstd::ostream& operator<<(std::ostream& os, const Duration& d) {\n  return os << d.toString();\n}\n\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\n\nstd::ostream& operator<<(std::ostream& os, const Duration& d);\n\nvoid to_json(json& j, const Duration& p);\nvoid from_json(const json& j, Duration& p);\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "ResourceEstimates",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<Duration>",
-        "field_name": "executionTime",
-        "field_text": "Duration",
-        "optional": true,
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Duration>",
-        "field_name": "cpuTime",
-        "field_text": "Duration",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DataSize>",
-        "field_name": "peakMemory",
-        "field_text": "DataSize",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DataSize>",
-        "field_name": "peakTaskMemory",
-        "field_text": "DataSize",
-        "optional": true,
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "SessionRepresentation",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "queryId",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<TransactionId>",
-        "field_name": "transactionId",
-        "field_text": "TransactionId",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "clientTransactionSupport",
-        "field_text": "bool",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "user",
-        "field_text": "String",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "principal",
-        "field_text": "String",
-        "optional": true,
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "source",
-        "field_text": "String",
-        "optional": true,
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "catalog",
-        "field_text": "String",
-        "optional": true,
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "schema",
-        "field_text": "String",
-        "optional": true,
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "traceToken",
-        "field_text": "String",
-        "optional": true,
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "TimeZoneKey",
-        "field_name": "timeZoneKey",
-        "field_text": "TimeZoneKey",
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "Locale",
-        "field_name": "locale",
-        "field_text": "Locale",
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "remoteUserAddress",
-        "field_text": "String",
-        "optional": true,
-        "_N": 12,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "userAgent",
-        "field_text": "String",
-        "optional": true,
-        "_N": 13,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "clientInfo",
-        "field_text": "String",
-        "optional": true,
-        "_N": 14,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<String>",
-        "field_name": "clientTags",
-        "field_text": "List<String>",
-        "_N": 15,
-        "field_local": true
-      },
-      {
-        "field_type": "ResourceEstimates",
-        "field_name": "resourceEstimates",
-        "field_text": "ResourceEstimates",
-        "_N": 16,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "startTime",
-        "field_text": "int64_t",
-        "_N": 17,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, String>",
-        "field_name": "systemProperties",
-        "field_text": "Map<String, String>",
-        "_N": 18,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<ConnectorId, Map<String, String>>",
-        "field_name": "catalogProperties",
-        "field_text": "Map<ConnectorId, Map<String, String>>",
-        "_N": 19,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, Map<String, String>>",
-        "field_name": "unprocessedCatalogProperties",
-        "field_text": "Map<String, Map<String, String>>",
-        "_N": 20,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, SelectedRole>",
-        "field_name": "roles",
-        "field_text": "Map<String, SelectedRole>",
-        "_N": 21,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, String>",
-        "field_name": "preparedStatements",
-        "field_text": "Map<String, String>",
-        "_N": 22,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<SqlFunctionId, SqlInvokedFunction>",
-        "field_name": "sessionFunctions",
-        "field_text": "Map<SqlFunctionId, SqlInvokedFunction>",
-        "_N": 23,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ConnectorTableLayoutHandle",
-    "field_name": "connectorTableLayoutHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveTableLayoutHandle",
-        "name": "hiveTableLayoutHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTableLayoutHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableLayoutHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorTableLayoutHandle  ConnectorTableLayoutHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTableLayoutHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableLayoutHandle\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "ConnectorTableHandle",
-    "field_name": "connectorTableHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveTableHandle",
-        "name": "hiveTableHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTableHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) + \" ConnectorTableHandle  ConnectorTableHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTableHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableHandle\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "TableHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorTableHandle",
-        "field_name": "connectorHandle",
-        "field_text": "ConnectorTableHandle",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "ConnectorTransactionHandle",
-        "field_name": "transaction",
-        "field_text": "ConnectorTransactionHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Optional<ConnectorTableLayoutHandle>",
-        "field_name": "connectorTableLayout",
-        "field_text": "ConnectorTableLayoutHandle",
-        "optional": true,
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "DeleteScanInfo",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "TableHandle",
-        "field_name": "tableHandle",
-        "field_text": "TableHandle",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "AnalyzeTableHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorTransactionHandle",
-        "field_name": "transactionHandle",
-        "field_text": "ConnectorTransactionHandle",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "ConnectorTableHandle",
-        "field_name": "connectorHandle",
-        "field_text": "ConnectorTableHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      }
-    ]
-  },
-  {
-    "class_name": "ExecutionWriterTarget",
-    "field_name": "executionWriterTarget",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "CreateHandle",
-        "name": "createHandle",
-        "key": "CreateHandle",
-        "_N": 1
-      },
-      {
-        "type": "InsertHandle",
-        "name": "insertHandle",
-        "key": "InsertHandle",
-        "_N": 2
-      },
-      {
-        "type": "DeleteHandle",
-        "name": "deleteHandle",
-        "key": "DeleteHandle",
-        "_N": 3,
-        "_last": true
-      }
-    ],
-    "fields": []
-  },
-  {
-    "class_name": "TableWriteInfo",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<ExecutionWriterTarget>",
-        "field_name": "writerTarget",
-        "field_text": "ExecutionWriterTarget",
-        "optional": true,
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<AnalyzeTableHandle>",
-        "field_name": "analyzeTableHandle",
-        "field_text": "AnalyzeTableHandle",
-        "optional": true,
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DeleteScanInfo>",
-        "field_name": "deleteScanInfo",
-        "field_text": "DeleteScanInfo",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ConnectorSplit",
-    "field_name": "connectorSplit",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveSplit",
-        "name": "hiveSplit",
-        "key": "hive",
-        "_N": 1
-      },
-      {
-        "type": "RemoteSplit",
-        "name": "remoteSplit",
-        "key": "$remote",
-        "_N": 2
-      },
-      {
-        "type": "EmptySplit",
-        "name": "emptySplit",
-        "key": "$empty",
-        "_N": 3,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorSplit>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<RemoteSplit>(p);\n    return;\n  }\n  if (type == \"$empty\") {\n    j = *std::static_pointer_cast<EmptySplit>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveSplit>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorSplit\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorSplit>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorSplit\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<RemoteSplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (type == \"$empty\") {\n    auto k = std::make_shared<EmptySplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveSplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorSplit\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "SplitContext",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "boolean",
-        "field_name": "cacheable",
-        "field_text": "bool",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "Lifespan",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Lifespan& p) {\n  if (p.isgroup) {\n    j = \"Group\" + std::to_string(p.groupid);\n  } else {\n    j = \"TaskWide\";\n  }\n}\n\nvoid from_json(const json& j, Lifespan& p) {\n  String lifespan = j;\n\n  if (lifespan == \"TaskWide\") {\n    p.isgroup = false;\n    p.groupid = 0;\n  } else {\n    if (lifespan != \"Group\") {\n      // fail...\n    }\n    p.isgroup = true;\n    p.groupid = std::stoi(lifespan.substr(strlen(\"Group\")));\n  }\n}\n\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct Lifespan {\n  bool isgroup = false;\n  long groupid = 0;\n\n  bool operator<(const Lifespan& o) const {\n    return groupid < o.groupid;\n  }\n};\n\nvoid to_json(json& j, const Lifespan& p);\nvoid from_json(const json& j, Lifespan& p);\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "Split",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorTransactionHandle",
-        "field_name": "transactionHandle",
-        "field_text": "ConnectorTransactionHandle",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "ConnectorSplit",
-        "field_name": "connectorSplit",
-        "field_text": "ConnectorSplit",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Lifespan",
-        "field_name": "lifespan",
-        "field_text": "Lifespan",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "SplitContext",
-        "field_name": "splitContext",
-        "field_text": "SplitContext",
-        "_N": 5,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ScheduledSplit",
-    "hinc": "namespace facebook::presto::protocol {\n\nstruct ScheduledSplit {\n  long sequenceId = {};\n  PlanNodeId planNodeId = {}; // dependency\n  Split split = {};\n\n  bool operator<(const ScheduledSplit& o) const {\n    return sequenceId < o.sequenceId;\n  }\n};\n\nvoid to_json(json& j, const ScheduledSplit& p);\nvoid from_json(const json& j, ScheduledSplit& p);\n\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "long",
-        "field_name": "sequenceId",
-        "field_text": "int64_t",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "planNodeId",
-        "field_text": "PlanNodeId",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Split",
-        "field_name": "split",
-        "field_text": "Split",
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "TaskSource",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "planNodeId",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<ScheduledSplit>",
-        "field_name": "splits",
-        "field_text": "List<ScheduledSplit>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<Lifespan>",
-        "field_name": "noMoreSplitsForLifespan",
-        "field_text": "List<Lifespan>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "noMoreSplits",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "TaskUpdateRequest",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "SessionRepresentation",
-        "field_name": "session",
-        "field_text": "SessionRepresentation",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, String>",
-        "field_name": "extraCredentials",
-        "field_text": "Map<String, String>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<byte[]>",
-        "field_name": "fragment",
-        "field_text": "String",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "List<TaskSource>",
-        "field_name": "sources",
-        "field_text": "List<TaskSource>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "OutputBuffers",
-        "field_name": "outputIds",
-        "field_text": "OutputBuffers",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<TableWriteInfo>",
-        "field_name": "tableWriteInfo",
-        "field_text": "TableWriteInfo",
-        "optional": true,
-        "_N": 6,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "AssignUniqueId",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "idVariable",
-        "field_text": "VariableReferenceExpression",
-        "_N": 3,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.AssignUniqueId"
-  },
-  {
-    "class_name": "ConnectorOutputTableHandle",
-    "field_name": "connectorOutputTableHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveOutputTableHandle",
-        "name": "hiveOutputTableHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveOutputTableHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorOutputTableHandle \");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorOutputTableHandle  ConnectorOutputTableHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    std::shared_ptr<HiveOutputTableHandle> k =\n        std::make_shared<HiveOutputTableHandle>();\n    j.get_to(*k);\n    p = std::static_pointer_cast<ConnectorOutputTableHandle>(k);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorOutputTableHandle \");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "OutputTableHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorTransactionHandle",
-        "field_name": "transactionHandle",
-        "field_text": "ConnectorTransactionHandle",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "ConnectorOutputTableHandle",
-        "field_name": "connectorHandle",
-        "field_text": "ConnectorOutputTableHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      }
-    ]
-  },
-  {
-    "class_name": "SchemaTableName",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "schema",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "table",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "CreateHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "OutputTableHandle",
-        "field_name": "handle",
-        "field_text": "OutputTableHandle",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "SchemaTableName",
-        "field_name": "schemaTableName",
-        "field_text": "SchemaTableName",
-        "_N": 2,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ExecutionWriterTarget",
-    "json_key": "CreateHandle"
-  },
-  {
-    "class_name": "ErrorType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "USER_ERROR",
-        "_N": 1
-      },
-      {
-        "element": "INTERNAL_ERROR",
-        "_N": 2
-      },
-      {
-        "element": "INSUFFICIENT_RESOURCES",
-        "_N": 3
-      },
-      {
-        "element": "EXTERNAL",
-        "_N": 4,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "ErrorCode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "int",
-        "field_name": "code",
-        "field_text": "int",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "ErrorType",
-        "field_name": "type",
-        "field_text": "ErrorType",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "retriable",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ErrorLocation",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "int",
-        "field_name": "lineNumber",
-        "field_text": "int",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "columnNumber",
-        "field_text": "int",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "ExecutionFailureInfo",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "type",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "message",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "ExecutionFailureInfo",
-        "field_name": "cause",
-        "field_text": "ExecutionFailureInfo",
-        "_N": 3,
-        "optional": true,
-        "field_local": true
-      },
-      {
-        "field_type": "List<ExecutionFailureInfo>",
-        "field_name": "suppressed",
-        "field_text": "List<ExecutionFailureInfo>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<String>",
-        "field_name": "stack",
-        "field_text": "List<String>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "ErrorLocation",
-        "field_name": "errorLocation",
-        "field_text": "ErrorLocation",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "ErrorCode",
-        "field_name": "errorCode",
-        "field_text": "ErrorCode",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "HostAddress",
-        "field_name": "remoteHost",
-        "field_text": "HostAddress",
-        "_N": 8,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "JsonEncodedSubclass",
-    "cinc": "// dependency KeyedSubclass\n\nnamespace facebook::presto::protocol {\n\nstd::string JsonEncodedSubclass::getSubclassKey(nlohmann::json j) {\n  return j[\"@type\"];\n}\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "SortedRangeSet",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "List<Range>",
-        "field_name": "ranges",
-        "field_text": "List<Range>",
-        "_N": 2,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ValueSet",
-    "json_key": "sortable"
-  },
-  {
-    "class_name": "ValuesNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<List<RowExpression>>",
-        "field_name": "rows",
-        "field_text": "List<List<std::shared_ptr<RowExpression>>>",
-        "_N": 3,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".ValuesNode"
-  },
-  {
-    "class_name": "Locality",
-    "enum": true,
-    "elements": [
-      {
-        "element": "UNKNOWN",
-        "_N": 1
-      },
-      {
-        "element": "LOCAL",
-        "_N": 2
-      },
-      {
-        "element": "REMOTE",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "ProjectNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Assignments",
-        "field_name": "assignments",
-        "field_text": "Assignments",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Locality",
-        "field_name": "locality",
-        "field_text": "Locality",
-        "_N": 4,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".ProjectNode"
-  },
-  {
-    "class_name": "ConnectorInsertTableHandle",
-    "field_name": "connectorInsertTableHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveInsertTableHandle",
-        "name": "hiveInsertTableHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": []
-  },
-  {
-    "class_name": "InsertTableHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "ConnectorTransactionHandle",
-        "field_name": "transactionHandle",
-        "field_text": "ConnectorTransactionHandle",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "ConnectorInsertTableHandle",
-        "field_name": "connectorHandle",
-        "field_text": "ConnectorInsertTableHandle",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      }
-    ]
-  },
-  {
-    "class_name": "RuntimeUnit",
-    "enum": true,
-    "elements": [
-      {
-        "element": "NONE",
-        "_N": 1
-      },
-      {
-        "element": "NANO",
-        "_N": 2
-      },
-      {
-        "element": "BYTE",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "RuntimeMetric",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "name",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "RuntimeUnit",
-        "field_name": "unit",
-        "field_text": "RuntimeUnit",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "sum",
-        "field_text": "int64_t",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "count",
-        "field_text": "int64_t",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "max",
-        "field_text": "int64_t",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "min",
-        "field_text": "int64_t",
-        "_N": 6,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveTransactionHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "UUID",
-        "field_name": "uuid",
-        "field_text": "UUID",
-        "_N": 1,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorTransactionHandle",
-    "json_key": "hive"
-  },
-  {
-    "class_name": "JoinNodeType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "INNER",
-        "_N": 1
-      },
-      {
-        "element": "LEFT",
-        "_N": 2
-      },
-      {
-        "element": "RIGHT",
-        "_N": 3
-      },
-      {
-        "element": "FULL",
-        "_N": 4,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "DistributionType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "PARTITIONED",
-        "_N": 1
-      },
-      {
-        "element": "REPLICATED",
-        "_N": 2,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "JoinNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "JoinNodeType",
-        "field_name": "type",
-        "field_text": "JoinNodeType",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "left",
-        "field_text": "PlanNode",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "right",
-        "field_text": "PlanNode",
-        "_N": 4,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "List<EquiJoinClause>",
-        "field_name": "criteria",
-        "field_text": "List<EquiJoinClause>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<RowExpression>",
-        "field_name": "filter",
-        "field_text": "std::shared_ptr<RowExpression>",
-        "optional": true,
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "leftHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "rightHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DistributionType>",
-        "field_name": "distributionType",
-        "field_text": "DistributionType",
-        "optional": true,
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, VariableReferenceExpression>",
-        "field_name": "dynamicFilters",
-        "field_text": "Map<String, VariableReferenceExpression>",
-        "_N": 11,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.JoinNode"
-  },
-  {
-    "class_name": "MergeJoinNode",
-    "hinc": "namespace facebook::presto::protocol {\nstruct MergeJoinNode : public PlanNode {\n  MergeJoinNode() noexcept;\n  PlanNodeId id = {};\n  // JoinNodeType is referenced as JoinNode.Type in Presto\n  // Since presto_cpp codegen can't nicely handle inner class references\n  // So a special hard-coded template is required here\n  JoinNodeType type = {};\n  std::shared_ptr<PlanNode> left = {};\n  std::shared_ptr<PlanNode> right = {};\n  // EquiJoinClause is referenced as JoinNode.EquiJoinClause in Presto\n  List<EquiJoinClause> criteria = {};\n  List<VariableReferenceExpression> outputVariables = {};\n  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};\n  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};\n  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};\n};\nvoid to_json(json& j, const MergeJoinNode& p);\nvoid from_json(const json& j, MergeJoinNode& p);\n} // namespace facebook::presto::protocol",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "JoinNode.Type",
-        "field_name": "type",
-        "field_text": "JoinNode.Type",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "left",
-        "field_text": "PlanNode",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "right",
-        "field_text": "PlanNode",
-        "_N": 4,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "List<JoinNode.EquiJoinClause>",
-        "field_name": "criteria",
-        "field_text": "List<JoinNode.EquiJoinClause>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<RowExpression>",
-        "field_name": "filter",
-        "field_text": "std::shared_ptr<RowExpression>",
-        "optional": true,
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "leftHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "rightHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 9,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.MergeJoinNode"
-  },
-  {
-    "class_name": "NodeVersion",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "version",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "MemoryAllocation",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "tag",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "allocation",
-        "field_text": "int64_t",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "MemoryPoolInfo",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "long",
-        "field_name": "maxBytes",
-        "field_text": "int64_t",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "reservedBytes",
-        "field_text": "int64_t",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "reservedRevocableBytes",
-        "field_text": "int64_t",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<QueryId, Long>",
-        "field_name": "queryMemoryReservations",
-        "field_text": "Map<QueryId, Long>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<QueryId, List<MemoryAllocation>>",
-        "field_name": "queryMemoryAllocations",
-        "field_text": "Map<QueryId, List<MemoryAllocation>>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<QueryId, Long>",
-        "field_name": "queryMemoryRevocableReservations",
-        "field_text": "Map<QueryId, Long>",
-        "_N": 6,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "MemoryInfo",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "DataSize",
-        "field_name": "totalNodeMemory",
-        "field_text": "DataSize",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<MemoryPoolId, MemoryPoolInfo>",
-        "field_name": "pools",
-        "field_text": "Map<MemoryPoolId, MemoryPoolInfo>",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "NodeStatus",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "nodeId",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "NodeVersion",
-        "field_name": "nodeVersion",
-        "field_text": "NodeVersion",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "environment",
-        "field_text": "String",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "coordinator",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Duration",
-        "field_name": "uptime",
-        "field_text": "Duration",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "externalAddress",
-        "field_text": "String",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "internalAddress",
-        "field_text": "String",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "MemoryInfo",
-        "field_name": "memoryInfo",
-        "field_text": "MemoryInfo",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "processors",
-        "field_text": "int",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "processCpuLoad",
-        "field_text": "double",
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "systemCpuLoad",
-        "field_text": "double",
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "heapUsed",
-        "field_text": "int64_t",
-        "_N": 12,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "heapAvailable",
-        "field_text": "int64_t",
-        "_N": 13,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "nonHeapUsed",
-        "field_text": "int64_t",
-        "_N": 14,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "PlanCostEstimate",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "double",
-        "field_name": "cpuCost",
-        "field_text": "double",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "maxMemory",
-        "field_text": "double",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "maxMemoryWhenOutputting",
-        "field_text": "double",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "networkCost",
-        "field_text": "double",
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "VariableStatsEstimate",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "double",
-        "field_name": "lowValue",
-        "field_text": "double",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "highValue",
-        "field_text": "double",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "nullsFraction",
-        "field_text": "double",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "averageRowSize",
-        "field_text": "double",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "distinctValuesCount",
-        "field_text": "double",
-        "_N": 5,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "PlanNodeStatsEstimate",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "double",
-        "field_name": "outputRowCount",
-        "field_text": "double",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "totalSize",
-        "field_text": "double",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "confident",
-        "field_text": "bool",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<VariableReferenceExpression, VariableStatsEstimate>",
-        "field_name": "variableStatistics",
-        "field_text": "Map<VariableReferenceExpression, VariableStatsEstimate>",
-        "_N": 4,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "StatsAndCosts",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Map<PlanNodeId, PlanNodeStatsEstimate>",
-        "field_name": "stats",
-        "field_text": "Map<PlanNodeId, PlanNodeStatsEstimate>",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<PlanNodeId, PlanCostEstimate>",
-        "field_name": "costs",
-        "field_text": "Map<PlanNodeId, PlanCostEstimate>",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "LambdaDefinitionExpression",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Optional<SourceLocation>",
-        "field_name": "sourceLocation",
-        "field_text": "SourceLocation",
-        "optional": true,
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "List<Type>",
-        "field_name": "argumentTypes",
-        "field_text": "List<Type>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<String>",
-        "field_name": "arguments",
-        "field_text": "List<String>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "RowExpression",
-        "field_name": "body",
-        "field_text": "RowExpression",
-        "_N": 4,
-        "field_local": true,
-        "optional": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "RowExpression",
-    "json_key": "lambda"
-  },
-  {
-    "class_name": "HiveStorageFormat",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const HiveStorageFormat& p) {\n  throw ParseError(\"Not implemented\");\n}\n\nstatic const std::pair<HiveStorageFormat, json> HiveStorageFormat_enum_table[] =\n    { // NOLINT: cert-err58-cpp\n        {HiveStorageFormat::ORC, \"ORC\"},\n        {HiveStorageFormat::DWRF, \"DWRF\"},\n        {HiveStorageFormat::PARQUET, \"PARQUET\"},\n        {HiveStorageFormat::AVRO, \"AVRO\"},\n        {HiveStorageFormat::RCBINARY, \"RCBINARY\"},\n        {HiveStorageFormat::RCTEXT, \"RCTEXT\"},\n        {HiveStorageFormat::SEQUENCEFILE, \"SEQUENCEFILE\"},\n        {HiveStorageFormat::JSON, \"JSON\"},\n        {HiveStorageFormat::TEXTFILE, \"TEXTFILE\"},\n        {HiveStorageFormat::CSV, \"CSV\"},\n        {HiveStorageFormat::PAGEFILE, \"PAGEFILE\"}};\n\nvoid from_json(const json& j, HiveStorageFormat& e) {\n  static_assert(\n      std::is_enum<HiveStorageFormat>::value,\n      \"HiveStorageFormat must be an enum!\");\n  const auto* it = std::find_if(\n      std::begin(HiveStorageFormat_enum_table),\n      std::end(HiveStorageFormat_enum_table),\n      [&j](const std::pair<HiveStorageFormat, json>& ej_pair) -> bool {\n        return ej_pair.second == j;\n      });\n  e = ((it != std::end(HiveStorageFormat_enum_table))\n           ? it\n           : std::begin(HiveStorageFormat_enum_table))\n          ->first;\n}\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\n\nenum class HiveStorageFormat {\n  ORC,\n  DWRF,\n  PARQUET,\n  AVRO,\n  RCBINARY,\n  RCTEXT,\n  SEQUENCEFILE,\n  JSON,\n  TEXTFILE,\n  CSV,\n  PAGEFILE\n};\n\nvoid to_json(json& j, const HiveStorageFormat& p);\nvoid from_json(const json& j, HiveStorageFormat& p);\n\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "TableType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "NEW",
-        "_N": 1
-      },
-      {
-        "element": "EXISTING",
-        "_N": 2
-      },
-      {
-        "element": "TEMPORARY",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "WriteMode",
-    "enum": true,
-    "elements": [
-      {
-        "element": "STAGE_AND_MOVE_TO_TARGET_DIRECTORY",
-        "_N": 1
-      },
-      {
-        "element": "DIRECT_TO_TARGET_NEW_DIRECTORY",
-        "_N": 2
-      },
-      {
-        "element": "DIRECT_TO_TARGET_EXISTING_DIRECTORY",
-        "_N": 3,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "LocationHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "targetPath",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "writePath",
-        "field_text": "String",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "tempPath",
-        "field_text": "String",
-        "optional": true,
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "TableType",
-        "field_name": "tableType",
-        "field_text": "TableType",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "WriteMode",
-        "field_name": "writeMode",
-        "field_text": "WriteMode",
-        "_N": 5,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveCompressionCodec",
-    "enum": true,
-    "elements": [
-      {
-        "element": "NONE",
-        "_N": 1
-      },
-      {
-        "element": "SNAPPY",
-        "_N": 2
-      },
-      {
-        "element": "GZIP",
-        "_N": 3
-      },
-      {
-        "element": "LZ4",
-        "_N": 4
-      },
-      {
-        "element": "ZSTD",
-        "_N": 5,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "PrestoTableType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "MANAGED_TABLE",
-        "_N": 1
-      },
-      {
-        "element": "EXTERNAL_TABLE",
-        "_N": 2
-      },
-      {
-        "element": "VIRTUAL_VIEW",
-        "_N": 3
-      },
-      {
-        "element": "MATERIALIZED_VIEW",
-        "_N": 4
-      },
-      {
-        "element": "TEMPORARY_TABLE",
-        "_N": 5
-      },
-      {
-        "element": "OTHER",
-        "_N": 6,
-        "_last": true
       }
     ]
   },
@@ -3823,6 +1342,11 @@
     "class_name": "HivePageSinkMetadata",
     "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const HivePageSinkMetadata& p) {\n  j = json::object();\n  to_json_key(\n      j,\n      \"schemaTableName\",\n      p.schemaTableName,\n      \"HivePageSinkMetadata\",\n      \"SchemaTableName\",\n      \"schemaTableName\");\n  to_json_key(j, \"table\", p.table, \"HivePageSinkMetadata\", \"Table\", \"table\");\n}\n\nvoid from_json(const json& j, HivePageSinkMetadata& p) {\n  from_json_key(\n      j,\n      \"schemaTableName\",\n      p.schemaTableName,\n      \"HivePageSinkMetadata\",\n      \"SchemaTableName\",\n      \"schemaTableName\");\n  from_json_key(j, \"table\", p.table, \"HivePageSinkMetadata\", \"Table\", \"table\");\n}\n} // namespace facebook::presto::protocol",
     "hinc": "// dependency Table\n// dependency SchemaTableName\n\nnamespace facebook::presto::protocol {\n\nstruct HivePageSinkMetadata {\n  SchemaTableName schemaTableName = {};\n  std::shared_ptr<Table> table = {};\n  // TODO Add modifiedPartitions\n};\nvoid to_json(json& j, const HivePageSinkMetadata& p);\nvoid from_json(const json& j, HivePageSinkMetadata& p);\n\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "HiveStorageFormat",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const HiveStorageFormat& p) {\n  throw ParseError(\"Not implemented\");\n}\n\nstatic const std::pair<HiveStorageFormat, json> HiveStorageFormat_enum_table[] =\n    { // NOLINT: cert-err58-cpp\n        {HiveStorageFormat::ORC, \"ORC\"},\n        {HiveStorageFormat::DWRF, \"DWRF\"},\n        {HiveStorageFormat::PARQUET, \"PARQUET\"},\n        {HiveStorageFormat::AVRO, \"AVRO\"},\n        {HiveStorageFormat::RCBINARY, \"RCBINARY\"},\n        {HiveStorageFormat::RCTEXT, \"RCTEXT\"},\n        {HiveStorageFormat::SEQUENCEFILE, \"SEQUENCEFILE\"},\n        {HiveStorageFormat::JSON, \"JSON\"},\n        {HiveStorageFormat::TEXTFILE, \"TEXTFILE\"},\n        {HiveStorageFormat::CSV, \"CSV\"},\n        {HiveStorageFormat::PAGEFILE, \"PAGEFILE\"}};\n\nvoid from_json(const json& j, HiveStorageFormat& e) {\n  static_assert(\n      std::is_enum<HiveStorageFormat>::value,\n      \"HiveStorageFormat must be an enum!\");\n  const auto* it = std::find_if(\n      std::begin(HiveStorageFormat_enum_table),\n      std::end(HiveStorageFormat_enum_table),\n      [&j](const std::pair<HiveStorageFormat, json>& ej_pair) -> bool {\n        return ej_pair.second == j;\n      });\n  e = ((it != std::end(HiveStorageFormat_enum_table))\n           ? it\n           : std::begin(HiveStorageFormat_enum_table))\n          ->first;\n}\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\n\nenum class HiveStorageFormat {\n  ORC,\n  DWRF,\n  PARQUET,\n  AVRO,\n  RCBINARY,\n  RCTEXT,\n  SEQUENCEFILE,\n  JSON,\n  TEXTFILE,\n  CSV,\n  PAGEFILE\n};\n\nvoid to_json(json& j, const HiveStorageFormat& p);\nvoid from_json(const json& j, HiveStorageFormat& p);\n\n} // namespace facebook::presto::protocol"
   },
   {
     "class_name": "HiveInsertTableHandle",
@@ -3920,55 +1444,201 @@
     "json_key": "hive"
   },
   {
-    "class_name": "ValueEntry",
-    "hinc": "namespace facebook::presto::protocol {\n\nclass ValueEntry {\n public:\n  Type type;\n  std::shared_ptr<Block> block;\n};\n\nvoid to_json(json& j, const ValueEntry& p);\nvoid from_json(const json& j, ValueEntry& p);\n\n} // namespace facebook::presto::protocol",
+    "class_name": "ConnectorPartitioningHandle",
+    "field_name": "connectorPartitioningHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "SystemPartitioningHandle",
+        "name": "systemPartitioningHandle",
+        "key": "$remote",
+        "_N": 1
+      },
+      {
+        "type": "HivePartitioningHandle",
+        "name": "hivePartitioningHandle",
+        "key": "hive",
+        "_N": 2,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorPartitioningHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<SystemPartitioningHandle>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HivePartitioningHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorPartitioningHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorPartitioningHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorPartitioningHandle\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<SystemPartitioningHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HivePartitioningHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorPartitioningHandle\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "ConnectorTransactionHandle",
+    "field_name": "connectorTransactionHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveTransactionHandle",
+        "name": "hiveTransactionHandle",
+        "key": "hive",
+        "_N": 1
+      },
+      {
+        "type": "RemoteTransactionHandle",
+        "name": "remoteTransactionHandle",
+        "key": "$remote",
+        "_N": 2,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<RemoteTransactionHandle>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTransactionHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTransactionHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorTransactionHandle  ConnectorTransactionHandle\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<RemoteTransactionHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTransactionHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTransactionHandle\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "PartitioningHandle",
     "struct": true,
     "fields": [
       {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
+        "field_type": "Optional<ConnectorId>",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "optional": true,
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "Block",
-        "field_name": "block",
-        "field_text": "Block",
+        "field_type": "Optional<ConnectorTransactionHandle>",
+        "field_name": "transactionHandle",
+        "field_text": "ConnectorTransactionHandle",
+        "optional": true,
         "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorPartitioningHandle",
+        "field_name": "connectorHandle",
+        "field_text": "ConnectorPartitioningHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      }
+    ]
+  },
+  {
+    "class_name": "DistributionSnapshot",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "double",
+        "field_name": "maxError",
+        "field_text": "double",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "count",
+        "field_text": "double",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "total",
+        "field_text": "double",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p01",
+        "field_text": "int64_t",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p05",
+        "field_text": "int64_t",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p10",
+        "field_text": "int64_t",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p25",
+        "field_text": "int64_t",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p50",
+        "field_text": "int64_t",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p75",
+        "field_text": "int64_t",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p90",
+        "field_text": "int64_t",
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p95",
+        "field_text": "int64_t",
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "p99",
+        "field_text": "int64_t",
+        "_N": 12,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "min",
+        "field_text": "int64_t",
+        "_N": 13,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "max",
+        "field_text": "int64_t",
+        "_N": 14,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "avg",
+        "field_text": "double",
+        "_N": 15,
         "field_local": true
       }
     ]
   },
   {
-    "class_name": "EquatableValueSet",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "whiteList",
-        "field_text": "bool",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<ValueEntry>",
-        "field_name": "entries",
-        "field_text": "List<ValueEntry>",
-        "_N": 3,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ValueSet",
-    "json_key": "equatable"
+    "class_name": "Lifespan",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Lifespan& p) {\n  if (p.isgroup) {\n    j = \"Group\" + std::to_string(p.groupid);\n  } else {\n    j = \"TaskWide\";\n  }\n}\n\nvoid from_json(const json& j, Lifespan& p) {\n  String lifespan = j;\n\n  if (lifespan == \"TaskWide\") {\n    p.isgroup = false;\n    p.groupid = 0;\n  } else {\n    if (lifespan != \"Group\") {\n      // fail...\n    }\n    p.isgroup = true;\n    p.groupid = std::stoi(lifespan.substr(strlen(\"Group\")));\n  }\n}\n\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct Lifespan {\n  bool isgroup = false;\n  long groupid = 0;\n\n  bool operator<(const Lifespan& o) const {\n    return groupid < o.groupid;\n  }\n};\n\nvoid to_json(json& j, const Lifespan& p);\nvoid from_json(const json& j, Lifespan& p);\n\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "Duration",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Duration& p) {\n  j = p.toString();\n}\n\nvoid from_json(const json& j, Duration& p) {\n  p = Duration(std::string(j));\n}\n\nstd::ostream& operator<<(std::ostream& os, const Duration& d) {\n  return os << d.toString();\n}\n\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\n\nstd::ostream& operator<<(std::ostream& os, const Duration& d);\n\nvoid to_json(json& j, const Duration& p);\nvoid from_json(const json& j, Duration& p);\n\n} // namespace facebook::presto::protocol"
   },
   {
     "class_name": "BlockedReason",
@@ -3985,6 +1655,11 @@
     "class_name": "OperatorInfo",
     "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const OperatorInfo& p) {}\nvoid from_json(const json& j, OperatorInfo& p) {}\n} // namespace facebook::presto::protocol",
     "hinc": "namespace facebook::presto::protocol {\nstruct OperatorInfo {};\nvoid to_json(json& j, const OperatorInfo& p);\nvoid from_json(const json& j, OperatorInfo& p);\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "DataSize",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(nlohmann::json& j, const DataSize& p) {\n  j = p.toString();\n}\n\nvoid from_json(const nlohmann::json& j, DataSize& p) {\n  p = DataSize(std::string(j));\n}\n\nstd::ostream& operator<<(std::ostream& os, const DataSize& d) {\n  return os << d.toString();\n}\n\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\n\nstd::ostream& operator<<(std::ostream& os, const DataSize& d);\n\nvoid to_json(nlohmann::json& j, const DataSize& p);\nvoid from_json(const nlohmann::json& j, DataSize& p);\n\n} // namespace facebook::presto::protocol"
   },
   {
     "class_name": "OperatorStats",
@@ -4441,117 +2116,6 @@
     ]
   },
   {
-    "class_name": "DistributionSnapshot",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "double",
-        "field_name": "maxError",
-        "field_text": "double",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "count",
-        "field_text": "double",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "total",
-        "field_text": "double",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p01",
-        "field_text": "int64_t",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p05",
-        "field_text": "int64_t",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p10",
-        "field_text": "int64_t",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p25",
-        "field_text": "int64_t",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p50",
-        "field_text": "int64_t",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p75",
-        "field_text": "int64_t",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p90",
-        "field_text": "int64_t",
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p95",
-        "field_text": "int64_t",
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "p99",
-        "field_text": "int64_t",
-        "_N": 12,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "min",
-        "field_text": "int64_t",
-        "_N": 13,
-        "field_local": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "max",
-        "field_text": "int64_t",
-        "_N": 14,
-        "field_local": true
-      },
-      {
-        "field_type": "double",
-        "field_name": "avg",
-        "field_text": "double",
-        "_N": 15,
-        "field_local": true
-      }
-    ]
-  },
-  {
     "class_name": "PipelineStats",
     "struct": true,
     "fields": [
@@ -4801,225 +2365,6 @@
         "field_local": true
       }
     ]
-  },
-  {
-    "class_name": "Location",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "String",
-        "field_name": "location",
-        "field_text": "String",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "UnnestNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "replicateVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
-        "field_name": "unnestVariables",
-        "field_text": "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "ordinalityVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 5,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.UnnestNode"
-  },
-  {
-    "class_name": "ConnectorMetadataUpdateHandle",
-    "field_name": "connectorMetadataUpdateHandle",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "HiveMetadataUpdateHandle",
-        "name": "hiveMetadataUpdateHandle",
-        "key": "hive",
-        "_N": 1,
-        "_last": true
-      }
-    ],
-    "fields": [],
-    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveMetadataUpdateHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorMetadataUpdateHandle\");\n}\n\nvoid from_json(\n    const json& j,\n    std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorMetadataUpdateHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveMetadataUpdateHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorMetadataUpdateHandle\");\n}\n} // namespace facebook::presto::protocol"
-  },
-  {
-    "class_name": "MetadataUpdates",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "ConnectorId",
-        "field_name": "connectorId",
-        "field_text": "ConnectorId",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "List<ConnectorMetadataUpdateHandle>",
-        "field_name": "metadataUpdates",
-        "field_text": "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "SortNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "OrderingScheme",
-        "field_name": "orderingScheme",
-        "field_text": "OrderingScheme",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "isPartial",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.SortNode"
-  },
-  {
-    "class_name": "DistinctLimitNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "long",
-        "field_name": "limit",
-        "field_text": "int64_t",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "partial",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "distinctVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "hashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 6,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".DistinctLimitNode"
-  },
-  {
-    "class_name": "FilterNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "RowExpression",
-        "field_name": "predicate",
-        "field_text": "RowExpression",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".FilterNode"
   },
   {
     "class_name": "TaskStats",
@@ -5315,6 +2660,1695 @@
     ]
   },
   {
+    "class_name": "Form",
+    "enum": true,
+    "elements": [
+      {
+        "element": "IF",
+        "_N": 1
+      },
+      {
+        "element": "NULL_IF",
+        "_N": 2
+      },
+      {
+        "element": "SWITCH",
+        "_N": 3
+      },
+      {
+        "element": "WHEN",
+        "_N": 4
+      },
+      {
+        "element": "IS_NULL",
+        "_N": 5
+      },
+      {
+        "element": "COALESCE",
+        "_N": 6
+      },
+      {
+        "element": "IN",
+        "_N": 7
+      },
+      {
+        "element": "AND",
+        "_N": 8
+      },
+      {
+        "element": "OR",
+        "_N": 9
+      },
+      {
+        "element": "DEREFERENCE",
+        "_N": 10
+      },
+      {
+        "element": "ROW_CONSTRUCTOR",
+        "_N": 11
+      },
+      {
+        "element": "BIND",
+        "_N": 12,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "SpecialFormExpression",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<SourceLocation>",
+        "field_name": "sourceLocation",
+        "field_text": "SourceLocation",
+        "optional": true,
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "Form",
+        "field_name": "form",
+        "field_text": "Form",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Type",
+        "field_name": "returnType",
+        "field_text": "Type",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "List<RowExpression>",
+        "field_name": "arguments",
+        "field_text": "List<std::shared_ptr<RowExpression>>",
+        "_N": 4,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "RowExpression",
+    "json_key": "special"
+  },
+  {
+    "class_name": "AssignUniqueId",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "idVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 3,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.AssignUniqueId"
+  },
+  {
+    "class_name": "Location",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "location",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ConnectorOutputTableHandle",
+    "field_name": "connectorOutputTableHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveOutputTableHandle",
+        "name": "hiveOutputTableHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveOutputTableHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorOutputTableHandle \");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorOutputTableHandle  ConnectorOutputTableHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    std::shared_ptr<HiveOutputTableHandle> k =\n        std::make_shared<HiveOutputTableHandle>();\n    j.get_to(*k);\n    p = std::static_pointer_cast<ConnectorOutputTableHandle>(k);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorOutputTableHandle \");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "OutputTableHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorTransactionHandle",
+        "field_name": "transactionHandle",
+        "field_text": "ConnectorTransactionHandle",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "ConnectorOutputTableHandle",
+        "field_name": "connectorHandle",
+        "field_text": "ConnectorOutputTableHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      }
+    ]
+  },
+  {
+    "class_name": "BufferType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "PARTITIONED",
+        "_N": 1
+      },
+      {
+        "element": "BROADCAST",
+        "_N": 2
+      },
+      {
+        "element": "ARBITRARY",
+        "_N": 3
+      },
+      {
+        "element": "DISCARDING",
+        "_N": 4
+      },
+      {
+        "element": "SPOOLING",
+        "_N": 5,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "OutputBuffers",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "BufferType",
+        "field_name": "type",
+        "field_text": "BufferType",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "version",
+        "field_text": "int64_t",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "noMoreBufferIds",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<OutputBufferId, Integer>",
+        "field_name": "buffers",
+        "field_text": "Map<OutputBufferId, Integer>",
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ExecutionWriterTarget",
+    "field_name": "executionWriterTarget",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "CreateHandle",
+        "name": "createHandle",
+        "key": "CreateHandle",
+        "_N": 1
+      },
+      {
+        "type": "InsertHandle",
+        "name": "insertHandle",
+        "key": "InsertHandle",
+        "_N": 2
+      },
+      {
+        "type": "DeleteHandle",
+        "name": "deleteHandle",
+        "key": "DeleteHandle",
+        "_N": 3,
+        "_last": true
+      }
+    ],
+    "fields": []
+  },
+  {
+    "class_name": "ConnectorTableLayoutHandle",
+    "field_name": "connectorTableLayoutHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveTableLayoutHandle",
+        "name": "hiveTableLayoutHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTableLayoutHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableLayoutHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) +\n        \" ConnectorTableLayoutHandle  ConnectorTableLayoutHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTableLayoutHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableLayoutHandle\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "ConnectorTableHandle",
+    "field_name": "connectorTableHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveTableHandle",
+        "name": "hiveTableHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveTableHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableHandle\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(\n        std::string(e.what()) + \" ConnectorTableHandle  ConnectorTableHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveTableHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorTableHandle\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "TableHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorTableHandle",
+        "field_name": "connectorHandle",
+        "field_text": "ConnectorTableHandle",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "ConnectorTransactionHandle",
+        "field_name": "transaction",
+        "field_text": "ConnectorTransactionHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Optional<ConnectorTableLayoutHandle>",
+        "field_name": "connectorTableLayout",
+        "field_text": "ConnectorTableLayoutHandle",
+        "optional": true,
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "DeleteScanInfo",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "TableHandle",
+        "field_name": "tableHandle",
+        "field_text": "TableHandle",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "AnalyzeTableHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorTransactionHandle",
+        "field_name": "transactionHandle",
+        "field_text": "ConnectorTransactionHandle",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "ConnectorTableHandle",
+        "field_name": "connectorHandle",
+        "field_text": "ConnectorTableHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      }
+    ]
+  },
+  {
+    "class_name": "TableWriteInfo",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<ExecutionWriterTarget>",
+        "field_name": "writerTarget",
+        "field_text": "ExecutionWriterTarget",
+        "optional": true,
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<AnalyzeTableHandle>",
+        "field_name": "analyzeTableHandle",
+        "field_text": "AnalyzeTableHandle",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<DeleteScanInfo>",
+        "field_name": "deleteScanInfo",
+        "field_text": "DeleteScanInfo",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "SplitContext",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "boolean",
+        "field_name": "cacheable",
+        "field_text": "bool",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ConnectorSplit",
+    "field_name": "connectorSplit",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveSplit",
+        "name": "hiveSplit",
+        "key": "hive",
+        "_N": 1
+      },
+      {
+        "type": "RemoteSplit",
+        "name": "remoteSplit",
+        "key": "$remote",
+        "_N": 2
+      },
+      {
+        "type": "EmptySplit",
+        "name": "emptySplit",
+        "key": "$empty",
+        "_N": 3,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorSplit>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (type == \"$remote\") {\n    j = *std::static_pointer_cast<RemoteSplit>(p);\n    return;\n  }\n  if (type == \"$empty\") {\n    j = *std::static_pointer_cast<EmptySplit>(p);\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveSplit>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorSplit\");\n}\n\nvoid from_json(const json& j, std::shared_ptr<ConnectorSplit>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorSplit\");\n  }\n\n  if (type == \"$remote\") {\n    auto k = std::make_shared<RemoteSplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (type == \"$empty\") {\n    auto k = std::make_shared<EmptySplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveSplit>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorSplit\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "Split",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorTransactionHandle",
+        "field_name": "transactionHandle",
+        "field_text": "ConnectorTransactionHandle",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "ConnectorSplit",
+        "field_name": "connectorSplit",
+        "field_text": "ConnectorSplit",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Lifespan",
+        "field_name": "lifespan",
+        "field_text": "Lifespan",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "SplitContext",
+        "field_name": "splitContext",
+        "field_text": "SplitContext",
+        "_N": 5,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ScheduledSplit",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct ScheduledSplit {\n  long sequenceId = {};\n  PlanNodeId planNodeId = {}; // dependency\n  Split split = {};\n\n  bool operator<(const ScheduledSplit& o) const {\n    return sequenceId < o.sequenceId;\n  }\n};\n\nvoid to_json(json& j, const ScheduledSplit& p);\nvoid from_json(const json& j, ScheduledSplit& p);\n\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "long",
+        "field_name": "sequenceId",
+        "field_text": "int64_t",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "planNodeId",
+        "field_text": "PlanNodeId",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Split",
+        "field_name": "split",
+        "field_text": "Split",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "TaskSource",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "planNodeId",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<ScheduledSplit>",
+        "field_name": "splits",
+        "field_text": "List<ScheduledSplit>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<Lifespan>",
+        "field_name": "noMoreSplitsForLifespan",
+        "field_text": "List<Lifespan>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "noMoreSplits",
+        "field_text": "bool",
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ResourceEstimates",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<Duration>",
+        "field_name": "executionTime",
+        "field_text": "Duration",
+        "optional": true,
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Duration>",
+        "field_name": "cpuTime",
+        "field_text": "Duration",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<DataSize>",
+        "field_name": "peakMemory",
+        "field_text": "DataSize",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<DataSize>",
+        "field_name": "peakTaskMemory",
+        "field_text": "DataSize",
+        "optional": true,
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "SelectedRoleType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "ROLE",
+        "_N": 1
+      },
+      {
+        "element": "ALL",
+        "_N": 2
+      },
+      {
+        "element": "NONE",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "SelectedRole",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "SelectedRoleType",
+        "field_name": "type",
+        "field_text": "SelectedRoleType",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "role",
+        "field_text": "String",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Parameter",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "TypeSignature",
+        "field_name": "type",
+        "field_text": "TypeSignature",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Language",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "language",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "NullCallClause",
+    "enum": true,
+    "elements": [
+      {
+        "element": "RETURNS_NULL_ON_NULL_INPUT",
+        "_N": 1
+      },
+      {
+        "element": "CALLED_ON_NULL_INPUT",
+        "_N": 2,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Determinism",
+    "enum": true,
+    "elements": [
+      {
+        "element": "DETERMINISTIC",
+        "_N": 1
+      },
+      {
+        "element": "NOT_DETERMINISTIC",
+        "_N": 2
+      }
+    ]
+  },
+  {
+    "class_name": "RoutineCharacteristics",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<Language>",
+        "field_name": "language",
+        "field_text": "Language",
+        "optional": true,
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Determinism>",
+        "field_name": "determinism",
+        "field_text": "Determinism",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<NullCallClause>",
+        "field_name": "nullCallClause",
+        "field_text": "NullCallClause",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "LongVariableConstraint",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "expression",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "TypeVariableConstraint",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct TypeVariableConstraint {\n  String name = {};\n  bool comparableRequired = {};\n  bool orderableRequired = {};\n  String variadicBound = {};\n  bool nonDecimalNumericRequired = {};\n  String boundedBy = {};\n};\nvoid to_json(json& j, const TypeVariableConstraint& p);\nvoid from_json(const json& j, TypeVariableConstraint& p);\n\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "comparableRequired",
+        "field_text": "bool",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "orderableRequired",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "variadicBound",
+        "field_text": "String",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "nonDecimalNumericRequired",
+        "field_text": "bool",
+        "_N": 5,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "FunctionKind",
+    "enum": true,
+    "elements": [
+      {
+        "element": "SCALAR",
+        "_N": 1
+      },
+      {
+        "element": "AGGREGATE",
+        "_N": 2
+      },
+      {
+        "element": "WINDOW",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Signature",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "QualifiedObjectName",
+        "field_name": "name",
+        "field_text": "QualifiedObjectName",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "FunctionKind",
+        "field_name": "kind",
+        "field_text": "FunctionKind",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<TypeVariableConstraint>",
+        "field_name": "typeVariableConstraints",
+        "field_text": "List<TypeVariableConstraint>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "List<LongVariableConstraint>",
+        "field_name": "longVariableConstraints",
+        "field_text": "List<LongVariableConstraint>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "TypeSignature",
+        "field_name": "returnType",
+        "field_text": "TypeSignature",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "List<TypeSignature>",
+        "field_name": "argumentTypes",
+        "field_text": "List<TypeSignature>",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "variableArity",
+        "field_text": "bool",
+        "_N": 7,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "SqlInvokedFunction",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "List<Parameter>",
+        "field_name": "parameters",
+        "field_text": "List<Parameter>",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "description",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "RoutineCharacteristics",
+        "field_name": "routineCharacteristics",
+        "field_text": "RoutineCharacteristics",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "body",
+        "field_text": "String",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Signature",
+        "field_name": "signature",
+        "field_text": "Signature",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "SqlFunctionId",
+        "field_name": "functionId",
+        "field_text": "SqlFunctionId",
+        "_N": 6,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "SessionRepresentation",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "queryId",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<TransactionId>",
+        "field_name": "transactionId",
+        "field_text": "TransactionId",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "clientTransactionSupport",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "user",
+        "field_text": "String",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "principal",
+        "field_text": "String",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "source",
+        "field_text": "String",
+        "optional": true,
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "catalog",
+        "field_text": "String",
+        "optional": true,
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "schema",
+        "field_text": "String",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "traceToken",
+        "field_text": "String",
+        "optional": true,
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "TimeZoneKey",
+        "field_name": "timeZoneKey",
+        "field_text": "TimeZoneKey",
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "Locale",
+        "field_name": "locale",
+        "field_text": "Locale",
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "remoteUserAddress",
+        "field_text": "String",
+        "optional": true,
+        "_N": 12,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "userAgent",
+        "field_text": "String",
+        "optional": true,
+        "_N": 13,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "clientInfo",
+        "field_text": "String",
+        "optional": true,
+        "_N": 14,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<String>",
+        "field_name": "clientTags",
+        "field_text": "List<String>",
+        "_N": 15,
+        "field_local": true
+      },
+      {
+        "field_type": "ResourceEstimates",
+        "field_name": "resourceEstimates",
+        "field_text": "ResourceEstimates",
+        "_N": 16,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "startTime",
+        "field_text": "int64_t",
+        "_N": 17,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, String>",
+        "field_name": "systemProperties",
+        "field_text": "Map<String, String>",
+        "_N": 18,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<ConnectorId, Map<String, String>>",
+        "field_name": "catalogProperties",
+        "field_text": "Map<ConnectorId, Map<String, String>>",
+        "_N": 19,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, Map<String, String>>",
+        "field_name": "unprocessedCatalogProperties",
+        "field_text": "Map<String, Map<String, String>>",
+        "_N": 20,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, SelectedRole>",
+        "field_name": "roles",
+        "field_text": "Map<String, SelectedRole>",
+        "_N": 21,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, String>",
+        "field_name": "preparedStatements",
+        "field_text": "Map<String, String>",
+        "_N": 22,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<SqlFunctionId, SqlInvokedFunction>",
+        "field_name": "sessionFunctions",
+        "field_text": "Map<SqlFunctionId, SqlInvokedFunction>",
+        "_N": 23,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "TaskUpdateRequest",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "SessionRepresentation",
+        "field_name": "session",
+        "field_text": "SessionRepresentation",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, String>",
+        "field_name": "extraCredentials",
+        "field_text": "Map<String, String>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<byte[]>",
+        "field_name": "fragment",
+        "field_text": "String",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "List<TaskSource>",
+        "field_name": "sources",
+        "field_text": "List<TaskSource>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "OutputBuffers",
+        "field_name": "outputIds",
+        "field_text": "OutputBuffers",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<TableWriteInfo>",
+        "field_name": "tableWriteInfo",
+        "field_text": "TableWriteInfo",
+        "optional": true,
+        "_N": 6,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Specification",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "partitionBy",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<OrderingScheme>",
+        "field_name": "orderingScheme",
+        "field_text": "OrderingScheme",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "WindowType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "RANGE",
+        "_N": 1
+      },
+      {
+        "element": "ROWS",
+        "_N": 2
+      }
+    ]
+  },
+  {
+    "class_name": "BoundType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "UNBOUNDED_PRECEDING",
+        "_N": 1
+      },
+      {
+        "element": "PRECEDING",
+        "_N": 2
+      },
+      {
+        "element": "CURRENT_ROW",
+        "_N": 3
+      },
+      {
+        "element": "FOLLOWING",
+        "_N": 4
+      },
+      {
+        "element": "UNBOUNDED_FOLLOWING",
+        "_N": 5,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Frame",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "WindowType",
+        "field_name": "type",
+        "field_text": "WindowType",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "BoundType",
+        "field_name": "startType",
+        "field_text": "BoundType",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "startValue",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "BoundType",
+        "field_name": "endType",
+        "field_text": "BoundType",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "endValue",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "originalStartValue",
+        "field_text": "String",
+        "optional": true,
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "originalEndValue",
+        "field_text": "String",
+        "optional": true,
+        "_N": 7,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Function",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "CallExpression",
+        "field_name": "functionCall",
+        "field_text": "CallExpression",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Frame",
+        "field_name": "frame",
+        "field_text": "Frame",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "ignoreNulls",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "WindowNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Specification",
+        "field_name": "specification",
+        "field_text": "Specification",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, Function>",
+        "field_name": "windowFunctions",
+        "field_text": "Map<VariableReferenceExpression, Function>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "hashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<VariableReferenceExpression>",
+        "field_name": "prePartitionedInputs",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "preSortedOrderPrefix",
+        "field_text": "int",
+        "_N": 7,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.WindowNode"
+  },
+  {
+    "class_name": "DeleteHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "TableHandle",
+        "field_name": "handle",
+        "field_text": "TableHandle",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "SchemaTableName",
+        "field_name": "schemaTableName",
+        "field_text": "SchemaTableName",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ExecutionWriterTarget",
+    "json_key": "DeleteHandle"
+  },
+  {
+    "class_name": "ValuesNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<List<RowExpression>>",
+        "field_name": "rows",
+        "field_text": "List<List<std::shared_ptr<RowExpression>>>",
+        "_N": 3,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": ".ValuesNode"
+  },
+  {
+    "class_name": "ConnectorInsertTableHandle",
+    "field_name": "connectorInsertTableHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveInsertTableHandle",
+        "name": "hiveInsertTableHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": []
+  },
+  {
+    "class_name": "InsertTableHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "ConnectorTransactionHandle",
+        "field_name": "transactionHandle",
+        "field_text": "ConnectorTransactionHandle",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "ConnectorInsertTableHandle",
+        "field_name": "connectorHandle",
+        "field_text": "ConnectorInsertTableHandle",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      }
+    ]
+  },
+  {
+    "class_name": "RefreshMaterializedViewHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "InsertTableHandle",
+        "field_name": "handle",
+        "field_text": "InsertTableHandle",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "SchemaTableName",
+        "field_name": "schemaTableName",
+        "field_text": "SchemaTableName",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Locality",
+    "enum": true,
+    "elements": [
+      {
+        "element": "UNKNOWN",
+        "_N": 1
+      },
+      {
+        "element": "LOCAL",
+        "_N": 2
+      },
+      {
+        "element": "REMOTE",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Assignments",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Map<VariableReferenceExpression, RowExpression>",
+        "field_name": "assignments",
+        "field_text": "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ProjectNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Assignments",
+        "field_name": "assignments",
+        "field_text": "Assignments",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Locality",
+        "field_name": "locality",
+        "field_text": "Locality",
+        "_N": 4,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": ".ProjectNode"
+  },
+  {
+    "class_name": "HostAddress",
+    "hinc": "namespace facebook::presto::protocol {\n\nusing HostAddress = std::string;\n\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "ErrorType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "USER_ERROR",
+        "_N": 1
+      },
+      {
+        "element": "INTERNAL_ERROR",
+        "_N": 2
+      },
+      {
+        "element": "INSUFFICIENT_RESOURCES",
+        "_N": 3
+      },
+      {
+        "element": "EXTERNAL",
+        "_N": 4,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "ErrorCode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "int",
+        "field_name": "code",
+        "field_text": "int",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "ErrorType",
+        "field_name": "type",
+        "field_text": "ErrorType",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "retriable",
+        "field_text": "bool",
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ErrorLocation",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "int",
+        "field_name": "lineNumber",
+        "field_text": "int",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "columnNumber",
+        "field_text": "int",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ExecutionFailureInfo",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "type",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "message",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "ExecutionFailureInfo",
+        "field_name": "cause",
+        "field_text": "ExecutionFailureInfo",
+        "_N": 3,
+        "optional": true,
+        "field_local": true
+      },
+      {
+        "field_type": "List<ExecutionFailureInfo>",
+        "field_name": "suppressed",
+        "field_text": "List<ExecutionFailureInfo>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "List<String>",
+        "field_name": "stack",
+        "field_text": "List<String>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "ErrorLocation",
+        "field_name": "errorLocation",
+        "field_text": "ErrorLocation",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "ErrorCode",
+        "field_name": "errorCode",
+        "field_text": "ErrorCode",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "HostAddress",
+        "field_name": "remoteHost",
+        "field_text": "HostAddress",
+        "_N": 8,
+        "field_local": true
+      }
+    ]
+  },
+  {
     "class_name": "PageBufferInfo",
     "struct": true,
     "fields": [
@@ -5397,104 +4431,490 @@
     ]
   },
   {
-    "class_name": "BufferState",
-    "enum": true,
-    "elements": [
-      {
-        "element": "OPEN",
-        "_N": 1
-      },
-      {
-        "element": "NO_MORE_BUFFERS",
-        "_N": 2
-      },
-      {
-        "element": "NO_MORE_PAGES",
-        "_N": 3
-      },
-      {
-        "element": "FLUSHING",
-        "_N": 4
-      },
-      {
-        "element": "FINISHED",
-        "_N": 5
-      },
-      {
-        "element": "FAILED",
-        "_N": 6,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "OutputBufferInfo",
+    "class_name": "Partitioning",
     "struct": true,
     "fields": [
       {
-        "field_type": "String",
-        "field_name": "type",
-        "field_text": "String",
+        "field_type": "PartitioningHandle",
+        "field_name": "handle",
+        "field_text": "PartitioningHandle",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "BufferState",
-        "field_name": "state",
-        "field_text": "BufferState",
+        "field_type": "List<RowExpression>",
+        "field_name": "arguments",
+        "field_text": "List<std::shared_ptr<RowExpression>>",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "PartitioningScheme",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Partitioning",
+        "field_name": "partitioning",
+        "field_text": "Partitioning",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputLayout",
+        "field_text": "List<VariableReferenceExpression>",
         "_N": 2,
         "field_local": true
       },
       {
-        "field_type": "boolean",
-        "field_name": "canAddBuffers",
-        "field_text": "bool",
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "hashColumn",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
         "_N": 3,
         "field_local": true
       },
       {
         "field_type": "boolean",
-        "field_name": "canAddPages",
+        "field_name": "replicateNullsAndAny",
         "field_text": "bool",
         "_N": 4,
         "field_local": true
       },
       {
+        "field_type": "Optional<int[]>",
+        "field_name": "bucketToPartition",
+        "field_text": "List<int>",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "TableWriterNode",
+    "cinc": "namespace facebook::presto::protocol {\nTableWriterNode::TableWriterNode() noexcept {\n  _type = \"com.facebook.presto.sql.planner.plan.TableWriterNode\";\n}\n\nvoid to_json(json& j, const TableWriterNode& p) {\n  j = json::object();\n  j[\"@type\"] = \"com.facebook.presto.sql.planner.plan.TableWriterNode\";\n  to_json_key(j, \"id\", p.id, \"TableWriterNode\", \"PlanNodeId\", \"id\");\n  to_json_key(j, \"source\", p.source, \"TableWriterNode\", \"PlanNode\", \"source\");\n  to_json_key(\n      j,\n      \"rowCountVariable\",\n      p.rowCountVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"rowCountVariable\");\n  to_json_key(\n      j,\n      \"fragmentVariable\",\n      p.fragmentVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"fragmentVariable\");\n  to_json_key(\n      j,\n      \"tableCommitContextVariable\",\n      p.tableCommitContextVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"tableCommitContextVariable\");\n  to_json_key(\n      j,\n      \"columns\",\n      p.columns,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"columns\");\n  to_json_key(\n      j,\n      \"columnNames\",\n      p.columnNames,\n      \"TableWriterNode\",\n      \"List<String>\",\n      \"columnNames\");\n  to_json_key(\n      j,\n      \"notNullColumnVariables\",\n      p.notNullColumnVariables,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"notNullColumnVariables\");\n  to_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  to_json_key(\n      j,\n      \"preferredShufflePartitioningScheme\",\n      p.preferredShufflePartitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"preferredShufflePartitioningScheme\");\n}\n\nvoid from_json(const json& j, TableWriterNode& p) {\n  p._type = j[\"@type\"];\n  from_json_key(j, \"id\", p.id, \"TableWriterNode\", \"PlanNodeId\", \"id\");\n  from_json_key(j, \"source\", p.source, \"TableWriterNode\", \"PlanNode\", \"source\");\n  from_json_key(\n      j,\n      \"rowCountVariable\",\n      p.rowCountVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"rowCountVariable\");\n  from_json_key(\n      j,\n      \"fragmentVariable\",\n      p.fragmentVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"fragmentVariable\");\n  from_json_key(\n      j,\n      \"tableCommitContextVariable\",\n      p.tableCommitContextVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"tableCommitContextVariable\");\n  from_json_key(\n      j,\n      \"columns\",\n      p.columns,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"columns\");\n  from_json_key(\n      j,\n      \"columnNames\",\n      p.columnNames,\n      \"TableWriterNode\",\n      \"List<String>\",\n      \"columnNames\");\n  from_json_key(\n      j,\n      \"notNullColumnVariables\",\n      p.notNullColumnVariables,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"notNullColumnVariables\");\n  from_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  from_json_key(\n      j,\n      \"preferredShufflePartitioningScheme\",\n      p.preferredShufflePartitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"preferredShufflePartitioningScheme\");\n}\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\nstruct TableWriterNode : public PlanNode {\n  std::shared_ptr<PlanNode> source = {};\n  // TODO Add target\n  VariableReferenceExpression rowCountVariable = {};\n  VariableReferenceExpression fragmentVariable = {};\n  VariableReferenceExpression tableCommitContextVariable = {};\n  List<VariableReferenceExpression> columns = {};\n  List<String> columnNames = {};\n  List<VariableReferenceExpression> notNullColumnVariables = {};\n  std::shared_ptr<PartitioningScheme> partitioningScheme = {};\n  std::shared_ptr<PartitioningScheme> preferredShufflePartitioningScheme = {};\n  // TODO Add statisticsAggregation\n\n  TableWriterNode() noexcept;\n};\nvoid to_json(json& j, const TableWriterNode& p);\nvoid from_json(const json& j, TableWriterNode& p);\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Optional<WriterTarget>",
+        "field_name": "target",
+        "field_text": "WriterTarget",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "rowCountVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "fragmentVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "tableCommitContextVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "columns",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "List<String>",
+        "field_name": "columnNames",
+        "field_text": "List<String>",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<VariableReferenceExpression>",
+        "field_name": "notNullColumnVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<PartitioningScheme>",
+        "field_name": "partitioningScheme",
+        "field_text": "PartitioningScheme",
+        "optional": true,
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<PartitioningScheme>",
+        "field_name": "preferredShufflePartitioningScheme",
+        "field_text": "PartitioningScheme",
+        "optional": true,
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<StatisticAggregations>",
+        "field_name": "statisticsAggregation",
+        "field_text": "StatisticAggregations",
+        "optional": true,
+        "_N": 12,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.TableWriterNode"
+  },
+  {
+    "class_name": "GroupIdNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<List<VariableReferenceExpression>>",
+        "field_name": "groupingSets",
+        "field_text": "List<List<VariableReferenceExpression>>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, VariableReferenceExpression>",
+        "field_name": "groupingColumns",
+        "field_text": "Map<VariableReferenceExpression, VariableReferenceExpression>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "aggregationArguments",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "groupIdVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 6,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.GroupIdNode"
+  },
+  {
+    "class_name": "HiveMetadataUpdateHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "UUID",
+        "field_name": "requestId",
+        "field_text": "UUID",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "SchemaTableName",
+        "field_name": "schemaTableName",
+        "field_text": "SchemaTableName",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "partitionName",
+        "field_text": "String",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "fileName",
+        "field_text": "String",
+        "optional": true,
+        "_N": 4,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorMetadataUpdateHandle",
+    "json_key": "hive"
+  },
+  {
+    "class_name": "VariableStatsEstimate",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "double",
+        "field_name": "lowValue",
+        "field_text": "double",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "highValue",
+        "field_text": "double",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "nullsFraction",
+        "field_text": "double",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "averageRowSize",
+        "field_text": "double",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "distinctValuesCount",
+        "field_text": "double",
+        "_N": 5,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "PlanNodeStatsEstimate",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "double",
+        "field_name": "outputRowCount",
+        "field_text": "double",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "totalSize",
+        "field_text": "double",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "confident",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, VariableStatsEstimate>",
+        "field_name": "variableStatistics",
+        "field_text": "Map<VariableReferenceExpression, VariableStatsEstimate>",
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "EmptySplit",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorSplit",
+    "json_key": "$empty"
+  },
+  {
+    "class_name": "RemoteTransactionHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<String>",
+        "field_name": "dummy",
+        "field_text": "String",
+        "optional": true,
+        "_N": 1,
+        "field_local": true,
+        "last": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorTransactionHandle",
+    "json_key": "$remote"
+  },
+  {
+    "class_name": "RuntimeUnit",
+    "enum": true,
+    "elements": [
+      {
+        "element": "NONE",
+        "_N": 1
+      },
+      {
+        "element": "NANO",
+        "_N": 2
+      },
+      {
+        "element": "BYTE",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "RuntimeMetric",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "RuntimeUnit",
+        "field_name": "unit",
+        "field_text": "RuntimeUnit",
+        "_N": 2,
+        "field_local": true
+      },
+      {
         "field_type": "long",
-        "field_name": "totalBufferedBytes",
+        "field_name": "sum",
+        "field_text": "int64_t",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "count",
+        "field_text": "int64_t",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "max",
         "field_text": "int64_t",
         "_N": 5,
         "field_local": true
       },
       {
         "field_type": "long",
-        "field_name": "totalBufferedPages",
+        "field_name": "min",
         "field_text": "int64_t",
         "_N": 6,
         "field_local": true
-      },
+      }
+    ]
+  },
+  {
+    "class_name": "Block",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const Block& p) {\n  j = p.data;\n}\n\nvoid from_json(const json& j, Block& p) {\n  p.data = std::string(j);\n}\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\n\nstruct Block {\n  std::string data;\n};\n\nvoid to_json(json& j, const Block& p);\n\nvoid from_json(const json& j, Block& p);\n\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "ValueEntry",
+    "hinc": "namespace facebook::presto::protocol {\n\nclass ValueEntry {\n public:\n  Type type;\n  std::shared_ptr<Block> block;\n};\n\nvoid to_json(json& j, const ValueEntry& p);\nvoid from_json(const json& j, ValueEntry& p);\n\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
       {
-        "field_type": "long",
-        "field_name": "totalRowsSent",
-        "field_text": "int64_t",
-        "_N": 7,
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "long",
-        "field_name": "totalPagesSent",
-        "field_text": "int64_t",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "List<BufferInfo>",
-        "field_name": "buffers",
-        "field_text": "List<BufferInfo>",
-        "_N": 9,
+        "field_type": "Block",
+        "field_name": "block",
+        "field_text": "Block",
+        "_N": 2,
         "field_local": true
       }
     ]
+  },
+  {
+    "class_name": "EquatableValueSet",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "whiteList",
+        "field_text": "bool",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<ValueEntry>",
+        "field_name": "entries",
+        "field_text": "List<ValueEntry>",
+        "_N": 3,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ValueSet",
+    "json_key": "equatable"
   },
   {
     "class_name": "TaskState",
@@ -5681,6 +5101,143 @@
     ]
   },
   {
+    "class_name": "BufferState",
+    "enum": true,
+    "elements": [
+      {
+        "element": "OPEN",
+        "_N": 1
+      },
+      {
+        "element": "NO_MORE_BUFFERS",
+        "_N": 2
+      },
+      {
+        "element": "NO_MORE_PAGES",
+        "_N": 3
+      },
+      {
+        "element": "FLUSHING",
+        "_N": 4
+      },
+      {
+        "element": "FINISHED",
+        "_N": 5
+      },
+      {
+        "element": "FAILED",
+        "_N": 6,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "OutputBufferInfo",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "type",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "BufferState",
+        "field_name": "state",
+        "field_text": "BufferState",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "canAddBuffers",
+        "field_text": "bool",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "canAddPages",
+        "field_text": "bool",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "totalBufferedBytes",
+        "field_text": "int64_t",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "totalBufferedPages",
+        "field_text": "int64_t",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "totalRowsSent",
+        "field_text": "int64_t",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "totalPagesSent",
+        "field_text": "int64_t",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "List<BufferInfo>",
+        "field_name": "buffers",
+        "field_text": "List<BufferInfo>",
+        "_N": 9,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ConnectorMetadataUpdateHandle",
+    "field_name": "connectorMetadataUpdateHandle",
+    "abstract": true,
+    "super_class": "JsonEncodedSubclass",
+    "subclasses": [
+      {
+        "type": "HiveMetadataUpdateHandle",
+        "name": "hiveMetadataUpdateHandle",
+        "key": "hive",
+        "_N": 1,
+        "_last": true
+      }
+    ],
+    "fields": [],
+    "cinc": "namespace facebook::presto::protocol {\nvoid to_json(json& j, const std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {\n  if (p == nullptr) {\n    return;\n  }\n  String type = p->_type;\n\n  if (getConnectorKey(type) == \"hive\") {\n    j = *std::static_pointer_cast<HiveMetadataUpdateHandle>(p);\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorMetadataUpdateHandle\");\n}\n\nvoid from_json(\n    const json& j,\n    std::shared_ptr<ConnectorMetadataUpdateHandle>& p) {\n  String type;\n  try {\n    type = p->getSubclassKey(j);\n  } catch (json::parse_error& e) {\n    throw ParseError(std::string(e.what()) + \" ConnectorMetadataUpdateHandle\");\n  }\n\n  if (getConnectorKey(type) == \"hive\") {\n    auto k = std::make_shared<HiveMetadataUpdateHandle>();\n    j.get_to(*k);\n    p = k;\n    return;\n  }\n\n  throw TypeError(type + \" no abstract type ConnectorMetadataUpdateHandle\");\n}\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "MetadataUpdates",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "ConnectorId",
+        "field_name": "connectorId",
+        "field_text": "ConnectorId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "List<ConnectorMetadataUpdateHandle>",
+        "field_name": "metadataUpdates",
+        "field_text": "List<std::shared_ptr<ConnectorMetadataUpdateHandle>>",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
     "class_name": "TaskInfo",
     "struct": true,
     "fields": [
@@ -5750,167 +5307,266 @@
     ]
   },
   {
-    "class_name": "TableWriterNode",
-    "cinc": "namespace facebook::presto::protocol {\nTableWriterNode::TableWriterNode() noexcept {\n  _type = \"com.facebook.presto.sql.planner.plan.TableWriterNode\";\n}\n\nvoid to_json(json& j, const TableWriterNode& p) {\n  j = json::object();\n  j[\"@type\"] = \"com.facebook.presto.sql.planner.plan.TableWriterNode\";\n  to_json_key(j, \"id\", p.id, \"TableWriterNode\", \"PlanNodeId\", \"id\");\n  to_json_key(j, \"source\", p.source, \"TableWriterNode\", \"PlanNode\", \"source\");\n  to_json_key(\n      j,\n      \"rowCountVariable\",\n      p.rowCountVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"rowCountVariable\");\n  to_json_key(\n      j,\n      \"fragmentVariable\",\n      p.fragmentVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"fragmentVariable\");\n  to_json_key(\n      j,\n      \"tableCommitContextVariable\",\n      p.tableCommitContextVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"tableCommitContextVariable\");\n  to_json_key(\n      j,\n      \"columns\",\n      p.columns,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"columns\");\n  to_json_key(\n      j,\n      \"columnNames\",\n      p.columnNames,\n      \"TableWriterNode\",\n      \"List<String>\",\n      \"columnNames\");\n  to_json_key(\n      j,\n      \"notNullColumnVariables\",\n      p.notNullColumnVariables,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"notNullColumnVariables\");\n  to_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  to_json_key(\n      j,\n      \"preferredShufflePartitioningScheme\",\n      p.preferredShufflePartitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"preferredShufflePartitioningScheme\");\n}\n\nvoid from_json(const json& j, TableWriterNode& p) {\n  p._type = j[\"@type\"];\n  from_json_key(j, \"id\", p.id, \"TableWriterNode\", \"PlanNodeId\", \"id\");\n  from_json_key(j, \"source\", p.source, \"TableWriterNode\", \"PlanNode\", \"source\");\n  from_json_key(\n      j,\n      \"rowCountVariable\",\n      p.rowCountVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"rowCountVariable\");\n  from_json_key(\n      j,\n      \"fragmentVariable\",\n      p.fragmentVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"fragmentVariable\");\n  from_json_key(\n      j,\n      \"tableCommitContextVariable\",\n      p.tableCommitContextVariable,\n      \"TableWriterNode\",\n      \"VariableReferenceExpression\",\n      \"tableCommitContextVariable\");\n  from_json_key(\n      j,\n      \"columns\",\n      p.columns,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"columns\");\n  from_json_key(\n      j,\n      \"columnNames\",\n      p.columnNames,\n      \"TableWriterNode\",\n      \"List<String>\",\n      \"columnNames\");\n  from_json_key(\n      j,\n      \"notNullColumnVariables\",\n      p.notNullColumnVariables,\n      \"TableWriterNode\",\n      \"List<VariableReferenceExpression>\",\n      \"notNullColumnVariables\");\n  from_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  from_json_key(\n      j,\n      \"preferredShufflePartitioningScheme\",\n      p.preferredShufflePartitioningScheme,\n      \"TableWriterNode\",\n      \"PartitioningScheme\",\n      \"preferredShufflePartitioningScheme\");\n}\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\nstruct TableWriterNode : public PlanNode {\n  std::shared_ptr<PlanNode> source = {};\n  // TODO Add target\n  VariableReferenceExpression rowCountVariable = {};\n  VariableReferenceExpression fragmentVariable = {};\n  VariableReferenceExpression tableCommitContextVariable = {};\n  List<VariableReferenceExpression> columns = {};\n  List<String> columnNames = {};\n  List<VariableReferenceExpression> notNullColumnVariables = {};\n  std::shared_ptr<PartitioningScheme> partitioningScheme = {};\n  std::shared_ptr<PartitioningScheme> preferredShufflePartitioningScheme = {};\n  // TODO Add statisticsAggregation\n\n  TableWriterNode() noexcept;\n};\nvoid to_json(json& j, const TableWriterNode& p);\nvoid from_json(const json& j, TableWriterNode& p);\n} // namespace facebook::presto::protocol",
+    "class_name": "MemoryAllocation",
     "struct": true,
     "fields": [
       {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
+        "field_type": "String",
+        "field_name": "tag",
+        "field_text": "String",
         "_N": 1,
-        "field_local": false
+        "field_local": true
       },
       {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
+        "field_type": "long",
+        "field_name": "allocation",
+        "field_text": "int64_t",
         "_N": 2,
-        "field_local": true,
-        "optional": true
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "MemoryPoolInfo",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "long",
+        "field_name": "maxBytes",
+        "field_text": "int64_t",
+        "_N": 1,
+        "field_local": true
       },
       {
-        "field_type": "Optional<WriterTarget>",
-        "field_name": "target",
-        "field_text": "WriterTarget",
-        "optional": true,
+        "field_type": "long",
+        "field_name": "reservedBytes",
+        "field_text": "int64_t",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "reservedRevocableBytes",
+        "field_text": "int64_t",
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "rowCountVariable",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "Map<QueryId, Long>",
+        "field_name": "queryMemoryReservations",
+        "field_text": "Map<QueryId, Long>",
         "_N": 4,
         "field_local": true
       },
       {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "fragmentVariable",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "Map<QueryId, List<MemoryAllocation>>",
+        "field_name": "queryMemoryAllocations",
+        "field_text": "Map<QueryId, List<MemoryAllocation>>",
         "_N": 5,
         "field_local": true
       },
       {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "tableCommitContextVariable",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "Map<QueryId, Long>",
+        "field_name": "queryMemoryRevocableReservations",
+        "field_text": "Map<QueryId, Long>",
         "_N": 6,
         "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "columns",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "List<String>",
-        "field_name": "columnNames",
-        "field_text": "List<String>",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<VariableReferenceExpression>",
-        "field_name": "notNullColumnVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<PartitioningScheme>",
-        "field_name": "partitioningScheme",
-        "field_text": "PartitioningScheme",
-        "optional": true,
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<PartitioningScheme>",
-        "field_name": "preferredShufflePartitioningScheme",
-        "field_text": "PartitioningScheme",
-        "optional": true,
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<StatisticAggregations>",
-        "field_name": "statisticsAggregation",
-        "field_text": "StatisticAggregations",
-        "optional": true,
-        "_N": 12,
-        "field_local": true
       }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.TableWriterNode"
+    ]
   },
   {
-    "class_name": "TableScanNode",
+    "class_name": "MemoryInfo",
     "struct": true,
     "fields": [
       {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
+        "field_type": "DataSize",
+        "field_name": "totalNodeMemory",
+        "field_text": "DataSize",
         "_N": 1,
-        "field_local": false
+        "field_local": true
       },
       {
-        "field_type": "TableHandle",
-        "field_name": "table",
-        "field_text": "TableHandle",
+        "field_type": "Map<MemoryPoolId, MemoryPoolInfo>",
+        "field_name": "pools",
+        "field_text": "Map<MemoryPoolId, MemoryPoolInfo>",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "NodeVersion",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "version",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "NodeStatus",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "nodeId",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "NodeVersion",
+        "field_name": "nodeVersion",
+        "field_text": "NodeVersion",
         "_N": 2,
         "field_local": true
       },
       {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputVariables",
-        "field_text": "List<VariableReferenceExpression>",
+        "field_type": "String",
+        "field_name": "environment",
+        "field_text": "String",
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "Map<VariableReferenceExpression, ColumnHandle>",
-        "field_name": "assignments",
-        "field_text": "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
+        "field_type": "boolean",
+        "field_name": "coordinator",
+        "field_text": "bool",
         "_N": 4,
         "field_local": true
+      },
+      {
+        "field_type": "Duration",
+        "field_name": "uptime",
+        "field_text": "Duration",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "externalAddress",
+        "field_text": "String",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "internalAddress",
+        "field_text": "String",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "MemoryInfo",
+        "field_name": "memoryInfo",
+        "field_text": "MemoryInfo",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "processors",
+        "field_text": "int",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "processCpuLoad",
+        "field_text": "double",
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "systemCpuLoad",
+        "field_text": "double",
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "heapUsed",
+        "field_text": "int64_t",
+        "_N": 12,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "heapAvailable",
+        "field_text": "int64_t",
+        "_N": 13,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "nonHeapUsed",
+        "field_text": "int64_t",
+        "_N": 14,
+        "field_local": true
       }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".TableScanNode"
+    ]
   },
   {
-    "class_name": "AllOrNoneValueSet",
+    "class_name": "PlanCostEstimate",
     "struct": true,
     "fields": [
       {
-        "field_type": "Type",
-        "field_name": "type",
-        "field_text": "Type",
+        "field_type": "double",
+        "field_name": "cpuCost",
+        "field_text": "double",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "boolean",
-        "field_name": "all",
-        "field_text": "bool",
+        "field_type": "double",
+        "field_name": "maxMemory",
+        "field_text": "double",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "maxMemoryWhenOutputting",
+        "field_text": "double",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "double",
+        "field_name": "networkCost",
+        "field_text": "double",
+        "_N": 4,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "StatsAndCosts",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Map<PlanNodeId, PlanNodeStatsEstimate>",
+        "field_name": "stats",
+        "field_text": "Map<PlanNodeId, PlanNodeStatsEstimate>",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<PlanNodeId, PlanCostEstimate>",
+        "field_name": "costs",
+        "field_text": "Map<PlanNodeId, PlanCostEstimate>",
         "_N": 2,
         "field_local": true
       }
-    ],
-    "subclass": true,
-    "super_class": "ValueSet",
-    "json_key": "allOrNone"
+    ]
   },
   {
-    "class_name": "AggregationNodeStep",
+    "class_name": "LimitNodeStep",
     "enum": true,
     "elements": [
       {
@@ -5919,48 +5575,13 @@
       },
       {
         "element": "FINAL",
-        "_N": 2
-      },
-      {
-        "element": "INTERMEDIATE",
-        "_N": 3
-      },
-      {
-        "element": "SINGLE",
-        "_N": 4,
+        "_N": 2,
         "_last": true
       }
     ]
   },
   {
-    "class_name": "GroupingSetDescriptor",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "groupingKeys",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "groupingSetCount",
-        "field_text": "int",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "Set<Integer>",
-        "field_name": "globalGroupingSets",
-        "field_text": "List<Integer>",
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "AggregationNode",
+    "class_name": "LimitNode",
     "struct": true,
     "fields": [
       {
@@ -5979,100 +5600,86 @@
         "optional": true
       },
       {
-        "field_type": "Map<VariableReferenceExpression, Aggregation>",
-        "field_name": "aggregations",
-        "field_text": "Map<VariableReferenceExpression, Aggregation>",
+        "field_type": "long",
+        "field_name": "count",
+        "field_text": "int64_t",
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "GroupingSetDescriptor",
-        "field_name": "groupingSets",
-        "field_text": "GroupingSetDescriptor",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "preGroupedVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "AggregationNodeStep",
+        "field_type": "LimitNodeStep",
         "field_name": "step",
-        "field_text": "AggregationNodeStep",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "hashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "groupIdVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 8,
+        "field_text": "LimitNodeStep",
+        "_N": 4,
         "field_local": true
       }
     ],
     "subclass": true,
     "super_class": "PlanNode",
-    "json_key": ".AggregationNode"
+    "json_key": ".LimitNode"
   },
   {
-    "class_name": "ValueSet",
-    "field_name": "valueSet",
-    "abstract": true,
-    "super_class": "JsonEncodedSubclass",
-    "subclasses": [
-      {
-        "type": "EquatableValueSet",
-        "name": "equatableValueSet",
-        "key": "equatable",
-        "_N": 1
-      },
-      {
-        "type": "SortedRangeSet",
-        "name": "sortedRangeSet",
-        "key": "sortable",
-        "_N": 2
-      },
-      {
-        "type": "AllOrNoneValueSet",
-        "name": "allOrNoneValueSet",
-        "key": "allOrNone",
-        "_N": 3,
-        "_last": true
-      }
-    ],
-    "fields": []
-  },
-  {
-    "class_name": "Domain",
+    "class_name": "HivePartitioningHandle",
     "struct": true,
     "fields": [
       {
-        "field_type": "ValueSet",
-        "field_name": "values",
-        "field_text": "ValueSet",
+        "field_type": "int",
+        "field_name": "bucketCount",
+        "field_text": "int",
         "_N": 1,
-        "field_local": true,
-        "optional": true
+        "field_local": true
       },
       {
-        "field_type": "boolean",
-        "field_name": "nullAllowed",
-        "field_text": "bool",
+        "field_type": "OptionalInt",
+        "field_name": "maxCompatibleBucketCount",
+        "field_text": "int",
+        "optional": true,
         "_N": 2,
         "field_local": true
+      },
+      {
+        "field_type": "BucketFunctionType",
+        "field_name": "bucketFunctionType",
+        "field_text": "BucketFunctionType",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<List<HiveType>>",
+        "field_name": "hiveTypes",
+        "field_text": "List<HiveType>",
+        "optional": true,
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<List<Type>>",
+        "field_name": "types",
+        "field_text": "List<Type>",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorPartitioningHandle",
+    "json_key": "hive"
+  },
+  {
+    "class_name": "ExchangeNodeType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "GATHER",
+        "_N": 1
+      },
+      {
+        "element": "REPARTITION",
+        "_N": 2
+      },
+      {
+        "element": "REPLICATE",
+        "_N": 3
       }
     ]
   },
@@ -6092,24 +5699,6 @@
         "element": "REMOTE_MATERIALIZED",
         "_N": 3,
         "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "ExchangeNodeType",
-    "enum": true,
-    "elements": [
-      {
-        "element": "GATHER",
-        "_N": 1
-      },
-      {
-        "element": "REPARTITION",
-        "_N": 2
-      },
-      {
-        "element": "REPLICATE",
-        "_N": 3
       }
     ]
   },
@@ -6180,22 +5769,56 @@
     "json_key": "com.facebook.presto.sql.planner.plan.ExchangeNode"
   },
   {
-    "class_name": "RemoteTransactionHandle",
+    "class_name": "RemoteSourceNode",
     "struct": true,
     "fields": [
       {
-        "field_type": "Optional<String>",
-        "field_name": "dummy",
-        "field_text": "String",
-        "optional": true,
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
         "_N": 1,
-        "field_local": true,
-        "last": true
+        "field_local": false
+      },
+      {
+        "field_type": "List<PlanFragmentId>",
+        "field_name": "sourceFragmentIds",
+        "field_text": "List<PlanFragmentId>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "ensureSourceOrdering",
+        "field_text": "bool",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<OrderingScheme>",
+        "field_name": "orderingScheme",
+        "field_text": "OrderingScheme",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "ExchangeNode.Type",
+        "field_name": "exchangeType",
+        "field_text": "ExchangeNodeType",
+        "_N": 6,
+        "field_local": true
       }
     ],
     "subclass": true,
-    "super_class": "ConnectorTransactionHandle",
-    "json_key": "$remote"
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.RemoteSourceNode"
   },
   {
     "class_name": "ServerInfo",
@@ -6240,323 +5863,193 @@
     ]
   },
   {
-    "class_name": "TupleDomain",
-    "hinc": "namespace facebook::presto::protocol {\n\ntemplate <typename T>\nstruct pointerDerefCompare {\n  bool operator()(const std::shared_ptr<T>& a, const std::shared_ptr<T>& b)\n      const {\n    return *a < *b;\n  }\n};\n\ntemplate <typename T>\nstruct TupleDomain {\n  std::shared_ptr<Map<T, Domain>> domains;\n};\n\ntemplate <typename T>\nstruct TupleDomain<std::shared_ptr<T>> {\n  std::shared_ptr<std::map<std::shared_ptr<T>, Domain, pointerDerefCompare<T>>>\n      domains;\n};\n\ntemplate <class T>\nstruct ColumnDomain {\n  T column;\n  Domain domain; // dependency\n};\n\n} // namespace facebook::presto::protocol\n\nnamespace nlohmann {\n\ntemplate <typename T>\nstruct adl_serializer<facebook::presto::protocol::ColumnDomain<T>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::ColumnDomain<T>& p) {\n    facebook::presto::protocol::to_json_key(\n        j, \"column\", p.column, \"ColumnDomain\", \"T\", \"column\");\n    facebook::presto::protocol::to_json_key(\n        j, \"domain\", p.domain, \"ColumnDomain\", \"Domain\", \"domain\");\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::ColumnDomain<T>& p) {\n    facebook::presto::protocol::from_json_key(\n        j, \"column\", p.column, \"ColumnDomain\", \"T\", \"column\");\n    facebook::presto::protocol::from_json_key(\n        j, \"domain\", p.domain, \"ColumnDomain\", \"Domain\", \"domain\");\n  }\n};\n\ntemplate <typename T>\nstruct adl_serializer<facebook::presto::protocol::TupleDomain<T>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::TupleDomain<T>& tup) {\n    facebook::presto::protocol::List<\n        facebook::presto::protocol::ColumnDomain<T>>\n        list;\n    if (tup.domains != nullptr) {\n      for (auto& el : *tup.domains) {\n        facebook::presto::protocol::ColumnDomain<T> domain;\n        domain.column = el.first;\n        domain.domain = el.second;\n        list.push_back(domain);\n      }\n    }\n\n    j[\"columnDomains\"] = list;\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::TupleDomain<T>& tup) {\n    if (j.count(\"columnDomains\") != 0U) {\n      std::shared_ptr<facebook::presto::protocol::\n                          Map<T, facebook::presto::protocol::Domain>>\n          map = std::make_shared<\n              std::map<T, facebook::presto::protocol::Domain>>();\n\n      facebook::presto::protocol::List<\n          facebook::presto::protocol::ColumnDomain<T>>\n          list = j.at(\"columnDomains\");\n      for (const facebook::presto::protocol::ColumnDomain<T>& value : list) {\n        map->insert(std::make_pair(T(value.column), value.domain));\n      }\n      tup.domains = map;\n    }\n  }\n};\n\ntemplate <typename T>\nstruct adl_serializer<\n    facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>> {\n  static void to_json(\n      json& j,\n      const facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>& tup) {\n    facebook::presto::protocol::List<\n        facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>>\n        list;\n    if (tup.domains != nullptr) {\n      for (auto& el : *tup.domains) {\n        facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>> domain;\n        domain.column = el.first;\n        domain.domain = el.second;\n        list.push_back(domain);\n      }\n    }\n\n    j[\"columnDomains\"] = list;\n  }\n\n  static void from_json(\n      const json& j,\n      facebook::presto::protocol::TupleDomain<std::shared_ptr<T>>& tup) {\n    if (j.count(\"columnDomains\") != 0U) {\n      auto map = std::make_shared<std::map<\n          std::shared_ptr<T>,\n          facebook::presto::protocol::Domain,\n          facebook::presto::protocol::pointerDerefCompare<T>>>();\n\n      facebook::presto::protocol::List<\n          facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>>\n          list = j.at(\"columnDomains\");\n      for (const facebook::presto::protocol::ColumnDomain<std::shared_ptr<T>>&\n               value : list) {\n        map->insert(\n            std::make_pair(std::shared_ptr<T>(value.column), value.domain));\n      }\n      tup.domains = map;\n    }\n  }\n};\n\n} // namespace nlohmann"
-  },
-  {
-    "class_name": "HiveBucketFilter",
+    "class_name": "CreateHandle",
     "struct": true,
     "fields": [
       {
-        "field_type": "Set<Integer>",
-        "field_name": "bucketsToKeep",
-        "field_text": "List<Integer>",
-        "_N": 1,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveBucketHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "List<HiveColumnHandle>",
-        "field_name": "columns",
-        "field_text": "List<HiveColumnHandle>",
+        "field_type": "OutputTableHandle",
+        "field_name": "handle",
+        "field_text": "OutputTableHandle",
         "_N": 1,
         "field_local": true
       },
-      {
-        "field_type": "int",
-        "field_name": "tableBucketCount",
-        "field_text": "int",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "int",
-        "field_name": "readBucketCount",
-        "field_text": "int",
-        "_N": 3,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "HiveTableLayoutHandle",
-    "struct": true,
-    "fields": [
       {
         "field_type": "SchemaTableName",
         "field_name": "schemaTableName",
         "field_text": "SchemaTableName",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "tablePath",
-        "field_text": "String",
         "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<HiveColumnHandle>",
-        "field_name": "partitionColumns",
-        "field_text": "List<HiveColumnHandle>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "List<Column>",
-        "field_name": "dataColumns",
-        "field_text": "List<Column>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, String>",
-        "field_name": "tableParameters",
-        "field_text": "Map<String, String>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "TupleDomain<Subfield>",
-        "field_name": "domainPredicate",
-        "field_text": "TupleDomain<Subfield>",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "RowExpression",
-        "field_name": "remainingPredicate",
-        "field_text": "RowExpression",
-        "_N": 7,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Map<String, HiveColumnHandle>",
-        "field_name": "predicateColumns",
-        "field_text": "Map<String, HiveColumnHandle>",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "TupleDomain<ColumnHandle>",
-        "field_name": "partitionColumnPredicate",
-        "field_text": "TupleDomain<std::shared_ptr<ColumnHandle>>",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<HiveBucketHandle>",
-        "field_name": "bucketHandle",
-        "field_text": "HiveBucketHandle",
-        "optional": true,
-        "_N": 10,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<HiveBucketFilter>",
-        "field_name": "bucketFilter",
-        "field_text": "HiveBucketFilter",
-        "optional": true,
-        "_N": 11,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "pushdownFilterEnabled",
-        "field_text": "bool",
-        "_N": 12,
-        "field_local": true
-      },
-      {
-        "field_type": "String",
-        "field_name": "layoutString",
-        "field_text": "String",
-        "_N": 13,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Set<HiveColumnHandle>>",
-        "field_name": "requestedColumns",
-        "field_text": "List<HiveColumnHandle>",
-        "optional": true,
-        "_N": 14,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "partialAggregationsPushedDown",
-        "field_text": "bool",
-        "_N": 15,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "appendRowNumber",
-        "field_text": "bool",
-        "_N": 16,
         "field_local": true
       }
     ],
     "subclass": true,
-    "super_class": "ConnectorTableLayoutHandle",
-    "json_key": "hive"
+    "super_class": "ExecutionWriterTarget",
+    "json_key": "CreateHandle"
   },
   {
-    "class_name": "PlanFragment",
-    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const PlanFragment& p) {\n  j = json::object();\n  to_json_key(j, \"id\", p.id, \"PlanFragment\", \"PlanFragmentId\", \"id\");\n  to_json_key(j, \"root\", p.root, \"PlanFragment\", \"PlanNode\", \"root\");\n  to_json_key(\n      j,\n      \"variables\",\n      p.variables,\n      \"PlanFragment\",\n      \"List<VariableReferenceExpression>\",\n      \"variables\");\n  to_json_key(\n      j,\n      \"partitioning\",\n      p.partitioning,\n      \"PlanFragment\",\n      \"PartitioningHandle\",\n      \"partitioning\");\n  to_json_key(\n      j,\n      \"tableScanSchedulingOrder\",\n      p.tableScanSchedulingOrder,\n      \"PlanFragment\",\n      \"List<PlanNodeId>\",\n      \"tableScanSchedulingOrder\");\n  to_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"PlanFragment\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  to_json_key(\n      j,\n      \"stageExecutionDescriptor\",\n      p.stageExecutionDescriptor,\n      \"PlanFragment\",\n      \"StageExecutionDescriptor\",\n      \"stageExecutionDescriptor\");\n  to_json_key(\n      j,\n      \"outputTableWriterFragment\",\n      p.outputTableWriterFragment,\n      \"PlanFragment\",\n      \"bool\",\n      \"outputTableWriterFragment\");\n  to_json_key(\n      j,\n      \"jsonRepresentation\",\n      p.jsonRepresentation,\n      \"PlanFragment\",\n      \"String\",\n      \"jsonRepresentation\");\n}\n\nvoid from_json(const json& j, PlanFragment& p) {\n  from_json_key(j, \"id\", p.id, \"PlanFragment\", \"PlanFragmentId\", \"id\");\n  from_json_key(j, \"root\", p.root, \"PlanFragment\", \"PlanNode\", \"root\");\n  from_json_key(\n      j,\n      \"variables\",\n      p.variables,\n      \"PlanFragment\",\n      \"List<VariableReferenceExpression>\",\n      \"variables\");\n  from_json_key(\n      j,\n      \"partitioning\",\n      p.partitioning,\n      \"PlanFragment\",\n      \"PartitioningHandle\",\n      \"partitioning\");\n  from_json_key(\n      j,\n      \"tableScanSchedulingOrder\",\n      p.tableScanSchedulingOrder,\n      \"PlanFragment\",\n      \"List<PlanNodeId>\",\n      \"tableScanSchedulingOrder\");\n  from_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"PlanFragment\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  from_json_key(\n      j,\n      \"stageExecutionDescriptor\",\n      p.stageExecutionDescriptor,\n      \"PlanFragment\",\n      \"StageExecutionDescriptor\",\n      \"stageExecutionDescriptor\");\n  from_json_key(\n      j,\n      \"outputTableWriterFragment\",\n      p.outputTableWriterFragment,\n      \"PlanFragment\",\n      \"bool\",\n      \"outputTableWriterFragment\");\n  from_json_key(\n      j,\n      \"jsonRepresentation\",\n      p.jsonRepresentation,\n      \"PlanFragment\",\n      \"String\",\n      \"jsonRepresentation\");\n}\n} // namespace facebook::presto::protocol",
-    "hinc": "namespace facebook::presto::protocol {\nstruct PlanFragment {\n  PlanFragmentId id = {};\n  std::shared_ptr<PlanNode> root = {};\n  List<VariableReferenceExpression> variables = {};\n  PartitioningHandle partitioning = {};\n  List<PlanNodeId> tableScanSchedulingOrder = {};\n  PartitioningScheme partitioningScheme = {};\n  StageExecutionDescriptor stageExecutionDescriptor = {};\n  bool outputTableWriterFragment = {};\n  std::shared_ptr<String> jsonRepresentation = {};\n};\nvoid to_json(json& j, const PlanFragment& p);\nvoid from_json(const json& j, PlanFragment& p);\n} // namespace facebook::presto::protocol",
+    "class_name": "BuiltInFunctionHandle",
     "struct": true,
     "fields": [
       {
-        "field_type": "PlanFragmentId",
-        "field_name": "id",
-        "field_text": "PlanFragmentId",
+        "field_type": "Signature",
+        "field_name": "signature",
+        "field_text": "Signature",
+        "_N": 1,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "FunctionHandle",
+    "json_key": "$static"
+  },
+  {
+    "class_name": "DistributionType",
+    "enum": true,
+    "elements": [
+      {
+        "element": "PARTITIONED",
+        "_N": 1
+      },
+      {
+        "element": "REPLICATED",
+        "_N": 2,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "EquiJoinClause",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "left",
+        "field_text": "VariableReferenceExpression",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "PlanNode",
-        "field_name": "root",
-        "field_text": "PlanNode",
+        "field_type": "VariableReferenceExpression",
+        "field_name": "right",
+        "field_text": "VariableReferenceExpression",
         "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "Set<VariableReferenceExpression>",
-        "field_name": "variables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "PartitioningHandle",
-        "field_name": "partitioning",
-        "field_text": "PartitioningHandle",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<PlanNodeId>",
-        "field_name": "tableScanSchedulingOrder",
-        "field_text": "List<PlanNodeId>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "PartitioningScheme",
-        "field_name": "partitioningScheme",
-        "field_text": "PartitioningScheme",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "StageExecutionDescriptor",
-        "field_name": "stageExecutionDescriptor",
-        "field_text": "StageExecutionDescriptor",
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "outputTableWriterFragment",
-        "field_text": "bool",
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "StatsAndCosts",
-        "field_name": "statsAndCosts",
-        "field_text": "StatsAndCosts",
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<String>",
-        "field_name": "jsonRepresentation",
-        "field_text": "String",
-        "optional": true,
-        "_N": 10,
         "field_local": true
       }
     ]
   },
   {
-    "class_name": "RemoteSplit",
-    "struct": true,
-    "fields": [
+    "class_name": "JoinNodeType",
+    "enum": true,
+    "elements": [
       {
-        "field_type": "Location",
-        "field_name": "location",
-        "field_text": "Location",
-        "_N": 1,
-        "field_local": true
+        "element": "INNER",
+        "_N": 1
       },
       {
-        "field_type": "TaskId",
-        "field_name": "remoteSourceTaskId",
-        "field_text": "TaskId",
-        "_N": 2,
-        "field_local": true
+        "element": "LEFT",
+        "_N": 2
+      },
+      {
+        "element": "RIGHT",
+        "_N": 3
+      },
+      {
+        "element": "FULL",
+        "_N": 4,
+        "_last": true
       }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorSplit",
-    "json_key": "$remote"
+    ]
   },
   {
-    "class_name": "HivePartitioningHandle",
+    "class_name": "JoinNode",
     "struct": true,
     "fields": [
       {
-        "field_type": "int",
-        "field_name": "bucketCount",
-        "field_text": "int",
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
         "_N": 1,
-        "field_local": true
+        "field_local": false
       },
       {
-        "field_type": "OptionalInt",
-        "field_name": "maxCompatibleBucketCount",
-        "field_text": "int",
-        "optional": true,
+        "field_type": "JoinNodeType",
+        "field_name": "type",
+        "field_text": "JoinNodeType",
         "_N": 2,
         "field_local": true
       },
       {
-        "field_type": "BucketFunctionType",
-        "field_name": "bucketFunctionType",
-        "field_text": "BucketFunctionType",
+        "field_type": "PlanNode",
+        "field_name": "left",
+        "field_text": "PlanNode",
         "_N": 3,
-        "field_local": true
+        "field_local": true,
+        "optional": true
       },
       {
-        "field_type": "Optional<List<HiveType>>",
-        "field_name": "hiveTypes",
-        "field_text": "List<HiveType>",
-        "optional": true,
+        "field_type": "PlanNode",
+        "field_name": "right",
+        "field_text": "PlanNode",
         "_N": 4,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<EquiJoinClause>",
+        "field_name": "criteria",
+        "field_text": "List<EquiJoinClause>",
+        "_N": 5,
         "field_local": true
       },
       {
-        "field_type": "Optional<List<Type>>",
-        "field_name": "types",
-        "field_text": "List<Type>",
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<RowExpression>",
+        "field_name": "filter",
+        "field_text": "std::shared_ptr<RowExpression>",
         "optional": true,
-        "_N": 5,
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "leftHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "rightHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<DistributionType>",
+        "field_name": "distributionType",
+        "field_text": "DistributionType",
+        "optional": true,
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, VariableReferenceExpression>",
+        "field_name": "dynamicFilters",
+        "field_text": "Map<String, VariableReferenceExpression>",
+        "_N": 11,
         "field_local": true
       }
     ],
     "subclass": true,
-    "super_class": "ConnectorPartitioningHandle",
-    "json_key": "hive"
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.JoinNode"
   },
   {
     "class_name": "SystemPartitioning",
@@ -6640,7 +6133,291 @@
     "json_key": "$remote"
   },
   {
-    "class_name": "LimitNodeStep",
+    "class_name": "Bound",
+    "enum": true,
+    "elements": [
+      {
+        "element": "BELOW",
+        "_N": 1
+      },
+      {
+        "element": "EXACTLY",
+        "_N": 2
+      },
+      {
+        "element": "ABOVE",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "Marker",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Block>",
+        "field_name": "valueBlock",
+        "field_text": "Block",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Bound",
+        "field_name": "bound",
+        "field_text": "Bound",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "Range",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Marker",
+        "field_name": "low",
+        "field_text": "Marker",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Marker",
+        "field_name": "high",
+        "field_text": "Marker",
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "SortedRangeSet",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "List<Range>",
+        "field_name": "ranges",
+        "field_text": "List<Range>",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ValueSet",
+    "json_key": "sortable"
+  },
+  {
+    "class_name": "TableScanNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "TableHandle",
+        "field_name": "table",
+        "field_text": "TableHandle",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, ColumnHandle>",
+        "field_name": "assignments",
+        "field_text": "Map<VariableReferenceExpression, std::shared_ptr<ColumnHandle>>",
+        "_N": 4,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": ".TableScanNode"
+  },
+  {
+    "class_name": "StageExecutionStrategy",
+    "enum": true,
+    "elements": [
+      {
+        "element": "UNGROUPED_EXECUTION",
+        "_N": 1
+      },
+      {
+        "element": "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION",
+        "_N": 2
+      },
+      {
+        "element": "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION",
+        "_N": 3
+      },
+      {
+        "element": "RECOVERABLE_GROUPED_EXECUTION",
+        "_N": 4,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "StageExecutionDescriptor",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "StageExecutionStrategy",
+        "field_name": "stageExecutionStrategy",
+        "field_text": "StageExecutionStrategy",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<PlanNodeId>",
+        "field_name": "groupedExecutionScanNodes",
+        "field_text": "List<PlanNodeId>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "totalLifespans",
+        "field_text": "int",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "PlanFragment",
+    "cinc": "namespace facebook::presto::protocol {\n\nvoid to_json(json& j, const PlanFragment& p) {\n  j = json::object();\n  to_json_key(j, \"id\", p.id, \"PlanFragment\", \"PlanFragmentId\", \"id\");\n  to_json_key(j, \"root\", p.root, \"PlanFragment\", \"PlanNode\", \"root\");\n  to_json_key(\n      j,\n      \"variables\",\n      p.variables,\n      \"PlanFragment\",\n      \"List<VariableReferenceExpression>\",\n      \"variables\");\n  to_json_key(\n      j,\n      \"partitioning\",\n      p.partitioning,\n      \"PlanFragment\",\n      \"PartitioningHandle\",\n      \"partitioning\");\n  to_json_key(\n      j,\n      \"tableScanSchedulingOrder\",\n      p.tableScanSchedulingOrder,\n      \"PlanFragment\",\n      \"List<PlanNodeId>\",\n      \"tableScanSchedulingOrder\");\n  to_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"PlanFragment\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  to_json_key(\n      j,\n      \"stageExecutionDescriptor\",\n      p.stageExecutionDescriptor,\n      \"PlanFragment\",\n      \"StageExecutionDescriptor\",\n      \"stageExecutionDescriptor\");\n  to_json_key(\n      j,\n      \"outputTableWriterFragment\",\n      p.outputTableWriterFragment,\n      \"PlanFragment\",\n      \"bool\",\n      \"outputTableWriterFragment\");\n  to_json_key(\n      j,\n      \"jsonRepresentation\",\n      p.jsonRepresentation,\n      \"PlanFragment\",\n      \"String\",\n      \"jsonRepresentation\");\n}\n\nvoid from_json(const json& j, PlanFragment& p) {\n  from_json_key(j, \"id\", p.id, \"PlanFragment\", \"PlanFragmentId\", \"id\");\n  from_json_key(j, \"root\", p.root, \"PlanFragment\", \"PlanNode\", \"root\");\n  from_json_key(\n      j,\n      \"variables\",\n      p.variables,\n      \"PlanFragment\",\n      \"List<VariableReferenceExpression>\",\n      \"variables\");\n  from_json_key(\n      j,\n      \"partitioning\",\n      p.partitioning,\n      \"PlanFragment\",\n      \"PartitioningHandle\",\n      \"partitioning\");\n  from_json_key(\n      j,\n      \"tableScanSchedulingOrder\",\n      p.tableScanSchedulingOrder,\n      \"PlanFragment\",\n      \"List<PlanNodeId>\",\n      \"tableScanSchedulingOrder\");\n  from_json_key(\n      j,\n      \"partitioningScheme\",\n      p.partitioningScheme,\n      \"PlanFragment\",\n      \"PartitioningScheme\",\n      \"partitioningScheme\");\n  from_json_key(\n      j,\n      \"stageExecutionDescriptor\",\n      p.stageExecutionDescriptor,\n      \"PlanFragment\",\n      \"StageExecutionDescriptor\",\n      \"stageExecutionDescriptor\");\n  from_json_key(\n      j,\n      \"outputTableWriterFragment\",\n      p.outputTableWriterFragment,\n      \"PlanFragment\",\n      \"bool\",\n      \"outputTableWriterFragment\");\n  from_json_key(\n      j,\n      \"jsonRepresentation\",\n      p.jsonRepresentation,\n      \"PlanFragment\",\n      \"String\",\n      \"jsonRepresentation\");\n}\n} // namespace facebook::presto::protocol",
+    "hinc": "namespace facebook::presto::protocol {\nstruct PlanFragment {\n  PlanFragmentId id = {};\n  std::shared_ptr<PlanNode> root = {};\n  List<VariableReferenceExpression> variables = {};\n  PartitioningHandle partitioning = {};\n  List<PlanNodeId> tableScanSchedulingOrder = {};\n  PartitioningScheme partitioningScheme = {};\n  StageExecutionDescriptor stageExecutionDescriptor = {};\n  bool outputTableWriterFragment = {};\n  std::shared_ptr<String> jsonRepresentation = {};\n};\nvoid to_json(json& j, const PlanFragment& p);\nvoid from_json(const json& j, PlanFragment& p);\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanFragmentId",
+        "field_name": "id",
+        "field_text": "PlanFragmentId",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "root",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Set<VariableReferenceExpression>",
+        "field_name": "variables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "PartitioningHandle",
+        "field_name": "partitioning",
+        "field_text": "PartitioningHandle",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "List<PlanNodeId>",
+        "field_name": "tableScanSchedulingOrder",
+        "field_text": "List<PlanNodeId>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "PartitioningScheme",
+        "field_name": "partitioningScheme",
+        "field_text": "PartitioningScheme",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "StageExecutionDescriptor",
+        "field_name": "stageExecutionDescriptor",
+        "field_text": "StageExecutionDescriptor",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "outputTableWriterFragment",
+        "field_text": "bool",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "StatsAndCosts",
+        "field_name": "statsAndCosts",
+        "field_text": "StatsAndCosts",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<String>",
+        "field_name": "jsonRepresentation",
+        "field_text": "String",
+        "optional": true,
+        "_N": 10,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "GroupingSetDescriptor",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "groupingKeys",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "groupingSetCount",
+        "field_text": "int",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<Integer>",
+        "field_name": "globalGroupingSets",
+        "field_text": "List<Integer>",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "AggregationNodeStep",
     "enum": true,
     "elements": [
       {
@@ -6649,13 +6426,367 @@
       },
       {
         "element": "FINAL",
-        "_N": 2,
+        "_N": 2
+      },
+      {
+        "element": "INTERMEDIATE",
+        "_N": 3
+      },
+      {
+        "element": "SINGLE",
+        "_N": 4,
         "_last": true
       }
     ]
   },
   {
-    "class_name": "LimitNode",
+    "class_name": "AggregationNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, Aggregation>",
+        "field_name": "aggregations",
+        "field_text": "Map<VariableReferenceExpression, Aggregation>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "GroupingSetDescriptor",
+        "field_name": "groupingSets",
+        "field_text": "GroupingSetDescriptor",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "preGroupedVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "AggregationNodeStep",
+        "field_name": "step",
+        "field_text": "AggregationNodeStep",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "hashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "groupIdVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": ".AggregationNode"
+  },
+  {
+    "class_name": "JsonEncodedSubclass",
+    "cinc": "// dependency KeyedSubclass\n\nnamespace facebook::presto::protocol {\n\nstd::string JsonEncodedSubclass::getSubclassKey(nlohmann::json j) {\n  return j[\"@type\"];\n}\n\n} // namespace facebook::presto::protocol"
+  },
+  {
+    "class_name": "RowNumberNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "partitionBy",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "rowNumberVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<Integer>",
+        "field_name": "maxRowCountPerPartition",
+        "field_text": "Integer",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "hashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 6,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.RowNumberNode"
+  },
+  {
+    "class_name": "UnnestNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "replicateVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
+        "field_name": "unnestVariables",
+        "field_text": "Map<VariableReferenceExpression, List<VariableReferenceExpression>>",
+        "_N": 4,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "ordinalityVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 5,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.UnnestNode"
+  },
+  {
+    "class_name": "InsertHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "InsertTableHandle",
+        "field_name": "handle",
+        "field_text": "InsertTableHandle",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "SchemaTableName",
+        "field_name": "schemaTableName",
+        "field_text": "SchemaTableName",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ExecutionWriterTarget",
+    "json_key": "InsertHandle"
+  },
+  {
+    "class_name": "AllOrNoneValueSet",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "all",
+        "field_text": "bool",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ValueSet",
+    "json_key": "allOrNone"
+  },
+  {
+    "class_name": "MergeJoinNode",
+    "hinc": "namespace facebook::presto::protocol {\nstruct MergeJoinNode : public PlanNode {\n  MergeJoinNode() noexcept;\n  PlanNodeId id = {};\n  // JoinNodeType is referenced as JoinNode.Type in Presto\n  // Since presto_cpp codegen can't nicely handle inner class references\n  // So a special hard-coded template is required here\n  JoinNodeType type = {};\n  std::shared_ptr<PlanNode> left = {};\n  std::shared_ptr<PlanNode> right = {};\n  // EquiJoinClause is referenced as JoinNode.EquiJoinClause in Presto\n  List<EquiJoinClause> criteria = {};\n  List<VariableReferenceExpression> outputVariables = {};\n  std::shared_ptr<std::shared_ptr<RowExpression>> filter = {};\n  std::shared_ptr<VariableReferenceExpression> leftHashVariable = {};\n  std::shared_ptr<VariableReferenceExpression> rightHashVariable = {};\n};\nvoid to_json(json& j, const MergeJoinNode& p);\nvoid from_json(const json& j, MergeJoinNode& p);\n} // namespace facebook::presto::protocol",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "JoinNode.Type",
+        "field_name": "type",
+        "field_text": "JoinNode.Type",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "left",
+        "field_text": "PlanNode",
+        "_N": 3,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "right",
+        "field_text": "PlanNode",
+        "_N": 4,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "List<JoinNode.EquiJoinClause>",
+        "field_name": "criteria",
+        "field_text": "List<JoinNode.EquiJoinClause>",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "List<VariableReferenceExpression>",
+        "field_name": "outputVariables",
+        "field_text": "List<VariableReferenceExpression>",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<RowExpression>",
+        "field_name": "filter",
+        "field_text": "std::shared_ptr<RowExpression>",
+        "optional": true,
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "leftHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "rightHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 9,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.MergeJoinNode"
+  },
+  {
+    "class_name": "HiveTableHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "schemaName",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "tableName",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<List<List<String>>>",
+        "field_name": "analyzePartitionValues",
+        "field_text": "List<List<String>>",
+        "optional": true,
+        "_N": 3,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorTableHandle",
+    "json_key": "hive"
+  },
+  {
+    "class_name": "Step",
+    "enum": true,
+    "elements": [
+      {
+        "element": "SINGLE",
+        "_N": 1
+      },
+      {
+        "element": "PARTIAL",
+        "_N": 2
+      },
+      {
+        "element": "FINAL",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "TopNNode",
     "struct": true,
     "fields": [
       {
@@ -6681,248 +6812,101 @@
         "field_local": true
       },
       {
-        "field_type": "LimitNodeStep",
-        "field_name": "step",
-        "field_text": "LimitNodeStep",
-        "_N": 4,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": ".LimitNode"
-  },
-  {
-    "class_name": "GroupIdNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "List<List<VariableReferenceExpression>>",
-        "field_name": "groupingSets",
-        "field_text": "List<List<VariableReferenceExpression>>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<VariableReferenceExpression, VariableReferenceExpression>",
-        "field_name": "groupingColumns",
-        "field_text": "Map<VariableReferenceExpression, VariableReferenceExpression>",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "aggregationArguments",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "groupIdVariable",
-        "field_text": "VariableReferenceExpression",
-        "_N": 6,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.GroupIdNode"
-  },
-  {
-    "class_name": "RemoteSourceNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "List<PlanFragmentId>",
-        "field_name": "sourceFragmentIds",
-        "field_text": "List<PlanFragmentId>",
-        "_N": 2,
-        "field_local": true
-      },
-      {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "outputVariables",
-        "field_text": "List<VariableReferenceExpression>",
-        "_N": 3,
-        "field_local": true
-      },
-      {
-        "field_type": "boolean",
-        "field_name": "ensureSourceOrdering",
-        "field_text": "bool",
-        "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<OrderingScheme>",
+        "field_type": "OrderingScheme",
         "field_name": "orderingScheme",
         "field_text": "OrderingScheme",
-        "optional": true,
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "ExchangeNode.Type",
-        "field_name": "exchangeType",
-        "field_text": "ExchangeNodeType",
-        "_N": 6,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.RemoteSourceNode"
-  },
-  {
-    "class_name": "RefreshMaterializedViewHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "InsertTableHandle",
-        "field_name": "handle",
-        "field_text": "InsertTableHandle",
-        "_N": 1,
-        "field_local": true
-      },
-      {
-        "field_type": "SchemaTableName",
-        "field_name": "schemaTableName",
-        "field_text": "SchemaTableName",
-        "_N": 2,
-        "field_local": true
-      }
-    ]
-  },
-  {
-    "class_name": "EnforceSingleRowNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode"
-  },
-  {
-    "class_name": "SemiJoinNode",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "PlanNodeId",
-        "field_name": "id",
-        "field_text": "PlanNodeId",
-        "_N": 1,
-        "field_local": false
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "source",
-        "field_text": "PlanNode",
-        "_N": 2,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "PlanNode",
-        "field_name": "filteringSource",
-        "field_text": "PlanNode",
-        "_N": 3,
-        "field_local": true,
-        "optional": true
-      },
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "sourceJoinVariable",
-        "field_text": "VariableReferenceExpression",
         "_N": 4,
         "field_local": true
       },
       {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "filteringSourceJoinVariable",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "Step",
+        "field_name": "step",
+        "field_text": "Step",
         "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "semiJoinOutput",
-        "field_text": "VariableReferenceExpression",
-        "_N": 6,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "sourceHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 7,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "filteringSourceHashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 8,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<DistributionType>",
-        "field_name": "distributionType",
-        "field_text": "DistributionType",
-        "optional": true,
-        "_N": 9,
-        "field_local": true
-      },
-      {
-        "field_type": "Map<String, VariableReferenceExpression>",
-        "field_name": "dynamicFilters",
-        "field_text": "Map<String, VariableReferenceExpression>",
-        "_N": 10,
         "field_local": true
       }
     ],
     "subclass": true,
     "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.SemiJoinNode"
+    "json_key": ".TopNNode"
+  },
+  {
+    "class_name": "HiveTransactionHandle",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "UUID",
+        "field_name": "uuid",
+        "field_text": "UUID",
+        "_N": 1,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorTransactionHandle",
+    "json_key": "hive"
+  },
+  {
+    "class_name": "LambdaDefinitionExpression",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Optional<SourceLocation>",
+        "field_name": "sourceLocation",
+        "field_text": "SourceLocation",
+        "optional": true,
+        "_N": 1,
+        "field_local": false
+      },
+      {
+        "field_type": "List<Type>",
+        "field_name": "argumentTypes",
+        "field_text": "List<Type>",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "List<String>",
+        "field_name": "arguments",
+        "field_text": "List<String>",
+        "_N": 3,
+        "field_local": true
+      },
+      {
+        "field_type": "RowExpression",
+        "field_name": "body",
+        "field_text": "RowExpression",
+        "_N": 4,
+        "field_local": true,
+        "optional": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "RowExpression",
+    "json_key": "lambda"
+  },
+  {
+    "class_name": "RemoteSplit",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Location",
+        "field_name": "location",
+        "field_text": "Location",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "TaskId",
+        "field_name": "remoteSourceTaskId",
+        "field_text": "TaskId",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "ConnectorSplit",
+    "json_key": "$remote"
   },
   {
     "class_name": "HiveOutputTableHandle",
@@ -7041,30 +7025,51 @@
     "json_key": "hive"
   },
   {
-    "class_name": "InsertHandle",
+    "class_name": "CacheQuotaScope",
+    "enum": true,
+    "elements": [
+      {
+        "element": "GLOBAL",
+        "_N": 1
+      },
+      {
+        "element": "SCHEMA",
+        "_N": 2
+      },
+      {
+        "element": "TABLE",
+        "_N": 3
+      },
+      {
+        "element": "PARTITION",
+        "_N": 4,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "CacheQuotaRequirement",
     "struct": true,
     "fields": [
       {
-        "field_type": "InsertTableHandle",
-        "field_name": "handle",
-        "field_text": "InsertTableHandle",
+        "field_type": "CacheQuotaScope",
+        "field_name": "cacheQuotaScope",
+        "field_text": "CacheQuotaScope",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "SchemaTableName",
-        "field_name": "schemaTableName",
-        "field_text": "SchemaTableName",
+        "field_type": "Optional<DataSize>",
+        "field_name": "quota",
+        "field_text": "DataSize",
+        "optional": true,
         "_N": 2,
         "field_local": true
       }
-    ],
-    "subclass": true,
-    "super_class": "ExecutionWriterTarget",
-    "json_key": "InsertHandle"
+    ]
   },
   {
-    "class_name": "RowNumberNode",
+    "class_name": "SortNode",
     "struct": true,
     "fields": [
       {
@@ -7083,101 +7088,295 @@
         "optional": true
       },
       {
-        "field_type": "List<VariableReferenceExpression>",
-        "field_name": "partitionBy",
-        "field_text": "List<VariableReferenceExpression>",
+        "field_type": "OrderingScheme",
+        "field_name": "orderingScheme",
+        "field_text": "OrderingScheme",
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "VariableReferenceExpression",
-        "field_name": "rowNumberVariable",
-        "field_text": "VariableReferenceExpression",
+        "field_type": "boolean",
+        "field_name": "isPartial",
+        "field_text": "bool",
         "_N": 4,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<Integer>",
-        "field_name": "maxRowCountPerPartition",
-        "field_text": "Integer",
-        "optional": true,
-        "_N": 5,
-        "field_local": true
-      },
-      {
-        "field_type": "Optional<VariableReferenceExpression>",
-        "field_name": "hashVariable",
-        "field_text": "VariableReferenceExpression",
-        "optional": true,
-        "_N": 6,
         "field_local": true
       }
     ],
     "subclass": true,
     "super_class": "PlanNode",
-    "json_key": "com.facebook.presto.sql.planner.plan.RowNumberNode"
+    "json_key": "com.facebook.presto.sql.planner.plan.SortNode"
   },
   {
-    "class_name": "HiveMetadataUpdateHandle",
+    "class_name": "HivePartitionKey",
     "struct": true,
     "fields": [
       {
-        "field_type": "UUID",
-        "field_name": "requestId",
-        "field_text": "UUID",
+        "field_type": "String",
+        "field_name": "name",
+        "field_text": "String",
         "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "SchemaTableName",
-        "field_name": "schemaTableName",
-        "field_text": "SchemaTableName",
+        "field_type": "Optional<String>",
+        "field_name": "value",
+        "field_text": "String",
+        "optional": true,
+        "_N": 2,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "ConstantExpression",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "Block",
+        "field_name": "valueBlock",
+        "field_text": "Block",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "Type",
+        "field_name": "type",
+        "field_text": "Type",
+        "_N": 2,
+        "field_local": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "RowExpression",
+    "json_key": "constant"
+  },
+  {
+    "class_name": "BucketConversion",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "int",
+        "field_name": "tableBucketCount",
+        "field_text": "int",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "partitionBucketCount",
+        "field_text": "int",
         "_N": 2,
         "field_local": true
       },
       {
-        "field_type": "Optional<String>",
+        "field_type": "List<HiveColumnHandle>",
+        "field_name": "bucketColumnHandles",
+        "field_text": "List<HiveColumnHandle>",
+        "_N": 3,
+        "field_local": true
+      }
+    ]
+  },
+  {
+    "class_name": "NodeSelectionStrategy",
+    "enum": true,
+    "elements": [
+      {
+        "element": "HARD_AFFINITY",
+        "_N": 1
+      },
+      {
+        "element": "SOFT_AFFINITY",
+        "_N": 2
+      },
+      {
+        "element": "NO_PREFERENCE",
+        "_N": 3,
+        "_last": true
+      }
+    ]
+  },
+  {
+    "class_name": "HiveSplit",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "String",
+        "field_name": "database",
+        "field_text": "String",
+        "_N": 1,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
+        "field_name": "table",
+        "field_text": "String",
+        "_N": 2,
+        "field_local": true
+      },
+      {
+        "field_type": "String",
         "field_name": "partitionName",
         "field_text": "String",
-        "optional": true,
         "_N": 3,
         "field_local": true
       },
       {
-        "field_type": "Optional<String>",
-        "field_name": "fileName",
+        "field_type": "String",
+        "field_name": "path",
         "field_text": "String",
-        "optional": true,
         "_N": 4,
-        "field_local": true
-      }
-    ],
-    "subclass": true,
-    "super_class": "ConnectorMetadataUpdateHandle",
-    "json_key": "hive"
-  },
-  {
-    "class_name": "DeleteHandle",
-    "struct": true,
-    "fields": [
-      {
-        "field_type": "TableHandle",
-        "field_name": "handle",
-        "field_text": "TableHandle",
-        "_N": 1,
         "field_local": true
       },
       {
-        "field_type": "SchemaTableName",
-        "field_name": "schemaTableName",
-        "field_text": "SchemaTableName",
-        "_N": 2,
+        "field_type": "long",
+        "field_name": "start",
+        "field_text": "int64_t",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "length",
+        "field_text": "int64_t",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "fileSize",
+        "field_text": "int64_t",
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "long",
+        "field_name": "fileModifiedTime",
+        "field_text": "int64_t",
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Storage",
+        "field_name": "storage",
+        "field_text": "Storage",
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "List<HivePartitionKey>",
+        "field_name": "partitionKeys",
+        "field_text": "List<HivePartitionKey>",
+        "_N": 10,
+        "field_local": true
+      },
+      {
+        "field_type": "List<HostAddress>",
+        "field_name": "addresses",
+        "field_text": "List<HostAddress>",
+        "_N": 11,
+        "field_local": true
+      },
+      {
+        "field_type": "OptionalInt",
+        "field_name": "readBucketNumber",
+        "field_text": "int",
+        "optional": true,
+        "_N": 12,
+        "field_local": true
+      },
+      {
+        "field_type": "OptionalInt",
+        "field_name": "tableBucketNumber",
+        "field_text": "int",
+        "optional": true,
+        "_N": 13,
+        "field_local": true
+      },
+      {
+        "field_type": "NodeSelectionStrategy",
+        "field_name": "nodeSelectionStrategy",
+        "field_text": "NodeSelectionStrategy",
+        "_N": 14,
+        "field_local": true
+      },
+      {
+        "field_type": "int",
+        "field_name": "partitionDataColumnCount",
+        "field_text": "int",
+        "_N": 15,
+        "field_local": true
+      },
+      {
+        "field_type": "TableToPartitionMapping",
+        "field_name": "tableToPartitionMapping",
+        "field_text": "TableToPartitionMapping",
+        "_N": 16,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<BucketConversion>",
+        "field_name": "bucketConversion",
+        "field_text": "BucketConversion",
+        "optional": true,
+        "_N": 17,
+        "field_local": true
+      },
+      {
+        "field_type": "boolean",
+        "field_name": "s3SelectPushdownEnabled",
+        "field_text": "bool",
+        "_N": 18,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<byte[]>",
+        "field_name": "extraFileInfo",
+        "field_text": "String",
+        "optional": true,
+        "_N": 19,
+        "field_local": true
+      },
+      {
+        "field_type": "CacheQuotaRequirement",
+        "field_name": "cacheQuota",
+        "field_text": "CacheQuotaRequirement",
+        "_N": 20,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<EncryptionInformation>",
+        "field_name": "encryptionMetadata",
+        "field_text": "EncryptionInformation",
+        "optional": true,
+        "_N": 21,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, String>",
+        "field_name": "customSplitInfo",
+        "field_text": "Map<String, String>",
+        "_N": 22,
+        "field_local": true
+      },
+      {
+        "field_type": "Set<ColumnHandle>",
+        "field_name": "redundantColumnDomains",
+        "field_text": "List<std::shared_ptr<ColumnHandle>>",
+        "_N": 23,
+        "field_local": true
+      },
+      {
+        "field_type": "SplitWeight",
+        "field_name": "splitWeight",
+        "field_text": "SplitWeight",
+        "_N": 24,
         "field_local": true
       }
     ],
     "subclass": true,
-    "super_class": "ExecutionWriterTarget",
-    "json_key": "DeleteHandle"
+    "super_class": "ConnectorSplit",
+    "json_key": "hive"
   },
   {
     "class_name": "OutputNode",
@@ -7218,97 +7417,112 @@
     "json_key": "com.facebook.presto.sql.planner.plan.OutputNode"
   },
   {
-    "class_name": "Form",
-    "enum": true,
-    "elements": [
-      {
-        "element": "IF",
-        "_N": 1
-      },
-      {
-        "element": "NULL_IF",
-        "_N": 2
-      },
-      {
-        "element": "SWITCH",
-        "_N": 3
-      },
-      {
-        "element": "WHEN",
-        "_N": 4
-      },
-      {
-        "element": "IS_NULL",
-        "_N": 5
-      },
-      {
-        "element": "COALESCE",
-        "_N": 6
-      },
-      {
-        "element": "IN",
-        "_N": 7
-      },
-      {
-        "element": "AND",
-        "_N": 8
-      },
-      {
-        "element": "OR",
-        "_N": 9
-      },
-      {
-        "element": "DEREFERENCE",
-        "_N": 10
-      },
-      {
-        "element": "ROW_CONSTRUCTOR",
-        "_N": 11
-      },
-      {
-        "element": "BIND",
-        "_N": 12,
-        "_last": true
-      }
-    ]
-  },
-  {
-    "class_name": "SpecialFormExpression",
+    "class_name": "EnforceSingleRowNode",
     "struct": true,
     "fields": [
       {
-        "field_type": "Optional<SourceLocation>",
-        "field_name": "sourceLocation",
-        "field_text": "SourceLocation",
-        "optional": true,
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
         "_N": 1,
         "field_local": false
       },
       {
-        "field_type": "Form",
-        "field_name": "form",
-        "field_text": "Form",
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
         "_N": 2,
-        "field_local": true
+        "field_local": true,
+        "optional": true
+      }
+    ],
+    "subclass": true,
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.EnforceSingleRowNode"
+  },
+  {
+    "class_name": "SemiJoinNode",
+    "struct": true,
+    "fields": [
+      {
+        "field_type": "PlanNodeId",
+        "field_name": "id",
+        "field_text": "PlanNodeId",
+        "_N": 1,
+        "field_local": false
       },
       {
-        "field_type": "Type",
-        "field_name": "returnType",
-        "field_text": "Type",
+        "field_type": "PlanNode",
+        "field_name": "source",
+        "field_text": "PlanNode",
+        "_N": 2,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "PlanNode",
+        "field_name": "filteringSource",
+        "field_text": "PlanNode",
         "_N": 3,
+        "field_local": true,
+        "optional": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "sourceJoinVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 4,
         "field_local": true
       },
       {
-        "field_type": "List<RowExpression>",
-        "field_name": "arguments",
-        "field_text": "List<std::shared_ptr<RowExpression>>",
-        "_N": 4,
+        "field_type": "VariableReferenceExpression",
+        "field_name": "filteringSourceJoinVariable",
+        "field_text": "VariableReferenceExpression",
+        "_N": 5,
+        "field_local": true
+      },
+      {
+        "field_type": "VariableReferenceExpression",
+        "field_name": "semiJoinOutput",
+        "field_text": "VariableReferenceExpression",
+        "_N": 6,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "sourceHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 7,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<VariableReferenceExpression>",
+        "field_name": "filteringSourceHashVariable",
+        "field_text": "VariableReferenceExpression",
+        "optional": true,
+        "_N": 8,
+        "field_local": true
+      },
+      {
+        "field_type": "Optional<DistributionType>",
+        "field_name": "distributionType",
+        "field_text": "DistributionType",
+        "optional": true,
+        "_N": 9,
+        "field_local": true
+      },
+      {
+        "field_type": "Map<String, VariableReferenceExpression>",
+        "field_name": "dynamicFilters",
+        "field_text": "Map<String, VariableReferenceExpression>",
+        "_N": 10,
         "field_local": true
       }
     ],
     "subclass": true,
-    "super_class": "RowExpression",
-    "json_key": "special"
+    "super_class": "PlanNode",
+    "json_key": "com.facebook.presto.sql.planner.plan.SemiJoinNode"
   },
   {
     "class_name": "NodeState",

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -126,6 +126,7 @@ AbstractClasses:
         - { name: ValuesNode,               key: .ValuesNode }
         - { name: AssignUniqueId,           key: com.facebook.presto.sql.planner.plan.AssignUniqueId }
         - { name: MergeJoinNode,            key: com.facebook.presto.sql.planner.plan.MergeJoinNode }
+        - { name: WindowNode,               key: com.facebook.presto.sql.planner.plan.WindowNode }
 
     RowExpression:
       super: JsonEncodedSubclass
@@ -190,6 +191,7 @@ JavaClasses:
   - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
   - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
   - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/UnnestNode.java
+  - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/ErrorType.java
   - presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
   - presto-main/src/main/java/com/facebook/presto/execution/Location.java

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveAggregationQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveAggregationQueries.java
@@ -50,7 +50,9 @@ public class TestHiveAggregationQueries
         // non-deterministic query
         assertQuerySucceeds("SELECT orderkey, arbitrary(comment) FROM lineitem GROUP BY 1");
 
-        assertQuery("SELECT orderkey, array_agg(linenumber) FROM lineitem GROUP BY 1");
+        // TODO results from array_agg() are not deterministic so we just compare cardinality for the time being
+        // We can switch to array_sort() once it becomes available from velox
+        assertQuery("SELECT orderkey, cardinality(array_agg(linenumber)) FROM lineitem GROUP BY 1");
         assertQuery("SELECT orderkey, map_agg(linenumber, discount) FROM lineitem GROUP BY 1");
         assertQuery("SELECT orderkey, count_if(linenumber % 2 > 0) FROM lineitem GROUP BY 1");
         assertQuery("SELECT orderkey, bool_and(linenumber % 2 = 1) FROM lineitem GROUP BY 1");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveWindowQueries.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import org.testng.annotations.Test;
+
+public class TestHiveWindowQueries
+        extends AbstractTestHiveQueries
+{
+    public TestHiveWindowQueries()
+    {
+        super(true);
+    }
+
+    @Test
+    public void testWindow()
+    {
+        assertQueryFails("SELECT clerk, orderdate, orderkey, totalprice, rank() OVER (PARTITION BY clerk ORDER BY totalprice) AS rnk FROM orders ORDER BY clerk, rnk", ".*Unknown plan node type com.facebook.presto.sql.planner.plan.WindowNode.*");
+    }
+}


### PR DESCRIPTION
Add github action tests for native workers (presto_cpp)
Here is a summary of the changes:
- Pull latest changes from presto_cpp and velox
- Add a new github action job in .github/workflows/test-native.yml that runs unit tests and e2e tests for native workers. Since cache has been enabled for the workflow, the entire test will finish in about 20 mins when the cache is warm.
- Add presto-native-execution module to the root pom.xml. This way we can run the e2e from the presto project root as presto_cpp (presto-native-execution) is now part of presto. And its version should get updated along with other presto components as the release is being rolled out, so we are free from maintaining the version as we did in presto_cpp repository.
- After the PR is merged, we can get signals to see if the native worker is broken by a PR (either the change is on Java or C++ side)

Currently, presto-native-execution contains both C++ worker and Java e2e test code. It's more convenient for us to synchronize the code and tests in one pass to fbcode. We may consider extracting the java test code to its standalone component later.

Test plan - (Please fill in how you tested your changes)
Check if the newly added job `test native / build-and-test` runs fine from the "Checks" tab of this PR.

== NO RELEASE NOTE ==
