### PR TITLE
Query failing with exceed local memory doesn't free memory correctly

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -459,20 +459,20 @@ public class QueryContext
         @Override
         public ListenableFuture<?> reserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
         {
-            ListenableFuture<?> future = reserveMemoryFunction.apply(allocationTag, delta);
             if (enforceBroadcastMemoryLimit) {
                 updateBroadcastMemoryFunction.accept(delta);
             }
+            ListenableFuture<?> future = reserveMemoryFunction.apply(allocationTag, delta);
             return future;
         }
 
         @Override
         public boolean tryReserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
         {
-            if (!tryReserveMemoryFunction.test(allocationTag, delta)) {
+            if (enforceBroadcastMemoryLimit && !tryUpdateBroadcastMemoryFunction.test(delta)) {
                 return false;
             }
-            return !enforceBroadcastMemoryLimit || tryUpdateBroadcastMemoryFunction.test(delta);
+            return tryReserveMemoryFunction.test(allocationTag, delta);
         }
     }
 


### PR DESCRIPTION
Query with HashBuildOperator, if fails with exceed local memory doesn't free memory for the operator.
This leads to general pool keeping the memory for it and makes the amount of memory not usable by other
running queries.
Reason for the leak, we reserve the memory and then do memory constraint check. And if query fails due to memory
constraint, we don't free the reserved memory. We changing the order so first do memory constraint check to address it.

Test plan - unit test and hive query runner locally

```
== RELEASE NOTES ==

General Changes
* Fix broadcast join memory leak caused by exceeding local memory query failure
