### PR TITLE
Enable the coordinators to retrieve metadata from the catalog server [Experimental Feature]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RandomCatalogServerAddressSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RandomCatalogServerAddressSelector.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.client.address.AddressSelector;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.HostAddress;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+import static com.facebook.drift.client.address.SimpleAddressSelector.SimpleAddress;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class RandomCatalogServerAddressSelector
+        implements AddressSelector<SimpleAddress>
+{
+    private final InternalNodeManager internalNodeManager;
+    private final Function<List<HostAndPort>, Optional<HostAndPort>> hostSelector;
+
+    @Inject
+    public RandomCatalogServerAddressSelector(InternalNodeManager internalNodeManager)
+    {
+        this(internalNodeManager, RandomCatalogServerAddressSelector::selectRandomHost);
+    }
+
+    @VisibleForTesting
+    RandomCatalogServerAddressSelector(
+            InternalNodeManager internalNodeManager,
+            Function<List<HostAndPort>, Optional<HostAndPort>> hostSelector)
+    {
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.hostSelector = requireNonNull(hostSelector, "hostSelector is null");
+    }
+
+    @Override
+    public Optional<SimpleAddress> selectAddress(Optional<String> addressSelectionContext)
+    {
+        if (addressSelectionContext.isPresent()) {
+            return addressSelectionContext
+                    .map(HostAndPort::fromString)
+                    .map(SimpleAddress::new);
+        }
+        List<HostAndPort> catalogServers = internalNodeManager.getCatalogServers().stream()
+                .filter(node -> node.getThriftPort().isPresent())
+                .map(catalogServerNode -> {
+                    HostAddress hostAndPort = catalogServerNode.getHostAndPort();
+                    return HostAndPort.fromParts(hostAndPort.getHostText(), catalogServerNode.getThriftPort().getAsInt());
+                })
+                .collect(toImmutableList());
+        return hostSelector.apply(catalogServers).map(SimpleAddress::new);
+    }
+
+    private static Optional<HostAndPort> selectRandomHost(List<HostAndPort> hostAndPorts)
+    {
+        if (hostAndPorts.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(hostAndPorts.get(ThreadLocalRandom.current().nextInt(hostAndPorts.size())));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
@@ -27,14 +27,22 @@ public class AllNodes
     private final Set<InternalNode> shuttingDownNodes;
     private final Set<InternalNode> activeCoordinators;
     private final Set<InternalNode> activeResourceManagers;
+    private final Set<InternalNode> activeCatalogServers;
 
-    public AllNodes(Set<InternalNode> activeNodes, Set<InternalNode> inactiveNodes, Set<InternalNode> shuttingDownNodes, Set<InternalNode> activeCoordinators, Set<InternalNode> activeResourceManagers)
+    public AllNodes(
+            Set<InternalNode> activeNodes,
+            Set<InternalNode> inactiveNodes,
+            Set<InternalNode> shuttingDownNodes,
+            Set<InternalNode> activeCoordinators,
+            Set<InternalNode> activeResourceManagers,
+            Set<InternalNode> activeCatalogServers)
     {
         this.activeNodes = ImmutableSet.copyOf(requireNonNull(activeNodes, "activeNodes is null"));
         this.inactiveNodes = ImmutableSet.copyOf(requireNonNull(inactiveNodes, "inactiveNodes is null"));
         this.shuttingDownNodes = ImmutableSet.copyOf(requireNonNull(shuttingDownNodes, "shuttingDownNodes is null"));
         this.activeCoordinators = ImmutableSet.copyOf(requireNonNull(activeCoordinators, "activeCoordinators is null"));
         this.activeResourceManagers = ImmutableSet.copyOf(requireNonNull(activeResourceManagers, "activeResourceManagers is null"));
+        this.activeCatalogServers = ImmutableSet.copyOf(requireNonNull(activeCatalogServers, "activeCatalogServers is null"));
     }
 
     public Set<InternalNode> getActiveNodes()
@@ -62,6 +70,11 @@ public class AllNodes
         return activeResourceManagers;
     }
 
+    public Set<InternalNode> getActiveCatalogServers()
+    {
+        return activeCatalogServers;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -76,12 +89,13 @@ public class AllNodes
                 Objects.equals(inactiveNodes, allNodes.inactiveNodes) &&
                 Objects.equals(shuttingDownNodes, allNodes.shuttingDownNodes) &&
                 Objects.equals(activeCoordinators, allNodes.activeCoordinators) &&
-                Objects.equals(activeResourceManagers, allNodes.activeResourceManagers);
+                Objects.equals(activeResourceManagers, allNodes.activeResourceManagers) &&
+                Objects.equals(activeCatalogServers, allNodes.activeCatalogServers);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(activeNodes, inactiveNodes, shuttingDownNodes, activeCoordinators, activeResourceManagers);
+        return Objects.hash(activeNodes, inactiveNodes, shuttingDownNodes, activeCoordinators, activeResourceManagers, activeCatalogServers);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -122,6 +122,9 @@ public final class DiscoveryNodeManager
     private Set<InternalNode> resourceManagers;
 
     @GuardedBy("this")
+    private Set<InternalNode> catalogServers;
+
+    @GuardedBy("this")
     private final List<Consumer<AllNodes>> listeners = new ArrayList<>();
 
     @Inject
@@ -163,7 +166,15 @@ public final class DiscoveryNodeManager
             OptionalInt thriftPort = getThriftServerPort(service);
             NodeVersion nodeVersion = getNodeVersion(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, isCoordinator(service), isResourceManager(service), ALIVE);
+                InternalNode node = new InternalNode(
+                        service.getNodeId(),
+                        uri,
+                        thriftPort,
+                        nodeVersion,
+                        isCoordinator(service),
+                        isResourceManager(service),
+                        isCatalogServer(service),
+                        ALIVE);
 
                 if (node.getNodeIdentifier().equals(currentNodeId)) {
                     checkState(
@@ -261,6 +272,7 @@ public final class DiscoveryNodeManager
         ImmutableSet.Builder<InternalNode> shuttingDownNodesBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<InternalNode> coordinatorsBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<InternalNode> resourceManagersBuilder = ImmutableSet.builder();
+        ImmutableSet.Builder<InternalNode> catalogServersBuilder = ImmutableSet.builder();
         ImmutableSetMultimap.Builder<ConnectorId, InternalNode> byConnectorIdBuilder = ImmutableSetMultimap.builder();
         Map<String, InternalNode> nodes = new HashMap<>();
         SetMultimap<String, ConnectorId> connectorIdsByNodeId = HashMultimap.create();
@@ -283,8 +295,9 @@ public final class DiscoveryNodeManager
             // take the form of a coordinator, hence these flags are not exclusive.
             boolean coordinator = isCoordinator(service);
             boolean resourceManager = isResourceManager(service);
+            boolean catalogServer = isCatalogServer(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, ALIVE);
+                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, catalogServer, ALIVE);
                 NodeState nodeState = getNodeState(node);
 
                 switch (nodeState) {
@@ -295,6 +308,9 @@ public final class DiscoveryNodeManager
                         }
                         if (resourceManager) {
                             resourceManagersBuilder.add(node);
+                        }
+                        if (catalogServer) {
+                            catalogServersBuilder.add(node);
                         }
 
                         nodes.put(node.getNodeIdentifier(), node);
@@ -348,7 +364,17 @@ public final class DiscoveryNodeManager
                 InternalNode deadNode = nodes.get(nodeId);
                 Set<ConnectorId> deadNodeConnectorIds = connectorIdsByNodeId.get(nodeId);
                 for (ConnectorId id : deadNodeConnectorIds) {
-                    byConnectorIdBuilder.put(id, new InternalNode(deadNode.getNodeIdentifier(), deadNode.getInternalUri(), deadNode.getThriftPort(), deadNode.getNodeVersion(), deadNode.isCoordinator(), deadNode.isResourceManager(), DEAD));
+                    byConnectorIdBuilder.put(
+                            id,
+                            new InternalNode(
+                                    deadNode.getNodeIdentifier(),
+                                    deadNode.getInternalUri(),
+                                    deadNode.getThriftPort(),
+                                    deadNode.getNodeVersion(),
+                                    deadNode.isCoordinator(),
+                                    deadNode.isResourceManager(),
+                                    deadNode.isCatalogServer(),
+                                    DEAD));
                 }
             }
         }
@@ -356,13 +382,20 @@ public final class DiscoveryNodeManager
         this.nodesByConnectorId = byConnectorIdBuilder.build();
         this.connectorIdsByNodeId = ImmutableSetMultimap.copyOf(connectorIdsByNodeId);
 
-        AllNodes allNodes = new AllNodes(activeNodesBuilder.build(), inactiveNodesBuilder.build(), shuttingDownNodesBuilder.build(), coordinatorsBuilder.build(), resourceManagersBuilder.build());
+        AllNodes allNodes = new AllNodes(
+                activeNodesBuilder.build(),
+                inactiveNodesBuilder.build(),
+                shuttingDownNodesBuilder.build(),
+                coordinatorsBuilder.build(),
+                resourceManagersBuilder.build(),
+                catalogServersBuilder.build());
         // only update if all nodes actually changed (note: this does not include the connectors registered with the nodes)
         if (!allNodes.equals(this.allNodes)) {
             // assign allNodes to a local variable for use in the callback below
             this.allNodes = allNodes;
             coordinators = coordinatorsBuilder.build();
             resourceManagers = resourceManagersBuilder.build();
+            catalogServers = catalogServersBuilder.build();
 
             // notify listeners
             List<Consumer<AllNodes>> listeners = ImmutableList.copyOf(this.listeners);
@@ -468,6 +501,12 @@ public final class DiscoveryNodeManager
     }
 
     @Override
+    public synchronized Set<InternalNode> getCatalogServers()
+    {
+        return catalogServers;
+    }
+
+    @Override
     public synchronized void addNodeChangeListener(Consumer<AllNodes> listener)
     {
         listeners.add(requireNonNull(listener, "listener is null"));
@@ -523,22 +562,33 @@ public final class DiscoveryNodeManager
         return Boolean.parseBoolean(service.getProperties().get("resource_manager"));
     }
 
+    private static boolean isCatalogServer(ServiceDescriptor service)
+    {
+        return Boolean.parseBoolean(service.getProperties().get("catalog_server"));
+    }
+
     /**
      * The predicate filters out the services to allow selecting relevant nodes
      * for discovery and sending heart beat.
      * Coordinator      -> All Nodes
      * Resource Manager -> All Nodes
-     * Worker           -> Resource Managers
+     * Catalog Server   -> All Nodes
+     * Worker           -> Resource Managers or Catalog Servers
      *
      * @return Predicate to filter Service Descriptor for Nodes
      */
     private Predicate<ServiceDescriptor> filterRelevantNodes()
     {
-        if (currentNode.isCoordinator() || currentNode.isResourceManager()) {
+        if (currentNode.isCoordinator() || currentNode.isResourceManager() || currentNode.isCatalogServer()) {
             // Allowing coordinator node in the list of services, even if it's not allowed by nodeStatusService with currentNode check
-            return service -> !nodeStatusService.isPresent() || nodeStatusService.get().isAllowed(service.getLocation()) || isCoordinator(service) || isResourceManager(service);
+            return service ->
+                    !nodeStatusService.isPresent()
+                            || nodeStatusService.get().isAllowed(service.getLocation())
+                            || isCoordinator(service)
+                            || isResourceManager(service)
+                            || isCatalogServer(service);
         }
 
-        return DiscoveryNodeManager::isResourceManager;
+        return service -> isResourceManager(service) || isCatalogServer(service);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
@@ -121,7 +121,8 @@ public class InMemoryNodeManager
                 ImmutableSet.of(),
                 shuttingDownNodesBuilder.build(),
                 concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isCoordinator).collect(toImmutableSet()),
-                concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isResourceManager).collect(toImmutableSet()));
+                concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isResourceManager).collect(toImmutableSet()),
+                concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isCatalogServer).collect(toImmutableSet()));
     }
 
     @Override
@@ -147,6 +148,12 @@ public class InMemoryNodeManager
     public Set<InternalNode> getResourceManagers()
     {
         return getAllNodes().getActiveResourceManagers();
+    }
+
+    @Override
+    public Set<InternalNode> getCatalogServers()
+    {
+        return getAllNodes().getActiveCatalogServers();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
@@ -65,25 +65,34 @@ public class InternalNode
     private final NodeVersion nodeVersion;
     private final boolean coordinator;
     private final boolean resourceManager;
+    private final boolean catalogServer;
     private final NodeStatus nodeStatus;
 
     public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator)
     {
-        this(nodeIdentifier, internalUri, nodeVersion, coordinator, false);
+        this(nodeIdentifier, internalUri, nodeVersion, coordinator, false, false);
     }
 
-    public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator, boolean resourceManager)
+    public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator, boolean resourceManager, boolean catalogServer)
     {
-        this(nodeIdentifier, internalUri, OptionalInt.empty(), nodeVersion, coordinator, resourceManager, ALIVE);
+        this(nodeIdentifier, internalUri, OptionalInt.empty(), nodeVersion, coordinator, resourceManager, catalogServer, ALIVE);
     }
 
     @ThriftConstructor
-    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, String nodeVersion, boolean coordinator, boolean resourceManager)
+    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, String nodeVersion, boolean coordinator, boolean resourceManager, boolean catalogServer)
     {
-        this(nodeIdentifier, internalUri, thriftPort, new NodeVersion(nodeVersion), coordinator, resourceManager, ALIVE);
+        this(nodeIdentifier, internalUri, thriftPort, new NodeVersion(nodeVersion), coordinator, resourceManager, catalogServer, ALIVE);
     }
 
-    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, NodeVersion nodeVersion, boolean coordinator, boolean resourceManager, NodeStatus nodeStatus)
+    public InternalNode(
+            String nodeIdentifier,
+            URI internalUri,
+            OptionalInt thriftPort,
+            NodeVersion nodeVersion,
+            boolean coordinator,
+            boolean resourceManager,
+            boolean catalogServer,
+            NodeStatus nodeStatus)
     {
         nodeIdentifier = emptyToNull(nullToEmpty(nodeIdentifier).trim());
         this.nodeIdentifier = requireNonNull(nodeIdentifier, "nodeIdentifier is null or empty");
@@ -92,6 +101,7 @@ public class InternalNode
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.coordinator = coordinator;
         this.resourceManager = resourceManager;
+        this.catalogServer = catalogServer;
         this.nodeStatus = nodeStatus;
     }
 
@@ -165,6 +175,13 @@ public class InternalNode
         return nodeStatus;
     }
 
+    @ThriftField(8)
+    @Override
+    public boolean isCatalogServer()
+    {
+        return catalogServer;
+    }
+
     @Override
     public boolean equals(Object obj)
     {
@@ -194,6 +211,7 @@ public class InternalNode
                 .add("nodeVersion", nodeVersion)
                 .add("coordinator", coordinator)
                 .add("resourceManager", resourceManager)
+                .add("catalogServer", catalogServer)
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
@@ -35,6 +35,8 @@ public interface InternalNodeManager
 
     Set<InternalNode> getResourceManagers();
 
+    Set<InternalNode> getCatalogServers();
+
     AllNodes getAllNodes();
 
     void refreshNodes();

--- a/presto-main/src/main/java/com/facebook/presto/server/CatalogServerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CatalogServerModule.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.airlift.discovery.server.EmbeddedDiscoveryModule;
+import com.facebook.presto.catalogserver.CatalogServer;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.resourceGroups.NoOpResourceGroupManager;
+import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.failureDetector.FailureDetectorModule;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.transaction.ForTransactionManager;
+import com.facebook.presto.transaction.InMemoryTransactionManager;
+import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.transaction.TransactionManagerConfig;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+
+import javax.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+import static com.facebook.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
+import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+// TODO : Eventually move this component to its own dedicated directory
+public class CatalogServerModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        // discovery server
+        install(installModuleIf(EmbeddedDiscoveryConfig.class, EmbeddedDiscoveryConfig::isEnabled, new EmbeddedDiscoveryModule()));
+
+        // presto %s/coordinator/catalogServer announcement
+        discoveryBinder(binder).bindHttpAnnouncement("presto-catalog-server");
+
+        // failure detector
+        binder.install(new FailureDetectorModule());
+
+        // query manager
+        binder.bind(QueryManager.class).to(NoOpQueryManager.class).in(Scopes.SINGLETON);
+
+        // resource group manager
+        binder.bind(ResourceGroupManager.class).to(NoOpResourceGroupManager.class);
+
+        // catalog server
+        driftServerBinder(binder).bindService(CatalogServer.class);
+
+        binder.bind(NodeResourceStatusProvider.class).toInstance(() -> true);
+    }
+
+    @Provides
+    @Singleton
+    @ForTransactionManager
+    public static ScheduledExecutorService createTransactionIdleCheckExecutor()
+    {
+        return newSingleThreadScheduledExecutor(daemonThreadsNamed("transaction-idle-check"));
+    }
+
+    @Provides
+    @Singleton
+    @ForTransactionManager
+    public static ExecutorService createTransactionFinishingExecutor()
+    {
+        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%s"));
+    }
+
+    @Provides
+    @Singleton
+    public static TransactionManager createTransactionManager(
+            TransactionManagerConfig config,
+            CatalogManager catalogManager,
+            @ForTransactionManager ScheduledExecutorService idleCheckExecutor,
+            @ForTransactionManager ExecutorService finishingExecutor)
+    {
+        return InMemoryTransactionManager.create(config, idleCheckExecutor, catalogManager, finishingExecutor);
+    }
+
+    @Provides
+    @Singleton
+    public static ResourceGroupManager<?> getResourceGroupManager(@SuppressWarnings("rawtypes") ResourceGroupManager manager)
+    {
+        return manager;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -24,6 +24,8 @@ public class ServerConfig
 {
     private boolean resourceManager;
     private boolean resourceManagerEnabled;
+    private boolean catalogServer;
+    private boolean catalogServerEnabled;
     private boolean coordinator = true;
     private String prestoVersion = getClass().getPackage().getImplementationVersion();
     private String dataSources;
@@ -53,6 +55,30 @@ public class ServerConfig
     public ServerConfig setResourceManagerEnabled(boolean resourceManagerEnabled)
     {
         this.resourceManagerEnabled = resourceManagerEnabled;
+        return this;
+    }
+
+    public boolean isCatalogServer()
+    {
+        return catalogServer;
+    }
+
+    @Config("catalog-server")
+    public ServerConfig setCatalogServer(boolean catalogServer)
+    {
+        this.catalogServer = catalogServer;
+        return this;
+    }
+
+    public boolean isCatalogServerEnabled()
+    {
+        return catalogServerEnabled;
+    }
+
+    @Config("catalog-server-enabled")
+    public ServerConfig setCatalogServerEnabled(boolean catalogServerEnabled)
+    {
+        this.catalogServerEnabled = catalogServerEnabled;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -29,6 +29,9 @@ import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.catalogserver.CatalogServerClient;
+import com.facebook.presto.catalogserver.RandomCatalogServerAddressSelector;
+import com.facebook.presto.catalogserver.RemoteMetadataManager;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.common.block.Block;
@@ -269,6 +272,9 @@ public class ServerMainModule
         if (serverConfig.isResourceManager()) {
             install(new ResourceManagerModule());
         }
+        else if (serverConfig.isCatalogServer()) {
+            install(new CatalogServerModule());
+        }
         else if (serverConfig.isCoordinator()) {
             install(new CoordinatorModule());
         }
@@ -379,6 +385,13 @@ public class ServerMainModule
                     }
                     return new ExceptionClassification(Optional.of(true), NORMAL);
                 });
+
+        binder.bind(RandomCatalogServerAddressSelector.class).in(Scopes.SINGLETON);
+        driftClientBinder(binder)
+                .bindDriftClient(CatalogServerClient.class)
+                .withAddressSelector((addressSelectorBinder, annotation, prefix) ->
+                        addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(RandomCatalogServerAddressSelector.class));
+
         newOptionalBinder(binder, ClusterMemoryManagerService.class);
         install(installModuleIf(
                 ServerConfig.class,
@@ -539,7 +552,14 @@ public class ServerMainModule
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
         binder.bind(FunctionAndTypeManager.class).in(Scopes.SINGLETON);
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
-        binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
+
+        if (serverConfig.isCatalogServerEnabled() && serverConfig.isCoordinator()) {
+            binder.bind(RemoteMetadataManager.class).in(Scopes.SINGLETON);
+            binder.bind(Metadata.class).to(RemoteMetadataManager.class).in(Scopes.SINGLETON);
+        }
+        else {
+            binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
+        }
 
         // row expression utils
         binder.bind(DomainTranslator.class).to(RowExpressionDomainTranslator.class).in(Scopes.SINGLETON);
@@ -613,10 +633,13 @@ public class ServerMainModule
         // presto announcement
         checkArgument(!(serverConfig.isResourceManager() && serverConfig.isCoordinator()),
                 "Server cannot be configured as both resource manager and coordinator");
+        checkArgument(!(serverConfig.isCatalogServer() && serverConfig.isCoordinator()),
+                "Server cannot be configured as both catalog server and coordinator");
         discoveryBinder(binder).bindHttpAnnouncement("presto")
                 .addProperty("node_version", nodeVersion.toString())
                 .addProperty("coordinator", String.valueOf(serverConfig.isCoordinator()))
                 .addProperty("resource_manager", String.valueOf(serverConfig.isResourceManager()))
+                .addProperty("catalog_server", String.valueOf(serverConfig.isCatalogServer()))
                 .addProperty("connectorIds", nullToEmpty(serverConfig.getDataSources()));
 
         // server info resource

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestRandomCatalogServerAddressSelector.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestRandomCatalogServerAddressSelector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.resourcemanager;
+package com.facebook.presto.catalogserver;
 
 import com.facebook.drift.client.address.SimpleAddressSelector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
@@ -27,7 +27,7 @@ import java.util.OptionalInt;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class TestRandomResourceManagerAddressSelector
+public class TestRandomCatalogServerAddressSelector
 {
     public static final ConnectorId CONNECTOR_ID = new ConnectorId("dummy");
 
@@ -35,7 +35,7 @@ public class TestRandomResourceManagerAddressSelector
     public void testAddressSelectionContextPresent()
     {
         InMemoryNodeManager internalNodeManager = new InMemoryNodeManager();
-        RandomResourceManagerAddressSelector selector = new RandomResourceManagerAddressSelector(internalNodeManager);
+        RandomCatalogServerAddressSelector selector = new RandomCatalogServerAddressSelector(internalNodeManager);
 
         HostAndPort hostAndPort = HostAndPort.fromParts("abc", 123);
         Optional<SimpleAddressSelector.SimpleAddress> address = selector.selectAddress(Optional.of(hostAndPort.toString()));
@@ -47,7 +47,7 @@ public class TestRandomResourceManagerAddressSelector
     public void testAddressSelectionContextPresentWithInvalidAddress()
     {
         InMemoryNodeManager internalNodeManager = new InMemoryNodeManager();
-        RandomResourceManagerAddressSelector selector = new RandomResourceManagerAddressSelector(internalNodeManager);
+        RandomCatalogServerAddressSelector selector = new RandomCatalogServerAddressSelector(internalNodeManager);
 
         selector.selectAddress(Optional.of("host:123.456"));
     }
@@ -56,18 +56,18 @@ public class TestRandomResourceManagerAddressSelector
     public void testAddressSelectionNoContext()
     {
         InMemoryNodeManager internalNodeManager = new InMemoryNodeManager();
-        RandomResourceManagerAddressSelector selector = new RandomResourceManagerAddressSelector(internalNodeManager, hostAndPorts -> Optional.of(hostAndPorts.get(0)));
+        RandomCatalogServerAddressSelector selector = new RandomCatalogServerAddressSelector(internalNodeManager, hostAndPorts -> Optional.of(hostAndPorts.get(0)));
 
         internalNodeManager.addNode(
                 CONNECTOR_ID,
                 new InternalNode(
-                    "1",
-                    URI.create("local://localhost:123/1"),
-                    OptionalInt.empty(),
-                    "1",
-                    false,
-                    true,
-                    false));
+                        "1",
+                        URI.create("local://localhost:123/1"),
+                        OptionalInt.empty(),
+                        "1",
+                        false,
+                        false,
+                        true));
         internalNodeManager.addNode(
                 CONNECTOR_ID,
                 new InternalNode(
@@ -76,8 +76,8 @@ public class TestRandomResourceManagerAddressSelector
                         OptionalInt.of(2),
                         "1",
                         false,
-                        true,
-                        false));
+                        false,
+                        true));
         internalNodeManager.addNode(
                 CONNECTOR_ID,
                 new InternalNode(
@@ -86,8 +86,8 @@ public class TestRandomResourceManagerAddressSelector
                         OptionalInt.of(3),
                         "1",
                         false,
-                        true,
-                        false));
+                        false,
+                        true));
 
         Optional<SimpleAddressSelector.SimpleAddress> address = selector.selectAddress(Optional.empty());
         assertTrue(address.isPresent());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
@@ -172,6 +172,14 @@ public class TestClusterSizeMonitor
     private void addResourceManager(InMemoryNodeManager nodeManager)
     {
         String identifier = "resource_manager/" + numResourceManagers.incrementAndGet();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode(identifier, URI.create("localhost/" + identifier), new NodeVersion("1"), false, true));
+        nodeManager.addNode(
+                CONNECTOR_ID,
+                new InternalNode(
+                        identifier,
+                        URI.create("localhost/" + identifier),
+                        new NodeVersion("1"),
+                        false,
+                        true,
+                        false));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -66,8 +66,20 @@ public class TestPartialResultQueryTaskTracker
             throws Exception
     {
         PartialResultQueryTaskTracker tracker = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.50, 2.0, warningCollector);
-        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false);
-        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false);
+        InternalNode node1 = new InternalNode(
+                UUID.randomUUID().toString(),
+                URI.create("https://192.0.2.8"),
+                new NodeVersion("1"),
+                false,
+                false,
+                false);
+        InternalNode node2 = new InternalNode(
+                UUID.randomUUID().toString(),
+                URI.create("https://192.0.2.9"),
+                new NodeVersion("1"),
+                false,
+                false,
+                false);
         TaskId taskId1 = new TaskId("test1", 1, 0, 1);
         TaskId taskId2 = new TaskId("test2", 2, 0, 1);
         RemoteTask task1 = taskFactory.createTableScanTask(taskId1, node1, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -69,7 +69,16 @@ public class TestResourceManagerClusterStatusSender
     {
         resourceManagerClient = new TestingResourceManagerClient();
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode("identifier", URI.create("http://localhost:80/identifier"), OptionalInt.of(1), "1", false, true));
+        nodeManager.addNode(
+                CONNECTOR_ID,
+                new InternalNode(
+                        "identifier",
+                        URI.create("http://localhost:80/identifier"),
+                        OptionalInt.of(1),
+                        "1",
+                        false,
+                        true,
+                        false));
 
         sender = new ResourceManagerClusterStatusSender(
                 (addressSelectionContext, headers) -> resourceManagerClient,

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -38,7 +38,9 @@ public class TestServerConfig
                 .setEnhancedErrorReporting(true)
                 .setQueryResultsCompressionEnabled(true)
                 .setResourceManagerEnabled(false)
-                .setResourceManager(false));
+                .setResourceManager(false)
+                .setCatalogServer(false)
+                .setCatalogServerEnabled(false));
     }
 
     @Test
@@ -54,6 +56,8 @@ public class TestServerConfig
                 .put("query-results.compression-enabled", "false")
                 .put("resource-manager-enabled", "true")
                 .put("resource-manager", "true")
+                .put("catalog-server-enabled", "true")
+                .put("catalog-server", "true")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -65,7 +69,9 @@ public class TestServerConfig
                 .setEnhancedErrorReporting(false)
                 .setQueryResultsCompressionEnabled(false)
                 .setResourceManagerEnabled(true)
-                .setResourceManager(true);
+                .setResourceManager(true)
+                .setCatalogServer(true)
+                .setCatalogServerEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
@@ -40,6 +40,7 @@ public class PrestoSparkInternalNodeManager
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableSet.of(),
+            ImmutableSet.of(),
             ImmutableSet.of());
 
     @Override
@@ -83,6 +84,12 @@ public class PrestoSparkInternalNodeManager
 
     @Override
     public Set<InternalNode> getResourceManagers()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<InternalNode> getCatalogServers()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
@@ -34,4 +34,6 @@ public interface Node
     boolean isCoordinator();
 
     boolean isResourceManager();
+
+    boolean isCatalogServer();
 }

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -445,7 +445,7 @@ public class TestMemoryManager
                 .put("experimental.reserved-pool-enabled", "false")
                 .build();
 
-        queryRunner2 = createQueryRunner(rmProperties, coordinatorProperties, extraProperties, 2);
+        queryRunner2 = createQueryRunner(rmProperties, extraProperties, coordinatorProperties, extraProperties, 2);
     }
 
     @AfterGroups(groups = {"reservedPoolDisabledMultiCoordinator"})
@@ -502,7 +502,7 @@ public class TestMemoryManager
                 .put("resource-manager.query-heartbeat-interval", "10ms")
                 .put("resource-manager.node-status-timeout", "5s")
                 .build();
-        queryRunner2 = createQueryRunner(properties, ImmutableMap.of(), properties, 2);
+        queryRunner2 = createQueryRunner(properties, ImmutableMap.of(), ImmutableMap.of(), properties, 2);
     }
 
     @AfterGroups(groups = {"clusterPoolsMultiCoordinator"})

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -73,6 +73,7 @@ public class TestDistributedClusterStatsResource
                 ImmutableMap.of(
                         "resource-manager.query-expiration-timeout", "4m",
                         "resource-manager.completed-query-expiration-timeout", "4m"),
+                ImmutableMap.of(),
                 ImmutableMap.of(
                         "query.client.timeout", "20s",
                         "resource-manager.query-heartbeat-interval", "100ms",

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
@@ -86,6 +86,7 @@ public class TestServerInfoResource
     {
         queryRunner = createQueryRunner(
                 ImmutableMap.of(),
+                ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "1", "cluster.required-coordinators-active", "1"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
     }
@@ -105,6 +106,7 @@ public class TestServerInfoResource
     {
         queryRunner = createQueryRunnerWithNoClusterReadyCheck(
                 ImmutableMap.of(),
+                ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "2", "cluster.required-coordinators-active", "1"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
     }
@@ -123,6 +125,7 @@ public class TestServerInfoResource
             throws Exception
     {
         queryRunner = createQueryRunnerWithNoClusterReadyCheck(
+                ImmutableMap.of(),
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "1", "cluster.required-coordinators-active", "3"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -51,23 +51,40 @@ public final class TpchQueryRunner
         return queryRunner;
     }
 
-    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount)
+    public static DistributedQueryRunner createQueryRunner(
+            Map<String, String> resourceManagerProperties,
+            Map<String, String> catalogServerProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> extraProperties,
+            int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, coordinatorProperties, extraProperties, coordinatorCount, false);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, false);
     }
 
-    public static DistributedQueryRunner createQueryRunnerWithNoClusterReadyCheck(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount)
+    public static DistributedQueryRunner createQueryRunnerWithNoClusterReadyCheck(
+            Map<String, String> resourceManagerProperties,
+            Map<String, String> catalogServerProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> extraProperties,
+            int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, coordinatorProperties, extraProperties, coordinatorCount, true);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, true);
     }
 
-    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, boolean skipClusterReadyCheck)
+    public static DistributedQueryRunner createQueryRunner(
+            Map<String, String> resourceManagerProperties,
+            Map<String, String> catalogServerProperties,
+            Map<String, String> coordinatorProperties,
+            Map<String, String> extraProperties,
+            int coordinatorCount,
+            boolean skipClusterReadyCheck)
             throws Exception
     {
         DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
                 .setResourceManagerProperties(resourceManagerProperties)
+                .setCatalogServerProperties(catalogServerProperties)
                 .setCoordinatorProperties(coordinatorProperties)
                 .setExtraProperties(extraProperties)
                 .setResourceManagerEnabled(true)


### PR DESCRIPTION
### Enable the coordinators to retrieve metadata from the catalog server
- Allowed a node to be discovered as a CatalogServer
- Added the catalog server module with its dependencies (nothing but the necessary ones and CatalogServer) and then installed them on the server module whenever the node is identified as a catalog server
- Allowed properties to be set for the catalog server

### Refrence
 - (https://github.com/prestodb/presto/pull/15479, https://github.com/prestodb/presto/pull/15673)

### Test plan
- You can try running **TestDiscoveryNodeManager.java** to see if the catalog server nodes are discoverable
- To test that the coordinators are retrieving metadata from the catalog servers you can try running a local query runner such as **TpchQueryRunner.java**. Just make sure to set the [coordinator count](https://github.com/prestodb/presto/blob/master/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java#L86) to 1. Also change the node selection strategy on **TpchSplit.java** to have [NO_PREFRENCE](https://github.com/prestodb/presto/blob/master/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java#L89).
- Now you should be able to run and perform some queries. You can check the logs or debug to see that the catalog server is being called to retrieve the metadata. Ex : **select name from tpch.sf1.nation;**


```
== NO RELEASE NOTE ==
```
