### PR TITLE
Add query level aggregated shuffle bytes and rows in QueryStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -1056,6 +1056,8 @@ public class QueryStateMachine
                 queryStats.getRawInputPositions(),
                 queryStats.getProcessedInputDataSize(),
                 queryStats.getProcessedInputPositions(),
+                queryStats.getShuffledDataSize(),
+                queryStats.getShuffledPositions(),
                 queryStats.getOutputDataSize(),
                 queryStats.getOutputPositions(),
                 queryStats.getWrittenOutputPositions(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -222,6 +222,9 @@ public class TestQueryStats
             new DataSize(26, BYTE),
             27,
 
+            new DataSize(30, BYTE),
+            29,
+
             new DataSize(28, BYTE),
             29,
 
@@ -305,6 +308,9 @@ public class TestQueryStats
 
         assertEquals(actual.getProcessedInputDataSize(), new DataSize(26, BYTE));
         assertEquals(actual.getProcessedInputPositions(), 27);
+
+        assertEquals(actual.getShuffledDataSize(), new DataSize(30, BYTE));
+        assertEquals(actual.getShuffledPositions(), 29);
 
         assertEquals(actual.getOutputDataSize(), new DataSize(28, BYTE));
         assertEquals(actual.getOutputPositions(), 29);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -103,6 +103,8 @@ public class TestBasicQueryInfo
                                 30,
                                 DataSize.valueOf("31GB"),
                                 32,
+                                DataSize.valueOf("32GB"),
+                                40,
                                 33,
                                 DataSize.valueOf("34GB"),
                                 DataSize.valueOf("35GB"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -260,6 +260,8 @@ public class TestQueryStateInfo
                         28,
                         DataSize.valueOf("29GB"),
                         30,
+                        DataSize.valueOf("32GB"),
+                        40,
                         DataSize.valueOf("31GB"),
                         32,
                         33,

--- a/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
+++ b/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
@@ -61,6 +61,8 @@
     "rawInputPositions": 0,
     "processedInputDataSize": "0B",
     "processedInputPositions": 0,
+    "shuffledDataSize": "0B",
+    "shuffledPositions": 0,
     "outputDataSize": "0B",
     "outputPositions": 0,
     "writtenOutputPositions": 0,


### PR DESCRIPTION
Add query level aggregated shuffle bytes and rows in QueryStats.

== NO RELEASE NOTE ==