### PR TITLE
Support nested sql functions with lambdas when not inlined

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
@@ -43,7 +43,6 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.gen.LambdaBytecodeGenerator.CompiledLambda;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Primitives;
@@ -72,7 +71,6 @@ import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.CommonSubE
 import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.CommonSubExpressionFields.initializeCommonSubExpressionFields;
 import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.collectCSEByLevel;
 import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.rewriteExpressionWithCSE;
-import static com.facebook.presto.sql.gen.LambdaBytecodeGenerator.generateMethodsForLambda;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
@@ -103,14 +101,6 @@ public class CursorProcessorCompiler
                 .add(filter)
                 .build();
 
-        Map<LambdaDefinitionExpression, CompiledLambda> compiledLambdaMap = generateMethodsForLambda(classDefinition,
-                callSiteBinder,
-                cachedInstanceBinder,
-                rowExpressions,
-                metadata,
-                sqlFunctionProperties,
-                sessionFunctions,
-                "");
         Map<VariableReferenceExpression, CommonSubExpressionFields> cseFields = ImmutableMap.of();
         RowExpressionCompiler compiler = new RowExpressionCompiler(
                 classDefinition,
@@ -120,7 +110,7 @@ public class CursorProcessorCompiler
                 metadata,
                 sqlFunctionProperties,
                 sessionFunctions,
-                compiledLambdaMap);
+                ImmutableMap.of());
 
         if (isOptimizeCommonSubExpressions) {
             Map<Integer, Map<RowExpression, VariableReferenceExpression>> commonSubExpressionsByLevel = collectCSEByLevel(rowExpressions);
@@ -135,7 +125,7 @@ public class CursorProcessorCompiler
                         metadata,
                         sqlFunctionProperties,
                         sessionFunctions,
-                        compiledLambdaMap);
+                        ImmutableMap.of());
                 generateCommonSubExpressionMethods(classDefinition, compiler, commonSubExpressionsByLevel, cseFields);
 
                 Map<RowExpression, VariableReferenceExpression> commonSubExpressions = commonSubExpressionsByLevel.values().stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -716,15 +716,6 @@ public class PageFunctionCompiler
 
         CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
 
-        Map<LambdaDefinitionExpression, CompiledLambda> compiledLambdaMap = generateMethodsForLambda(
-                classDefinition,
-                callSiteBinder,
-                cachedInstanceBinder,
-                filter,
-                metadata,
-                sqlFunctionProperties,
-                sessionFunctions);
-
         // cse
         Map<VariableReferenceExpression, CommonSubExpressionFields> cseFields = ImmutableMap.of();
         RowExpressionCompiler compiler = new RowExpressionCompiler(
@@ -735,7 +726,7 @@ public class PageFunctionCompiler
                 metadata,
                 sqlFunctionProperties,
                 sessionFunctions,
-                compiledLambdaMap);
+                ImmutableMap.of());
 
         if (isOptimizeCommonSubExpression) {
             Map<Integer, Map<RowExpression, VariableReferenceExpression>> commonSubExpressionsByLevel = collectCSEByLevel(filter);
@@ -749,7 +740,7 @@ public class PageFunctionCompiler
                         metadata,
                         sqlFunctionProperties,
                         sessionFunctions,
-                        compiledLambdaMap);
+                        ImmutableMap.of());
 
                 generateCommonSubExpressionMethods(classDefinition, compiler, commonSubExpressionsByLevel, cseFields);
                 Map<RowExpression, VariableReferenceExpression> commonSubExpressions = commonSubExpressionsByLevel.values().stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
@@ -116,6 +116,17 @@ public class RowExpressionCompiler
             BytecodeGeneratorContext generatorContext;
             switch (functionMetadata.getImplementationType()) {
                 case JAVA:
+                    // Pre-compile lambda bytecode and update compiled lambda map
+                    compiledLambdaMap.putAll(generateMethodsForLambda(
+                            classDefinition,
+                            callSiteBinder,
+                            cachedInstanceBinder,
+                            call,
+                            metadata,
+                            sqlFunctionProperties,
+                            sessionFunctions,
+                            "sql" + call.hashCode(),
+                            compiledLambdaMap.keySet()));
                     generatorContext = new BytecodeGeneratorContext(
                             RowExpressionCompiler.this,
                             context.getScope(),

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -537,6 +537,30 @@ public class TestSqlFunctions
         assertQueryFails("SELECT reduce(a, '', (s, x) -> s || testing.test.foo(x), s -> s) from (VALUES (array['a', 'b'])) t(a)", ".*External functions in Lambda expression is not supported:.*");
     }
 
+    @Test
+    void testNestedSqlFunctionsWithLambdas()
+    {
+        assertQuerySucceeds(
+                "WITH tmp AS (\n" +
+                "    SELECT\n" +
+                "        1 AS id,\n" +
+                "        MAP(ARRAY['a', 'b'], ARRAY[3.0, 4.0]) AS hist\n" +
+                "\n" +
+                "    UNION ALL\n" +
+                "\n" +
+                "    SELECT\n" +
+                "        2 AS id,\n" +
+                "        MAP(ARRAY['b', 'c'], ARRAY[4.0, 5.0]) AS hist\n" +
+                ")\n" +
+                "SELECT\n" +
+                "    ARRAY_SUM(\n" +
+                "        MAP_VALUES(\n" +
+                "            (MAP_NORMALIZE(hist)\n" +
+                "        )\n" +
+                "    ))\n" +
+                "FROM tmp");
+    }
+
     private Session createSessionWithTempFunctionFoo()
     {
         SqlFunctionId bigintSignature = new SqlFunctionId(QualifiedObjectName.valueOf("presto.session.foo"), ImmutableList.of(parseTypeSignature("bigint")));


### PR DESCRIPTION
Fixes #17923

Test plan - unit test, github test runs, verifier

```
== RELEASE NOTES ==

General Changes
* Add support to nested SQL functions with lambdas when ``inline_sql_functions = false``.
```
