### PR TITLE
Construct TDigest Function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMEN
 import static com.facebook.presto.spi.function.SqlFunctionVisibility.EXPERIMENTAL;
 import static com.facebook.presto.tdigest.TDigest.createTDigest;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
 
 public final class TDigestFunctions
 {
@@ -146,5 +147,38 @@ public final class TDigestFunctions
         checkCondition(upperQuantileBound >= 0 && upperQuantileBound <= 1, INVALID_FUNCTION_ARGUMENT, "Upper quantile bound should be in [0,1].");
         TDigest digest = createTDigest(input);
         return digest.trimmedMean(lowerQuantileBound, upperQuantileBound);
+    }
+
+    @ScalarFunction(value = "construct_tdigest", visibility = EXPERIMENTAL)
+    @Description("Create a TDigest by passing in its internal state.")
+    @SqlType("tdigest(double)")
+    public static Slice constructTDigest(
+            @SqlType("array(double)") Block centroidMeansBlock,
+            @SqlType("array(double)") Block centroidWeightsBlock,
+            @SqlType(StandardTypes.DOUBLE) double compression,
+            @SqlType(StandardTypes.DOUBLE) double min,
+            @SqlType(StandardTypes.DOUBLE) double max,
+            @SqlType(StandardTypes.DOUBLE) double sum,
+            @SqlType(StandardTypes.BIGINT) long count)
+    {
+        double[] centroidMeans = new double[centroidMeansBlock.getPositionCount()];
+        for (int i = 0; i < centroidMeansBlock.getPositionCount(); i++) {
+            centroidMeans[i] = DOUBLE.getDouble(centroidMeansBlock, i);
+        }
+        double[] centroidWeights = new double[centroidWeightsBlock.getPositionCount()];
+        for (int i = 0; i < centroidWeightsBlock.getPositionCount(); i++) {
+            centroidWeights[i] = DOUBLE.getDouble(centroidWeightsBlock, i);
+        }
+
+        TDigest tDigest = createTDigest(
+                centroidMeans,
+                centroidWeights,
+                compression,
+                min,
+                max,
+                sum,
+                toIntExact(count));
+
+        return tDigest.serialize();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -159,6 +159,26 @@ public class TDigest
         return new TDigest(compression);
     }
 
+    public static TDigest createTDigest(
+            double[] centroidMeans,
+            double[] centroidWeights,
+            double compression,
+            double min,
+            double max,
+            double sum,
+            int count)
+    {
+        TDigest tDigest = new TDigest(compression);
+        tDigest.setMinMax(min, max);
+        tDigest.setSum(sum);
+        tDigest.totalWeight = Arrays.stream(centroidWeights).sum(); // set totalWeight to sum of all centroidWeights
+        tDigest.activeCentroids = count;
+        tDigest.weight = centroidWeights;
+        tDigest.mean = centroidMeans;
+
+        return tDigest;
+    }
+
     public static TDigest createTDigest(Slice slice)
     {
         if (slice == null) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -443,6 +443,35 @@ public class TestTDigestFunctions
     }
 
     @Test
+    public void testConstructTDigest()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        ImmutableList<Double> values = ImmutableList.of(0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, 9.0d);
+        values.stream().forEach(tDigest::add);
+
+        List<Double> weights = Collections.nCopies(values.size(), 1.0);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        int count = values.size();
+
+        String sql = format("construct_tdigest(ARRAY%s, ARRAY%s, %s, %s, %s, %s, %s)",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        functionAssertions.selectSingleValue(
+                sql,
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+    }
+
+    @Test
     public void testDestructureTDigest()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
@@ -479,6 +508,39 @@ public class TestTDigestFunctions
     }
 
     @Test
+    public void testConstructTDigestLarge()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        List<Double> values = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            values.add((double) i);
+        }
+
+        values.stream().forEach(tDigest::add);
+
+        List<Double> weights = Collections.nCopies(values.size(), 1.0);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        long count = values.size();
+
+        String sql = format("construct_tdigest(ARRAY%s, ARRAY%s, %s, %s, %s, %s, %s)",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        functionAssertions.selectSingleValue(
+                sql,
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+    }
+
+    @Test
     public void testDestructureTDigestLarge()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
@@ -502,6 +564,105 @@ public class TestTDigestFunctions
         functionAssertions.assertFunction(format("%s.max", sql), DOUBLE, max);
         functionAssertions.assertFunction(format("%s.sum", sql), DOUBLE, sum);
         functionAssertions.assertFunction(format("%s.count", sql), BIGINT, count);
+    }
+
+    @Test
+    public void testConstructTDigestNormalDistribution()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        List<Double> values = new ArrayList<>();
+        NormalDistribution normal = new NormalDistribution(500, 20);
+        int samples = 100;
+
+        for (int k = 0; k < samples; k++) {
+            double value = normal.sample();
+            tDigest.add(value);
+            values.add(value);
+        }
+
+        List<Double> weights = Collections.nCopies(values.size(), 1.0);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        long count = values.size();
+
+        String sql = format("construct_tdigest(ARRAY%s, ARRAY%s, %s, %s, %s, %s, %s)",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        functionAssertions.selectSingleValue(
+                sql,
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+    }
+
+    @Test
+    public void testConstructTDigestInverse()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        ImmutableList<Double> values = ImmutableList.of(0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, 9.0d);
+        values.stream().forEach(tDigest::add);
+
+        List<Integer> weights = Collections.nCopies(values.size(), 1);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        long count = values.size();
+
+        SqlVarbinary sqlVarbinary = new SqlVarbinary(tDigest.serialize().getBytes());
+        String tdigestStr = sqlVarbinary.toString().replaceAll("\\s+", " ");
+
+        String destructureTdigestSql = format("destructure_tdigest(CAST(X'%s' AS tdigest(%s)))",
+                new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " "),
+                DOUBLE);
+
+        // Asserting that calling destructure_tdigest on the generated tdigest
+        // produces values that equal those declared above
+        functionAssertions.assertFunction(
+                destructureTdigestSql,
+                TDIGEST_CENTROIDS_ROW_TYPE,
+                ImmutableList.of(values, weights, compression, min, max, sum, count));
+
+        functionAssertions.assertFunction(format("%s.compression", destructureTdigestSql), DOUBLE, compression);
+        functionAssertions.assertFunction(format("%s.min", destructureTdigestSql), DOUBLE, min);
+        functionAssertions.assertFunction(format("%s.max", destructureTdigestSql), DOUBLE, max);
+        functionAssertions.assertFunction(format("%s.sum", destructureTdigestSql), DOUBLE, sum);
+        functionAssertions.assertFunction(format("%s.count", destructureTdigestSql), BIGINT, count);
+        functionAssertions.assertFunction(
+                format("%s.centroid_means", destructureTdigestSql),
+                new ArrayType(DOUBLE),
+                values);
+        functionAssertions.assertFunction(
+                format("%s.centroid_weights", destructureTdigestSql),
+                new ArrayType(INTEGER),
+                weights);
+
+        String constructTdigestSql = format("construct_tdigest(ARRAY%s, ARRAY%s, %s, %s, %s, %s, %s)",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        // Asserting that calling construct_tdigest with the raw values
+        // produces a varbinary that equals the generated tdigest declared above
+        SqlVarbinary constructedSqlVarbinary = functionAssertions.selectSingleValue(
+                constructTdigestSql,
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+
+        // If this is true then by definition calling construct_tdigest(destructure_tdigest(...)...)
+        // will work
+        assertEquals(constructedSqlVarbinary, sqlVarbinary);
     }
 
     // disabled because test takes almost 10s


### PR DESCRIPTION
Test plan - `mvn -Dtest="TestTDigest,TestTDigestFunctions" test`

Creating a function that allows users to generate a TDigest varbinary from the internal tdigest representation.

```
== RELEASE NOTES ==

General Changes
* Added CONSTRUCT_TDIGEST() for Tdigest. The prototype of the function is:

CONSTRUCT_TDIGEST(
  double[] centroidMeans,
  double[] centroidWeights,
  double compression,
  double min,
  double max,
  double sum,
  bigint count)
) -> Slice
```

cc @amellnik