### PR TITLE
Fix metastore bindings and add sample configurations

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
@@ -36,7 +36,9 @@ import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.gcs.GcsConfigurationInitializer;
 import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
+import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.facebook.presto.plugin.base.security.AllowAllAccessControl;
 import com.facebook.presto.spi.connector.Connector;
@@ -63,6 +65,7 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class HudiModule
@@ -94,6 +97,8 @@ public class HudiModule
         binder.bind(HdfsConfiguration.class).annotatedWith(ForMetastoreHdfsEnvironment.class).to(HiveCachingHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForCachingFileSystem.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
         binder.bind(MBeanServer.class).toInstance(new TestingMBeanServer());
 
         binder.bind(HdfsConfigurationInitializer.class).in(Scopes.SINGLETON);

--- a/presto-main/etc/catalog/hudi.properties
+++ b/presto-main/etc/catalog/hudi.properties
@@ -1,0 +1,2 @@
+connector.name=hudi
+hive.metastore.uri=thrift://localhost:9083

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -49,7 +49,8 @@ plugin.bundles=\
   ../presto-cluster-ttl-providers/pom.xml,\
   ../presto-node-ttl-fetchers/pom.xml,\
   ../presto-hive-function-namespace/pom.xml,\
-  ../presto-delta/pom.xml
+  ../presto-delta/pom.xml,\
+  ../presto-hudi/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -364,6 +364,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hudi</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -208,5 +208,9 @@
             <directory>${project.build.directory}/dependency/presto-delta-${project.version}</directory>
             <outputDirectory>plugin/delta</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/presto-hudi-${project.version}</directory>
+            <outputDirectory>plugin/hudi</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
This PR  
1.  fixes a minor bug on dependency bingdings of metastore related classes;
2.  adds sample configurations for hudi connector;
3. bundles hudi connector to presto-server;

Test plan - No tests needed.

```
== NO RELEASE NOTE ==
```
