### PR TITLE
Support renaming table in MongoDB

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -261,3 +261,11 @@ MongoDB collection has the special field ``_id``. The connector tries to follow 
 .. note::
 
     Unfortunately, there is no way to represent ``_id`` fields more fancy like ``55b151633864d6438c61a9ce``.
+
+SQL support
+-----------
+
+ALTER TABLE
+^^^^^^^^^^^
+
+The connector supports ``ALTER TABLE RENAME TO`` operation. Other uses of ``ALTER TABLE`` are not supported.

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
@@ -212,7 +212,8 @@ public class MongoMetadata
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
-        throw new UnsupportedOperationException();
+        MongoTableHandle table = (MongoTableHandle) tableHandle;
+        mongoSession.renameTable(table.getSchemaTableName(), newTableName);
     }
 
     @Override


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11423
Support renaming table in MongoDB

Co-authored-by: Yuya Ebihara <ebyhry@gmail.com>

Test plan - Added a test

```
== RELEASE NOTES ==

MongoDB Changes
* Support renaming tables.  Users can use ``ALTER TABLE RENAME TO`` to rename a table.
```
