### PR TITLE
Fix int overflow in ORC double and float column writers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -52,6 +52,7 @@ public class DoubleColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(DoubleColumnWriter.class).instanceSize();
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
+    private static final long TYPE_SIZE = Double.BYTES;
 
     private final int column;
     private final int sequence;
@@ -118,7 +119,7 @@ public class DoubleColumnWriter
                 nonNullValueCount++;
             }
         }
-        return nonNullValueCount * Double.BYTES + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+        return nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -53,6 +53,7 @@ public class FloatColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(FloatColumnWriter.class).instanceSize();
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
+    private static final long TYPE_SIZE = Float.BYTES;
 
     private final int column;
     private final int sequence;
@@ -120,7 +121,7 @@ public class FloatColumnWriter
                 nonNullValueCount++;
             }
         }
-        return nonNullValueCount * Float.BYTES + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+        return nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
     }
 
     @Override


### PR DESCRIPTION
In some extreme cases double and float column writers will report invalid (negative) raw data sizes written.

This is caused by the fact that the type of Double.BYTES/Float.BYTES are ints, and when reporting the written size they will be implicitly cast to long. The reported value will overflow when the number of written values is greater than Integer.MAX / Double.BYTES or 268,435,465 values (for double case).

I did a manual testing by debugging OrcWriter to confirm the overflow and to confirm the fix.

Before the fix:
```
Chunk position count: 268435465
written: -2147483576
stripeRawSize: -2147483576
```

After the fix:
```
Chunk position count: 268435465
written: 2147483720
stripeRawSize: 2147483720
```

Test plan:
- manual testing

```
== NO RELEASE NOTE ==
```
