### PR TITLE
Add mapStatisticsEnabled flag to OrcWriterOptions

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -42,6 +42,7 @@ public class ColumnWriterOptions
     private final int preserveDirectEncodingStripeCount;
     private final CompressionBufferPool compressionBufferPool;
     private final Set<Integer> flattenedNodes;
+    private final boolean mapStatisticsEnabled;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
@@ -54,7 +55,8 @@ public class ColumnWriterOptions
             boolean ignoreDictionaryRowGroupSizes,
             int preserveDirectEncodingStripeCount,
             CompressionBufferPool compressionBufferPool,
-            Set<Integer> flattenedNodes)
+            Set<Integer> flattenedNodes,
+            boolean mapStatisticsEnabled)
     {
         this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
         this.compressionLevel = requireNonNull(compressionLevel, "compressionLevel is null");
@@ -68,6 +70,7 @@ public class ColumnWriterOptions
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
         this.compressionBufferPool = requireNonNull(compressionBufferPool, "compressionBufferPool is null");
         this.flattenedNodes = requireNonNull(flattenedNodes, "flattenedNodes is null");
+        this.mapStatisticsEnabled = mapStatisticsEnabled;
     }
 
     public CompressionKind getCompressionKind()
@@ -125,6 +128,11 @@ public class ColumnWriterOptions
         return flattenedNodes;
     }
 
+    public boolean isMapStatisticsEnabled()
+    {
+        return mapStatisticsEnabled;
+    }
+
     /**
      * Create a copy of this ColumnWriterOptions, but disable string and integer dictionary encodings.
      */
@@ -149,7 +157,8 @@ public class ColumnWriterOptions
                 .setIgnoreDictionaryRowGroupSizes(isIgnoreDictionaryRowGroupSizes())
                 .setPreserveDirectEncodingStripeCount(getPreserveDirectEncodingStripeCount())
                 .setCompressionBufferPool(getCompressionBufferPool())
-                .setFlattenedNodes(getFlattenedNodes());
+                .setFlattenedNodes(getFlattenedNodes())
+                .setMapStatisticsEnabled(isMapStatisticsEnabled());
     }
 
     public static Builder builder()
@@ -170,6 +179,7 @@ public class ColumnWriterOptions
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
         private CompressionBufferPool compressionBufferPool = new LastUsedCompressionBufferPool();
         private Set<Integer> flattenedNodes = ImmutableSet.of();
+        private boolean mapStatisticsEnabled;
 
         private Builder() {}
 
@@ -239,6 +249,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setMapStatisticsEnabled(boolean mapStatisticsEnabled)
+        {
+            this.mapStatisticsEnabled = mapStatisticsEnabled;
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
             return new ColumnWriterOptions(
@@ -252,7 +268,8 @@ public class ColumnWriterOptions
                     ignoreDictionaryRowGroupSizes,
                     preserveDirectEncodingStripeCount,
                     compressionBufferPool,
-                    flattenedNodes);
+                    flattenedNodes,
+                    mapStatisticsEnabled);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -226,6 +226,7 @@ public class OrcWriter
                 .setPreserveDirectEncodingStripeCount(options.getPreserveDirectEncodingStripeCount())
                 .setCompressionBufferPool(compressionBufferPool)
                 .setFlattenedNodes(flattenedNodes)
+                .setMapStatisticsEnabled(options.isMapStatisticsEnabled())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
         recordValidation(validation -> validation.setFlattenedNodes(flattenedNodes));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -64,6 +64,7 @@ public class OrcWriterOptions
     private final boolean ignoreDictionaryRowGroupSizes;
     private final Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
     private final int preserveDirectEncodingStripeCount;
+    private final boolean mapStatisticsEnabled;
 
     /**
      * Contains indexes of columns (not nodes!) for which writer should use flattened encoding, e.g. flat maps.
@@ -87,7 +88,8 @@ public class OrcWriterOptions
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions,
             boolean ignoreDictionaryRowGroupSizes,
             int preserveDirectEncodingStripeCount,
-            Set<Integer> flattenedColumns)
+            Set<Integer> flattenedColumns,
+            boolean mapStatisticsEnabled)
     {
         requireNonNull(flushPolicy, "flushPolicy is null");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
@@ -118,6 +120,7 @@ public class OrcWriterOptions
         this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
         this.flattenedColumns = flattenedColumns;
+        this.mapStatisticsEnabled = mapStatisticsEnabled;
     }
 
     public OrcWriterFlushPolicy getFlushPolicy()
@@ -205,6 +208,11 @@ public class OrcWriterOptions
         return flattenedColumns;
     }
 
+    public boolean isMapStatisticsEnabled()
+    {
+        return mapStatisticsEnabled;
+    }
+
     @Override
     public String toString()
     {
@@ -226,6 +234,7 @@ public class OrcWriterOptions
                 .add("ignoreDictionaryRowGroupSizes", ignoreDictionaryRowGroupSizes)
                 .add("preserveDirectEncodingStripeCount", preserveDirectEncodingStripeCount)
                 .add("flattenedColumns", flattenedColumns)
+                .add("mapStatisticsEnabled", mapStatisticsEnabled)
                 .toString();
     }
 
@@ -260,6 +269,7 @@ public class OrcWriterOptions
         private boolean ignoreDictionaryRowGroupSizes;
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
         private Set<Integer> flattenedColumns = ImmutableSet.of();
+        private boolean mapStatisticsEnabled;
 
         public Builder withFlushPolicy(OrcWriterFlushPolicy flushPolicy)
         {
@@ -377,6 +387,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withMapStatisticsEnabled(boolean mapStatisticsEnabled)
+        {
+            this.mapStatisticsEnabled = mapStatisticsEnabled;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -404,7 +420,8 @@ public class OrcWriterOptions
                     dwrfWriterOptions,
                     ignoreDictionaryRowGroupSizes,
                     preserveDirectEncodingStripeCount,
-                    flattenedColumns);
+                    flattenedColumns,
+                    mapStatisticsEnabled);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
@@ -43,6 +43,7 @@ public class TestColumnWriterOptions
         int preserveDirectEncodingStripeCount = 27;
         CompressionBufferPool compressionBufferPool = new CompressionBufferPool.LastUsedCompressionBufferPool();
         Set<Integer> flattenedNodes = ImmutableSet.of(1, 5);
+        boolean mapStatisticsEnabled = true;
 
         ColumnWriterOptions options = ColumnWriterOptions.builder()
                 .setCompressionKind(compressionKind)
@@ -56,6 +57,7 @@ public class TestColumnWriterOptions
                 .setPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .setCompressionBufferPool(compressionBufferPool)
                 .setFlattenedNodes(flattenedNodes)
+                .setMapStatisticsEnabled(mapStatisticsEnabled)
                 .build();
 
         boolean checkDisabledDictionaryEncoding = false;
@@ -70,6 +72,7 @@ public class TestColumnWriterOptions
             assertEquals(actual.getPreserveDirectEncodingStripeCount(), preserveDirectEncodingStripeCount);
             assertEquals(actual.getCompressionBufferPool(), compressionBufferPool);
             assertEquals(actual.getFlattenedNodes(), flattenedNodes);
+            assertEquals(actual.isMapStatisticsEnabled(), mapStatisticsEnabled);
 
             if (checkDisabledDictionaryEncoding) {
                 assertFalse(actual.isStringDictionaryEncodingEnabled());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -30,6 +30,7 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 public class TestOrcWriterOptions
 {
@@ -63,7 +64,8 @@ public class TestOrcWriterOptions
     {
         OrcWriterOptions options = OrcWriterOptions.builder().build();
 
-        assertEquals(ImmutableSet.of(), options.getFlattenedColumns());
+        assertEquals(options.getFlattenedColumns(), ImmutableSet.of());
+        assertFalse(options.isMapStatisticsEnabled());
     }
 
     @Test
@@ -85,6 +87,7 @@ public class TestOrcWriterOptions
         boolean stringDictionarySortingEnabled = false;
         boolean stringDictionaryEncodingEnabled = false;
         int preserveDirectEncodingStripeCount = 10;
+        boolean mapStatisticsEnabled = true;
 
         OrcWriterOptions.Builder builder = OrcWriterOptions.builder()
                 .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
@@ -105,7 +108,8 @@ public class TestOrcWriterOptions
                 .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
                 .withStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
-                .withFlattenedColumns(ImmutableSet.of(4, 3));
+                .withFlattenedColumns(ImmutableSet.of(4, 3))
+                .withMapStatisticsEnabled(mapStatisticsEnabled);
 
         OrcWriterOptions options = builder.build();
 
@@ -126,7 +130,8 @@ public class TestOrcWriterOptions
         assertEquals(stringDictionaryEncodingEnabled, options.isStringDictionaryEncodingEnabled());
         assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
         assertEquals(preserveDirectEncodingStripeCount, options.getPreserveDirectEncodingStripeCount());
-        assertEquals(ImmutableSet.of(4, 3), options.getFlattenedColumns());
+        assertEquals(options.getFlattenedColumns(), ImmutableSet.of(4, 3));
+        assertEquals(options.isMapStatisticsEnabled(), mapStatisticsEnabled);
     }
 
     @Test
@@ -149,6 +154,7 @@ public class TestOrcWriterOptions
         boolean integerDictionaryEncodingEnabled = false;
         boolean stringDictionarySortingEnabled = true;
         int preserveDirectEncodingStripeCount = 0;
+        boolean mapStatisticsEnabled = true;
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
@@ -172,6 +178,7 @@ public class TestOrcWriterOptions
                 .withDwrfStripeCacheMode(dwrfStripeCacheMode)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .withFlattenedColumns(ImmutableSet.of(4))
+                .withMapStatisticsEnabled(mapStatisticsEnabled)
                 .build();
 
         String expectedString = "OrcWriterOptions{flushPolicy=DefaultOrcWriterFlushPolicy{stripeMaxRowCount=1100000, " +
@@ -181,7 +188,7 @@ public class TestOrcWriterOptions
                 "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +
                 "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
                 "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
-                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4]}";
+                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4], mapStatisticsEnabled=true}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
Add a flag to enable map statistics. The flag is currently noop as it's not consumed by the flat map writer yet. The default value is false.

Test plan:
- updated tests

```
== NO RELEASE NOTE ==
```
