### PR TITLE
Support queryUpdate event in EventListener

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.eventlistener.QueryInputMetadata;
 import com.facebook.presto.spi.eventlistener.QueryMetadata;
 import com.facebook.presto.spi.eventlistener.QueryOutputMetadata;
 import com.facebook.presto.spi.eventlistener.QueryStatistics;
+import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.ResourceDistribution;
 import com.facebook.presto.spi.eventlistener.StageStatistics;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
@@ -137,6 +138,11 @@ public class QueryMonitor
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 queryInfo.getSession().getTraceToken())));
+    }
+
+    public void queryUpdatedEvent(QueryInfo queryInfo)
+    {
+        eventListenerManager.queryUpdated(new QueryUpdatedEvent(createQueryMetadata(queryInfo)));
     }
 
     public void queryImmediateFailureEvent(BasicQueryInfo queryInfo, ExecutionFailureInfo failure)

--- a/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -107,6 +108,13 @@ public class EventListenerManager
     {
         if (configuredEventListener.get().isPresent()) {
             configuredEventListener.get().get().queryCreated(queryCreatedEvent);
+        }
+    }
+
+    public void queryUpdated(QueryUpdatedEvent queryUpdatedEvent)
+    {
+        if (configuredEventListener.get().isPresent()) {
+            configuredEventListener.get().get().queryUpdated(queryUpdatedEvent);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.collect.ImmutableMap;
 
@@ -48,6 +49,14 @@ public class TestingEventListenerManager
     {
         if (configuredEventListener.get().isPresent()) {
             configuredEventListener.get().get().queryCreated(queryCreatedEvent);
+        }
+    }
+
+    @Override
+    public void queryUpdated(QueryUpdatedEvent queryUpdatedEvent)
+    {
+        if (configuredEventListener.get().isPresent()) {
+            configuredEventListener.get().get().queryUpdated(queryUpdatedEvent);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisites;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesContext;
@@ -505,6 +506,12 @@ public class TestLocalDispatchQuery
         public void queryCreated(QueryCreatedEvent queryCreatedEvent)
         {
             fail("Query creation events should not be created in this test");
+        }
+
+        @Override
+        public void queryUpdated(QueryUpdatedEvent queryUpdatedEvent)
+        {
+            fail("Query update events should not be created in this test");
         }
 
         @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -420,6 +420,19 @@ public class PrestoSparkQueryExecutionFactory
             else {
                 planAndMore = queryPlanner.createQueryPlan(session, preparedQuery, warningCollector);
                 SubPlan fragmentedPlan = planFragmenter.fragmentQueryPlan(session, planAndMore.getPlan(), warningCollector);
+
+                queryMonitor.queryUpdatedEvent(
+                        createQueryInfo(
+                                session,
+                                sql,
+                                PLANNING,
+                                Optional.of(planAndMore),
+                                sparkQueueName,
+                                Optional.empty(),
+                                queryStateTimer,
+                                Optional.of(createStageInfo(session.getQueryId(), fragmentedPlan, ImmutableList.of())),
+                                warningCollector));
+
                 log.info(textDistributedPlan(fragmentedPlan, metadata.getFunctionAndTypeManager(), session, true));
                 fragmentedPlan = configureOutputPartitioning(session, fragmentedPlan);
                 TableWriteInfo tableWriteInfo = getTableWriteInfo(session, fragmentedPlan);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryUpdatedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryUpdatedEvent.java
@@ -13,25 +13,19 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
-public interface EventListener
+import static java.util.Objects.requireNonNull;
+
+public class QueryUpdatedEvent
 {
-    default void queryCreated(QueryCreatedEvent queryCreatedEvent)
+    private final QueryMetadata metadata;
+
+    public QueryUpdatedEvent(QueryMetadata metadata)
     {
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
-    /**
-     * Called after queryCreated event and can be used to capture intermediate
-     * info like query_plan, partial stats while the query is running
-     */
-    default void queryUpdated(QueryUpdatedEvent queryUpdatedEvent)
+    public QueryMetadata getMetadata()
     {
-    }
-
-    default void queryCompleted(QueryCompletedEvent queryCompletedEvent)
-    {
-    }
-
-    default void splitCompleted(SplitCompletedEvent splitCompletedEvent)
-    {
+        return metadata;
     }
 }


### PR DESCRIPTION
Currently, EventListener supports queryCreated and queryCompleted
events only. So, while the query is running, no events are generated.
queryUpdate event can be used to send progress events while the query 
execution is in progress like queryPlan, partial stats etc.

```
== NO RELEASE NOTE ==
```
