### PR TITLE
Replace Joda-Time libraries with java.time

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -48,6 +48,7 @@ import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -116,6 +117,25 @@ class GenericHiveRecordCursor<K, V extends Writable>
     private long completedBytes;
     private Object rowData;
     private boolean closed;
+
+    public GenericHiveRecordCursor(
+            Configuration configuration,
+            Path path,
+            RecordReader<K, V> recordReader,
+            long totalBytes,
+            Properties splitSchema,
+            List<HiveColumnHandle> columns,
+            ZoneId hiveStorageTimeZoneId,
+            TypeManager typeManager)
+    {
+        this(configuration, path, recordReader, totalBytes, splitSchema, columns, getDateTimeZone(hiveStorageTimeZoneId), typeManager);
+    }
+
+    private static DateTimeZone getDateTimeZone(ZoneId hiveStorageTimeZoneId)
+    {
+        requireNonNull(hiveStorageTimeZoneId, "hiveStorageTimeZoneId is null");
+        return DateTimeZone.forID(hiveStorageTimeZoneId.getId());
+    }
 
     public GenericHiveRecordCursor(
             Configuration configuration,

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -45,11 +45,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/presto-hudi/src/main/java/com/facebook/presto/hive/HudiRecordCursors.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hive/HudiRecordCursors.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.RecordReader;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -40,7 +40,7 @@ public final class HudiRecordCursors
             long totalBytes,
             Properties hiveSchema,
             List<HudiColumnHandle> hiveColumnHandles,
-            DateTimeZone hiveStorageTimeZone,
+            ZoneId hiveStorageTimeZone,
             TypeManager typeManager)
     {
         return new GenericHiveRecordCursor<>(

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
@@ -34,10 +34,10 @@ import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -131,7 +131,7 @@ public class HudiPageSourceProvider
                     schema,
                     hudiSplit,
                     dataColumns,
-                    DateTimeZone.UTC, // TODO configurable
+                    ZoneId.of("UTC"), // TODO configurable
                     typeManager);
             List<Type> types = dataColumns.stream()
                     .map(column -> column.getHiveType().getType(typeManager))

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
@@ -36,9 +36,9 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ class HudiRecordCursors
             Properties schema,
             HudiSplit split,
             List<HudiColumnHandle> dataColumns,
-            DateTimeZone hiveStorageTimeZone,
+            ZoneId hiveStorageTimeZone,
             TypeManager typeManager)
     {
         requireNonNull(session, "session is null");


### PR DESCRIPTION
Since Java 8 we have java.time packages which are equivalent to Joda and
the recommendation from the author of the Joda-Time is to migrate to
java.time(JSR-310) library.

These Joda time deprecation is done in presto-hudi.

```
== NO RELEASE NOTE ==
```
