### PR TITLE
Remove try catch from materialized view query optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -37,7 +37,6 @@ import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
 import com.facebook.presto.sql.tree.AliasedRelation;
-import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Cast;
@@ -419,7 +418,7 @@ public class MaterializedViewQueryOptimizer
                 return querySpecification;
             }
             catch (Exception e) {
-                log.info("Materialized view optimization failed exceptionally with: %s", e.getMessage());
+                log.info("Materialized view optimization failed with exception: %s", e.getMessage());
                 return querySpecification;
             }
         }
@@ -559,13 +558,6 @@ public class MaterializedViewQueryOptimizer
                 alias = Optional.of((Identifier) node.getExpression());
             }
             return new SingleColumn(processedColumn, alias);
-        }
-
-        @Override
-        protected Node visitAllColumns(AllColumns node, Void context)
-        {
-            setErrorMessage("All columns rewrite is not supported in query optimizer");
-            return null;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
@@ -75,8 +76,16 @@ public final class MaterializedViewRewriteQueryShapeValidator
             QualifiedName name = node.getName();
             if (!SUPPORTED_FUNCTION_CALLS.contains(name)) {
                 errorMessage = Optional.of(format("Query shape invalid: %s function is not supported for materialized view optimizations", name));
+                return null;
             }
             return super.visitFunctionCall(node, context);
+        }
+
+        @Override
+        protected Void visitAllColumns(AllColumns node, Void context)
+        {
+            errorMessage = Optional.of("All columns rewrite is not supported in query optimizer");
+            return null;
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
@@ -49,6 +49,12 @@ public class TestMaterializedViewRewriteQueryShapeValidator
                 "Query shape invalid: HAVING is not supported for materialized view optimizations");
     }
 
+    @Test
+    public void allColumns()
+    {
+        assertFails("SELECT * FROM tbl", "All columns rewrite is not supported in query optimizer");
+    }
+
     private static void assertFails(String baseQuerySql, String expectedErrorMessage)
     {
         QuerySpecification querySpecification = (QuerySpecification) ((Query) SQL_PARSER.createStatement(baseQuerySql)).getQueryBody();


### PR DESCRIPTION
Addresses https://github.com/prestodb/presto/issues/16541

Test plan - Existing test coverage to check for regressions

Previously we used a throw/catch flow to validate compatibility between a materialized view and base query for automatic optimization. This PR removes the reliance on throwing for non-exceptional cases.


```
== NO RELEASE NOTE ==
```
