### PR TITLE
Optimize merging of stats in DoubleStatisticsBuilder

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -17,6 +17,8 @@ import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.DoubleStatistics;
+import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.proto.DwrfProto.RowIndexEntry;
 import com.facebook.presto.orc.proto.DwrfProto.Type;
@@ -222,20 +224,22 @@ public class DwrfMetadataWriter
                     .build());
         }
 
-        if (columnStatistics.getIntegerStatistics() != null) {
-            DwrfProto.IntegerStatistics.Builder integerStatistics = DwrfProto.IntegerStatistics.newBuilder()
-                    .setMinimum(columnStatistics.getIntegerStatistics().getMin())
-                    .setMaximum(columnStatistics.getIntegerStatistics().getMax());
-            if (columnStatistics.getIntegerStatistics().getSum() != null) {
-                integerStatistics.setSum(columnStatistics.getIntegerStatistics().getSum());
+        IntegerStatistics integerStatistics = columnStatistics.getIntegerStatistics();
+        if (integerStatistics != null) {
+            DwrfProto.IntegerStatistics.Builder dwrfIntegerStatistics = DwrfProto.IntegerStatistics.newBuilder()
+                    .setMinimum(integerStatistics.getMinPrimitive())
+                    .setMaximum(integerStatistics.getMaxPrimitive());
+            if (integerStatistics.hasSum()) {
+                dwrfIntegerStatistics.setSum(integerStatistics.getSumPrimitive());
             }
-            builder.setIntStatistics(integerStatistics.build());
+            builder.setIntStatistics(dwrfIntegerStatistics.build());
         }
 
-        if (columnStatistics.getDoubleStatistics() != null) {
+        DoubleStatistics doubleStatistics = columnStatistics.getDoubleStatistics();
+        if (doubleStatistics != null) {
             builder.setDoubleStatistics(DwrfProto.DoubleStatistics.newBuilder()
-                    .setMinimum(columnStatistics.getDoubleStatistics().getMin())
-                    .setMaximum(columnStatistics.getDoubleStatistics().getMax())
+                    .setMinimum(doubleStatistics.getMinPrimitive())
+                    .setMaximum(doubleStatistics.getMaxPrimitive())
                     .build());
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 public class DoubleStatistics
         implements RangeStatistics<Double>, Hashable
@@ -54,10 +55,22 @@ public class DoubleStatistics
         return hasMinimum ? minimum : null;
     }
 
+    public double getMinPrimitive()
+    {
+        checkState(hasMinimum, "minimum value is missing");
+        return minimum;
+    }
+
     @Override
     public Double getMax()
     {
         return hasMaximum ? maximum : null;
+    }
+
+    public double getMaxPrimitive()
+    {
+        checkState(hasMaximum, "maximum value is missing");
+        return maximum;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -62,12 +62,10 @@ public class DoubleStatisticsBuilder
     private void addDoubleStatistics(long valueCount, DoubleStatistics value)
     {
         requireNonNull(value, "value is null");
-        requireNonNull(value.getMin(), "value.getMin() is null");
-        requireNonNull(value.getMax(), "value.getMax() is null");
 
         nonNullValueCount += valueCount;
-        minimum = Math.min(value.getMin(), minimum);
-        maximum = Math.max(value.getMax(), maximum);
+        minimum = Math.min(value.getMinPrimitive(), minimum);
+        maximum = Math.max(value.getMaxPrimitive(), maximum);
     }
 
     private Optional<DoubleStatistics> buildDoubleStatistics()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
@@ -60,7 +60,7 @@ public class IntegerStatistics
 
     public long getMinPrimitive()
     {
-        checkState(hasMinimum);
+        checkState(hasMinimum, "minimum value is missing");
         return minimum;
     }
 
@@ -72,7 +72,7 @@ public class IntegerStatistics
 
     public long getMaxPrimitive()
     {
-        checkState(hasMaximum);
+        checkState(hasMaximum, "maximum value is missing");
         return maximum;
     }
 


### PR DESCRIPTION
Add getMin/getMax methods returning primitive double values to avoid boxing/unboxing in DoubleStatisticsBuilder while merging stats. This is a valuable change for flat map writer which can merge thousands of value node stats.

This is a follow up PR for a similar change in the IntegerStatisticsBuilder.

Test plan:
- existing tests


```
== NO RELEASE NOTE ==
```
