### PR TITLE
Fix tests in preparation of TestNG upgrade

### DIFF
--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -868,6 +868,15 @@ public class TestElasticsearchIntegrationSmokeTest
         assertQuery(
                 "SELECT count(*) FROM orders_alias",
                 "SELECT count(*) FROM orders");
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .aliases(indexAliasesRequest()
+                        .addAliasAction(IndicesAliasesRequest.AliasActions.remove()
+                                .index("orders")
+                                .alias("orders_alias")))
+                .actionGet();
     }
 
     @Test(enabled = false)

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveScalarFunctions.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveScalarFunctions.java
@@ -171,10 +171,10 @@ public class TestHiveScalarFunctions
     private static void assertNaN(Object o)
     {
         if (o instanceof Double) {
-            assertEquals((Double) o, Double.NaN);
+            assertEquals(((Double) o).doubleValue(), Double.NaN);
         }
         else if (o instanceof Float) {
-            assertEquals((Float) o, Float.NaN);
+            assertEquals(((Float) o).floatValue(), Float.NaN);
         }
         else {
             fail("Unexpected " + o);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5778,6 +5778,9 @@ public class TestHiveIntegrationSmokeTest
                         ", ds\n" +
                         "FROM\n" +
                         "  orders_partitioned\n");
+
+        computeActual("DROP TABLE orders_partitioned");
+        computeActual("DROP MATERIALIZED VIEW test_orders_view");
     }
 
     @Test

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/KuduQueryRunnerFactory.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/KuduQueryRunnerFactory.java
@@ -98,11 +98,12 @@ public class KuduQueryRunnerFactory
         return prefix;
     }
 
-    private static void installKuduConnector(QueryRunner runner, String schema)
+    private static synchronized void installKuduConnector(QueryRunner runner, String schema)
     {
         String masterAddresses = System.getProperty("kudu.client.master-addresses", "localhost:7051");
         Map<String, String> properties;
-        if (!isSchemaEmulationEnabled()) {
+        boolean isSchemaEmulationEnabled = isSchemaEmulationEnabled();
+        if (!isSchemaEmulationEnabled) {
             properties = ImmutableMap.of(
                     "kudu.schema-emulation.enabled", "false",
                     "kudu.client.master-addresses", masterAddresses);
@@ -117,7 +118,7 @@ public class KuduQueryRunnerFactory
         runner.installPlugin(new KuduPlugin());
         runner.createCatalog("kudu", "kudu", properties);
 
-        if (isSchemaEmulationEnabled()) {
+        if (isSchemaEmulationEnabled) {
             runner.execute("DROP SCHEMA IF EXISTS " + schema);
             runner.execute("CREATE SCHEMA " + schema);
         }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -560,15 +560,16 @@ public class TestRaptorIntegrationSmokeTest
     public void testBucketingMixedTypes()
     {
         assertUpdate("" +
-                        "CREATE TABLE orders_bucketed_mixed " +
+                        "CREATE TABLE bucketed_mixed " +
                         "WITH (bucket_count = 50, bucketed_on = ARRAY ['custkey', 'clerk', 'shippriority']) " +
                         "AS SELECT * FROM orders",
                 "SELECT count(*) FROM orders");
 
-        assertQuery("SELECT * FROM orders_bucketed_mixed", "SELECT * FROM orders");
-        assertQuery("SELECT count(*) FROM orders_bucketed_mixed", "SELECT count(*) FROM orders");
-        assertQuery("SELECT count(DISTINCT \"$shard_uuid\") FROM orders_bucketed_mixed", "SELECT 50");
-        assertQuery("SELECT count(DISTINCT \"$bucket_number\") FROM orders_bucketed_mixed", "SELECT 50");
+        assertQuery("SELECT * FROM bucketed_mixed", "SELECT * FROM orders");
+        assertQuery("SELECT count(*) FROM bucketed_mixed", "SELECT count(*) FROM orders");
+        assertQuery("SELECT count(DISTINCT \"$shard_uuid\") FROM bucketed_mixed", "SELECT 50");
+        assertQuery("SELECT count(DISTINCT \"$bucket_number\") FROM bucketed_mixed", "SELECT 50");
+        assertUpdate("DROP TABLE bucketed_mixed");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -857,8 +857,8 @@ public abstract class AbstractTestAggregations
         List<MaterializedRow> actualRows = actual.getMaterializedRows();
         assertEquals(actualRows.size(), 1);
         assertTrue(Double.isNaN(((List<Double>) actualRows.get(0).getField(0)).get(0)));
-        assertEquals(((List<Double>) actualRows.get(0).getField(0)).get(1), 2.0);
-        assertEquals(((List<Double>) actualRows.get(0).getField(0)).get(2), 3.0);
+        assertEquals(((List<Double>) actualRows.get(0).getField(0)).get(1).doubleValue(), 2.0);
+        assertEquals(((List<Double>) actualRows.get(0).getField(0)).get(2).doubleValue(), 3.0);
     }
 
     @Test


### PR DESCRIPTION
1. API overloads cause compilation failure, updated to use the
correct APIs.
2. Tests run order are changing and more parallelism. Cleanup
after creating some views, so the later queries does not fail.
3. Handle multi threaded initialization gracefully in Kudu Runner.

Test plan - (Please fill in how you tested your changes)
Existing tests. 

```
== NO RELEASE NOTE ==
```
