### PR TITLE
Add read/write support for map stats

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcEncoding.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcEncoding.java
@@ -25,7 +25,7 @@ public enum OrcEncoding
 {
     ORC {
         @Override
-        public MetadataReader createMetadataReader(RuntimeStats runtimeStats)
+        public MetadataReader createMetadataReader(RuntimeStats runtimeStats, OrcReaderOptions orcReaderOptions)
         {
             return new OrcMetadataReader(runtimeStats);
         }
@@ -38,9 +38,9 @@ public enum OrcEncoding
     },
     DWRF {
         @Override
-        public MetadataReader createMetadataReader(RuntimeStats runtimeStats)
+        public MetadataReader createMetadataReader(RuntimeStats runtimeStats, OrcReaderOptions orcReaderOptions)
         {
-            return new DwrfMetadataReader(runtimeStats);
+            return new DwrfMetadataReader(runtimeStats, orcReaderOptions);
         }
 
         @Override
@@ -50,7 +50,7 @@ public enum OrcEncoding
         }
     };
 
-    public abstract MetadataReader createMetadataReader(RuntimeStats runtimeStats);
+    public abstract MetadataReader createMetadataReader(RuntimeStats runtimeStats, OrcReaderOptions orcReaderOptions);
 
     public abstract MetadataWriter createMetadataWriter();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -158,7 +158,7 @@ public class OrcReader
         this.orcDataSource = orcDataSource;
         requireNonNull(orcEncoding, "orcEncoding is null");
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
-        this.metadataReader = new ExceptionWrappingMetadataReader(orcDataSource.getId(), orcEncoding.createMetadataReader(runtimeStats));
+        this.metadataReader = new ExceptionWrappingMetadataReader(orcDataSource.getId(), orcEncoding.createMetadataReader(runtimeStats, orcReaderOptions));
 
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -28,13 +28,20 @@ public class OrcReaderOptions
     // if the option is set to true, OrcSelectiveReader will append a row number block at the end of the page
     private final boolean appendRowNumber;
 
+    /**
+     * Read column statistics for flat map columns. Usually there are quite a
+     * lot of map statistics, so enable only if it's really needed.
+     */
+    private final boolean readMapStatistics;
+
     private OrcReaderOptions(
             DataSize maxMergeDistance,
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,
             boolean zstdJniDecompressionEnabled,
             boolean mapNullKeysEnabled,
-            boolean appendRowNumber)
+            boolean appendRowNumber,
+            boolean readMapStatistics)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -42,6 +49,7 @@ public class OrcReaderOptions
         this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         this.mapNullKeysEnabled = mapNullKeysEnabled;
         this.appendRowNumber = appendRowNumber;
+        this.readMapStatistics = readMapStatistics;
     }
 
     public DataSize getMaxMergeDistance()
@@ -74,6 +82,11 @@ public class OrcReaderOptions
         return appendRowNumber;
     }
 
+    public boolean readMapStatistics()
+    {
+        return readMapStatistics;
+    }
+
     @Override
     public String toString()
     {
@@ -84,6 +97,7 @@ public class OrcReaderOptions
                 .add("zstdJniDecompressionEnabled", zstdJniDecompressionEnabled)
                 .add("mapNullKeysEnabled", mapNullKeysEnabled)
                 .add("appendRowNumber", appendRowNumber)
+                .add("readMapStatistics", readMapStatistics)
                 .toString();
     }
 
@@ -100,6 +114,7 @@ public class OrcReaderOptions
         private boolean zstdJniDecompressionEnabled;
         private boolean mapNullKeysEnabled;
         private boolean appendRowNumber;
+        private boolean readMapStatistics;
 
         private Builder() {}
 
@@ -139,6 +154,12 @@ public class OrcReaderOptions
             return this;
         }
 
+        public Builder withReadMapStatistics(boolean readMapStatistics)
+        {
+            this.readMapStatistics = readMapStatistics;
+            return this;
+        }
+
         public OrcReaderOptions build()
         {
             return new OrcReaderOptions(
@@ -147,7 +168,8 @@ public class OrcReaderOptions
                     maxBlockSize,
                     zstdJniDecompressionEnabled,
                     mapNullKeysEnabled,
-                    appendRowNumber);
+                    appendRowNumber,
+                    readMapStatistics);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -19,6 +19,7 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatistics;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
+import com.facebook.presto.orc.metadata.statistics.MapStatisticsEntry;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.proto.DwrfProto.RowIndexEntry;
 import com.facebook.presto.orc.proto.DwrfProto.Type;
@@ -259,6 +260,17 @@ public class DwrfMetadataWriter
             builder.setBinaryStatistics(DwrfProto.BinaryStatistics.newBuilder()
                     .setSum(columnStatistics.getBinaryStatistics().getSum())
                     .build());
+        }
+
+        if (columnStatistics.getMapStatistics() != null) {
+            DwrfProto.MapStatistics.Builder statisticsBuilder = DwrfProto.MapStatistics.newBuilder();
+            for (MapStatisticsEntry entry : columnStatistics.getMapStatistics().getEntries()) {
+                statisticsBuilder.addStats(DwrfProto.MapEntryStatistics.newBuilder()
+                        .setKey(entry.getKey())
+                        .setStats(toColumnStatistics(entry.getColumnStatistics()))
+                        .build());
+            }
+            builder.setMapStatistics(statisticsBuilder.build());
         }
 
         return builder.build();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1612,18 +1612,19 @@ public class OrcTester
         DataSize dataSize = new DataSize(1, MEGABYTE);
         OrcDataSource orcDataSource = new FileOrcDataSource(inputFile, dataSize, dataSize, dataSize, true);
         RuntimeStats runtimeStats = new RuntimeStats();
+        OrcReaderOptions orcReaderOptions = OrcReaderOptions.builder()
+                .withMaxMergeDistance(dataSize)
+                .withTinyStripeThreshold(dataSize)
+                .withMaxBlockSize(dataSize)
+                .withZstdJniDecompressionEnabled(zstdJniDecompressionEnabled)
+                .build();
         OrcReader reader = new OrcReader(
                 orcDataSource,
                 encoding,
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                OrcReaderOptions.builder()
-                        .withMaxMergeDistance(dataSize)
-                        .withTinyStripeThreshold(dataSize)
-                        .withMaxBlockSize(dataSize)
-                        .withZstdJniDecompressionEnabled(zstdJniDecompressionEnabled)
-                        .build(),
+                orcReaderOptions,
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
@@ -1645,7 +1646,7 @@ public class OrcTester
                     Optional.empty(),
                     new TestingHiveOrcAggregatedMemoryContext(),
                     tailBuffer.length)) {
-                StripeFooter stripeFooter = encoding.createMetadataReader(runtimeStats).readStripeFooter(orcDataSource.getId(), footer.getTypes(), inputStream);
+                StripeFooter stripeFooter = encoding.createMetadataReader(runtimeStats, orcReaderOptions).readStripeFooter(orcDataSource.getId(), footer.getTypes(), inputStream);
                 stripes.add(stripeFooter);
             }
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
@@ -48,6 +48,12 @@ public class TestStorageOrcFileTailSource
     private static final DataSize DEFAULT_SIZE = new DataSize(1, MEGABYTE);
     private static final int FOOTER_READ_SIZE_IN_BYTES = (int) DEFAULT_SIZE.toBytes();
 
+    private final OrcReaderOptions orcReaderOptions = OrcReaderOptions.builder()
+            .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+            .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+            .withMaxBlockSize(new DataSize(1, MEGABYTE))
+            .build();
+
     private TempFile file;
     private MetadataReader metadataReader;
 
@@ -56,7 +62,7 @@ public class TestStorageOrcFileTailSource
             throws Exception
     {
         this.file = new TempFile();
-        this.metadataReader = new DwrfMetadataReader(new RuntimeStats());
+        this.metadataReader = new DwrfMetadataReader(new RuntimeStats(), orcReaderOptions);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
@@ -18,13 +18,20 @@ import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
+import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.IntegerColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
+import com.facebook.presto.orc.metadata.statistics.MapColumnStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.StringStatistics;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.protobuf.ByteString;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -42,6 +49,7 @@ import static com.facebook.presto.orc.metadata.TestOrcMetadataReader.TEST_CODE_P
 import static com.facebook.presto.orc.metadata.TestOrcMetadataReader.concatSlice;
 import static com.facebook.presto.orc.proto.DwrfProto.Stream.Kind.DATA;
 import static io.airlift.slice.SliceUtf8.codePointToUtf8;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -51,7 +59,14 @@ public class TestDwrfMetadataReader
 {
     private final long footerLength = 10;
     private final long compressionBlockSize = 8192;
-    private final DwrfMetadataReader dwrfMetadataReader = new DwrfMetadataReader(new RuntimeStats());
+    private final OrcReaderOptions orcReaderOptions = OrcReaderOptions.builder()
+            .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+            .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+            .withMaxBlockSize(new DataSize(1, MEGABYTE))
+            .withReadMapStatistics(true)
+            .build();
+    // this metadata reader has enabled map stats
+    private final DwrfMetadataReader dwrfMetadataReader = new DwrfMetadataReader(new RuntimeStats(), orcReaderOptions);
     private final DwrfProto.PostScript baseProtoPostScript = DwrfProto.PostScript.newBuilder()
             .setWriterVersion(HiveWriterVersion.ORC_HIVE_8732.getOrcWriterVersion())
             .setFooterLength(footerLength)
@@ -332,5 +347,49 @@ public class TestDwrfMetadataReader
                 minStringTruncateToValidRange(min, version),
                 maxStringTruncateToValidRange(max, version),
                 sum);
+    }
+
+    @DataProvider
+    public Object[][] columnStatisticsSupplier()
+    {
+        ColumnStatistics integerColumnStatistics1 = new IntegerColumnStatistics(7L, null, new IntegerStatistics(25L, 95L, 100L));
+        ColumnStatistics integerColumnStatistics2 = new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L));
+
+        MapColumnStatisticsBuilder mapStatsIntKeyBuilder = new MapColumnStatisticsBuilder();
+        mapStatsIntKeyBuilder.addMapStatistics(DwrfProto.KeyInfo.newBuilder().setIntKey(2).build(), integerColumnStatistics1);
+        mapStatsIntKeyBuilder.addMapStatistics(DwrfProto.KeyInfo.newBuilder().setIntKey(3).build(), integerColumnStatistics2);
+        ColumnStatistics mapColumnStatisticsIntKey = mapStatsIntKeyBuilder.buildColumnStatistics();
+
+        MapColumnStatisticsBuilder mapStatsStringKeyBuilder = new MapColumnStatisticsBuilder();
+        mapStatsStringKeyBuilder.addMapStatistics(DwrfProto.KeyInfo.newBuilder().setBytesKey(ByteString.copyFromUtf8("k1")).build(), integerColumnStatistics1);
+        mapStatsStringKeyBuilder.addMapStatistics(DwrfProto.KeyInfo.newBuilder().setBytesKey(ByteString.copyFromUtf8("k2")).build(), integerColumnStatistics2);
+        ColumnStatistics mapColumnStatisticsStringKey = mapStatsStringKeyBuilder.buildColumnStatistics();
+
+        ColumnStatistics expectedDisabledMapStats = new ColumnStatistics(16L, null);
+
+        OrcReaderOptions orcReaderOptionsDisabledMapStats = OrcReaderOptions.builder()
+                .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                .withReadMapStatistics(false)
+                .build();
+        DwrfMetadataReader dwrfMetadataReaderDisabledMapStats = new DwrfMetadataReader(new RuntimeStats(), orcReaderOptionsDisabledMapStats);
+
+        return new Object[][] {
+                {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReader},
+                {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReaderDisabledMapStats},
+                {mapColumnStatisticsIntKey, mapColumnStatisticsIntKey, dwrfMetadataReader},
+                {mapColumnStatisticsIntKey, expectedDisabledMapStats, dwrfMetadataReaderDisabledMapStats},
+                {mapColumnStatisticsStringKey, mapColumnStatisticsStringKey, dwrfMetadataReader},
+                {mapColumnStatisticsStringKey, expectedDisabledMapStats, dwrfMetadataReaderDisabledMapStats}
+        };
+    }
+
+    @Test(dataProvider = "columnStatisticsSupplier")
+    public void testToColumnStatisticsRoundtrip(ColumnStatistics input, ColumnStatistics output, DwrfMetadataReader dwrfMetadataReader)
+    {
+        DwrfProto.ColumnStatistics dwrfColumnStatistics = DwrfMetadataWriter.toColumnStatistics(input);
+        ColumnStatistics actual = dwrfMetadataReader.toColumnStatistics(HiveWriterVersion.ORC_HIVE_8732, dwrfColumnStatistics, false, null);
+        assertEquals(actual, output);
     }
 }


### PR DESCRIPTION
Update DWRF metadata reader and writer to read and write map statistics from the file.

This change will make the reader read map stats from the file. Flat map column writer map stats are not wired yet, so the writer isn't going to change the behavior.

Wiring map stats and the new flag in the flat map column writer is going to be the last diff in this series of changes to enable map stats.

Test plan:
- new unit tests
- Ran Uncle Vader for flat map enabled tables, results can be found under presto_map_stats_rw tag


```
== NO RELEASE NOTE ==
```
