### PR TITLE
Use precomputed hash in probe side of HashSemiJoinOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
@@ -71,6 +71,11 @@ public class ChannelSet
         return hash.contains(position, page, hashChannels);
     }
 
+    public boolean contains(int position, Page page, long rawHash)
+    {
+        return hash.contains(position, page, hashChannels, rawHash);
+    }
+
     public static class ChannelSetBuilder
     {
         private static final int[] HASH_CHANNELS = {0};

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -75,6 +75,11 @@ public interface GroupByHash
 
     boolean contains(int position, Page page, int[] hashChannels);
 
+    default boolean contains(int position, Page page, int[] hashChannels, long rawHash)
+    {
+        return contains(position, page, hashChannels);
+    }
+
     long getRawHash(int groupId);
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -261,6 +261,12 @@ public class MultiChannelGroupByHash
     public boolean contains(int position, Page page, int[] hashChannels)
     {
         long rawHash = hashStrategy.hashRow(position, page);
+        return contains(position, page, hashChannels, rawHash);
+    }
+
+    @Override
+    public boolean contains(int position, Page page, int[] hashChannels, long rawHash)
+    {
         int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for a slot containing this key

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2465,6 +2465,7 @@ public class LocalExecutionPlanner
             int buildChannel = buildSource.getLayout().get(node.getFilteringSourceJoinVariable());
 
             Optional<Integer> buildHashChannel = node.getFilteringSourceHashVariable().map(variableChannelGetter(buildSource));
+            Optional<Integer> probeHashChannel = node.getSourceHashVariable().map(variableChannelGetter(probeSource));
 
             SetBuilderOperatorFactory setBuilderOperatorFactory = new SetBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),
@@ -2500,7 +2501,7 @@ public class LocalExecutionPlanner
                     .put(node.getSemiJoinOutput(), probeSource.getLayout().size())
                     .build();
 
-            HashSemiJoinOperatorFactory operator = new HashSemiJoinOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel);
+            HashSemiJoinOperatorFactory operator = new HashSemiJoinOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel, probeHashChannel);
             return new PhysicalOperation(operator, outputMappings, context, probeSource);
         }
 


### PR DESCRIPTION
Cherry pick of https://github.com/trinodb/trino/commit/fd5f4988df52dd49be6e95b681c0b87481ef4e4f

Co-authored by Shubham Tagra <stagra@qubole.com>

```
== NO RELEASE NOTE ==
```
