### PR TITLE
Setting Executor and Partition Count

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PhysicalResourceSettings.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PhysicalResourceSettings.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class PhysicalResourceSettings
+{
+    public static final PhysicalResourceSettings DISABLED_PHYSICAL_RESOURCE_SETTING = new PhysicalResourceSettings(0, 0, () -> {});
+
+    private final int executorCount;
+    private final int hashPartitionCount;
+
+    public PhysicalResourceSettings(int executorCount, int hashPartitionCount)
+    {
+        this(
+                executorCount,
+                hashPartitionCount,
+                () -> checkArgument(executorCount >= 0 && hashPartitionCount >= 0, "executorCount and hashPartitionCount should be positive"));
+    }
+
+    public PhysicalResourceSettings(int executorCount, int hashPartitionCount, Runnable check)
+    {
+        check.run();
+        this.executorCount = executorCount;
+        this.hashPartitionCount = hashPartitionCount;
+    }
+
+    public int getHashPartitionCount()
+    {
+        return hashPartitionCount;
+    }
+
+    public int getExecutorCount()
+    {
+        return executorCount;
+    }
+
+    public boolean isEnabled()
+    {
+        return ((executorCount > 0) && (hashPartitionCount > 0));
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -21,6 +21,7 @@ import io.airlift.units.DataSize;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.Map;
@@ -52,6 +53,13 @@ public class PrestoSparkConfig
     private boolean retryOnOutOfMemoryWithIncreasedMemorySettingsEnabled;
     private Map<String, String> outOfMemoryRetryPrestoSessionProperties = ImmutableMap.of();
     private Map<String, String> outOfMemoryRetrySparkConfigs = ImmutableMap.of();
+    private DataSize averageInputDataSizePerExecutor = new DataSize(10, GIGABYTE);
+    private int maxExecutorCount = 600;
+    private int minExecutorCount = 200;
+    private DataSize averageInputDataSizePerPartition = new DataSize(2, GIGABYTE);
+    private int maxHashPartitionCount = 4096;
+    private int minHashPartitionCount = 1024;
+    private boolean isResourceAllocationStrategyEnabled;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -286,6 +294,101 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setOutOfMemoryRetrySparkConfigs(String outOfMemoryRetrySparkConfigs)
     {
         this.outOfMemoryRetrySparkConfigs = MAP_SPLITTER.split(nullToEmpty(outOfMemoryRetrySparkConfigs));
+        return this;
+    }
+
+    public DataSize getAverageInputDataSizePerExecutor()
+    {
+        return averageInputDataSizePerExecutor;
+    }
+
+    @Config("spark.average-input-datasize-per-executor")
+    @ConfigDescription("Provides average input data size used per executor")
+    public PrestoSparkConfig setAverageInputDataSizePerExecutor(DataSize averageInputDataSizePerExecutor)
+    {
+        this.averageInputDataSizePerExecutor = averageInputDataSizePerExecutor;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxExecutorCount()
+    {
+        return maxExecutorCount;
+    }
+
+    @Config("spark.max-executor-count")
+    @ConfigDescription("Provides the maximum count of the executors the query will allocate")
+    public PrestoSparkConfig setMaxExecutorCount(int maxExecutorCount)
+    {
+        this.maxExecutorCount = maxExecutorCount;
+        return this;
+    }
+
+    @Min(1)
+    public int getMinExecutorCount()
+    {
+        return minExecutorCount;
+    }
+
+    @Config("spark.min-executor-count")
+    @ConfigDescription("Provides the minimum count of the executors the query will allocate")
+    public PrestoSparkConfig setMinExecutorCount(int minExecutorCount)
+    {
+        this.minExecutorCount = minExecutorCount;
+        return this;
+    }
+
+    public DataSize getAverageInputDataSizePerPartition()
+    {
+        return averageInputDataSizePerPartition;
+    }
+
+    @Config("spark.average-input-datasize-per-partition")
+    @ConfigDescription("Provides average input data size per partition")
+    public PrestoSparkConfig setAverageInputDataSizePerPartition(DataSize averageInputDataSizePerPartition)
+    {
+        this.averageInputDataSizePerPartition = averageInputDataSizePerPartition;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxHashPartitionCount()
+    {
+        return maxHashPartitionCount;
+    }
+
+    @Config("spark.max-hash-partition-count")
+    @ConfigDescription("Provides the maximum number of the hash partition count the query can allocate")
+    public PrestoSparkConfig setMaxHashPartitionCount(int maxHashPartitionCount)
+    {
+        this.maxHashPartitionCount = maxHashPartitionCount;
+        return this;
+    }
+
+    @Min(1)
+    public int getMinHashPartitionCount()
+    {
+        return minHashPartitionCount;
+    }
+
+    @Config("spark.min-hash-partition-count")
+    @ConfigDescription("Provides the minimum number of the hash partition count the query can allocate")
+    public PrestoSparkConfig setMinHashPartitionCount(int minHashPartitionCount)
+    {
+        this.minHashPartitionCount = minHashPartitionCount;
+        return this;
+    }
+
+    public boolean isSparkResourceAllocationStrategyEnabled()
+    {
+        return isResourceAllocationStrategyEnabled;
+    }
+
+    @Config("spark.resource-allocation-strategy-enabled")
+    @ConfigDescription("Determines whether the resource allocation strategy for executor and partition count is enabled")
+    public PrestoSparkConfig setSparkResourceAllocationStrategyEnabled(boolean isResourceAllocationStrategyEnabled)
+    {
+        this.isResourceAllocationStrategyEnabled = isResourceAllocationStrategyEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkPhysicalResourceCalculator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkPhysicalResourceCalculator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import io.airlift.units.DataSize;
+
+import static com.facebook.presto.spark.PhysicalResourceSettings.DISABLED_PHYSICAL_RESOURCE_SETTING;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getAverageInputDataSizePerExecutor;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getAverageInputDataSizePerPartition;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMaxExecutorCount;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMaxHashPartitionCount;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMinExecutorCount;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMinHashPartitionCount;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isSparkResourceAllocationStrategyEnabled;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.units.DataSize.Unit.BYTE;
+
+public class PrestoSparkPhysicalResourceCalculator
+{
+    private static final Logger log = Logger.get(PrestoSparkPhysicalResourceCalculator.class);
+
+    public PhysicalResourceSettings calculate(PlanNode plan, Metadata metaData, Session session)
+    {
+        if (!isSparkResourceAllocationStrategyEnabled(session)) {
+            return new PhysicalResourceSettings(0, 0);
+        }
+
+        double inputDataInBytes = new PrestoSparkSourceStatsCollector(metaData, session).collectSourceStats(plan);
+
+        if (inputDataInBytes < 0) {
+            log.warn(String.format("Input data statistics missing, inputDataInBytes=%.2f skipping automatic resource tuning.", inputDataInBytes));
+            return DISABLED_PHYSICAL_RESOURCE_SETTING;
+        }
+
+        if ((inputDataInBytes > Double.MAX_VALUE) || (Double.isNaN(inputDataInBytes))) {
+            log.warn(String.format("Failed to retrieve correct size, data read=%.2f, skipping automatic resource tuning.", inputDataInBytes));
+            return DISABLED_PHYSICAL_RESOURCE_SETTING;
+        }
+
+        DataSize inputSize = new DataSize(inputDataInBytes, BYTE);
+        int executorCount = calculateExecutorCount(session, inputSize);
+        int hashPartitionCount = calculateHashPartitionCount(session, inputSize);
+
+        return new PhysicalResourceSettings(executorCount, hashPartitionCount);
+    }
+
+    private static int calculateExecutorCount(Session session, DataSize inputData)
+    {
+        int minExecutorCount = getMinExecutorCount(session);
+        int maxExecutorCount = getMaxExecutorCount(session);
+        checkState(((maxExecutorCount >= minExecutorCount) && (minExecutorCount > 0)), String.format(
+                "maxExecutorCount: %d needs to greater than or equal to maxExecutorCount : %d", maxExecutorCount, maxExecutorCount));
+
+        long averageInputDataSizePerExecutorInBytes = getAverageInputDataSizePerExecutor(session).toBytes();
+        int calculatedNumberOfExecutors = (int) (inputData.toBytes() / averageInputDataSizePerExecutorInBytes);
+
+        return (Math.max(minExecutorCount, Math.min(maxExecutorCount, calculatedNumberOfExecutors)));
+    }
+
+    private static int calculateHashPartitionCount(Session session, DataSize inputDataInGB)
+    {
+        int maxHashPartitionCount = getMaxHashPartitionCount(session);
+        int minHashPartitionCount = getMinHashPartitionCount(session);
+        checkState(((maxHashPartitionCount >= minHashPartitionCount) && (minHashPartitionCount > 0)), String.format(
+                "maxHashPartitionCount : %d needs to greater than  or equal to minHashPartitionCount : %d", maxHashPartitionCount, minHashPartitionCount));
+
+        long averageInputDataSizePerPartitionInBytes = getAverageInputDataSizePerPartition(session).toBytes();
+        int calculatedNumberOfPartitions = (int) (inputDataInGB.toBytes() / averageInputDataSizePerPartitionInBytes);
+
+        return (Math.max(minHashPartitionCount, Math.min(maxHashPartitionCount, calculatedNumberOfPartitions)));
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -51,6 +51,13 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED = "spark_retry_on_out_of_memory_with_increased_memory_settings_enabled";
     public static final String OUT_OF_MEMORY_RETRY_PRESTO_SESSION_PROPERTIES = "out_of_memory_retry_presto_session_properties";
     public static final String OUT_OF_MEMORY_RETRY_SPARK_CONFIGS = "out_of_memory_retry_spark_configs";
+    public static final String SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR = "spark_average_input_data_size_per_executor";
+    public static final String SPARK_MAX_EXECUTOR_COUNT = "spark_max_executor_count";
+    public static final String SPARK_MIN_EXECUTOR_COUNT = "spark_min_executor_count";
+    public static final String SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION = "spark_average_input_data_size_per_partition";
+    public static final String SPARK_MAX_HASH_PARTITION_COUNT = "spark_max_hash_partition_count";
+    public static final String SPARK_MIN_HASH_PARTITION_COUNT = "spark_min_hash_partition_count";
+    public static final String SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED = "spark_resource_allocation_strategy_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -145,7 +152,42 @@ public class PrestoSparkSessionProperties
                         prestoSparkConfig.getOutOfMemoryRetrySparkConfigs(),
                         true,
                         value -> MAP_SPLITTER.split(nullToEmpty((String) value)),
-                        value -> value));
+                        value -> value),
+                dataSizeProperty(
+                        SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR,
+                        "Average input data size per executor",
+                        prestoSparkConfig.getAverageInputDataSizePerExecutor(),
+                       false),
+                integerProperty(
+                        SPARK_MAX_EXECUTOR_COUNT,
+                        "Maximum count of executors to run a query",
+                        prestoSparkConfig.getMaxExecutorCount(),
+                        false),
+                integerProperty(
+                        SPARK_MIN_EXECUTOR_COUNT,
+                        "Minimum count of executors to run a query",
+                        prestoSparkConfig.getMinExecutorCount(),
+                        false),
+                dataSizeProperty(
+                        SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION,
+                        "Average input data size per partition",
+                        prestoSparkConfig.getAverageInputDataSizePerPartition(),
+                        false),
+                integerProperty(
+                        SPARK_MAX_HASH_PARTITION_COUNT,
+                        "Maximum hash partition count required by the query",
+                        prestoSparkConfig.getMaxHashPartitionCount(),
+                        false),
+                integerProperty(
+                        SPARK_MIN_HASH_PARTITION_COUNT,
+                        "Minimum hash partition count required by the query",
+                        prestoSparkConfig.getMinHashPartitionCount(),
+                        false),
+                booleanProperty(
+                        SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED,
+                        "Flag to enable optimized resource allocation strategy",
+                        prestoSparkConfig.isSparkResourceAllocationStrategyEnabled(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -231,5 +273,39 @@ public class PrestoSparkSessionProperties
     public static Map<String, String> getOutOfMemoryRetrySparkConfigs(Session session)
     {
         return session.getSystemProperty(OUT_OF_MEMORY_RETRY_SPARK_CONFIGS, Map.class);
+    }
+
+    public static DataSize getAverageInputDataSizePerExecutor(Session session)
+    {
+        return session.getSystemProperty(SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR, DataSize.class);
+    }
+
+    public static int getMaxExecutorCount(Session session)
+    {
+        return session.getSystemProperty(SPARK_MAX_EXECUTOR_COUNT, Integer.class);
+    }
+
+    public static int getMinExecutorCount(Session session)
+    {
+        return session.getSystemProperty(SPARK_MIN_EXECUTOR_COUNT, Integer.class);
+    }
+
+    public static DataSize getAverageInputDataSizePerPartition(Session session)
+    {
+        return session.getSystemProperty(SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION, DataSize.class);
+    }
+
+    public static int getMaxHashPartitionCount(Session session)
+    {
+        return session.getSystemProperty(SPARK_MAX_HASH_PARTITION_COUNT, Integer.class);
+    }
+    public static int getMinHashPartitionCount(Session session)
+    {
+        return session.getSystemProperty(SPARK_MIN_HASH_PARTITION_COUNT, Integer.class);
+    }
+
+    public static boolean isSparkResourceAllocationStrategyEnabled(Session session)
+    {
+        return session.getSystemProperty(SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED, Boolean.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -38,6 +38,7 @@ public class PrestoSparkSettingsRequirements
 {
     public static final String SPARK_TASK_CPUS_PROPERTY = "spark.task.cpus";
     public static final String SPARK_EXECUTOR_CORES_PROPERTY = "spark.executor.cores";
+    public static final String SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS_CONFIG = "spark.dynamicAllocation.maxExecutors";
 
     public void verify(SparkContext sparkContext, Session session)
     {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSourceStatsCollector.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSourceStatsCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class PrestoSparkSourceStatsCollector
+{
+    private final Metadata metadata;
+    private final Session session;
+
+    public PrestoSparkSourceStatsCollector(Metadata metadata, Session session)
+    {
+        this.metadata = metadata;
+        this.session = session;
+    }
+
+    public double collectSourceStats(PlanNode root)
+    {
+        SourceTableStatsVisitor sourceTableStatsVisitor = new SourceTableStatsVisitor();
+        root.accept(sourceTableStatsVisitor, null);
+
+        List<TableStatistics> sourceStatistics = sourceTableStatsVisitor.getTableStatistics();
+
+        if (sourceTableStatsVisitor.isSourceMissingData()) {
+            return -1.0;
+        }
+
+        Iterator<TableStatistics> tableStatisticsIterator = sourceStatistics.iterator();
+        double totalSourceDataSizeInBytes = 0.0;
+        while (tableStatisticsIterator.hasNext()) {
+            TableStatistics tableStatistics = tableStatisticsIterator.next();
+            totalSourceDataSizeInBytes = totalSourceDataSizeInBytes + tableStatistics.getTotalSize().getValue();
+        }
+
+        return totalSourceDataSizeInBytes;
+    }
+
+    private class SourceTableStatsVisitor
+            extends InternalPlanVisitor<Void, Void>
+    {
+        private final ImmutableList.Builder<TableStatistics> tableStatisticsBuilder = ImmutableList.builder();
+        private boolean isSourceMissingData;
+
+        public List<TableStatistics> getTableStatistics()
+        {
+            return tableStatisticsBuilder.build();
+        }
+
+        public boolean isSourceMissingData()
+        {
+            return isSourceMissingData;
+        }
+
+        @Override
+        public Void visitTableScan(TableScanNode node, Void context)
+        {
+            TableHandle tableHandle = node.getTable();
+
+            List<ColumnHandle> desiredColumns = node.getAssignments().values().stream().collect(toImmutableList());
+            Constraint<ColumnHandle> constraint = new Constraint<>(node.getCurrentConstraint());
+            TableStatistics statistics = metadata.getTableStatistics(session, tableHandle, desiredColumns, constraint);
+
+            if ((null == statistics) || (statistics == TableStatistics.empty())) {
+                isSourceMissingData = true;
+            }
+            else {
+                tableStatisticsBuilder.add(statistics);
+            }
+
+            return null;
+        }
+        @Override
+        public Void visitPlan(PlanNode node, Void context)
+        {
+            for (PlanNode source : node.getSources()) {
+                source.accept(this, context);
+            }
+            return null;
+        }
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -49,7 +49,14 @@ public class TestPrestoSparkConfig
                 .setRetryOnOutOfMemoryBroadcastJoinEnabled(false)
                 .setRetryOnOutOfMemoryWithIncreasedMemorySettingsEnabled(false)
                 .setOutOfMemoryRetryPrestoSessionProperties("")
-                .setOutOfMemoryRetrySparkConfigs(""));
+                .setOutOfMemoryRetrySparkConfigs("")
+                .setAverageInputDataSizePerExecutor(new DataSize(10, GIGABYTE))
+                .setMaxExecutorCount(600)
+                .setMinExecutorCount(200)
+                .setAverageInputDataSizePerPartition(new DataSize(2, GIGABYTE))
+                .setMaxHashPartitionCount(4096)
+                .setMinHashPartitionCount(1024)
+                .setSparkResourceAllocationStrategyEnabled(false));
     }
 
     @Test
@@ -74,6 +81,13 @@ public class TestPrestoSparkConfig
                 .put("spark.retry-on-out-of-memory-with-increased-memory-settings-enabled", "true")
                 .put("spark.retry-presto-session-properties", "query_max_memory_per_node=1MB,query_max_total_memory_per_node=1MB")
                 .put("spark.retry-spark-configs", "spark.executor.memory=1g,spark.task.cpus=5")
+                .put("spark.average-input-datasize-per-executor", "5GB")
+                .put("spark.max-executor-count", "29")
+                .put("spark.min-executor-count", "2")
+                .put("spark.average-input-datasize-per-partition", "1GB")
+                .put("spark.max-hash-partition-count", "333")
+                .put("spark.min-hash-partition-count", "30")
+                .put("spark.resource-allocation-strategy-enabled", "true")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -93,7 +107,14 @@ public class TestPrestoSparkConfig
                 .setRetryOnOutOfMemoryBroadcastJoinEnabled(true)
                 .setRetryOnOutOfMemoryWithIncreasedMemorySettingsEnabled(true)
                 .setOutOfMemoryRetryPrestoSessionProperties("query_max_memory_per_node=1MB,query_max_total_memory_per_node=1MB")
-                .setOutOfMemoryRetrySparkConfigs("spark.executor.memory=1g,spark.task.cpus=5");
+                .setOutOfMemoryRetrySparkConfigs("spark.executor.memory=1g,spark.task.cpus=5")
+                .setAverageInputDataSizePerExecutor(new DataSize(5, GIGABYTE))
+                .setMaxExecutorCount(29)
+                .setMinExecutorCount(2)
+                .setAverageInputDataSizePerPartition(new DataSize(1, GIGABYTE))
+                .setMaxHashPartitionCount(333)
+                .setMinHashPartitionCount(30)
+                .setSparkResourceAllocationStrategyEnabled(true);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Calculate the executor and hash partition count based on the data read by the query. The motivation is to ensure CPU/Reserved CPU gains without unbounded latency regression for queries running in Presto on Spark. 

Test plan:
* Updated unit tests
* Ran different queries via verify to validate different executor and partition allocations.

```
== RELEASE NOTES ==

Spark Changes

* Added a new configuration property ``spark.resource-allocation-strategy-enabled`` and its session property ``spark_resource_allocation_strategy_enabled`` to allow optimized resource allocation strategy. This enables automatic executor and hash partition count to be estimated during planning time. The estimation could be bounded by configurations including ``spark.average-input-datasize-per-executor``, ``spark.max-executor-count``, ``spark.min-executor-count``, ``spark.average-input-datasize-per-partition``, ``spark.max-hash-partition-count``, and ``spark.min-hash-partition-count``. There are also corresponding session properties for these estimations.

```