### PR TITLE
Close down OrcReaderOptions c-tor for good

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
@@ -138,11 +138,12 @@ public class DwrfBatchPageSourceFactory
                 orcFileTailSource,
                 stripeMetadataSourceFactory,
                 hiveFileContext,
-                new OrcReaderOptions(
-                        getOrcMaxMergeDistance(session),
-                        getOrcTinyStripeThreshold(session),
-                        getOrcMaxReadBlockSize(session),
-                        isOrcZstdJniDecompressionEnabled(session)),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(getOrcMaxMergeDistance(session))
+                        .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
+                        .withMaxBlockSize(getOrcMaxReadBlockSize(session))
+                        .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .build(),
                 encryptionInformation,
                 dwrfEncryptionProvider));
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -186,11 +186,12 @@ public class OrcBatchPageSourceFactory
                 orcFileTailSource,
                 stripeMetadataSourceFactory,
                 hiveFileContext,
-                new OrcReaderOptions(
-                        getOrcMaxMergeDistance(session),
-                        getOrcTinyStripeThreshold(session),
-                        getOrcMaxReadBlockSize(session),
-                        isOrcZstdJniDecompressionEnabled(session)),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(getOrcMaxMergeDistance(session))
+                        .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
+                        .withMaxBlockSize(getOrcMaxReadBlockSize(session))
+                        .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .build(),
                 encryptionInformation,
                 NO_ENCRYPTION));
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -298,11 +298,13 @@ public class OrcSelectivePageSourceFactory
         DataSize streamBufferSize = getOrcStreamBufferSize(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);
         DataSize maxReadBlockSize = getOrcMaxReadBlockSize(session);
-        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance,
-                tinyStripeThreshold,
-                maxReadBlockSize,
-                isOrcZstdJniDecompressionEnabled(session),
-                appendRowNumberEnabled);
+        OrcReaderOptions orcReaderOptions = OrcReaderOptions.builder()
+                .withMaxMergeDistance(maxMergeDistance)
+                .withTinyStripeThreshold(tinyStripeThreshold)
+                .withMaxBlockSize(maxReadBlockSize)
+                .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                .withAppendRowNumber(appendRowNumberEnabled)
+                .build();
         boolean lazyReadSmallRanges = getOrcLazyReadSmallRanges(session);
 
         OrcDataSource orcDataSource;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -62,11 +62,11 @@ public class TempFileReader
                     new StorageOrcFileTailSource(),
                     new StorageStripeMetadataSource(),
                     new HiveOrcAggregatedMemoryContext(),
-                    new OrcReaderOptions(
-                            new DataSize(1, MEGABYTE),
-                            new DataSize(8, MEGABYTE),
-                            new DataSize(16, MEGABYTE),
-                            false),
+                    OrcReaderOptions.builder()
+                            .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                            .withTinyStripeThreshold(new DataSize(8, MEGABYTE))
+                            .withMaxBlockSize(new DataSize(16, MEGABYTE))
+                            .build(),
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -241,11 +241,12 @@ public class IcebergPageSourceProvider
                         fileFormatDataSourceStats,
                         false);
             case ORC:
-                OrcReaderOptions readerOptions = new OrcReaderOptions(
-                        getOrcMaxMergeDistance(session),
-                        getOrcTinyStripeThreshold(session),
-                        getOrcMaxReadBlockSize(session),
-                        isOrcZstdJniDecompressionEnabled(session));
+                OrcReaderOptions readerOptions = OrcReaderOptions.builder()
+                        .withMaxMergeDistance(getOrcMaxMergeDistance(session))
+                        .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
+                        .withMaxBlockSize(getOrcMaxReadBlockSize(session))
+                        .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .build();
 
                 // TODO: Implement EncryptionInformation in IcebergSplit instead of Optional.empty()
                 return createBatchOrcPageSource(

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -28,24 +28,7 @@ public class OrcReaderOptions
     // if the option is set to true, OrcSelectiveReader will append a row number block at the end of the page
     private final boolean appendRowNumber;
 
-    public OrcReaderOptions(DataSize maxMergeDistance,
-            DataSize tinyStripeThreshold,
-            DataSize maxBlockSize,
-            boolean zstdJniDecompressionEnabled)
-    {
-        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false);
-    }
-
-    public OrcReaderOptions(DataSize maxMergeDistance,
-            DataSize tinyStripeThreshold,
-            DataSize maxBlockSize,
-            boolean zstdJniDecompressionEnabled,
-            boolean appendRowNumber)
-    {
-        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, appendRowNumber);
-    }
-
-    public OrcReaderOptions(
+    private OrcReaderOptions(
             DataSize maxMergeDistance,
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -846,7 +846,11 @@ public class OrcWriter
                 types,
                 hiveStorageTimeZone,
                 orcEncoding,
-                new OrcReaderOptions(new DataSize(1, MEGABYTE), new DataSize(8, MEGABYTE), new DataSize(16, MEGABYTE), false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(8, MEGABYTE))
+                        .withMaxBlockSize(new DataSize(16, MEGABYTE))
+                        .build(),
                 dwrfEncryptionProvider,
                 DwrfKeyProvider.of(intermediateKeyMetadata.build()));
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.orc.OrcTester.writeOrcFileColumnHive;
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -241,7 +242,11 @@ public class TestCachingOrcDataSource
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, new DataSize(1, Unit.MEGABYTE), false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(maxMergeDistance)
+                        .withTinyStripeThreshold(tinyStripeThreshold)
+                        .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                        .build(),
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -487,13 +487,11 @@ public class TestDecryption
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        new DataSize(1, MEGABYTE),
-                        new DataSize(1, MEGABYTE),
-                        MAX_BLOCK_SIZE,
-                        false,
-                        false,
-                        false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                        .withMaxBlockSize(MAX_BLOCK_SIZE)
+                        .build(),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingPlainKeyEncryptionLibrary()),
                 DwrfKeyProvider.of(ImmutableMap.of(0, Slices.utf8Slice("key"))),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
@@ -140,11 +140,11 @@ public class TestOrcRecordReaderDwrfStripeCaching
             DwrfAwareStripeMetadataSourceFactory dwrfAwareFactory = new DwrfAwareStripeMetadataSourceFactory(delegateSourceFactory);
 
             // set zeroes to avoid file caching and merging of small disk ranges
-            OrcReaderOptions orcReaderOptions = new OrcReaderOptions(
-                    new DataSize(0, MEGABYTE),
-                    new DataSize(0, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    false);
+            OrcReaderOptions orcReaderOptions = OrcReaderOptions.builder()
+                    .withMaxMergeDistance(new DataSize(0, MEGABYTE))
+                    .withTinyStripeThreshold(new DataSize(0, MEGABYTE))
+                    .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                    .build();
 
             OrcReader orcReader = new OrcReader(
                     orcDataSource,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -278,11 +278,11 @@ public class TestStructBatchStreamReader
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        dataSize,
-                        dataSize,
-                        dataSize,
-                        false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(dataSize)
+                        .withTinyStripeThreshold(dataSize)
+                        .withMaxBlockSize(dataSize)
+                        .build(),
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -113,7 +113,12 @@ public final class OrcFileRewriter
                     orcFileTailSource,
                     stripeMetadataSourceFactory,
                     new RaptorOrcAggregatedMemoryContext(),
-                    new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
+                    OrcReaderOptions.builder()
+                            .withMaxMergeDistance(readerAttributes.getMaxMergeDistance())
+                            .withTinyStripeThreshold(readerAttributes.getTinyStripeThreshold())
+                            .withMaxBlockSize(HUGE_MAX_READ_BLOCK_SIZE)
+                            .withZstdJniDecompressionEnabled(readerAttributes.isZstdJniDecompressionEnabled())
+                            .build(),
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -296,7 +296,12 @@ public class OrcStorageManager
                     orcFileTailSource,
                     stripeMetadataSourceFactory,
                     new RaptorOrcAggregatedMemoryContext(),
-                    new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
+                    OrcReaderOptions.builder()
+                            .withMaxMergeDistance(readerAttributes.getMaxMergeDistance())
+                            .withTinyStripeThreshold(readerAttributes.getTinyStripeThreshold())
+                            .withMaxBlockSize(HUGE_MAX_READ_BLOCK_SIZE)
+                            .withZstdJniDecompressionEnabled(readerAttributes.isZstdJniDecompressionEnabled())
+                            .build(),
                     hiveFileContext.isCacheable(),
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,
@@ -388,11 +393,12 @@ public class OrcStorageManager
                     orcFileTailSource,
                     new StorageStripeMetadataSource(),
                     new RaptorOrcAggregatedMemoryContext(),
-                    new OrcReaderOptions(
-                            defaultReaderAttributes.getMaxMergeDistance(),
-                            defaultReaderAttributes.getTinyStripeThreshold(),
-                            HUGE_MAX_READ_BLOCK_SIZE,
-                            defaultReaderAttributes.isZstdJniDecompressionEnabled()),
+                    OrcReaderOptions.builder()
+                            .withMaxMergeDistance(defaultReaderAttributes.getMaxMergeDistance())
+                            .withTinyStripeThreshold(defaultReaderAttributes.getTinyStripeThreshold())
+                            .withMaxBlockSize(HUGE_MAX_READ_BLOCK_SIZE)
+                            .withZstdJniDecompressionEnabled(defaultReaderAttributes.isZstdJniDecompressionEnabled())
+                            .build(),
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,
@@ -558,7 +564,12 @@ public class OrcStorageManager
                     orcFileTailSource,
                     stripeMetadataSourceFactory,
                     new RaptorOrcAggregatedMemoryContext(),
-                    new OrcReaderOptions(defaultReaderAttributes.getMaxMergeDistance(), defaultReaderAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, defaultReaderAttributes.isZstdJniDecompressionEnabled()),
+                    OrcReaderOptions.builder()
+                            .withMaxMergeDistance(defaultReaderAttributes.getMaxMergeDistance())
+                            .withTinyStripeThreshold(defaultReaderAttributes.getTinyStripeThreshold())
+                            .withMaxBlockSize(HUGE_MAX_READ_BLOCK_SIZE)
+                            .withZstdJniDecompressionEnabled(defaultReaderAttributes.isZstdJniDecompressionEnabled())
+                            .build(),
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -129,10 +129,10 @@ final class OrcTestingUtil
 
     public static OrcReaderOptions createDefaultTestConfig()
     {
-        return new OrcReaderOptions(
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                false);
+        return OrcReaderOptions.builder()
+                .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                .build();
     }
 }


### PR DESCRIPTION
Make OrcReaderOptions' constructor private to stop expansion of overloading constructors. Migrate all usage to the builder.

Test plan:
- no changes


```
== NO RELEASE NOTE ==
```
