### PR TITLE
Add trimmed mean

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -58,6 +58,12 @@ Functions
     T-digest and array of values between 0 and 1 which represent the quantiles
     to return.
 
+.. function:: trimmed_mean(tdigest<double>, lower_quantile, upper_quantile) -> double
+
+    Returns an estimate of the mean, excluding portions of the distribution
+    outside the provided quantile bounds. Both ``lower_quantile`` and ``upper_quantile``
+    must be between 0 and 1.
+
 .. function:: tdigest_agg(x) -> tdigest<double>
 
     Returns the ``tdigest`` which is composed of  all input values of ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -136,4 +136,15 @@ public final class TDigestFunctions
         blockBuilder.closeEntry();
         return TDIGEST_CENTROIDS_ROW_TYPE.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
     }
+
+    @ScalarFunction(value = "trimmed_mean", visibility = EXPERIMENTAL)
+    @Description("Returns an estimate of the mean, excluding portions of the distribution outside the provided quantile bounds.")
+    @SqlType("double")
+    public static double trimmedMeanTDigestDouble(@SqlType("tdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double lowerQuantileBound, @SqlType(StandardTypes.DOUBLE) double upperQuantileBound)
+    {
+        checkCondition(lowerQuantileBound >= 0 && lowerQuantileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Lower quantile bound should be in [0,1].");
+        checkCondition(upperQuantileBound >= 0 && upperQuantileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Upper quantile bound should be in [0,1].");
+        TDigest digest = createTDigest(input);
+        return digest.trimmedMean(lowerQuantileBound, upperQuantileBound);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -566,32 +566,30 @@ public class TDigest
         return weightedAverage(mean[n - 1], z1, max, z2);
     }
 
-    public double trimmedMean(double l, double u)
+    public double trimmedMean(double lowerQuantileBound, double upperQuantileBound)
     {
-        checkArgument(l >= 0 && l <= 1, "l should be in [0,1], got %s", l);
-        checkArgument(u >= 0 && u <= 1, "u should be in [0,1], got %s", u);
+        checkArgument(lowerQuantileBound >= 0 && lowerQuantileBound <= 1, "lowerQuantileBound should be in [0,1], got %s", lowerQuantileBound);
+        checkArgument(upperQuantileBound >= 0 && upperQuantileBound <= 1, "upperQuantileBound should be in [0,1], got %s", upperQuantileBound);
 
         if (unmergedWeight > 0) {
             compress();
         }
 
-        if (activeCentroids == 0 || l >= u) {
+        if (activeCentroids == 0 || lowerQuantileBound >= upperQuantileBound) {
             return Double.NaN;
         }
 
-        if (l == 0 && u == 1) {
+        if (lowerQuantileBound == 0 && upperQuantileBound == 1) {
             return sum / totalWeight;
         }
 
-        double lowerIndex = l * totalWeight;
-        double upperIndex = u * totalWeight;
-
-        int n = activeCentroids;
+        double lowerIndex = lowerQuantileBound * totalWeight;
+        double upperIndex = upperQuantileBound * totalWeight;
 
         double weightSoFar = 0;
         double sumInBounds = 0;
         double weightInBounds = 0;
-        for (int i = 0; i < n; i++) {
+        for (int i = 0; i < activeCentroids; i++) {
             if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i] && upperIndex <= weightSoFar + weight[i]) {
                 // lower and upper bounds are so close together that they are in the same weight interval
                 return mean[i];

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -566,6 +566,60 @@ public class TDigest
         return weightedAverage(mean[n - 1], z1, max, z2);
     }
 
+    public double trimmedMean(double l, double u)
+    {
+        checkArgument(l >= 0 && l <= 1, "l should be in [0,1], got %s", l);
+        checkArgument(u >= 0 && u <= 1, "u should be in [0,1], got %s", u);
+
+        if (unmergedWeight > 0) {
+            compress();
+        }
+
+        if (activeCentroids == 0 || l >= u) {
+            return Double.NaN;
+        }
+
+        if (l == 0 && u == 1) {
+            return sum / totalWeight;
+        }
+
+        double lowerIndex = l * totalWeight;
+        double upperIndex = u * totalWeight;
+
+        int n = activeCentroids;
+
+        double weightSoFar = 0;
+        double sumInBounds = 0;
+        double weightInBounds = 0;
+        for (int i = 0; i < n; i++) {
+            if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i] && upperIndex <= weightSoFar + weight[i]) {
+                // lower and upper bounds are so close together that they are in the same weight interval
+                return mean[i];
+            }
+            else if (weightSoFar < lowerIndex && lowerIndex <= weightSoFar + weight[i]) {
+                // the lower bound is between our current point and the next point
+                double addedWeight = weightSoFar + weight[i] - lowerIndex;
+                sumInBounds += mean[i] * addedWeight;
+                weightInBounds += addedWeight;
+            }
+            else if (upperIndex < weightSoFar + weight[i] && upperIndex > weightSoFar) {
+                // the upper bound is between our current point and the next point
+                double addedWeight = upperIndex - weightSoFar;
+                sumInBounds += mean[i] * addedWeight;
+                weightInBounds += addedWeight;
+                return sumInBounds / weightInBounds;
+            }
+            else if (lowerIndex <= weightSoFar && weightSoFar <= upperIndex) {
+                // we are somewhere in between the lower and upper bounds
+                sumInBounds += mean[i] * weight[i];
+                weightInBounds += weight[i];
+            }
+            weightSoFar += weight[i];
+        }
+
+        return sumInBounds / weightInBounds;
+    }
+
     public int centroidCount()
     {
         mergeNewValues();


### PR DESCRIPTION
- Add `trimmedMean` to TDigest to compute the estimated [trimmed mean](https://en.wikipedia.org/wiki/Truncated_mean) given lower and upper percentile bounds
- Add the `trimmed_mean` as a scalar Presto function

It implements the following calculation, which as far as I understand is the same as the algorithm implemented in [python's tdigest](https://github.com/CamDavidsonPilon/tdigest/blob/master/tdigest/tdigest.py#L216).
![tdigest_trimmed_mean drawio (2)](https://user-images.githubusercontent.com/23248585/173343999-9694760a-65b0-48bb-80f7-7cd4355910db.png)
Test plan:
`mvn -Dtest="TestTDigest,TestTDigestFunctions" test`

- ensured that the returned estimated trimmed mean is ±0.05σ from the actual trimmed mean in TDigest. Tested for uniform, normal and Poisson distributions, accross all lower/upper quantile combinations. Disabled most of the tests for performance.
- followed the same logic to test the Presto function

```
== RELEASE NOTES ==

General Changes
* Add :func:`trimmed_mean` for :ref:`tdigest <tdigest_type>`. The prototype of the function is:
  trimmed_mean(tdigest: TDIGEST, lower_quantile: DOUBLE, upper_quantile: DOUBLE) -> DOUBLE
```
