### PR TITLE
Add option to limit the number of keys in the ORC flat map writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -227,6 +227,7 @@ public class OrcWriter
                 .setCompressionBufferPool(compressionBufferPool)
                 .setFlattenedNodes(flattenedNodes)
                 .setMapStatisticsEnabled(options.isMapStatisticsEnabled())
+                .setMaxFlattenedMapKeyCount(options.getMaxFlattenedMapKeyCount())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
         recordValidation(validation -> validation.setFlattenedNodes(flattenedNodes));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -43,6 +43,7 @@ public class OrcWriterOptions
     public static final DataSize DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE = new DataSize(8, MEGABYTE);
     public static final DwrfStripeCacheMode DEFAULT_DWRF_STRIPE_CACHE_MODE = INDEX_AND_FOOTER;
     public static final int DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT = 0;
+    public static final int DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT = 20000;
 
     private final OrcWriterFlushPolicy flushPolicy;
     private final int rowGroupMaxRowCount;
@@ -65,6 +66,7 @@ public class OrcWriterOptions
     private final Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
     private final int preserveDirectEncodingStripeCount;
     private final boolean mapStatisticsEnabled;
+    private final int maxFlattenedMapKeyCount;
 
     /**
      * Contains indexes of columns (not nodes!) for which writer should use flattened encoding, e.g. flat maps.
@@ -89,7 +91,8 @@ public class OrcWriterOptions
             boolean ignoreDictionaryRowGroupSizes,
             int preserveDirectEncodingStripeCount,
             Set<Integer> flattenedColumns,
-            boolean mapStatisticsEnabled)
+            boolean mapStatisticsEnabled,
+            int maxFlattenedMapKeyCount)
     {
         requireNonNull(flushPolicy, "flushPolicy is null");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
@@ -102,6 +105,7 @@ public class OrcWriterOptions
         requireNonNull(streamLayoutFactory, "streamLayoutFactory is null");
         requireNonNull(dwrfWriterOptions, "dwrfWriterOptions is null");
         requireNonNull(flattenedColumns, "flattenedColumns is null");
+        checkArgument(maxFlattenedMapKeyCount > 0, "maxFlattenedMapKeyCount must be positive: %s", maxFlattenedMapKeyCount);
 
         this.flushPolicy = flushPolicy;
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
@@ -121,6 +125,7 @@ public class OrcWriterOptions
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
         this.flattenedColumns = flattenedColumns;
         this.mapStatisticsEnabled = mapStatisticsEnabled;
+        this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
     }
 
     public OrcWriterFlushPolicy getFlushPolicy()
@@ -213,6 +218,11 @@ public class OrcWriterOptions
         return mapStatisticsEnabled;
     }
 
+    public int getMaxFlattenedMapKeyCount()
+    {
+        return maxFlattenedMapKeyCount;
+    }
+
     @Override
     public String toString()
     {
@@ -235,6 +245,7 @@ public class OrcWriterOptions
                 .add("preserveDirectEncodingStripeCount", preserveDirectEncodingStripeCount)
                 .add("flattenedColumns", flattenedColumns)
                 .add("mapStatisticsEnabled", mapStatisticsEnabled)
+                .add("maxFlattenedMapKeyCount", maxFlattenedMapKeyCount)
                 .toString();
     }
 
@@ -270,6 +281,7 @@ public class OrcWriterOptions
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
         private Set<Integer> flattenedColumns = ImmutableSet.of();
         private boolean mapStatisticsEnabled;
+        private int maxFlattenedMapKeyCount = DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT;
 
         public Builder withFlushPolicy(OrcWriterFlushPolicy flushPolicy)
         {
@@ -393,6 +405,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withMaxFlattenedMapKeyCount(int maxFlattenedMapKeyCount)
+        {
+            this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -421,7 +439,8 @@ public class OrcWriterOptions
                     ignoreDictionaryRowGroupSizes,
                     preserveDirectEncodingStripeCount,
                     flattenedColumns,
-                    mapStatisticsEnabled);
+                    mapStatisticsEnabled,
+                    maxFlattenedMapKeyCount);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
@@ -44,6 +44,7 @@ public class TestColumnWriterOptions
         CompressionBufferPool compressionBufferPool = new CompressionBufferPool.LastUsedCompressionBufferPool();
         Set<Integer> flattenedNodes = ImmutableSet.of(1, 5);
         boolean mapStatisticsEnabled = true;
+        int maxFlattenedMapKeyCount = 27;
 
         ColumnWriterOptions options = ColumnWriterOptions.builder()
                 .setCompressionKind(compressionKind)
@@ -58,6 +59,7 @@ public class TestColumnWriterOptions
                 .setCompressionBufferPool(compressionBufferPool)
                 .setFlattenedNodes(flattenedNodes)
                 .setMapStatisticsEnabled(mapStatisticsEnabled)
+                .setMaxFlattenedMapKeyCount(maxFlattenedMapKeyCount)
                 .build();
 
         boolean checkDisabledDictionaryEncoding = false;
@@ -73,6 +75,7 @@ public class TestColumnWriterOptions
             assertEquals(actual.getCompressionBufferPool(), compressionBufferPool);
             assertEquals(actual.getFlattenedNodes(), flattenedNodes);
             assertEquals(actual.isMapStatisticsEnabled(), mapStatisticsEnabled);
+            assertEquals(actual.getMaxFlattenedMapKeyCount(), maxFlattenedMapKeyCount);
 
             if (checkDisabledDictionaryEncoding) {
                 assertFalse(actual.isStringDictionaryEncodingEnabled());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -66,6 +66,7 @@ public class TestOrcWriterOptions
 
         assertEquals(options.getFlattenedColumns(), ImmutableSet.of());
         assertFalse(options.isMapStatisticsEnabled());
+        assertEquals(options.getMaxFlattenedMapKeyCount(), 20000);
     }
 
     @Test
@@ -88,6 +89,7 @@ public class TestOrcWriterOptions
         boolean stringDictionaryEncodingEnabled = false;
         int preserveDirectEncodingStripeCount = 10;
         boolean mapStatisticsEnabled = true;
+        int maxFlattenedMapKeyCount = 27;
 
         OrcWriterOptions.Builder builder = OrcWriterOptions.builder()
                 .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
@@ -109,7 +111,8 @@ public class TestOrcWriterOptions
                 .withStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .withFlattenedColumns(ImmutableSet.of(4, 3))
-                .withMapStatisticsEnabled(mapStatisticsEnabled);
+                .withMapStatisticsEnabled(mapStatisticsEnabled)
+                .withMaxFlattenedMapKeyCount(maxFlattenedMapKeyCount);
 
         OrcWriterOptions options = builder.build();
 
@@ -132,6 +135,7 @@ public class TestOrcWriterOptions
         assertEquals(preserveDirectEncodingStripeCount, options.getPreserveDirectEncodingStripeCount());
         assertEquals(options.getFlattenedColumns(), ImmutableSet.of(4, 3));
         assertEquals(options.isMapStatisticsEnabled(), mapStatisticsEnabled);
+        assertEquals(options.getMaxFlattenedMapKeyCount(), maxFlattenedMapKeyCount);
     }
 
     @Test
@@ -155,6 +159,7 @@ public class TestOrcWriterOptions
         boolean stringDictionarySortingEnabled = true;
         int preserveDirectEncodingStripeCount = 0;
         boolean mapStatisticsEnabled = true;
+        int maxFlattenedMapKeyCount = 27;
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
@@ -179,6 +184,7 @@ public class TestOrcWriterOptions
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .withFlattenedColumns(ImmutableSet.of(4))
                 .withMapStatisticsEnabled(mapStatisticsEnabled)
+                .withMaxFlattenedMapKeyCount(maxFlattenedMapKeyCount)
                 .build();
 
         String expectedString = "OrcWriterOptions{flushPolicy=DefaultOrcWriterFlushPolicy{stripeMaxRowCount=1100000, " +
@@ -188,7 +194,8 @@ public class TestOrcWriterOptions
                 "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +
                 "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
                 "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
-                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4], mapStatisticsEnabled=true}";
+                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4], mapStatisticsEnabled=true, " +
+                "maxFlattenedMapKeyCount=27}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
Add a capability to limit the number of keys in the flat map column writer. Default value is 20 000 keys similar to BBIO.

Test plan:
- new unit tests

```
== NO RELEASE NOTE ==
```
