### PR TITLE
Enable caching on the catalog server

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/CatalogSchemaName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/CatalogSchemaName.java
@@ -13,11 +13,16 @@
  */
 package com.facebook.presto.common;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
 import java.util.Objects;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class CatalogSchemaName
 {
     // TODO: Move out this class. Ideally this class should not be in presto-common module.
@@ -25,17 +30,20 @@ public final class CatalogSchemaName
     private final String catalogName;
     private final String schemaName;
 
+    @ThriftConstructor
     public CatalogSchemaName(String catalogName, String schemaName)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null").toLowerCase(ENGLISH);
         this.schemaName = requireNonNull(schemaName, "schemaName is null").toLowerCase(ENGLISH);
     }
 
+    @ThriftField(value = 1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
+    @ThriftField(value = 2)
     public String getSchemaName()
     {
         return schemaName;

--- a/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -25,6 +28,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
+@ThriftStruct
 public class QualifiedObjectName
 {
     private final String catalogName;
@@ -54,6 +58,7 @@ public class QualifiedObjectName
         return new QualifiedObjectName(catalogName, schemaName, objectName.toLowerCase(ENGLISH));
     }
 
+    @ThriftConstructor
     public QualifiedObjectName(String catalogName, String schemaName, String objectName)
     {
         checkLowerCase(catalogName, "catalogName");
@@ -69,16 +74,19 @@ public class QualifiedObjectName
         return new CatalogSchemaName(catalogName, schemaName);
     }
 
+    @ThriftField(value = 1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
+    @ThriftField(value = 2)
     public String getSchemaName()
     {
         return schemaName;
     }
 
+    @ThriftField(value = 3)
     public String getObjectName()
     {
         return objectName;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -164,6 +164,7 @@ public final class HiveQueryRunner
         DistributedQueryRunner queryRunner =
                 DistributedQueryRunner.builder(createSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))))
                         .setNodeCount(workerCount.orElse(4))
+                        .setResourceManagerEnabled(true)
                         .setExtraProperties(systemProperties)
                         .setCoordinatorProperties(extraCoordinatorProperties)
                         .setBaseDataDir(baseDataDir)

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.transaction.TransactionInfo;
+import com.facebook.presto.transaction.TransactionManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftService(value = "presto-catalog-server", idlName = "PrestoCatalogServer")
+public class CatalogServer
+{
+    private static final String EMPTY_STRING = "";
+    private final Metadata metadataProvider;
+    private final SessionPropertyManager sessionPropertyManager;
+    private final TransactionManager transactionManager;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public CatalogServer(MetadataManager metadataProvider, SessionPropertyManager sessionPropertyManager, TransactionManager transactionManager, ObjectMapper objectMapper)
+    {
+        this.metadataProvider = requireNonNull(metadataProvider, "metadataProvider is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.objectMapper = requireNonNull(objectMapper, "handleResolver is null");
+    }
+
+    @ThriftMethod
+    public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        return metadataProvider.schemaExists(session.toSession(sessionPropertyManager), schema);
+    }
+
+    @ThriftMethod
+    public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        return metadataProvider.catalogExists(session.toSession(sessionPropertyManager), catalogName);
+    }
+
+    @ThriftMethod
+    public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<String> schemaNames = metadataProvider.listSchemaNames(session.toSession(sessionPropertyManager), catalogName);
+        if (!schemaNames.isEmpty()) {
+            try {
+                return objectMapper.writeValueAsString(schemaNames);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<TableHandle> tableHandle = metadataProvider.getTableHandle(session.toSession(sessionPropertyManager), table);
+        if (tableHandle.isPresent()) {
+            try {
+                return objectMapper.writeValueAsString(tableHandle.get());
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> tableList = metadataProvider.listTables(session.toSession(sessionPropertyManager), prefix);
+        if (!tableList.isEmpty()) {
+            try {
+                return objectMapper.writeValueAsString(tableList);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> viewsList = metadataProvider.listViews(session.toSession(sessionPropertyManager), prefix);
+        if (!viewsList.isEmpty()) {
+            try {
+                return objectMapper.writeValueAsString(viewsList);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = metadataProvider.getViews(session.toSession(sessionPropertyManager), prefix);
+        if (!viewsMap.isEmpty()) {
+            try {
+                return objectMapper.writeValueAsString(viewsMap);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<ViewDefinition> viewDefinition = metadataProvider.getView(session.toSession(sessionPropertyManager), viewName);
+        if (viewDefinition.isPresent()) {
+            try {
+                return objectMapper.writeValueAsString(viewDefinition.get());
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition = metadataProvider.getMaterializedView(session.toSession(sessionPropertyManager), viewName);
+        if (connectorMaterializedViewDefinition.isPresent()) {
+            try {
+                return objectMapper.writeValueAsString(connectorMaterializedViewDefinition.get());
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> referencedMaterializedViewsList = metadataProvider.getReferencedMaterializedViews(session.toSession(sessionPropertyManager), tableName);
+        if (!referencedMaterializedViewsList.isEmpty()) {
+            try {
+                return objectMapper.writeValueAsString(referencedMaterializedViewsList);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return EMPTY_STRING;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
@@ -29,14 +29,20 @@ import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThriftService(value = "presto-catalog-server", idlName = "PrestoCatalogServer")
 public class CatalogServer
@@ -46,6 +52,16 @@ public class CatalogServer
     private final SessionPropertyManager sessionPropertyManager;
     private final TransactionManager transactionManager;
     private final ObjectMapper objectMapper;
+    private final LoadingCache<CacheKey, Boolean> catalogExistsCache;
+    private final LoadingCache<CacheKey, Boolean> schemaExistsCache;
+    private final LoadingCache<CacheKey, List<String>> listSchemaNamesCache;
+    private final LoadingCache<CacheKey, Optional<TableHandle>> getTableHandleCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> listTablesCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> listViewsCache;
+    private final LoadingCache<CacheKey, Map<QualifiedObjectName, ViewDefinition>> getViewsCache;
+    private final LoadingCache<CacheKey, Optional<ViewDefinition>> getViewCache;
+    private final LoadingCache<CacheKey, Optional<ConnectorMaterializedViewDefinition>> getMaterializedViewCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> getReferencedMaterializedViewsCache;
 
     @Inject
     public CatalogServer(MetadataManager metadataProvider, SessionPropertyManager sessionPropertyManager, TransactionManager transactionManager, ObjectMapper objectMapper)
@@ -54,27 +70,99 @@ public class CatalogServer
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.objectMapper = requireNonNull(objectMapper, "handleResolver is null");
+
+        OptionalLong cacheExpiresAfterWriteMillis = OptionalLong.of(600000);
+        long cacheMaximumSize = 1000;
+
+        this.catalogExistsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadCatalogExists));
+        this.schemaExistsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadSchemaExists));
+        this.listSchemaNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadListSchemaNames));
+        this.getTableHandleCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadGetTableHandle));
+        this.listTablesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadListTables));
+        this.listViewsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadListViews));
+        this.getViewsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadGetViews));
+        this.getViewCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadGetView));
+        this.getMaterializedViewCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadGetMaterializedView));
+        this.getReferencedMaterializedViewsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheMaximumSize).build(CacheLoader.from(this::loadGetReferencedMaterializedViews));
     }
+
+    /*
+        Loading Cache Methods
+     */
+
+    private Boolean loadCatalogExists(CacheKey key)
+    {
+        return metadataProvider.catalogExists(key.getSession().toSession(sessionPropertyManager), (String) key.getKey());
+    }
+
+    private Boolean loadSchemaExists(CacheKey key)
+    {
+        return metadataProvider.schemaExists(key.getSession().toSession(sessionPropertyManager), (CatalogSchemaName) key.getKey());
+    }
+
+    private List<String> loadListSchemaNames(CacheKey key)
+    {
+        return metadataProvider.listSchemaNames(key.getSession().toSession(sessionPropertyManager), (String) key.getKey());
+    }
+
+    private Optional<TableHandle> loadGetTableHandle(CacheKey key)
+    {
+        return metadataProvider.getTableHandle(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadListTables(CacheKey key)
+    {
+        return metadataProvider.listTables(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadListViews(CacheKey key)
+    {
+        return metadataProvider.listViews(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private Map<QualifiedObjectName, ViewDefinition> loadGetViews(CacheKey key)
+    {
+        return metadataProvider.getViews(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private Optional<ViewDefinition> loadGetView(CacheKey key)
+    {
+        return metadataProvider.getView(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private Optional<ConnectorMaterializedViewDefinition> loadGetMaterializedView(CacheKey key)
+    {
+        return metadataProvider.getMaterializedView(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadGetReferencedMaterializedViews(CacheKey key)
+    {
+        return metadataProvider.getReferencedMaterializedViews(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    /*
+        Metadata Manager Methods
+     */
 
     @ThriftMethod
     public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        return metadataProvider.schemaExists(session.toSession(sessionPropertyManager), schema);
+        return schemaExistsCache.getUnchecked(new CacheKey(session, schema));
     }
 
     @ThriftMethod
     public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        return metadataProvider.catalogExists(session.toSession(sessionPropertyManager), catalogName);
+        return catalogExistsCache.getUnchecked(new CacheKey(session, catalogName));
     }
 
     @ThriftMethod
     public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<String> schemaNames = metadataProvider.listSchemaNames(session.toSession(sessionPropertyManager), catalogName);
+        List<String> schemaNames = listSchemaNamesCache.getUnchecked(new CacheKey(session, catalogName));
         if (!schemaNames.isEmpty()) {
             try {
                 return objectMapper.writeValueAsString(schemaNames);
@@ -90,7 +178,12 @@ public class CatalogServer
     public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<TableHandle> tableHandle = metadataProvider.getTableHandle(session.toSession(sessionPropertyManager), table);
+        CacheKey cacheKey = new CacheKey(session, table);
+        Optional<TableHandle> tableHandle = getTableHandleCache.getUnchecked(cacheKey);
+        if (!tableHandle.isPresent()) {
+            getTableHandleCache.refresh(cacheKey);
+            tableHandle = getTableHandleCache.getUnchecked(cacheKey);
+        }
         if (tableHandle.isPresent()) {
             try {
                 return objectMapper.writeValueAsString(tableHandle.get());
@@ -106,7 +199,7 @@ public class CatalogServer
     public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> tableList = metadataProvider.listTables(session.toSession(sessionPropertyManager), prefix);
+        List<QualifiedObjectName> tableList = listTablesCache.getUnchecked(new CacheKey(session, prefix));
         if (!tableList.isEmpty()) {
             try {
                 return objectMapper.writeValueAsString(tableList);
@@ -122,7 +215,7 @@ public class CatalogServer
     public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> viewsList = metadataProvider.listViews(session.toSession(sessionPropertyManager), prefix);
+        List<QualifiedObjectName> viewsList = listViewsCache.getUnchecked(new CacheKey(session, prefix));
         if (!viewsList.isEmpty()) {
             try {
                 return objectMapper.writeValueAsString(viewsList);
@@ -138,7 +231,7 @@ public class CatalogServer
     public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Map<QualifiedObjectName, ViewDefinition> viewsMap = metadataProvider.getViews(session.toSession(sessionPropertyManager), prefix);
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = getViewsCache.getUnchecked(new CacheKey(session, prefix));
         if (!viewsMap.isEmpty()) {
             try {
                 return objectMapper.writeValueAsString(viewsMap);
@@ -154,7 +247,7 @@ public class CatalogServer
     public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<ViewDefinition> viewDefinition = metadataProvider.getView(session.toSession(sessionPropertyManager), viewName);
+        Optional<ViewDefinition> viewDefinition = getViewCache.getUnchecked(new CacheKey(session, viewName));
         if (viewDefinition.isPresent()) {
             try {
                 return objectMapper.writeValueAsString(viewDefinition.get());
@@ -170,7 +263,7 @@ public class CatalogServer
     public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition = metadataProvider.getMaterializedView(session.toSession(sessionPropertyManager), viewName);
+        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition = getMaterializedViewCache.getUnchecked(new CacheKey(session, viewName));
         if (connectorMaterializedViewDefinition.isPresent()) {
             try {
                 return objectMapper.writeValueAsString(connectorMaterializedViewDefinition.get());
@@ -186,7 +279,7 @@ public class CatalogServer
     public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> referencedMaterializedViewsList = metadataProvider.getReferencedMaterializedViews(session.toSession(sessionPropertyManager), tableName);
+        List<QualifiedObjectName> referencedMaterializedViewsList = getReferencedMaterializedViewsCache.getUnchecked(new CacheKey(session, tableName));
         if (!referencedMaterializedViewsList.isEmpty()) {
             try {
                 return objectMapper.writeValueAsString(referencedMaterializedViewsList);
@@ -196,5 +289,55 @@ public class CatalogServer
             }
         }
         return EMPTY_STRING;
+    }
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(OptionalLong expiresAfterWriteMillis, long maximumSize)
+    {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteMillis.isPresent()) {
+            cacheBuilder = cacheBuilder.expireAfterWrite(expiresAfterWriteMillis.getAsLong(), MILLISECONDS);
+        }
+        return cacheBuilder.maximumSize(maximumSize).recordStats();
+    }
+
+    private static class CacheKey<T>
+    {
+        private final SessionRepresentation session;
+        private final T key;
+
+        private CacheKey(SessionRepresentation session, T key)
+        {
+            this.session = session;
+            this.key = key;
+        }
+
+        public SessionRepresentation getSession()
+        {
+            return session;
+        }
+
+        public T getKey()
+        {
+            return key;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(key, cacheKey.key);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(key);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.transaction.TransactionInfo;
+
+@ThriftService("PrestoCatalogServer")
+public interface CatalogServerClient
+{
+    @ThriftMethod
+    boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema);
+
+    @ThriftMethod
+    boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+
+    @ThriftMethod
+    String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+
+    @ThriftMethod
+    String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table);
+
+    @ThriftMethod
+    String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+
+    @ThriftMethod
+    String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+
+    @ThriftMethod
+    String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName);
+}

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
@@ -13,44 +13,94 @@
  */
 package com.facebook.presto.catalogserver;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftMethod;
 import com.facebook.drift.annotations.ThriftService;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.transaction.TransactionInfo;
 
+import java.util.Objects;
+
 @ThriftService("PrestoCatalogServer")
 public interface CatalogServerClient
 {
-    @ThriftMethod
-    boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema);
+    @ThriftStruct
+    public static class MetadataEntry<T>
+    {
+        private final T returnValue;
+        private final boolean isCacheHit;
+
+        @ThriftConstructor
+        public MetadataEntry(T returnValue, boolean isCacheHit)
+        {
+            this.returnValue = returnValue;
+            this.isCacheHit = isCacheHit;
+        }
+
+        @ThriftField(1)
+        public T getReturnValue()
+        {
+            return returnValue;
+        }
+
+        @ThriftField(2)
+        public boolean getIsCacheHit()
+        {
+            return isCacheHit;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MetadataEntry metadataKey = (MetadataEntry) o;
+            return Objects.equals(returnValue, metadataKey.getReturnValue());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(returnValue);
+        }
+    }
 
     @ThriftMethod
-    boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+    MetadataEntry<Boolean> schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema);
 
     @ThriftMethod
-    String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+    MetadataEntry<Boolean> catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
 
     @ThriftMethod
-    String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table);
+    MetadataEntry<String> listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
 
     @ThriftMethod
-    String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+    MetadataEntry<String> getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table);
 
     @ThriftMethod
-    String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+    MetadataEntry<String> listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
 
     @ThriftMethod
-    String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+    MetadataEntry<String> listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
 
     @ThriftMethod
-    String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+    MetadataEntry<String> getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
 
     @ThriftMethod
-    String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+    MetadataEntry<String> getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
 
     @ThriftMethod
-    String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName);
+    MetadataEntry<String> getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+
+    @ThriftMethod
+    MetadataEntry<String> getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName);
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -1,0 +1,795 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.Session;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.metadata.AnalyzePropertyManager;
+import com.facebook.presto.metadata.AnalyzeTableHandle;
+import com.facebook.presto.metadata.CatalogMetadata;
+import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.InsertTableHandle;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataUpdates;
+import com.facebook.presto.metadata.NewTableLayout;
+import com.facebook.presto.metadata.OutputTableHandle;
+import com.facebook.presto.metadata.PartitioningMetadata;
+import com.facebook.presto.metadata.ProcedureRegistry;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.metadata.ResolvedIndex;
+import com.facebook.presto.metadata.SchemaPropertyManager;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.TableLayout;
+import com.facebook.presto.metadata.TableLayoutResult;
+import com.facebook.presto.metadata.TableMetadata;
+import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.RoleGrant;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
+import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.transaction.TransactionManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class RemoteMetadataManager
+        implements Metadata
+{
+    private static final String EMPTY_STRING = "";
+    private final Metadata delegate;
+    private final TransactionManager transactionManager;
+    private final ObjectMapper objectMapper;
+    private final DriftClient<CatalogServerClient> catalogServerClient;
+
+    @Inject
+    public RemoteMetadataManager(
+            MetadataManager metadataManager,
+            TransactionManager transactionManager,
+            ObjectMapper objectMapper,
+            DriftClient<CatalogServerClient> catalogServerClient)
+    {
+        this.delegate = requireNonNull(metadataManager, "metadata is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.catalogServerClient = requireNonNull(catalogServerClient, "catalogServerClient is null");
+    }
+
+    @Override
+    public final void verifyComparableOrderableContract()
+    {
+        delegate.verifyComparableOrderableContract();
+    }
+
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        return delegate.getType(signature);
+    }
+
+    @Override
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functionInfos)
+    {
+        delegate.registerBuiltInFunctions(functionInfos);
+    }
+
+    @Override
+    public boolean schemaExists(Session session, CatalogSchemaName schema)
+    {
+        return catalogServerClient.get().schemaExists(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                schema);
+    }
+
+    @Override
+    public boolean catalogExists(Session session, String catalogName)
+    {
+        return catalogServerClient.get().catalogExists(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                catalogName);
+    }
+
+    @Override
+    public List<String> listSchemaNames(Session session, String catalogName)
+    {
+        String schemaNamesJson = catalogServerClient.get().listSchemaNames(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                catalogName);
+        if (!schemaNamesJson.equals(EMPTY_STRING)) {
+            try {
+                List<String> schemaNames;
+                schemaNames = objectMapper.readValue(schemaNamesJson, new TypeReference<List<String>>() {});
+                return schemaNames;
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName table)
+    {
+        String tableHandleJson = catalogServerClient.get().getTableHandle(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                table);
+        if (!tableHandleJson.equals(EMPTY_STRING)) {
+            try {
+                TableHandle tableHandle = objectMapper.readValue(tableHandleJson, TableHandle.class);
+                Optional<CatalogMetadata> catalogMetadata = this.transactionManager.getOptionalCatalogMetadata(session.getRequiredTransactionId(), table.getCatalogName());
+                if (catalogMetadata.isPresent()) {
+                    ConnectorTransactionHandle connectorTransactionHandle = catalogMetadata.get().getTransactionHandleFor(tableHandle.getConnectorId());
+                    tableHandle.setTransaction(connectorTransactionHandle);
+                }
+                return Optional.of(tableHandle);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName table, Map<String, Object> analyzeProperties)
+    {
+        return delegate.getTableHandleForStatisticsCollection(session, table, analyzeProperties);
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
+    {
+        return delegate.getSystemTable(session, tableName);
+    }
+
+    @Override
+    public TableLayoutResult getLayout(Session session, TableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        return delegate.getLayout(session, table, constraint, desiredColumns);
+    }
+
+    @Override
+    public TableLayout getLayout(Session session, TableHandle handle)
+    {
+        return delegate.getLayout(session, handle);
+    }
+
+    @Override
+    public TableHandle getAlternativeTableHandle(Session session, TableHandle tableHandle, PartitioningHandle partitioningHandle)
+    {
+        return delegate.getAlternativeTableHandle(session, tableHandle, partitioningHandle);
+    }
+
+    @Override
+    public boolean isLegacyGetLayoutSupported(Session session, TableHandle tableHandle)
+    {
+        return delegate.isLegacyGetLayoutSupported(session, tableHandle);
+    }
+
+    @Override
+    public Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        return delegate.getCommonPartitioning(session, left, right);
+    }
+
+    @Override
+    public boolean isRefinedPartitioningOver(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        return delegate.isRefinedPartitioningOver(session, left, right);
+    }
+
+    @Override
+    public PartitioningHandle getPartitioningHandleForExchange(Session session, String catalogName, int partitionCount, List<Type> partitionTypes)
+    {
+        return delegate.getPartitioningHandleForExchange(session, catalogName, partitionCount, partitionTypes);
+    }
+
+    @Override
+    public Optional<Object> getInfo(Session session, TableHandle handle)
+    {
+        return delegate.getInfo(session, handle);
+    }
+
+    @Override
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        return delegate.getTableMetadata(session, tableHandle);
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    {
+        return delegate.getTableStatistics(session, tableHandle, columnHandles, constraint);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        return delegate.getColumnHandles(session, tableHandle);
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return delegate.getColumnMetadata(session, tableHandle, columnHandle);
+    }
+
+    @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        return delegate.toExplainIOConstraints(session, tableHandle, constraints);
+    }
+
+    @Override
+    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        String tableListJson = catalogServerClient.get().listTables(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                prefix);
+        if (!tableListJson.equals(EMPTY_STRING)) {
+            try {
+                List<QualifiedObjectName> tableList;
+                tableList = objectMapper.readValue(tableListJson, new TypeReference<List<QualifiedObjectName>>() {});
+                return tableList;
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listTableColumns(session, prefix);
+    }
+
+    @Override
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties)
+    {
+        delegate.createSchema(session, schema, properties);
+    }
+
+    @Override
+    public void dropSchema(Session session, CatalogSchemaName schema)
+    {
+        delegate.dropSchema(session, schema);
+    }
+
+    @Override
+    public void renameSchema(Session session, CatalogSchemaName source, String target)
+    {
+        delegate.renameSchema(session, source, target);
+    }
+
+    @Override
+    public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        delegate.createTable(session, catalogName, tableMetadata, ignoreExisting);
+    }
+
+    @Override
+    public TableHandle createTemporaryTable(Session session, String catalogName, List<ColumnMetadata> columns, Optional<PartitioningMetadata> partitioningMetadata)
+    {
+        return delegate.createTemporaryTable(session, catalogName, columns, partitioningMetadata);
+    }
+
+    @Override
+    public void renameTable(Session session, TableHandle tableHandle, QualifiedObjectName newTableName)
+    {
+        delegate.renameTable(session, tableHandle, newTableName);
+    }
+
+    @Override
+    public void renameColumn(Session session, TableHandle tableHandle, ColumnHandle source, String target)
+    {
+        delegate.renameColumn(session, tableHandle, source, target);
+    }
+
+    @Override
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    {
+        delegate.addColumn(session, tableHandle, column);
+    }
+
+    @Override
+    public void dropColumn(Session session, TableHandle tableHandle, ColumnHandle column)
+    {
+        delegate.dropColumn(session, tableHandle, column);
+    }
+
+    @Override
+    public void dropTable(Session session, TableHandle tableHandle)
+    {
+        delegate.dropTable(session, tableHandle);
+    }
+
+    @Override
+    public void truncateTable(Session session, TableHandle tableHandle)
+    {
+        delegate.truncateTable(session, tableHandle);
+    }
+
+    @Override
+    public Optional<NewTableLayout> getInsertLayout(Session session, TableHandle table)
+    {
+        return delegate.getInsertLayout(session, table);
+    }
+
+    @Override
+    public Optional<NewTableLayout> getPreferredShuffleLayoutForInsert(Session session, TableHandle table)
+    {
+        return delegate.getPreferredShuffleLayoutForInsert(session, table);
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getStatisticsCollectionMetadataForWrite(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getStatisticsCollectionMetadata(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public AnalyzeTableHandle beginStatisticsCollection(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginStatisticsCollection(session, tableHandle);
+    }
+
+    @Override
+    public void finishStatisticsCollection(Session session, AnalyzeTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
+    }
+
+    @Override
+    public Optional<NewTableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getNewTableLayout(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public Optional<NewTableLayout> getPreferredShuffleLayoutForNewTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getPreferredShuffleLayoutForNewTable(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public void beginQuery(Session session, Set<ConnectorId> connectors)
+    {
+        delegate.beginQuery(session, connectors);
+    }
+
+    @Override
+    public void cleanupQuery(Session session)
+    {
+        delegate.cleanupQuery(session);
+    }
+
+    @Override
+    public OutputTableHandle beginCreateTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, Optional<NewTableLayout> layout)
+    {
+        return delegate.beginCreateTable(session, catalogName, tableMetadata, layout);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
+    }
+
+    @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginInsert(session, tableHandle);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return delegate.finishInsert(session, tableHandle, fragments, computedStatistics);
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        return delegate.getUpdateRowIdColumnHandle(session, tableHandle);
+    }
+
+    @Override
+    public boolean supportsMetadataDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.supportsMetadataDelete(session, tableHandle);
+    }
+
+    @Override
+    public OptionalLong metadataDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.metadataDelete(session, tableHandle);
+    }
+
+    @Override
+    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginDelete(session, tableHandle);
+    }
+
+    @Override
+    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        delegate.finishDelete(session, tableHandle, fragments);
+    }
+
+    @Override
+    public Optional<ConnectorId> getCatalogHandle(Session session, String catalogName)
+    {
+        return delegate.getCatalogHandle(session, catalogName);
+    }
+
+    @Override
+    public Map<String, ConnectorId> getCatalogNames(Session session)
+    {
+        return delegate.getCatalogNames(session);
+    }
+
+    @Override
+    public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
+    {
+        String viewsListJson = catalogServerClient.get().listViews(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                prefix);
+        if (!viewsListJson.equals(EMPTY_STRING)) {
+            try {
+                List<QualifiedObjectName> viewsList;
+                viewsList = objectMapper.readValue(viewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+                return viewsList;
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
+    {
+        String viewsMapJson = catalogServerClient.get().getViews(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                prefix);
+        if (!viewsMapJson.equals(EMPTY_STRING)) {
+            try {
+                Map<QualifiedObjectName, ViewDefinition> viewsMap;
+                viewsMap = objectMapper.readValue(viewsMapJson, new TypeReference<Map<QualifiedObjectName, ViewDefinition>>() {});
+                return viewsMap;
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new HashMap<>();
+    }
+
+    @Override
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    {
+        String viewDefinitionJson = catalogServerClient.get().getView(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                viewName);
+        if (!viewDefinitionJson.equals(EMPTY_STRING)) {
+            try {
+                ViewDefinition viewDefinition = objectMapper.readValue(viewDefinitionJson, ViewDefinition.class);
+                return Optional.of(viewDefinition);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void createView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        delegate.createView(session, catalogName, viewMetadata, viewData, replace);
+    }
+
+    @Override
+    public void dropView(Session session, QualifiedObjectName viewName)
+    {
+        delegate.dropView(session, viewName);
+    }
+
+    @Override
+    public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        String connectorMaterializedViewDefinitionJson = catalogServerClient.get().getMaterializedView(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                viewName);
+        if (!connectorMaterializedViewDefinitionJson.equals(EMPTY_STRING)) {
+            try {
+                ConnectorMaterializedViewDefinition connectorMaterializedViewDefinition = objectMapper.readValue(connectorMaterializedViewDefinitionJson, ConnectorMaterializedViewDefinition.class);
+                return Optional.of(connectorMaterializedViewDefinition);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.isMaterializedView(session, viewName);
+    }
+
+    @Override
+    public void createMaterializedView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, ConnectorMaterializedViewDefinition viewDefinition, boolean ignoreExisting)
+    {
+        delegate.createMaterializedView(session, catalogName, viewMetadata, viewDefinition, ignoreExisting);
+    }
+
+    @Override
+    public void dropMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        delegate.dropMaterializedView(session, viewName);
+    }
+
+    @Override
+    public MaterializedViewStatus getMaterializedViewStatus(Session session, QualifiedObjectName materializedViewName)
+    {
+        return delegate.getMaterializedViewStatus(session, materializedViewName);
+    }
+
+    @Override
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginRefreshMaterializedView(session, tableHandle);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return delegate.finishRefreshMaterializedView(session, tableHandle, fragments, computedStatistics);
+    }
+
+    @Override
+    public List<QualifiedObjectName> getReferencedMaterializedViews(Session session, QualifiedObjectName tableName)
+    {
+        String referencedMaterializedViewsListJson = catalogServerClient.get().getReferencedMaterializedViews(
+                transactionManager.getTransactionInfo(session.getRequiredTransactionId()),
+                session.toSessionRepresentation(),
+                tableName);
+        if (!referencedMaterializedViewsListJson.equals(EMPTY_STRING)) {
+            try {
+                List<QualifiedObjectName> referencedMaterializedViewsList;
+                referencedMaterializedViewsList = objectMapper.readValue(referencedMaterializedViewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+                return referencedMaterializedViewsList;
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
+    }
+
+    @Override
+    public void createRole(Session session, String role, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        delegate.createRole(session, role, grantor, catalog);
+    }
+
+    @Override
+    public void dropRole(Session session, String role, String catalog)
+    {
+        delegate.dropRole(session, role, catalog);
+    }
+
+    @Override
+    public Set<String> listRoles(Session session, String catalog)
+    {
+        return delegate.listRoles(session, catalog);
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(Session session, String catalog, PrestoPrincipal principal)
+    {
+        return delegate.listRoleGrants(session, catalog, principal);
+    }
+
+    @Override
+    public void grantRoles(Session session, Set<String> roles, Set<PrestoPrincipal> grantees, boolean withAdminOption, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        delegate.grantRoles(session, roles, grantees, withAdminOption, grantor, catalog);
+    }
+
+    @Override
+    public void revokeRoles(Session session, Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOptionFor, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        delegate.revokeRoles(session, roles, grantees, adminOptionFor, grantor, catalog);
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(Session session, PrestoPrincipal principal, String catalog)
+    {
+        return delegate.listApplicableRoles(session, principal, catalog);
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Session session, String catalog)
+    {
+        return delegate.listEnabledRoles(session, catalog);
+    }
+
+    @Override
+    public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, PrestoPrincipal grantee, boolean grantOption)
+    {
+        delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, PrestoPrincipal grantee, boolean grantOption)
+    {
+        delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listTablePrivileges(session, prefix);
+    }
+
+    @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+    }
+
+    @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+    }
+
+    @Override
+    public MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdateRequests, QueryId queryId)
+    {
+        return delegate.getMetadataUpdateResults(session, queryManager, metadataUpdateRequests, queryId);
+    }
+
+    @Override
+    public FunctionAndTypeManager getFunctionAndTypeManager()
+    {
+        return delegate.getFunctionAndTypeManager();
+    }
+
+    @Override
+    public ProcedureRegistry getProcedureRegistry()
+    {
+        return delegate.getProcedureRegistry();
+    }
+
+    @Override
+    public BlockEncodingSerde getBlockEncodingSerde()
+    {
+        return delegate.getBlockEncodingSerde();
+    }
+
+    @Override
+    public SessionPropertyManager getSessionPropertyManager()
+    {
+        return delegate.getSessionPropertyManager();
+    }
+
+    @Override
+    public SchemaPropertyManager getSchemaPropertyManager()
+    {
+        return delegate.getSchemaPropertyManager();
+    }
+
+    @Override
+    public TablePropertyManager getTablePropertyManager()
+    {
+        return delegate.getTablePropertyManager();
+    }
+
+    @Override
+    public ColumnPropertyManager getColumnPropertyManager()
+    {
+        return delegate.getColumnPropertyManager();
+    }
+
+    @Override
+    public AnalyzePropertyManager getAnalyzePropertyManager()
+    {
+        return delegate.getAnalyzePropertyManager();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId connectorId)
+    {
+        return delegate.getConnectorCapabilities(session, connectorId);
+    }
+
+    @Override
+    public TableLayoutFilterCoverage getTableLayoutFilterCoverage(Session session, TableHandle tableHandle, Set<String> relevantPartitionColumns)
+    {
+        return delegate.getTableLayoutFilterCoverage(session, tableHandle, relevantPartitionColumns);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +31,7 @@ import static com.facebook.presto.metadata.MetadataUtil.checkSchemaName;
 import static com.facebook.presto.metadata.MetadataUtil.checkTableName;
 
 @Immutable
+@ThriftStruct
 public class QualifiedTablePrefix
 {
     private final String catalogName;
@@ -56,6 +60,7 @@ public class QualifiedTablePrefix
     }
 
     @JsonCreator
+    @ThriftConstructor
     public QualifiedTablePrefix(
             @JsonProperty("catalogName") String catalogName,
             @JsonProperty("schemaName") Optional<String> schemaName,
@@ -73,18 +78,21 @@ public class QualifiedTablePrefix
     }
 
     @JsonProperty
+    @ThriftField(value = 1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
     @JsonProperty
+    @ThriftField(value = 2)
     public Optional<String> getSchemaName()
     {
         return schemaName;
     }
 
     @JsonProperty
+    @ThriftField(value = 3)
     public Optional<String> getTableName()
     {
         return tableName;

--- a/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
@@ -63,6 +63,12 @@ public class DelegatingTransactionManager
     }
 
     @Override
+    public void tryRegisterTransaction(TransactionInfo transactionInfo)
+    {
+        delegate.tryRegisterTransaction(transactionInfo);
+    }
+
+    @Override
     public TransactionId beginTransaction(boolean autoCommitContext)
     {
         return delegate.beginTransaction(autoCommitContext);

--- a/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
@@ -50,6 +50,12 @@ public class NoOpTransactionManager
     }
 
     @Override
+    public void tryRegisterTransaction(TransactionInfo transactionInfo)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public TransactionId beginTransaction(boolean autoCommitContext)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.transaction;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.collect.ImmutableList;
@@ -24,6 +27,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class TransactionInfo
 {
     private final TransactionId transactionId;
@@ -35,6 +39,7 @@ public class TransactionInfo
     private final List<ConnectorId> connectorIds;
     private final Optional<ConnectorId> writtenConnectorId;
 
+    @ThriftConstructor
     public TransactionInfo(
             TransactionId transactionId,
             IsolationLevel isolationLevel,
@@ -55,41 +60,49 @@ public class TransactionInfo
         this.writtenConnectorId = requireNonNull(writtenConnectorId, "writtenConnectorId is null");
     }
 
+    @ThriftField(value = 1)
     public TransactionId getTransactionId()
     {
         return transactionId;
     }
 
+    @ThriftField(value = 2)
     public IsolationLevel getIsolationLevel()
     {
         return isolationLevel;
     }
 
+    @ThriftField(value = 3)
     public boolean isReadOnly()
     {
         return readOnly;
     }
 
+    @ThriftField(value = 4)
     public boolean isAutoCommitContext()
     {
         return autoCommitContext;
     }
 
+    @ThriftField(value = 5)
     public DateTime getCreateTime()
     {
         return createTime;
     }
 
+    @ThriftField(value = 6)
     public Duration getIdleTime()
     {
         return idleTime;
     }
 
+    @ThriftField(value = 7)
     public List<ConnectorId> getConnectorIds()
     {
         return connectorIds;
     }
 
+    @ThriftField(value = 8)
     public Optional<ConnectorId> getWrittenConnectorId()
     {
         return writtenConnectorId;

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -38,6 +38,8 @@ public interface TransactionManager
 
     List<TransactionInfo> getAllTransactionInfos();
 
+    void tryRegisterTransaction(TransactionInfo transactionInfo);
+
     TransactionId beginTransaction(boolean autoCommitContext);
 
     TransactionId beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommitContext);

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
@@ -60,7 +60,7 @@ public class TestCatalogServerResponse
     public void testSchemaExists()
             throws Exception
     {
-        boolean schemaExists = testingCatalogServerClient.schemaExists(null, null, null);
+        boolean schemaExists = testingCatalogServerClient.schemaExists(null, null, null).getReturnValue();
         boolean actualSchemaExists = false;
 
         assertEquals(schemaExists, actualSchemaExists);
@@ -70,7 +70,7 @@ public class TestCatalogServerResponse
     public void testCatalogExists()
             throws Exception
     {
-        boolean catalogExists = testingCatalogServerClient.catalogExists(null, null, null);
+        boolean catalogExists = testingCatalogServerClient.catalogExists(null, null, null).getReturnValue();
         boolean actualCatalogExists = true;
 
         assertEquals(catalogExists, actualCatalogExists);
@@ -80,7 +80,7 @@ public class TestCatalogServerResponse
     public void testListSchemaNames()
             throws Exception
     {
-        String schemaNamesJson = testingCatalogServerClient.listSchemaNames(null, null, null);
+        String schemaNamesJson = testingCatalogServerClient.listSchemaNames(null, null, null).getReturnValue();
         List<String> schemaNames = objectMapper.readValue(schemaNamesJson, new TypeReference<List<String>>() {});
         List<String> actualSchemaNames = new ArrayList<>(Arrays.asList("information_schema", "tiny", "sf1", "sf100", "sf300", "sf1000", "sf3000", "sf10000", "sf30000", "sf100000"));
 
@@ -91,7 +91,7 @@ public class TestCatalogServerResponse
     public void testGetTableHandle()
             throws Exception
     {
-        String tableHandleJson = testingCatalogServerClient.getTableHandle(null, null, null);
+        String tableHandleJson = testingCatalogServerClient.getTableHandle(null, null, null).getReturnValue();
         TableHandle tableHandle = objectMapper.readValue(tableHandleJson, TableHandle.class);
         ConnectorId connectorId = new ConnectorId("$info_schema@system");
         ConnectorTableHandle connectorHandle = new InformationSchemaTableHandle("system", "information_schema", "schemata");
@@ -106,7 +106,7 @@ public class TestCatalogServerResponse
     public void testListTables()
             throws Exception
     {
-        String tableListJson = testingCatalogServerClient.listTables(null, null, null);
+        String tableListJson = testingCatalogServerClient.listTables(null, null, null).getReturnValue();
         List<QualifiedObjectName> tableList = objectMapper.readValue(tableListJson, new TypeReference<List<QualifiedObjectName>>() {});
         List<QualifiedObjectName> actualTableList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("tpch", "sf1", "nation")));
 
@@ -117,7 +117,7 @@ public class TestCatalogServerResponse
     public void testListViews()
             throws Exception
     {
-        String viewsListJson = testingCatalogServerClient.listViews(null, null, null);
+        String viewsListJson = testingCatalogServerClient.listViews(null, null, null).getReturnValue();
         List<QualifiedObjectName> viewsList = objectMapper.readValue(viewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
         List<QualifiedObjectName> actualViewsList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("hive", "tpch", "eric"), new QualifiedObjectName("hive", "tpch", "eric2")));
 
@@ -128,7 +128,7 @@ public class TestCatalogServerResponse
     public void testGetViews()
             throws Exception
     {
-        String viewsMapJson = testingCatalogServerClient.getViews(null, null, null);
+        String viewsMapJson = testingCatalogServerClient.getViews(null, null, null).getReturnValue();
         Map<QualifiedObjectName, ViewDefinition> viewsMap = objectMapper.readValue(viewsMapJson, new TypeReference<Map<QualifiedObjectName, ViewDefinition>>() {});
         Map<QualifiedObjectName, ViewDefinition> actualViewsMap = new HashMap<>();
         QualifiedObjectName key = new QualifiedObjectName("hive", "tpch", "eric");
@@ -147,7 +147,7 @@ public class TestCatalogServerResponse
     public void testGetView()
             throws Exception
     {
-        String viewDefinitionJson = testingCatalogServerClient.getView(null, null, null);
+        String viewDefinitionJson = testingCatalogServerClient.getView(null, null, null).getReturnValue();
         ViewDefinition viewDefinition = objectMapper.readValue(viewDefinitionJson, ViewDefinition.class);
         ViewDefinition actualViewDefinition = new ViewDefinition("SELECT name\nFROM\n  tpch.sf1.nation\n", Optional.of("hive"), Optional.of("tpch"), new ArrayList<>(), Optional.of("ericn576"), false);
 
@@ -161,7 +161,7 @@ public class TestCatalogServerResponse
     public void testGetMaterializedView()
             throws Exception
     {
-        String connectorMaterializedViewDefinitionJson = testingCatalogServerClient.getMaterializedView(null, null, null);
+        String connectorMaterializedViewDefinitionJson = testingCatalogServerClient.getMaterializedView(null, null, null).getReturnValue();
         ConnectorMaterializedViewDefinition connectorMaterializedViewDefinition = objectMapper.readValue(connectorMaterializedViewDefinitionJson, ConnectorMaterializedViewDefinition.class);
         String originalSql = "SELECT\n  name\n, nationkey\nFROM\n  test_customer_base\n";
         String schema = "tpch";
@@ -190,7 +190,7 @@ public class TestCatalogServerResponse
     public void testGetReferencedMaterializedViews()
             throws Exception
     {
-        String referencedMaterializedViewsListJson = testingCatalogServerClient.getReferencedMaterializedViews(null, null, null);
+        String referencedMaterializedViewsListJson = testingCatalogServerClient.getReferencedMaterializedViews(null, null, null).getReturnValue();
         List<QualifiedObjectName> referencedMaterializedViewsList = objectMapper.readValue(referencedMaterializedViewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
         List<QualifiedObjectName> actualReferencedMaterializedViewsList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("hive", "tpch", "test_customer_base")));
 

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTableHandle;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTransactionHandle;
+import com.facebook.presto.metadata.HandleJsonModule;
+import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.transaction.TransactionId;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestCatalogServerResponse
+{
+    private TestingCatalogServerClient testingCatalogServerClient;
+    private ObjectMapper objectMapper;
+
+    @BeforeTest
+    public void setup()
+    {
+        this.testingCatalogServerClient = new TestingCatalogServerClient();
+        Injector injector = Guice.createInjector(new JsonModule(), new HandleJsonModule());
+        this.objectMapper = injector.getInstance(ObjectMapper.class);
+    }
+
+    @Test
+    public void testSchemaExists()
+            throws Exception
+    {
+        boolean schemaExists = testingCatalogServerClient.schemaExists(null, null, null);
+        boolean actualSchemaExists = false;
+
+        assertEquals(schemaExists, actualSchemaExists);
+    }
+
+    @Test
+    public void testCatalogExists()
+            throws Exception
+    {
+        boolean catalogExists = testingCatalogServerClient.catalogExists(null, null, null);
+        boolean actualCatalogExists = true;
+
+        assertEquals(catalogExists, actualCatalogExists);
+    }
+
+    @Test
+    public void testListSchemaNames()
+            throws Exception
+    {
+        String schemaNamesJson = testingCatalogServerClient.listSchemaNames(null, null, null);
+        List<String> schemaNames = objectMapper.readValue(schemaNamesJson, new TypeReference<List<String>>() {});
+        List<String> actualSchemaNames = new ArrayList<>(Arrays.asList("information_schema", "tiny", "sf1", "sf100", "sf300", "sf1000", "sf3000", "sf10000", "sf30000", "sf100000"));
+
+        assertEquals(schemaNames, actualSchemaNames);
+    }
+
+    @Test
+    public void testGetTableHandle()
+            throws Exception
+    {
+        String tableHandleJson = testingCatalogServerClient.getTableHandle(null, null, null);
+        TableHandle tableHandle = objectMapper.readValue(tableHandleJson, TableHandle.class);
+        ConnectorId connectorId = new ConnectorId("$info_schema@system");
+        ConnectorTableHandle connectorHandle = new InformationSchemaTableHandle("system", "information_schema", "schemata");
+        UUID uuid = UUID.fromString("ffe9ae3e-60de-4175-a0b5-d635767085fa");
+        ConnectorTransactionHandle connectorTransactionHandle = new InformationSchemaTransactionHandle(new TransactionId(uuid));
+        TableHandle actualTableHandle = new TableHandle(connectorId, connectorHandle, connectorTransactionHandle, Optional.empty());
+
+        assertEquals(tableHandle, actualTableHandle);
+    }
+
+    @Test
+    public void testListTables()
+            throws Exception
+    {
+        String tableListJson = testingCatalogServerClient.listTables(null, null, null);
+        List<QualifiedObjectName> tableList = objectMapper.readValue(tableListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualTableList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("tpch", "sf1", "nation")));
+
+        assertEquals(tableList, actualTableList);
+    }
+
+    @Test
+    public void testListViews()
+            throws Exception
+    {
+        String viewsListJson = testingCatalogServerClient.listViews(null, null, null);
+        List<QualifiedObjectName> viewsList = objectMapper.readValue(viewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualViewsList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("hive", "tpch", "eric"), new QualifiedObjectName("hive", "tpch", "eric2")));
+
+        assertEquals(viewsList, actualViewsList);
+    }
+
+    @Test
+    public void testGetViews()
+            throws Exception
+    {
+        String viewsMapJson = testingCatalogServerClient.getViews(null, null, null);
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = objectMapper.readValue(viewsMapJson, new TypeReference<Map<QualifiedObjectName, ViewDefinition>>() {});
+        Map<QualifiedObjectName, ViewDefinition> actualViewsMap = new HashMap<>();
+        QualifiedObjectName key = new QualifiedObjectName("hive", "tpch", "eric");
+        actualViewsMap.put(key, new ViewDefinition("SELECT name\nFROM\n  tpch.sf1.nation\n", Optional.of("hive"), Optional.of("tpch"), new ArrayList<>(), Optional.of("ericn576"), false));
+        assertEquals(viewsMap.keySet(), actualViewsMap.keySet());
+        ViewDefinition viewDefinition = viewsMap.get(key);
+        ViewDefinition actualViewDefinition = actualViewsMap.get(key);
+
+        assertEquals(viewDefinition.getOriginalSql(), actualViewDefinition.getOriginalSql());
+        assertEquals(viewDefinition.getCatalog(), actualViewDefinition.getCatalog());
+        assertEquals(viewDefinition.getSchema(), actualViewDefinition.getSchema());
+        assertEquals(viewDefinition.getOwner(), actualViewDefinition.getOwner());
+    }
+
+    @Test
+    public void testGetView()
+            throws Exception
+    {
+        String viewDefinitionJson = testingCatalogServerClient.getView(null, null, null);
+        ViewDefinition viewDefinition = objectMapper.readValue(viewDefinitionJson, ViewDefinition.class);
+        ViewDefinition actualViewDefinition = new ViewDefinition("SELECT name\nFROM\n  tpch.sf1.nation\n", Optional.of("hive"), Optional.of("tpch"), new ArrayList<>(), Optional.of("ericn576"), false);
+
+        assertEquals(viewDefinition.getOriginalSql(), actualViewDefinition.getOriginalSql());
+        assertEquals(viewDefinition.getCatalog(), actualViewDefinition.getCatalog());
+        assertEquals(viewDefinition.getSchema(), actualViewDefinition.getSchema());
+        assertEquals(viewDefinition.getOwner(), actualViewDefinition.getOwner());
+    }
+
+    @Test
+    public void testGetMaterializedView()
+            throws Exception
+    {
+        String connectorMaterializedViewDefinitionJson = testingCatalogServerClient.getMaterializedView(null, null, null);
+        ConnectorMaterializedViewDefinition connectorMaterializedViewDefinition = objectMapper.readValue(connectorMaterializedViewDefinitionJson, ConnectorMaterializedViewDefinition.class);
+        String originalSql = "SELECT\n  name\n, nationkey\nFROM\n  test_customer_base\n";
+        String schema = "tpch";
+        String table = "eric";
+        List<SchemaTableName> baseTables = new ArrayList<>(Arrays.asList(new SchemaTableName("tpch", "test_customer_base")));
+        Optional<String> owner = Optional.of("ericn576");
+        List<ConnectorMaterializedViewDefinition.ColumnMapping> columnMappings = new ArrayList<>();
+        ConnectorMaterializedViewDefinition.TableColumn tableColumn = new ConnectorMaterializedViewDefinition.TableColumn(new SchemaTableName("tpch", "eric"), "name", true);
+        ConnectorMaterializedViewDefinition.TableColumn listTableColumn = new ConnectorMaterializedViewDefinition.TableColumn(new SchemaTableName("tpch", "test_customer_base"), "name", true);
+        columnMappings.add(new ConnectorMaterializedViewDefinition.ColumnMapping(tableColumn, new ArrayList<>(Arrays.asList(listTableColumn))));
+        List<SchemaTableName> baseTablesOnOuterJoinSide = new ArrayList<>();
+        Optional<List<String>> validRefreshColumns = Optional.of(new ArrayList<>(Arrays.asList("nationkey")));
+        ConnectorMaterializedViewDefinition actualConnectorMaterializedViewDefinition = new ConnectorMaterializedViewDefinition(originalSql, schema, table, baseTables, owner, columnMappings, baseTablesOnOuterJoinSide, validRefreshColumns);
+
+        assertEquals(connectorMaterializedViewDefinition.getOriginalSql(), actualConnectorMaterializedViewDefinition.getOriginalSql());
+        assertEquals(connectorMaterializedViewDefinition.getSchema(), actualConnectorMaterializedViewDefinition.getSchema());
+        assertEquals(connectorMaterializedViewDefinition.getTable(), actualConnectorMaterializedViewDefinition.getTable());
+        assertEquals(connectorMaterializedViewDefinition.getBaseTables(), actualConnectorMaterializedViewDefinition.getBaseTables());
+        assertEquals(connectorMaterializedViewDefinition.getOwner(), actualConnectorMaterializedViewDefinition.getOwner());
+        assertEquals(connectorMaterializedViewDefinition.getColumnMappingsAsMap(), actualConnectorMaterializedViewDefinition.getColumnMappingsAsMap());
+        assertEquals(connectorMaterializedViewDefinition.getBaseTablesOnOuterJoinSide(), actualConnectorMaterializedViewDefinition.getBaseTablesOnOuterJoinSide());
+        assertEquals(connectorMaterializedViewDefinition.getValidRefreshColumns(), actualConnectorMaterializedViewDefinition.getValidRefreshColumns());
+    }
+
+    @Test
+    public void testGetReferencedMaterializedViews()
+            throws Exception
+    {
+        String referencedMaterializedViewsListJson = testingCatalogServerClient.getReferencedMaterializedViews(null, null, null);
+        List<QualifiedObjectName> referencedMaterializedViewsList = objectMapper.readValue(referencedMaterializedViewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualReferencedMaterializedViewsList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("hive", "tpch", "test_customer_base")));
+
+        assertEquals(referencedMaterializedViewsList, actualReferencedMaterializedViewsList);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.transaction.TransactionInfo;
+
+class TestingCatalogServerClient
+        implements CatalogServerClient
+{
+    @Override
+    public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        return true;
+    }
+
+    @Override
+    public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        return "[\"information_schema\",\"tiny\",\"sf1\",\"sf100\",\"sf300\",\"sf1000\",\"sf3000\",\"sf10000\",\"sf30000\",\"sf100000\"]";
+    }
+
+    @Override
+    public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
+    {
+        return "{\"connectorId\":\"$info_schema@system\",\"connectorHandle\":{\"@type\":\"$info_schema\",\"catalogName\":\"system\",\"schemaName\":\"information_schema\",\"tableName\":\"schemata\"},\"transaction\":{\"@type\":\"$info_schema\",\"transactionId\":\"ffe9ae3e-60de-4175-a0b5-d635767085fa\"}}";
+    }
+
+    @Override
+    public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "[\"tpch.sf1.nation\"]";
+    }
+
+    @Override
+    public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "[\"hive.tpch.eric\",\"hive.tpch.eric2\"]";
+    }
+
+    @Override
+    public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "{\"hive.tpch.eric\":{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}}";
+    }
+
+    @Override
+    public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        return "{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}";
+    }
+
+    @Override
+    public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        return "{\"originalSql\":\"SELECT\\n  name\\n, nationkey\\nFROM\\n  test_customer_base\\n\",\"schema\":\"tpch\",\"table\":\"eric\",\"baseTables\":[{\"schema\":\"tpch\",\"table\":\"test_customer_base\"}],\"owner\":\"ericn576\",\"columnMapping\":[{\"viewColumn\":{\"tableName\":{\"schema\":\"tpch\",\"table\":\"eric\"},\"columnName\":\"name\",\"isDirectMapped\":true},\"baseTableColumns\":[{\"tableName\":{\"schema\":\"tpch\",\"table\":\"test_customer_base\"},\"columnName\":\"name\",\"isDirectMapped\":true}]}],\"baseTablesOnOuterJoinSide\":[],\"validRefreshColumns\":[\"nationkey\"]}";
+    }
+
+    @Override
+    public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
+    {
+        return "[\"hive.tpch.test_customer_base\"]";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
@@ -23,62 +23,62 @@ class TestingCatalogServerClient
         implements CatalogServerClient
 {
     @Override
-    public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
+    public MetadataEntry<Boolean> schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
     {
-        return false;
+        return new MetadataEntry<>(false, false);
     }
 
     @Override
-    public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    public MetadataEntry<Boolean> catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
-        return true;
+        return new MetadataEntry<>(true, false);
     }
 
     @Override
-    public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    public MetadataEntry<String> listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
-        return "[\"information_schema\",\"tiny\",\"sf1\",\"sf100\",\"sf300\",\"sf1000\",\"sf3000\",\"sf10000\",\"sf30000\",\"sf100000\"]";
+        return new MetadataEntry<>("[\"information_schema\",\"tiny\",\"sf1\",\"sf100\",\"sf300\",\"sf1000\",\"sf3000\",\"sf10000\",\"sf30000\",\"sf100000\"]", false);
     }
 
     @Override
-    public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
+    public MetadataEntry<String> getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
     {
-        return "{\"connectorId\":\"$info_schema@system\",\"connectorHandle\":{\"@type\":\"$info_schema\",\"catalogName\":\"system\",\"schemaName\":\"information_schema\",\"tableName\":\"schemata\"},\"transaction\":{\"@type\":\"$info_schema\",\"transactionId\":\"ffe9ae3e-60de-4175-a0b5-d635767085fa\"}}";
+        return new MetadataEntry<>("{\"connectorId\":\"$info_schema@system\",\"connectorHandle\":{\"@type\":\"$info_schema\",\"catalogName\":\"system\",\"schemaName\":\"information_schema\",\"tableName\":\"schemata\"},\"transaction\":{\"@type\":\"$info_schema\",\"transactionId\":\"ffe9ae3e-60de-4175-a0b5-d635767085fa\"}}", false);
     }
 
     @Override
-    public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    public MetadataEntry<String> listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
-        return "[\"tpch.sf1.nation\"]";
+        return new MetadataEntry<>("[\"tpch.sf1.nation\"]", false);
     }
 
     @Override
-    public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    public MetadataEntry<String> listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
-        return "[\"hive.tpch.eric\",\"hive.tpch.eric2\"]";
+        return new MetadataEntry<>("[\"hive.tpch.eric\",\"hive.tpch.eric2\"]", false);
     }
 
     @Override
-    public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    public MetadataEntry<String> getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
-        return "{\"hive.tpch.eric\":{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}}";
+        return new MetadataEntry<>("{\"hive.tpch.eric\":{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}}", false);
     }
 
     @Override
-    public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    public MetadataEntry<String> getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
-        return "{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}";
+        return new MetadataEntry<>("{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\",\"runAsInvoker\":false}", false);
     }
 
     @Override
-    public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    public MetadataEntry<String> getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
-        return "{\"originalSql\":\"SELECT\\n  name\\n, nationkey\\nFROM\\n  test_customer_base\\n\",\"schema\":\"tpch\",\"table\":\"eric\",\"baseTables\":[{\"schema\":\"tpch\",\"table\":\"test_customer_base\"}],\"owner\":\"ericn576\",\"columnMapping\":[{\"viewColumn\":{\"tableName\":{\"schema\":\"tpch\",\"table\":\"eric\"},\"columnName\":\"name\",\"isDirectMapped\":true},\"baseTableColumns\":[{\"tableName\":{\"schema\":\"tpch\",\"table\":\"test_customer_base\"},\"columnName\":\"name\",\"isDirectMapped\":true}]}],\"baseTablesOnOuterJoinSide\":[],\"validRefreshColumns\":[\"nationkey\"]}";
+        return new MetadataEntry<>("{\"originalSql\":\"SELECT\\n  name\\n, nationkey\\nFROM\\n  test_customer_base\\n\",\"schema\":\"tpch\",\"table\":\"eric\",\"baseTables\":[{\"schema\":\"tpch\",\"table\":\"test_customer_base\"}],\"owner\":\"ericn576\",\"columnMapping\":[{\"viewColumn\":{\"tableName\":{\"schema\":\"tpch\",\"table\":\"eric\"},\"columnName\":\"name\",\"isDirectMapped\":true},\"baseTableColumns\":[{\"tableName\":{\"schema\":\"tpch\",\"table\":\"test_customer_base\"},\"columnName\":\"name\",\"isDirectMapped\":true}]}],\"baseTablesOnOuterJoinSide\":[],\"validRefreshColumns\":[\"nationkey\"]}", false);
     }
 
     @Override
-    public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
+    public MetadataEntry<String> getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
     {
-        return "[\"hive.tpch.test_customer_base\"]";
+        return new MetadataEntry<>("[\"hive.tpch.test_customer_base\"]", false);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
@@ -28,7 +28,7 @@ public final class TableHandle
 {
     private final ConnectorId connectorId;
     private final ConnectorTableHandle connectorHandle;
-    private final ConnectorTransactionHandle transaction;
+    private ConnectorTransactionHandle transaction;
 
     // ConnectorTableHandle will represent the engine's view of data set on a table, we will deprecate ConnectorTableLayoutHandle later.
     // TODO remove table layout once it is fully deprecated.
@@ -88,6 +88,11 @@ public final class TableHandle
     public Optional<Supplier<TupleDomain<ColumnHandle>>> getDynamicFilter()
     {
         return dynamicFilter;
+    }
+
+    public void setTransaction(ConnectorTransactionHandle connectorTransactionHandle)
+    {
+        this.transaction = connectorTransactionHandle;
     }
 
     public TableHandle withDynamicFilter(Supplier<TupleDomain<ColumnHandle>> dynamicFilter)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/transaction/IsolationLevel.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/transaction/IsolationLevel.java
@@ -13,17 +13,22 @@
  */
 package com.facebook.presto.spi.transaction;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
 import com.facebook.presto.spi.PrestoException;
 
 import static com.facebook.presto.spi.StandardErrorCode.UNSUPPORTED_ISOLATION_LEVEL;
 import static java.lang.String.format;
 
+@ThriftEnum
 public enum IsolationLevel
 {
-    SERIALIZABLE,
-    REPEATABLE_READ,
-    READ_COMMITTED,
-    READ_UNCOMMITTED;
+    SERIALIZABLE(0),
+    REPEATABLE_READ(1),
+    READ_COMMITTED(2),
+    READ_UNCOMMITTED(3);
+
+    private final int value;
 
     public boolean meetsRequirementOf(IsolationLevel requirement)
     {
@@ -45,6 +50,17 @@ public enum IsolationLevel
         }
 
         throw new AssertionError("Unhandled isolation level: " + this);
+    }
+
+    IsolationLevel(int value)
+    {
+        this.value = value;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return value;
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -83,7 +83,7 @@ public final class TpchQueryRunner
             throws Exception
     {
         Logging.initialize();
-        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
+        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"), 1);
         Thread.sleep(10);
         Logger log = Logger.get(TpchQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
 
-import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -86,7 +86,7 @@ public class TpcdsSplit
     @Override
     public NodeSelectionStrategy getNodeSelectionStrategy()
     {
-        return HARD_AFFINITY;
+        return NO_PREFERENCE;
     }
 
     @JsonProperty

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
 
-import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -86,7 +86,7 @@ public class TpchSplit
     @Override
     public NodeSelectionStrategy getNodeSelectionStrategy()
     {
-        return HARD_AFFINITY;
+        return NO_PREFERENCE;
     }
 
     @JsonProperty


### PR DESCRIPTION
## Do not merge this (Only review last 2 commits) Only for feedback
- Enabling caching on both the coordinator and the catalog server
- The cache will first check the coordinator and then defer to the catalog server if the cache misses
- Added runtimeStats to measure cache miss count both on the coordinator level and the catalog server
