### PR TITLE
Add rule to remove redundant EnforceSingleRowNode's

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -95,6 +95,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantAggregateDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantEnforceSingleRowNode;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantLimit;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSort;
@@ -447,6 +448,7 @@ public class PlanOptimizers
                                 new RemoveRedundantSort(),
                                 new RemoveRedundantLimit(),
                                 new RemoveRedundantDistinctLimit(),
+                                new RemoveRedundantEnforceSingleRowNode(),
                                 new RemoveRedundantAggregateDistinct(),
                                 new RemoveRedundantIdentityProjections(),
                                 new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantEnforceSingleRowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantEnforceSingleRowNode.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
+import static com.facebook.presto.sql.planner.plan.Patterns.enforceSingleRow;
+
+/**
+ * Remove EnforceSingleRow node when the subplan is guaranteed to produce only one row
+ */
+public class RemoveRedundantEnforceSingleRowNode
+        implements Rule<EnforceSingleRowNode>
+{
+    private static final Pattern<EnforceSingleRowNode> PATTERN = enforceSingleRow();
+
+    @Override
+    public Pattern<EnforceSingleRowNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(EnforceSingleRowNode enforceSingleRowNode, Captures captures, Context context)
+    {
+        if (isScalar(enforceSingleRowNode.getSource(), context.getLookup())) {
+            return Result.ofPlanNode(enforceSingleRowNode.getSource());
+        }
+
+        return Result.empty();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveRedundantEnforceSingleRowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveRedundantEnforceSingleRowNode.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+
+public class TestRemoveRedundantEnforceSingleRowNode
+        extends BaseRuleTest
+{
+    @Test
+    public void testValidateEnforceSingleRowNodeRemoved()
+    {
+        tester().assertThat(new RemoveRedundantEnforceSingleRowNode())
+                .on(p ->
+                        p.enforceSingleRow(
+                                p.values(1, p.variable("c"))))
+                .matches(node(ValuesNode.class));
+
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantEnforceSingleRowNode()))
+                .on("SELECT * FROM orders WHERE orderkey = (SELECT min(orderkey) FROM lineitem)")
+                .validates(plan -> assertNodeRemovedFromPlan(plan, EnforceSingleRowNode.class));
+
+        // Remove multiple EnforceSingleRowNode's
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantEnforceSingleRowNode()))
+                .on("SELECT * FROM orders WHERE orderkey = (SELECT min(orderkey) FROM lineitem) or orderkey = (SELECT max(orderkey) from lineitem)")
+                .validates(plan -> assertNodeRemovedFromPlan(plan, EnforceSingleRowNode.class));
+
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantEnforceSingleRowNode()))
+                .on("SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = (SELECT 1) AND o2.orderkey = (SELECT 1) AND o1.orderkey + o2.orderkey = (SELECT 2)")
+                .validates(plan -> assertNodeRemovedFromPlan(plan, EnforceSingleRowNode.class));
+
+        // negative test
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantEnforceSingleRowNode()))
+                .on("SELECT * FROM orders WHERE orderkey = (SELECT orderkey FROM lineitem ORDER BY orderkey LIMIT 2)")
+                .validates(plan -> assertNodePresentInPlan(plan, EnforceSingleRowNode.class));
+    }
+
+    @Test
+    public void testDoesNotFire()
+    {
+        tester().assertThat(new RemoveRedundantEnforceSingleRowNode())
+                .on(p ->
+                        p.enforceSingleRow(
+                                p.values(10, p.variable("c"))))
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Remove EnforceSingleRowNode from plans when the cardinality of the incoming node is provably less than or equal to 1

```
== NO RELEASE NOTE ==
```
