### PR TITLE
Add a singleton for NoOpOrcWriterStats

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
-import com.facebook.presto.orc.NoOpOrcWriterStats;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
@@ -34,6 +33,7 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.metadata.CompressionKind.LZ4;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -100,7 +100,7 @@ public class TempFileWriter
                     UTC,
                     false,
                     OrcWriteValidationMode.BOTH,
-                    new NoOpOrcWriterStats());
+                    NOOP_WRITER_STATS);
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -42,7 +42,6 @@ import com.facebook.presto.hive.pagefile.PageFilePageSourceFactory;
 import com.facebook.presto.hive.pagefile.PageWriter;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
-import com.facebook.presto.orc.NoOpOrcWriterStats;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
@@ -92,6 +91,7 @@ import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFo
 import static com.facebook.presto.hive.pagefile.PageFileWriterFactory.createPagesSerdeForPageFile;
 import static com.facebook.presto.hive.util.ConfigurationUtils.configureCompression;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
@@ -613,7 +613,7 @@ public enum FileFormat
                     hiveStorageTimeZone,
                     false,
                     BOTH,
-                    new NoOpOrcWriterStats());
+                    NOOP_WRITER_STATS);
         }
 
         @Override
@@ -652,7 +652,7 @@ public enum FileFormat
                     hiveStorageTimeZone,
                     false,
                     BOTH,
-                    new NoOpOrcWriterStats());
+                    NOOP_WRITER_STATS);
         }
 
         @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcOptimize
 import static com.facebook.presto.iceberg.TypeConverter.toOrcType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.PrimitiveTypeMapBuilder.makeTypeMap;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -78,7 +79,7 @@ public class IcebergFileWriterFactory
     private final TypeManager typeManager;
     private final FileFormatDataSourceStats readStats;
     private final NodeVersion nodeVersion;
-    private final NoOpOrcWriterStats orcWriterStats = new NoOpOrcWriterStats();
+    private final NoOpOrcWriterStats orcWriterStats = NOOP_WRITER_STATS;
     private final OrcFileWriterConfig orcFileWriterConfig;
     private final DwrfEncryptionProvider dwrfEncryptionProvider;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/NoOpOrcWriterStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/NoOpOrcWriterStats.java
@@ -20,6 +20,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class NoOpOrcWriterStats
         implements WriterStats
 {
+    public static final NoOpOrcWriterStats NOOP_WRITER_STATS = new NoOpOrcWriterStats();
+
     @Override
     public void recordStripeWritten(
             int stripeMinBytes,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.NoopOrcLocalMemoryContext.NOOP_ORC_LOCAL_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
@@ -203,7 +204,7 @@ public abstract class AbstractTestDwrfStripeCaching
                     HIVE_STORAGE_TIME_ZONE,
                     true,
                     BOTH,
-                    new NoOpOrcWriterStats());
+                    NOOP_WRITER_STATS);
 
             // write 4 stripes with 100 values each
             int count = 0;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkMapFlatWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkMapFlatWriter.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
 import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
@@ -117,7 +118,7 @@ public class BenchmarkMapFlatWriter
                 HIVE_STORAGE_TIME_ZONE,
                 false,
                 BOTH,
-                new NoOpOrcWriterStats());
+                NOOP_WRITER_STATS);
 
         for (Block block : data.blocks) {
             writer.write(new Page(block));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -82,6 +82,7 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
@@ -267,7 +268,7 @@ public class BenchmarkSelectiveStreamReaders
             }
 
             // Use writeOrcColumnsPresto so that orcType and varchar length can be written in file footer
-            writeOrcColumnsPresto(orcFile, ORC_12, NONE, Optional.empty(), Collections.nCopies(channelCount, type), values, new NoOpOrcWriterStats());
+            writeOrcColumnsPresto(orcFile, ORC_12, NONE, Optional.empty(), Collections.nCopies(channelCount, type), values, NOOP_WRITER_STATS);
         }
 
         @TearDown

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -155,6 +155,7 @@ import static com.facebook.presto.common.type.Varchars.truncateToLength;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.AbstractTestOrcReader.intsBetween;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.NoopOrcLocalMemoryContext.NOOP_ORC_LOCAL_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
@@ -635,7 +636,7 @@ public class OrcTester
         assertEquals(writeTypes.size(), readValues.size());
 
         AtomicLong totalSize = new AtomicLong(0);
-        WriterStats stats = new NoOpOrcWriterStats();
+        WriterStats stats = NOOP_WRITER_STATS;
 
         Set<Integer> flattenedColumns = ImmutableSet.of();
         if (flattenAllColumns) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.AbstractOrcRecordReader.getDecryptionKeyMetadata;
 import static com.facebook.presto.orc.AbstractTestOrcReader.intsBetween;
 import static com.facebook.presto.orc.DwrfEncryptionInfo.createNodeToGroupMap;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
@@ -617,7 +618,7 @@ public class TestDecryption
             throws Exception
     {
         try (TempFile tempFile = new TempFile()) {
-            writeOrcColumnsPresto(tempFile.getFile(), OrcTester.Format.DWRF, ZSTD, dwrfWriterEncryption, types, writtenValues, new NoOpOrcWriterStats());
+            writeOrcColumnsPresto(tempFile.getFile(), OrcTester.Format.DWRF, ZSTD, dwrfWriterEncryption, types, writtenValues, NOOP_WRITER_STATS);
 
             assertFileContentsPresto(
                     types,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
@@ -824,7 +825,7 @@ public class TestDictionaryColumnWriter
     {
         List<Type> types = ImmutableList.of(type);
         try (TempFile tempFile = new TempFile()) {
-            OrcWriter writer = createOrcWriter(tempFile.getFile(), encoding, ZSTD, Optional.empty(), types, orcWriterOptions, new NoOpOrcWriterStats());
+            OrcWriter writer = createOrcWriter(tempFile.getFile(), encoding, ZSTD, Optional.empty(), types, orcWriterOptions, NOOP_WRITER_STATS);
 
             int index = 0;
             int batchId = 0;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcTester.arrayType;
 import static com.facebook.presto.orc.OrcTester.createOrcWriter;
 import static com.facebook.presto.orc.OrcTester.mapType;
@@ -241,7 +242,7 @@ public class TestFlatMapWriter
                     Optional.empty(),
                     ImmutableList.of(mapType),
                     writerOptions,
-                    new NoOpOrcWriterStats())) {
+                    NOOP_WRITER_STATS)) {
                 // write a block with 2 keys
                 orcWriter.write(createMapPageForKeyLimitTest(mapType, maxFlattenedMapKeyCount - 1));
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
@@ -80,7 +81,7 @@ public class TestOrcSelectiveStreamReaders
 
             for (CompressionKind compression : compressions) {
                 TempFile tempFile = new TempFile();
-                writeOrcColumnsPresto(tempFile.getFile(), format, compression, Optional.empty(), types, values, new NoOpOrcWriterStats());
+                writeOrcColumnsPresto(tempFile.getFile(), format, compression, Optional.empty(), types, values, NOOP_WRITER_STATS);
 
                 OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
                 Map<Integer, Type> includedColumns = IntStream.range(0, types.size())

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -44,6 +44,7 @@ import java.util.function.Supplier;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
@@ -147,7 +148,7 @@ public class TestOrcWriter
                     HIVE_STORAGE_TIME_ZONE,
                     true,
                     validationMode,
-                    new NoOpOrcWriterStats());
+                    NOOP_WRITER_STATS);
 
             // write down some data with unsorted streams
             String[] data = new String[] {"a", "bbbbb", "ccc", "dd", "eeee"};
@@ -209,7 +210,7 @@ public class TestOrcWriter
                 HIVE_STORAGE_TIME_ZONE,
                 false,
                 null,
-                new NoOpOrcWriterStats());
+                NOOP_WRITER_STATS);
 
         int entries = 65536;
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, entries);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -78,6 +78,7 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
@@ -953,7 +954,7 @@ public class TestSelectiveOrcReader
         List<String> varcharDictionaryValues = newArrayList(limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), NUM_ROWS));
         List<List<?>> values = ImmutableList.of(intValues, varcharDirectValues, varcharDictionaryValues);
 
-        writeOrcColumnsPresto(tempFile.getFile(), DWRF, compression, Optional.empty(), types, values, new NoOpOrcWriterStats());
+        writeOrcColumnsPresto(tempFile.getFile(), DWRF, compression, Optional.empty(), types, values, NOOP_WRITER_STATS);
 
         OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
         Map<Integer, Type> includedColumns = IntStream.range(0, types.size())
@@ -1015,7 +1016,7 @@ public class TestSelectiveOrcReader
         List<String> varcharDirectValues = newArrayList(limit(cycle(ImmutableList.of("A", "B", "C")), NUM_ROWS));
         List<List<?>> values = ImmutableList.of(varcharDirectValues, varcharDirectValues);
 
-        writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, values, new NoOpOrcWriterStats());
+        writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, values, NOOP_WRITER_STATS);
 
         OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
         Map<Subfield, TupleDomainFilter> filters = ImmutableMap.of(new Subfield("c"), stringIn(true, "A", "B", "C")); //ImmutableMap.of(1, stringIn(true, "10", "11"));
@@ -1094,7 +1095,7 @@ public class TestSelectiveOrcReader
             }
         }
 
-        writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, ImmutableList.of(values), new NoOpOrcWriterStats());
+        writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, ImmutableList.of(values), NOOP_WRITER_STATS);
 
         try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false, false)) {
             assertEquals(recordReader.getFileRowCount(), rowCount);
@@ -1131,7 +1132,7 @@ public class TestSelectiveOrcReader
         List<List<?>> values = ImmutableList.of(ImmutableList.of(1L, 2L));
 
         TempFile tempFile = new TempFile();
-        writeOrcColumnsPresto(tempFile.getFile(), DWRF, ZSTD, Optional.empty(), types, values, new NoOpOrcWriterStats());
+        writeOrcColumnsPresto(tempFile.getFile(), DWRF, ZSTD, Optional.empty(), types, values, NOOP_WRITER_STATS);
 
         // Hidden columns like partition columns use negative indices (-13).
         int hiddenColumnIndex = -13;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
@@ -243,7 +244,7 @@ public class TestStructBatchStreamReader
                 HIVE_STORAGE_TIME_ZONE,
                 true,
                 BOTH,
-                new NoOpOrcWriterStats());
+                NOOP_WRITER_STATS);
 
         // write down some data with unsorted streams
         Block[] fieldBlocks = new Block[data.size()];

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
@@ -189,7 +190,7 @@ public class TestTimestampWriteAndRead
                         Optional.empty(),
                         ImmutableList.of(writeType),
                         ImmutableList.of(writeValues),
-                        new NoOpOrcWriterStats());
+                        NOOP_WRITER_STATS);
 
                 assertFileContentsPresto(
                         ImmutableList.of(readType),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
@@ -26,7 +26,6 @@ import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.DwrfEncryptionInfo;
 import com.facebook.presto.orc.FileOrcDataSource;
-import com.facebook.presto.orc.NoOpOrcWriterStats;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.OrcTester;
 import com.facebook.presto.orc.OrcWriter;
@@ -55,6 +54,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
 import static com.facebook.presto.orc.OrcTester.createOrcWriter;
@@ -312,7 +312,7 @@ public class TestWriterBlockRawSize
 
         for (OrcEncoding encoding : OrcEncoding.values()) {
             try (TempFile tempFile = new TempFile()) {
-                OrcWriter writer = createOrcWriter(tempFile.getFile(), encoding, ZSTD, Optional.empty(), types, writerOptions, new NoOpOrcWriterStats());
+                OrcWriter writer = createOrcWriter(tempFile.getFile(), encoding, ZSTD, Optional.empty(), types, writerOptions, NOOP_WRITER_STATS);
                 for (int i = 0; i < numBlocksPerFile; i++) {
                     writer.write(new Page(blocks));
                 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -103,6 +103,7 @@ import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorColumnHandle.isBucketNumberColumn;
@@ -167,7 +168,7 @@ public class OrcStorageManager
     private final ExecutorService commitExecutor;
     private final OrcDataEnvironment orcDataEnvironment;
     private final OrcFileRewriter fileRewriter;
-    private final NoOpOrcWriterStats stats = new NoOpOrcWriterStats();
+    private final NoOpOrcWriterStats stats = NOOP_WRITER_STATS;
     private final OrcFileTailSource orcFileTailSource;
     private final StripeMetadataSourceFactory stripeMetadataSourceFactory;
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.FileOrcDataSource;
-import com.facebook.presto.orc.NoOpOrcWriterStats;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
@@ -44,6 +43,7 @@ import java.util.Map;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
@@ -124,7 +124,7 @@ final class OrcTestingUtil
             throws IOException
     {
         FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
-        return new OrcFileWriter(columnIds, columnTypes, new OutputStreamDataSink(new FileOutputStream(file)), true, true, new NoOpOrcWriterStats(), functionAndTypeManager, ZSTD);
+        return new OrcFileWriter(columnIds, columnTypes, new OutputStreamDataSink(new FileOutputStream(file)), true, true, NOOP_WRITER_STATS, functionAndTypeManager, ZSTD);
     }
 
     public static OrcReaderOptions createDefaultTestConfig()

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -27,7 +27,6 @@ import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.orc.DwrfKeyProvider;
-import com.facebook.presto.orc.NoOpOrcWriterStats;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
@@ -76,6 +75,7 @@ import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.hive.HiveFileContext.DEFAULT_HIVE_FILE_CONTEXT;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
 import static com.facebook.presto.raptor.filesystem.FileSystemUtil.DEFAULT_RAPTOR_CONTEXT;
@@ -714,7 +714,7 @@ public class TestOrcFileRewriter
                 new OutputStreamDataSink(new FileOutputStream(file)),
                 writeMetadata,
                 true,
-                new NoOpOrcWriterStats(),
+                NOOP_WRITER_STATS,
                 createTestFunctionAndTypeManager(),
                 ZSTD);
     }
@@ -724,7 +724,7 @@ public class TestOrcFileRewriter
         return new OrcFileRewriter(
                 READER_ATTRIBUTES,
                 true,
-                new NoOpOrcWriterStats(),
+                NOOP_WRITER_STATS,
                 createTestFunctionAndTypeManager(),
                 new LocalOrcDataEnvironment(),
                 ZSTD,


### PR DESCRIPTION
Create a constant for an instance of NoOpOrcWriterStats and switch all consumers of NoOpOrcWriterStats to the new singleton.

I intentionally left the constructor open to avoid breaking presto-facebook, etc.

Test plan:
- existing tests 

```
== NO RELEASE NOTE ==
```
