### PR TITLE
Disable flaky test testDistributedQueue_burstTraffic

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesDb.java
@@ -170,7 +170,8 @@ public class TestDistributedQueuesDb
         waitForQueryState(queryRunner, 0, firstDashboardQuery, RUNNING);
     }
 
-    @Test(timeOut = 2_000)
+    // Temporarily disabling flaky test
+    @Test(timeOut = 2_000, enabled = false)
     public void testDistributedQueue_burstTraffic()
             throws Exception
     {


### PR DESCRIPTION
This test is flaky and sometimes times out. 
@swapsmagic I can see that this test was previously disabled due to flakiness, and you fixed this in PR #17162. 
Maybe we need to increase the timeout more. 



```
== NO RELEASE NOTE ==
```
