### PR TITLE
Fix print of ValuesNode from HiveFilterPushDown

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
@@ -20,6 +20,7 @@ public enum HiveWarningCode
         implements WarningCodeSupplier
 {
     PARTITION_NOT_READABLE(1),
+    HIVE_TABLESCAN_CONVERTED_TO_VALUESNODE(2),
     /**/;
     private final WarningCode warningCode;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -376,7 +376,7 @@ public class HiveFilterPushdown
             RowExpression replacedExpression = replaceExpression(expression, symbolToColumnMapping);
             // replaceExpression() may further optimize the expression; if the resulting expression is always false, then return empty Values node
             if (FALSE_CONSTANT.equals(replacedExpression)) {
-                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of());
+                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of(), Optional.of(tableScan.getTable().toString()));
             }
             ConnectorPushdownFilterResult pushdownFilterResult = pushdownFilter(
                     session,
@@ -387,7 +387,7 @@ public class HiveFilterPushdown
 
             ConnectorTableLayout layout = pushdownFilterResult.getLayout();
             if (layout.getPredicate().isNone()) {
-                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of());
+                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of(), Optional.of(tableScan.getTable().toString()));
             }
 
             TableScanNode node = new TableScanNode(
@@ -423,7 +423,7 @@ public class HiveFilterPushdown
                     TRUE_CONSTANT,
                     handle.getLayout());
             if (pushdownFilterResult.getLayout().getPredicate().isNone()) {
-                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of());
+                return new ValuesNode(tableScan.getSourceLocation(), idAllocator.getNextId(), tableScan.getOutputVariables(), ImmutableList.of(), Optional.of(tableScan.getTable().toString()));
             }
 
             return new TableScanNode(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1174,6 +1174,12 @@ public abstract class AbstractTestHiveClient
             {
                 return Optional.empty();
             }
+
+            @Override
+            public WarningCollector getWarningCollector()
+            {
+                return WarningCollector.NOOP;
+            }
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.ConnectorIdentity;
@@ -176,5 +177,11 @@ public class FullConnectorSession
                 .add("properties", properties)
                 .omitNullValues()
                 .toString();
+    }
+
+    @Override
+    public WarningCollector getWarningCollector()
+    {
+        return session.getWarningCollector();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.Identity;
@@ -331,6 +332,8 @@ public final class SessionRepresentation
                 sessionPropertyManager,
                 preparedStatements,
                 sessionFunctions,
-                Optional.empty());
+                Optional.empty(),
+                // we use NOOP to create a session from the representation as worker does not require warning collectors
+                WarningCollector.NOOP);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
 /**
@@ -23,7 +24,7 @@ public class NoOpSessionSupplier
         implements SessionSupplier
 {
     @Override
-    public Session createSession(QueryId queryId, SessionContext context)
+    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -14,9 +14,10 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
 public interface SessionSupplier
 {
-    Session createSession(QueryId queryId, SessionContext context);
+    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -231,7 +231,8 @@ public class LogicalPlanner
                     getSourceLocation(statement),
                     idAllocator.getNextId(),
                     ImmutableList.of(variable),
-                    ImmutableList.of(ImmutableList.of(constant(0L, BIGINT))));
+                    ImmutableList.of(ImmutableList.of(constant(0L, BIGINT))),
+                    Optional.empty());
             return new OutputNode(source.getSourceLocation(), idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(variable));
         }
         return createOutputPlan(planStatementWithoutOutput(analysis, statement), analysis);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -317,7 +317,7 @@ class QueryPlanner
     {
         Scope scope = Scope.create();
         return new RelationPlan(
-                new ValuesNode(Optional.empty(), idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(ImmutableList.of())),
+                new ValuesNode(Optional.empty(), idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(ImmutableList.of()), Optional.empty()),
                 scope,
                 ImmutableList.of());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -699,7 +699,7 @@ class RelationPlanner
             rowsBuilder.add(values.build());
         }
 
-        ValuesNode valuesNode = new ValuesNode(getSourceLocation(node), idAllocator.getNextId(), outputVariablesBuilder.build(), rowsBuilder.build());
+        ValuesNode valuesNode = new ValuesNode(getSourceLocation(node), idAllocator.getNextId(), outputVariablesBuilder.build(), rowsBuilder.build(), Optional.empty());
         return new RelationPlan(valuesNode, scope, outputVariablesBuilder.build());
     }
 
@@ -773,7 +773,8 @@ class RelationPlanner
                 getSourceLocation(node),
                 idAllocator.getNextId(),
                 argumentVariables.build(),
-                ImmutableList.of(values.build()));
+                ImmutableList.of(values.build()),
+                Optional.empty());
 
         UnnestNode unnestNode = new UnnestNode(getSourceLocation(node), idAllocator.getNextId(), valuesNode, ImmutableList.of(), unnestVariables.build(), ordinalityVariable);
         return new RelationPlan(unnestNode, scope, unnestedVariables);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -603,7 +603,8 @@ class SubqueryPlanner
                     node.getSourceLocation(),
                     idAllocator.getNextId(),
                     rewrittenNode.getOutputVariables(),
-                    rewrittenRows);
+                    rewrittenRows,
+                    node.getValuesNodeLabel());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateEmptyJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateEmptyJoins.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.isEmptyJoinOptimization;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
@@ -82,7 +83,7 @@ public class EliminateEmptyJoins
                 || (leftChildEmpty && joinNode.getType() == JoinNode.Type.LEFT)
                 || (rightChildEmpty && joinNode.getType() == JoinNode.Type.RIGHT)) {
             return Result.ofPlanNode(
-                    new ValuesNode(joinNode.getSourceLocation(), joinNode.getId(), joinNode.getOutputVariables(), Collections.emptyList()));
+                    new ValuesNode(joinNode.getSourceLocation(), joinNode.getId(), joinNode.getOutputVariables(), Collections.emptyList(), Optional.empty()));
         }
 
         /*

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
 import static com.facebook.presto.sql.planner.plan.Patterns.Limit.count;
 import static com.facebook.presto.sql.planner.plan.Patterns.limit;
 
@@ -38,6 +40,6 @@ public class EvaluateZeroLimit
     @Override
     public Result apply(LimitNode limit, Captures captures, Context context)
     {
-        return Result.ofPlanNode(new ValuesNode(limit.getSourceLocation(), limit.getId(), limit.getOutputVariables(), ImmutableList.of()));
+        return Result.ofPlanNode(new ValuesNode(limit.getSourceLocation(), limit.getId(), limit.getOutputVariables(), ImmutableList.of(), Optional.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroSample.java
@@ -20,6 +20,8 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
 import static com.facebook.presto.sql.planner.plan.Patterns.Sample.sampleRatio;
 import static com.facebook.presto.sql.planner.plan.Patterns.sample;
 
@@ -41,6 +43,6 @@ public class EvaluateZeroSample
     @Override
     public Result apply(SampleNode sample, Captures captures, Context context)
     {
-        return Result.ofPlanNode(new ValuesNode(sample.getSourceLocation(), sample.getId(), sample.getOutputVariables(), ImmutableList.of()));
+        return Result.ofPlanNode(new ValuesNode(sample.getSourceLocation(), sample.getId(), sample.getOutputVariables(), ImmutableList.of(), Optional.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -306,7 +306,7 @@ public class ExpressionRewriteRuleSet
                 rows.add(newRow.build());
             }
             if (anyRewritten) {
-                return Result.ofPlanNode(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), valuesNode.getOutputVariables(), rows.build()));
+                return Result.ofPlanNode(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), valuesNode.getOutputVariables(), rows.build(), valuesNode.getValuesNodeLabel()));
             }
             return Result.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -217,7 +217,7 @@ public class PickTableLayout
                             .collect(toImmutableSet())));
 
             if (layout.getLayout().getPredicate().isNone()) {
-                return Result.ofPlanNode(new ValuesNode(tableScanNode.getSourceLocation(), context.getIdAllocator().getNextId(), tableScanNode.getOutputVariables(), ImmutableList.of()));
+                return Result.ofPlanNode(new ValuesNode(tableScanNode.getSourceLocation(), context.getIdAllocator().getNextId(), tableScanNode.getOutputVariables(), ImmutableList.of(), Optional.empty()));
             }
 
             return Result.ofPlanNode(new TableScanNode(
@@ -300,7 +300,7 @@ public class PickTableLayout
             constraint = new Constraint<>(newDomain);
         }
         if (constraint.getSummary().isNone()) {
-            return new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of());
+            return new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(), Optional.empty());
         }
 
         // Layouts will be returned in order of the connector's preference
@@ -313,7 +313,7 @@ public class PickTableLayout
                         .collect(toImmutableSet())));
 
         if (layout.getLayout().getPredicate().isNone()) {
-            return new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of());
+            return new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(), Optional.empty());
         }
 
         TableScanNode tableScan = new TableScanNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
@@ -73,7 +74,8 @@ public class PruneCountAggregationOverScalar
                     parent.getSourceLocation(),
                     parent.getId(),
                     parent.getOutputVariables(),
-                    ImmutableList.of(ImmutableList.of(constant(1L, BIGINT)))));
+                    ImmutableList.of(ImmutableList.of(constant(1L, BIGINT))),
+                    Optional.empty()));
         }
         return Result.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
@@ -58,6 +58,6 @@ public class PruneValuesColumns
                     .collect(Collectors.toList()));
         }
 
-        return Optional.of(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), newOutputVariables, rowsBuilder.build()));
+        return Optional.of(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), newOutputVariables, rowsBuilder.build(), valuesNode.getValuesNodeLabel()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -305,7 +305,8 @@ public class PushAggregationThroughOuterJoin
                 referenceAggregation.getSourceLocation(),
                 idAllocator.getNextId(),
                 nullVariables.build(),
-                ImmutableList.of(nullLiterals.build()));
+                ImmutableList.of(nullLiterals.build()),
+                Optional.empty());
         Map<VariableReferenceExpression, VariableReferenceExpression> sourcesVariableMapping = sourcesVariableMappingBuilder.build();
 
         // For each aggregation function in the reference node, create a corresponding aggregation function

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveEmptyDelete.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveEmptyDelete.java
@@ -20,6 +20,8 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.matching.Pattern.empty;
 import static com.facebook.presto.sql.planner.plan.Patterns.Values.rows;
@@ -76,6 +78,7 @@ public class RemoveEmptyDelete
                         node.getSourceLocation(),
                         node.getId(),
                         node.getOutputVariables(),
-                        ImmutableList.of(ImmutableList.of(constant(0L, BIGINT)))));
+                        ImmutableList.of(ImmutableList.of(constant(0L, BIGINT))),
+                        Optional.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveTrivialFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveTrivialFilters.java
@@ -21,6 +21,8 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
@@ -47,7 +49,7 @@ public class RemoveTrivialFilters
         }
 
         if (predicate.equals(FALSE_LITERAL)) {
-            return Result.ofPlanNode(new ValuesNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), filterNode.getOutputVariables(), ImmutableList.of()));
+            return Result.ofPlanNode(new ValuesNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), filterNode.getOutputVariables(), ImmutableList.of(), Optional.empty()));
         }
 
         return Result.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -424,7 +424,7 @@ public class RowExpressionRewriteRuleSet
                 rows.add(newRow.build());
             }
             if (anyRewritten) {
-                return Result.ofPlanNode(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), valuesNode.getOutputVariables(), rows.build()));
+                return Result.ofPlanNode(new ValuesNode(valuesNode.getSourceLocation(), valuesNode.getId(), valuesNode.getOutputVariables(), rows.build(), valuesNode.getValuesNodeLabel()));
             }
             return Result.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -124,7 +124,8 @@ public class LimitPushDown
                         node.getSourceLocation(),
                         idAllocator.getNextId(),
                         node.getOutputVariables(),
-                        ImmutableList.of());
+                        ImmutableList.of(),
+                        Optional.empty());
             }
 
             // default visitPlan logic will insert the limit node

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -243,7 +243,7 @@ public class MetadataQueryOptimizer
             }
 
             // replace the tablescan node with a values node
-            return SimplePlanRewriter.rewriteWith(new Replacer(new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), inputs, rowsBuilder.build())), node);
+            return SimplePlanRewriter.rewriteWith(new Replacer(new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), inputs, rowsBuilder.build(), Optional.empty())), node);
         }
 
         private boolean isReducible(AggregationNode node, List<VariableReferenceExpression> inputs)
@@ -323,7 +323,7 @@ public class MetadataQueryOptimizer
                 }
             }
             Assignments assignments = assignmentsBuilder.build();
-            ValuesNode valuesNode = new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(new ArrayList<>(assignments.getExpressions())));
+            ValuesNode valuesNode = new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(new ArrayList<>(assignments.getExpressions())), Optional.empty());
             return new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), valuesNode, assignments, LOCAL);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -850,7 +850,7 @@ public class PruneUnreferencedOutputs
             List<List<RowExpression>> rewrittenRows = rowBuilders.stream()
                     .map(ImmutableList.Builder::build)
                     .collect(toImmutableList());
-            return new ValuesNode(node.getSourceLocation(), node.getId(), rewrittenOutputVariablesBuilder.build(), rewrittenRows);
+            return new ValuesNode(node.getSourceLocation(), node.getId(), rewrittenOutputVariablesBuilder.build(), rewrittenRows, node.getValuesNodeLabel());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -406,7 +406,8 @@ public class UnaliasSymbolReferences
                     node.getSourceLocation(),
                     node.getId(),
                     canonicalizedOutputVariables,
-                    canonicalizedRows);
+                    canonicalizedRows,
+                    node.getValuesNodeLabel());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -802,7 +802,13 @@ public class PlanPrinter
         @Override
         public Void visitValues(ValuesNode node, Void context)
         {
-            NodeRepresentation nodeOutput = addNode(node, "Values");
+            NodeRepresentation nodeOutput;
+            if (node.getValuesNodeLabel().isPresent()) {
+                nodeOutput = addNode(node, format("Values converted from TableScan[%s]", node.getValuesNodeLabel().get()));
+            }
+            else {
+                nodeOutput = addNode(node, "Values");
+            }
             for (List<RowExpression> row : node.getRows()) {
                 nodeOutput.appendDetailsLine("(" + row.stream().map(formatter::apply).collect(Collectors.joining(", ")) + ")");
             }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -498,7 +498,8 @@ public class LocalQueryRunner
                 metadata.getSessionPropertyManager(),
                 defaultSession.getPreparedStatements(),
                 defaultSession.getSessionFunctions(),
-                defaultSession.getTracer());
+                defaultSession.getTracer(),
+                defaultSession.getWarningCollector());
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.ConnectorIdentity;
@@ -189,6 +190,12 @@ public class TestingConnectorSession
     public Optional<String> getSchema()
     {
         return schema;
+    }
+
+    @Override
+    public WarningCollector getWarningCollector()
+    {
+        return WarningCollector.NOOP;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -473,7 +473,12 @@ public final class GraphvizPrinter
         @Override
         public Void visitValues(ValuesNode node, Void context)
         {
-            printNode(node, "Values", NODE_COLORS.get(NodeType.TABLESCAN));
+            if (node.getValuesNodeLabel().isPresent()) {
+                printNode(node, format("Values converted from TableScan[%s]", node.getValuesNodeLabel().get()), NODE_COLORS.get(NodeType.TABLESCAN));
+            }
+            else {
+                printNode(node, "Values", NODE_COLORS.get(NodeType.TABLESCAN));
+            }
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -15,9 +15,12 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.TimeZoneNotSupportedException;
+import com.facebook.presto.execution.warnings.WarningCollectorFactory;
+import com.facebook.presto.execution.warnings.WarningHandlingLevel;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.sql.SqlEnvironmentConfig;
@@ -87,7 +90,15 @@ public class TestQuerySessionSupplier
                 new AllowAllAccessControl(),
                 new SessionPropertyManager(),
                 new SqlEnvironmentConfig());
-        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context);
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -147,6 +158,14 @@ public class TestQuerySessionSupplier
                 new AllowAllAccessControl(),
                 new SessionPropertyManager(),
                 new SqlEnvironmentConfig());
-        sessionSupplier.createSession(new QueryId("test_query_id"), context);
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -292,6 +292,7 @@ public class TestEliminateCrossJoins
                 Optional.empty(),
                 idAllocator.getNextId(),
                 Arrays.asList(variables),
-                ImmutableList.of());
+                ImmutableList.of(),
+                Optional.empty());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -238,7 +238,7 @@ public class PlanBuilder
 
     public ValuesNode values(PlanNodeId id, List<VariableReferenceExpression> variables, List<List<RowExpression>> rows)
     {
-        return new ValuesNode(Optional.empty(), id, variables, rows);
+        return new ValuesNode(Optional.empty(), id, variables, rows, Optional.empty());
     }
 
     public EnforceSingleRowNode enforceSingleRow(PlanNode source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
@@ -100,7 +100,7 @@ public class TestStatisticsWriterNode
         return new StatisticsWriterNode(
                 Optional.empty(),
                 newId(),
-                new ValuesNode(Optional.empty(), newId(), COLUMNS.stream().map(column -> new VariableReferenceExpression(Optional.empty(), column, BIGINT)).collect(toImmutableList()), ImmutableList.of()),
+                new ValuesNode(Optional.empty(), newId(), COLUMNS.stream().map(column -> new VariableReferenceExpression(Optional.empty(), column, BIGINT)).collect(toImmutableList()), ImmutableList.of(), Optional.empty()),
                 new TableHandle(new ConnectorId("test"), new TestingTableHandle(), TestingTransactionHandle.create(), Optional.empty()),
                 variableAllocator.newVariable("count", BIGINT),
                 true,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -94,7 +94,8 @@ public class TestWindowNode
                 Optional.empty(),
                 newId(),
                 ImmutableList.of(columnA, columnB, columnC),
-                ImmutableList.of());
+                ImmutableList.of(),
+                Optional.empty());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
@@ -46,7 +46,8 @@ public class TestVerifyOnlyOneOutputNode
                                 new ValuesNode(
                                         Optional.empty(),
                                         idAllocator.getNextId(),
-                                        ImmutableList.of(), ImmutableList.of()),
+                                        ImmutableList.of(), ImmutableList.of(),
+                                        Optional.empty()),
                                 Assignments.of()
                         ), ImmutableList.of(), ImmutableList.of());
         new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
@@ -62,7 +63,7 @@ public class TestVerifyOnlyOneOutputNode
                                 new OutputNode(Optional.empty(), idAllocator.getNextId(),
                                         new ProjectNode(idAllocator.getNextId(),
                                                 new ValuesNode(Optional.empty(),
-                                                        idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of()),
+                                                        idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(), Optional.empty()),
                                                 Assignments.of()
                                         ), ImmutableList.of(), ImmutableList.of()
                                 ), new VariableReferenceExpression(Optional.empty(), "a", BIGINT),

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -119,7 +119,7 @@ public class TestGraphvizPrinter
     @Test
     public void testPrintLogicalForJoinNode()
     {
-        ValuesNode valuesNode = new ValuesNode(Optional.empty(), new PlanNodeId("right"), ImmutableList.of(), ImmutableList.of());
+        ValuesNode valuesNode = new ValuesNode(Optional.empty(), new PlanNodeId("right"), ImmutableList.of(), ImmutableList.of(), Optional.empty());
 
         PlanNode node = new JoinNode(
                 Optional.empty(),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -154,7 +154,6 @@ import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMe
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxExecutionTime;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxRunTime;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxTotalMemoryPerNode;
-import static com.facebook.presto.SystemSessionProperties.getWarningHandlingLevel;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
@@ -376,10 +375,10 @@ public class PrestoSparkQueryExecutionFactory
                 credentialsProviders,
                 authenticatorProviders);
 
-        Session session = sessionSupplier.createSession(queryId, sessionContext);
+        Session session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory);
         session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.empty());
 
-        WarningCollector warningCollector = warningCollectorFactory.create(getWarningHandlingLevel(session));
+        WarningCollector warningCollector = session.getWarningCollector();
 
         PlanAndMore planAndMore = null;
         try {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -58,4 +58,6 @@ public interface ConnectorSession
     {
         return false;
     }
+
+    WarningCollector getWarningCollector();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
@@ -37,13 +37,17 @@ public final class ValuesNode
 {
     private final List<VariableReferenceExpression> outputVariables;
     private final List<List<RowExpression>> rows;
+    // valuesNodeLabel is to record the original table information if the ValuesNode is converted from a table scan.
+    // Only used in query plan print, does not affect execution.
+    private final Optional<String> valuesNodeLabel;
 
     @JsonCreator
     public ValuesNode(
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
-            @JsonProperty("rows") List<List<RowExpression>> rows)
+            @JsonProperty("rows") List<List<RowExpression>> rows,
+            @JsonProperty("valuesNodeLabel") Optional<String> valuesNodeLabel)
     {
         super(sourceLocation, id);
         this.outputVariables = immutableListCopyOf(outputVariables);
@@ -54,6 +58,12 @@ public final class ValuesNode
                 throw new IllegalArgumentException(format("Expected row to have %s values, but row has %s values", outputVariables.size(), row.size()));
             }
         }
+        this.valuesNodeLabel = valuesNodeLabel;
+    }
+
+    public Optional<String> getValuesNodeLabel()
+    {
+        return valuesNodeLabel;
     }
 
     @JsonProperty

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -110,6 +110,12 @@ public final class TestingSession
         {
             return Optional.empty();
         }
+
+        @Override
+        public WarningCollector getWarningCollector()
+        {
+            return WarningCollector.NOOP;
+        }
     };
 
     private TestingSession() {}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -965,6 +965,7 @@ public abstract class AbstractTestQueries
                 "GROUP BY orderdate " +
                 "HAVING COUNT(DISTINCT clerk) > 1");
     }
+
     @Test
     public void testDistinctLimitWithQuickDistinctLimitEnabled()
     {
@@ -993,8 +994,8 @@ public abstract class AbstractTestQueries
     {
         assertQuery(session,
                 "SELECT DISTINCT orderstatus, custkey " +
-                "FROM (SELECT orderstatus, custkey FROM orders ORDER BY orderkey LIMIT 10) " +
-                "LIMIT 10");
+                        "FROM (SELECT orderstatus, custkey FROM orders ORDER BY orderkey LIMIT 10) " +
+                        "LIMIT 10");
         assertQuery(session, "SELECT COUNT(*) FROM (SELECT DISTINCT orderstatus, custkey FROM orders LIMIT 10)");
         assertQuery(session, "SELECT DISTINCT custkey, orderstatus FROM orders WHERE custkey = 1268 LIMIT 2");
         assertQuery(session, "SELECT DISTINCT custkey, orderstatus FROM orders WHERE custkey = 1268 LIMIT 10000");
@@ -2888,7 +2889,8 @@ public abstract class AbstractTestQueries
                 getQueryRunner().getMetadata().getSessionPropertyManager(),
                 getSession().getPreparedStatements(),
                 ImmutableMap.of(),
-                getSession().getTracer());
+                getSession().getTracer(),
+                getSession().getWarningCollector());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {


### PR DESCRIPTION
### What the issue is?
In HiveFilterPushdown, a table scan node will be replaced with an empty Value node if the table scan node produces empty output. It causes confusion when checking the query plan, as the table scan node is not present.

### What the fix is?
In the ValuesNode, add one optional property "origTableName", which is the table name scanned converted to the ValuesNode. It defaults to empty for other cases. In the printer classes, it will output this information if  "origTableName" is not empty.

### Test plan
Test locally with a simple scan query, manually trigger the HiveFilterPushDown optimization and check the explain output.

**Current behavior:**
presto:tpch> explain select * from nation where nationkey=100;
                                                          Query Plan                                                           
 - Output[nationkey, name, regionkey, comment] => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)] 
         Estimates: {rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                     
     - Values => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)]                                  
             Estimates: {rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                 
                                                                                                                               
(1 row)

**With this diff:**
presto:tpch> explain select * from nation where nationkey=100;
                                                                                                                                                               Query Plan                                                                                                                                                            
 - Output[nationkey, name, regionkey, comment] => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)]                                                                                                                                                                                                       
         Estimates: {rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                                                                                                                           
     - Values converted from TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=nation, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.nation{domains={nationkey=[ [["100"]] ]}}]'}] => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)]
             Estimates: {rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                                                                                                                       



(1 row)


```
== NO RELEASE NOTE ==
```
