### PR TITLE
support raft ha mode for alluxio metastore

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioMetastoreModule.java
@@ -62,11 +62,7 @@ public class AlluxioMetastoreModule
         }
         else {
             String address = config.getMasterAddress();
-            String[] parts = address.split(":", 2);
-            conf.set(PropertyKey.MASTER_HOSTNAME, parts[0]);
-            if (parts.length > 1) {
-                conf.set(PropertyKey.MASTER_RPC_PORT, Integer.parseInt(parts[1]));
-            }
+            conf.set(PropertyKey.MASTER_RPC_ADDRESSES, address);
         }
         MasterClientContext context = MasterClientContext.newBuilder(ClientContext.create(conf)).build();
         return new RetryHandlingTableMasterClient(context);


### PR DESCRIPTION
The current Alluxio connector configuration only support single master mode and zookeeper high availability mode.
This PR allow users to config multiple master addresses to connect RAFT HA Alluxio.

Fix https://github.com/prestodb/presto/issues/17595
