### PR TITLE
Annotate PoS RDDs with PlanFragment ID

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -173,6 +173,7 @@ import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_OOM;
 import static com.facebook.presto.spark.SparkErrorCode.UNSUPPORTED_STORAGE_TYPE;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collectScalaIterator;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static com.facebook.presto.spark.planner.PrestoSparkRddFactory.getRDDName;
 import static com.facebook.presto.spark.util.PrestoSparkFailureUtils.toPrestoSparkFailure;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.classTag;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
@@ -1204,7 +1205,7 @@ public class PrestoSparkQueryExecutionFactory
                 }
                 else {
                     RddAndMore<PrestoSparkMutableRow> childRdd = createRdd(child, PrestoSparkMutableRow.class);
-                    rddInputs.put(childFragment.getId(), partitionBy(childRdd.getRdd(), child.getFragment().getPartitioningScheme()));
+                    rddInputs.put(childFragment.getId(), partitionBy(childFragment.getId().getId(), childRdd.getRdd(), child.getFragment().getPartitioningScheme()));
                     broadcastDependencies.addAll(childRdd.getBroadcastDependencies());
                 }
             }
@@ -1223,6 +1224,7 @@ public class PrestoSparkQueryExecutionFactory
         }
 
         private static JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> partitionBy(
+                int planFragmentId,
                 JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> rdd,
                 PartitioningScheme partitioningScheme)
         {
@@ -1230,6 +1232,7 @@ public class PrestoSparkQueryExecutionFactory
             JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> javaPairRdd = rdd.partitionBy(partitioner);
             ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow> shuffledRdd = (ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow>) javaPairRdd.rdd();
             shuffledRdd.setSerializer(new PrestoSparkShuffleSerializer());
+            shuffledRdd.setName(getRDDName(planFragmentId));
             return JavaPairRDD.fromRDD(
                     shuffledRdd,
                     classTag(MutablePartitionId.class),


### PR DESCRIPTION
PoS internally converts a Presto physical plan (DAG of PlanFragments)
into a DAG of Spark RDDs which is then executed on Spark Cluster.
There is 1:1 mapping between a PlanFragment and an RDD in the DAG.
Currently, there is no way to map an RDD back to a planFragment
and this makes debugging difficult. RDD provides an API to specify
a name for the RDD which is then shown in Spark UI. We can leverage
this API to associate Presto's plan fragment ID with an RDD in Spark
DAG and this can help in tracking which Spark stage corresponds to
which planFragment in Presto plan.

Test Plan: Spark UI changes

Job View: PlanFragment Id is encoded in the stage nodes.
![image (14)](https://user-images.githubusercontent.com/14278768/177406712-63232b9d-bdc6-4985-8946-7b7bdcaae93b.png)

Stage View:
![image (15)](https://user-images.githubusercontent.com/14278768/177406819-cec14f94-91c3-4e6d-9db8-f358dd3df6c6.png)


```
== NO RELEASE NOTE ==
```
