### PR TITLE
Fix wrong return type of map_normalize function in document

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -71,7 +71,7 @@ Map Functions
 
     Returns all the keys in the map ``x``.
 
-.. function:: map_normalize(x(varchar,double)) -> array(varchar,double)
+.. function:: map_normalize(x(varchar,double)) -> map(varchar,double)
 
     Returns the map with the same keys but all non-null values are scaled proportionally so that the sum of values becomes 1.
     Map entries with null values remain unchanged.


### PR DESCRIPTION
The return type of map_normalize should be map(varchar,double), not array(varchar,double).