### PR TITLE
Remove source location from CanonicalPlanGenerator

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/CanonicalRowExpressionRewriter.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/CanonicalRowExpressionRewriter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class CanonicalRowExpressionRewriter
+        extends RowExpressionRewriter<Void>
+{
+    private static final CanonicalRowExpressionRewriter SINGLETON = new CanonicalRowExpressionRewriter();
+
+    private CanonicalRowExpressionRewriter() {}
+
+    public static RowExpression canonicalizeRowExpression(RowExpression expression)
+    {
+        return RowExpressionTreeRewriter.rewriteWith(SINGLETON, expression, null);
+    }
+
+    @Override
+    public RowExpression rewriteInputReference(InputReferenceExpression input, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return input.canonicalize();
+    }
+
+    @Override
+    public RowExpression rewriteCall(CallExpression call, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        List<RowExpression> arguments = rewrite(call.getArguments(), context, treeRewriter);
+
+        if (!sameElements(call.getArguments(), arguments)) {
+            return new CallExpression(Optional.empty(), call.getDisplayName(), call.getFunctionHandle(), call.getType(), arguments);
+        }
+        return call.canonicalize();
+    }
+
+    @Override
+    public RowExpression rewriteConstant(ConstantExpression literal, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return literal.canonicalize();
+    }
+
+    @Override
+    public RowExpression rewriteLambda(LambdaDefinitionExpression lambda, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        RowExpression body = treeRewriter.rewrite(lambda.getBody(), context);
+        if (body != lambda.getBody()) {
+            return new LambdaDefinitionExpression(Optional.empty(), lambda.getArgumentTypes(), lambda.getArguments(), body);
+        }
+
+        return lambda.canonicalize();
+    }
+
+    @Override
+    public RowExpression rewriteVariableReference(VariableReferenceExpression variable, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return variable.canonicalize();
+    }
+
+    @Override
+    public RowExpression rewriteSpecialForm(SpecialFormExpression specialForm, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        List<RowExpression> arguments = rewrite(specialForm.getArguments(), context, treeRewriter);
+
+        if (!sameElements(specialForm.getArguments(), arguments)) {
+            return new SpecialFormExpression(Optional.empty(), specialForm.getForm(), specialForm.getType(), arguments);
+        }
+        return specialForm.canonicalize();
+    }
+
+    private List<RowExpression> rewrite(List<RowExpression> items, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        List<RowExpression> rewrittenExpressions = new ArrayList<>();
+        for (RowExpression expression : items) {
+            rewrittenExpressions.add(treeRewriter.rewrite(expression, context));
+        }
+        return Collections.unmodifiableList(rewrittenExpressions);
+    }
+
+    @SuppressWarnings("ObjectEquality")
+    private static <T> boolean sameElements(Collection<? extends T> a, Collection<? extends T> b)
+    {
+        if (a.size() != b.size()) {
+            return false;
+        }
+
+        Iterator<? extends T> first = a.iterator();
+        Iterator<? extends T> second = b.iterator();
+
+        while (first.hasNext() && second.hasNext()) {
+            if (first.next() != second.next()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.expressions.CanonicalRowExpressionRewriter.canonicalizeRowExpression;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
@@ -276,7 +277,7 @@ public final class HiveTableLayoutHandle
         return ImmutableMap.builder()
                 .put("schemaTableName", schemaTableName)
                 .put("domainPredicate", domainPredicate)
-                .put("remainingPredicate", remainingPredicate)
+                .put("remainingPredicate", canonicalizeRowExpression(remainingPredicate))
                 .put("bucketFilter", bucketFilter)
                 .build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
@@ -183,7 +183,7 @@ public class TestHiveCanonicalPlanGenerator
                 .map(Optional::get)
                 .collect(Collectors.toList());
         assertEquals(leafCanonicalPlans.size(), 2);
-        assertEquals(objectMapper.writeValueAsString(leafCanonicalPlans.get(0)).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""), objectMapper.writeValueAsString(leafCanonicalPlans.get(1)).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""));
+        assertEquals(objectMapper.writeValueAsString(leafCanonicalPlans.get(0)), objectMapper.writeValueAsString(leafCanonicalPlans.get(1)));
     }
 
     private void assertDifferentCanonicalLeafSubPlan(Session session, String sql1, String sql2)
@@ -195,6 +195,6 @@ public class TestHiveCanonicalPlanGenerator
         Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), fragment2.getPartitioningScheme());
         assertTrue(canonicalPlan1.isPresent());
         assertTrue(canonicalPlan2.isPresent());
-        assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""), objectMapper.writeValueAsString(canonicalPlan2).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""));
+        assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
@@ -132,5 +132,11 @@ public final class OriginalExpressionUtils
         {
             throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
         }
+
+        @Override
+        public RowExpression canonicalize()
+        {
+            return this;
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -205,7 +205,7 @@ public class TestCanonicalPlanGenerator
                 .collect(Collectors.toList());
         assertEquals(leafCanonicalPlans.size(), 2);
         assertEquals(leafCanonicalPlans.get(0), leafCanonicalPlans.get(1));
-        assertEquals(objectMapper.writeValueAsString(leafCanonicalPlans.get(0)).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""), objectMapper.writeValueAsString(leafCanonicalPlans.get(1)).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""));
+        assertEquals(objectMapper.writeValueAsString(leafCanonicalPlans.get(0)), objectMapper.writeValueAsString(leafCanonicalPlans.get(1)));
     }
 
     private void assertDifferentCanonicalLeafSubPlan(String sql1, String sql2)
@@ -217,7 +217,7 @@ public class TestCanonicalPlanGenerator
         Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), fragment2.getPartitioningScheme());
         assertTrue(canonicalPlan1.isPresent());
         assertTrue(canonicalPlan2.isPresent());
-        assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""), objectMapper.writeValueAsString(canonicalPlan2).replaceAll("\"sourceLocation\":\\{[^\\}]*\\}", ""));
+        assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));
     }
 
     // We add the following field test to make sure corresponding canonical class is still correct.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
@@ -124,4 +124,10 @@ public final class CallExpression
     {
         return visitor.visitCall(this, context);
     }
+
+    @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new CallExpression(Optional.empty(), displayName, functionHandle, returnType, arguments) : this;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
@@ -114,4 +114,10 @@ public final class ConstantExpression
     {
         return visitor.visitConstant(this, context);
     }
+
+    @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new ConstantExpression(Optional.empty(), value, type) : this;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
@@ -77,6 +77,12 @@ public final class InputReferenceExpression
     }
 
     @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new InputReferenceExpression(Optional.empty(), field, type) : this;
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
@@ -117,6 +117,12 @@ public final class LambdaDefinitionExpression
         return visitor.visitLambda(this, context);
     }
 
+    @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new LambdaDefinitionExpression(Optional.empty(), argumentTypes, arguments, body) : this;
+    }
+
     private static void checkArgument(boolean condition, String message, Object... messageArgs)
     {
         if (!condition) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
@@ -66,4 +66,10 @@ public abstract class RowExpression
     public abstract String toString();
 
     public abstract <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context);
+
+    /**
+     * @return Canonical form of RowExpression by removing non-critical information
+     * from the node, like source location. Does NOT canonicalize the child expressions.
+     */
+    public abstract RowExpression canonicalize();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
@@ -121,6 +121,12 @@ public class SpecialFormExpression
         return visitor.visitSpecialForm(this, context);
     }
 
+    @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new SpecialFormExpression(Optional.empty(), form, returnType, arguments) : this;
+    }
+
     public enum Form
     {
         IF,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
@@ -76,6 +76,12 @@ public final class VariableReferenceExpression
     }
 
     @Override
+    public RowExpression canonicalize()
+    {
+        return getSourceLocation().isPresent() ? new VariableReferenceExpression(Optional.empty(), name, type) : this;
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {


### PR DESCRIPTION
Source location should not be included in Canonical Plan, which is used for fragment result caching.

```
== NO RELEASE NOTE ==
```
