### PR TITLE
Support complex JsonPath expressions using Jayway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <dep.hudi.version>0.11.0</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
+        <dep.jayway.version>2.6.0</dep.jayway.version>
         <dep.ratis.version>2.2.0</dep.ratis.version>
         <!--
           America/Bahia_Banderas has:
@@ -731,6 +732,22 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-afterburner</artifactId>
                 <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${dep.jayway.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -272,6 +272,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -231,6 +231,7 @@ public final class SystemSessionProperties
     public static final String PREFER_MERGE_JOIN = "prefer_merge_join";
     public static final String SEGMENTED_AGGREGATION_ENABLED = "segmented_aggregation_enabled";
     public static final String USE_HISTORY_BASED_PLAN_STATISTICS = "use_history_based_plan_statistics";
+    public static final String USE_EXTERNAL_PLAN_STATISTICS = "use_external_plan_statistics";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -2212,5 +2213,10 @@ public final class SystemSessionProperties
     public static boolean useHistoryBasedPlanStatisticsEnabled(Session session)
     {
         return session.getSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, Boolean.class);
+    }
+
+    public static boolean useExternalPlanStatisticsEnabled(Session session)
+    {
+        return session.getSystemProperty(USE_EXTERNAL_PLAN_STATISTICS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -78,7 +78,7 @@ public final class JsonFunctions
     @LiteralParameters("x")
     public static JsonPath castVarcharToJsonPath(@SqlType("varchar(x)") Slice pattern)
     {
-        return new JsonPath(pattern.toStringUtf8());
+        return JsonPath.build(pattern.toStringUtf8());
     }
 
     @ScalarOperator(OperatorType.CAST)
@@ -86,7 +86,7 @@ public final class JsonFunctions
     @SqlType(JsonPathType.NAME)
     public static JsonPath castCharToJsonPath(@LiteralParameter("x") Long charLength, @SqlType("char(x)") Slice pattern)
     {
-        return new JsonPath(padSpaces(pattern, charLength.intValue()).toStringUtf8());
+        return JsonPath.build(padSpaces(pattern, charLength.intValue()).toStringUtf8());
     }
 
     @ScalarFunction("is_json_scalar")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPath.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPath.java
@@ -13,19 +13,148 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class JsonPath
 {
     private final JsonExtract.JsonExtractor<Slice> scalarExtractor;
     private final JsonExtract.JsonExtractor<Slice> objectExtractor;
     private final JsonExtract.JsonExtractor<Long> sizeExtractor;
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-    public JsonPath(String pattern)
+    private static JsonExtract.JsonExtractor<Slice> getScalarExtractorForJayway(com.jayway.jsonpath.JsonPath jsonPath, Configuration jaywayConfig)
     {
-        scalarExtractor = JsonExtract.generateExtractor(pattern, new JsonExtract.ScalarValueJsonExtractor());
-        objectExtractor = JsonExtract.generateExtractor(pattern, new JsonExtract.JsonValueJsonExtractor());
-        sizeExtractor = JsonExtract.generateExtractor(pattern, new JsonExtract.JsonSizeExtractor());
+        return new JsonExtract.JsonExtractor<Slice>()
+        {
+            @Override
+            public Slice extract(InputStream inputStream)
+                    throws IOException
+            {
+                JsonNode node = jaywayExtract(jsonPath, jaywayConfig, inputStream);
+                if (node == null || !node.isValueNode()) {
+                    return null;
+                }
+                return utf8Slice(node.asText());
+            }
+        };
+    }
+
+    private static JsonExtract.JsonExtractor<Slice> getObjectExtractorForJayway(com.jayway.jsonpath.JsonPath jsonPath, Configuration jaywayConfig)
+    {
+        return new JsonExtract.JsonExtractor<Slice>()
+        {
+            @Override
+            public Slice extract(InputStream inputStream)
+                    throws IOException
+            {
+                JsonNode node = jaywayExtract(jsonPath, jaywayConfig, inputStream);
+                if (node == null) {
+                    return null;
+                }
+                return utf8Slice(node.toString());
+            }
+        };
+    }
+
+    private static JsonExtract.JsonExtractor<Long> getSizeExtractorForJayway(com.jayway.jsonpath.JsonPath jsonPath, Configuration jaywayConfig)
+    {
+        return new JsonExtract.JsonExtractor<Long>()
+        {
+            @Override
+            public Long extract(InputStream inputStream)
+                    throws IOException
+            {
+                JsonNode node = jaywayExtract(jsonPath, jaywayConfig, inputStream);
+                if (node == null) {
+                    return null;
+                }
+                return (long) node.size(); // Jackson correctly returns 0 for scalar nodes
+            }
+        };
+    }
+
+    private static JsonNode jaywayExtract(com.jayway.jsonpath.JsonPath jsonPath, Configuration jaywayConfig, InputStream inputStream)
+            throws IOException
+    {
+        try {
+            Object res = jsonPath.read(inputStream, jaywayConfig);
+            if (res instanceof JsonNode) {
+                return (JsonNode) res;
+            }
+            else {
+                // Jayway will respect Jackson mappings as provided in the configuration and return a JsonNode for simple cases.
+                // But for JsonPath functions ($.avg, ...), it will return a Java boxed type (Double, String etc.) instead
+                // of a properly formed JsonNode. This is why we need to re-create a JsonNode in that case
+                return mapper.valueToTree(res);
+            }
+        }
+        catch (InvalidJsonException | PathNotFoundException ex) {
+            // replicate Presto's JsonPath behaviour: if the input JSON is invalid or no result is found,
+            // then return NULL instead of throwing an exception
+            return null;
+        }
+    }
+
+    private static JsonPath buildPresto(String pattern)
+    {
+        return new JsonPath(JsonExtract.generateExtractor(pattern, new JsonExtract.ScalarValueJsonExtractor()),
+                JsonExtract.generateExtractor(pattern, new JsonExtract.JsonValueJsonExtractor()),
+                JsonExtract.generateExtractor(pattern, new JsonExtract.JsonSizeExtractor()));
+    }
+
+    private static JsonPath buildJayway(String pattern)
+    {
+        try {
+            Configuration jaywayConfig = Configuration.builder().jsonProvider(new JacksonJsonNodeJsonProvider()).build();
+            if (pattern == null || pattern.isEmpty()) {
+                // for some reason, jayway throws IllegalArgumentException for an empty path, but an InvalidPathException for other invalid paths
+                throw new InvalidPathException();
+            }
+            com.jayway.jsonpath.JsonPath jsonPath = com.jayway.jsonpath.JsonPath.compile(pattern);
+            return new JsonPath(getScalarExtractorForJayway(jsonPath, jaywayConfig), getObjectExtractorForJayway(jsonPath, jaywayConfig), getSizeExtractorForJayway(jsonPath, jaywayConfig));
+        }
+        catch (InvalidPathException ex) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Invalid JSON path: '%s'", pattern));
+        }
+    }
+
+    public static JsonPath build(String pattern)
+    {
+        try {
+            return buildPresto(pattern);
+        }
+        catch (PrestoException ex) {
+            if (ex.getErrorCode() == INVALID_FUNCTION_ARGUMENT.toErrorCode()) {
+                return buildJayway(pattern);
+            }
+            throw ex;
+        }
+    }
+
+    public JsonPath(JsonExtract.JsonExtractor<Slice> scalar, JsonExtract.JsonExtractor<Slice> object, JsonExtract.JsonExtractor<Long> size)
+    {
+        requireNonNull(scalar, "scalar extractor is null");
+        requireNonNull(object, "object extractor is null");
+        requireNonNull(size, "size extractor is null");
+        scalarExtractor = scalar;
+        objectExtractor = object;
+        sizeExtractor = size;
     }
 
     public JsonExtract.JsonExtractor<Slice> getScalarExtractor()

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -45,6 +45,7 @@ import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.math.BigDecimal;
@@ -112,9 +113,15 @@ public final class JsonUtil
     public static JsonParser createJsonParser(JsonFactory factory, Slice json)
             throws IOException
     {
+        return createJsonParser(factory, json.getInput());
+    }
+
+    public static JsonParser createJsonParser(JsonFactory factory, InputStream json)
+            throws IOException
+    {
         // Jackson tries to detect the character encoding automatically when using InputStream
         // so we pass an InputStreamReader instead.
-        return factory.createParser(new InputStreamReader(json.getInput(), UTF_8));
+        return factory.createParser(new InputStreamReader(json, UTF_8));
     }
 
     public static JsonGenerator createJsonGenerator(JsonFactory factory, SliceOutput output)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.PrestoException;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -348,10 +346,7 @@ public class TestJsonExtract
     private static String doExtract(JsonExtractor<Slice> jsonExtractor, String json)
             throws IOException
     {
-        JsonFactory jsonFactory = new JsonFactory();
-        JsonParser jsonParser = jsonFactory.createParser(json);
-        jsonParser.nextToken(); // Advance to the first token
-        Slice extract = jsonExtractor.extract(jsonParser);
+        Slice extract = jsonExtractor.extract(Slices.utf8Slice(json).getInput());
         return (extract == null) ? null : extract.toStringUtf8();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractFunctions.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+
+public class TestJsonExtractFunctions
+        extends AbstractTestFunctions
+{
+    private final String json = "{\n" +
+            "    \"store\": {\n" +
+            "        \"book\": [\n" +
+            "            {\n" +
+            "                \"category\": \"reference\",\n" +
+            "                \"author\": \"Nigel Rees\",\n" +
+            "                \"title\": \"Sayings of the Century\",\n" +
+            "                \"price\": 8.95\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Evelyn Waugh\",\n" +
+            "                \"title\": \"Sword of Honour\",\n" +
+            "                \"price\": 12.99\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Herman Melville\",\n" +
+            "                \"title\": \"Moby Dick\",\n" +
+            "                \"isbn\": \"0-553-21311-3\",\n" +
+            "                \"price\": 8.99\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"J. R. R. Tolkien\",\n" +
+            "                \"title\": \"The Lord of the Rings\",\n" +
+            "                \"isbn\": \"0-395-19395-8\",\n" +
+            "                \"price\": 22.99\n" +
+            "            }\n" +
+            "        ],\n" +
+            "        \"bicycle\": {\n" +
+            "            \"color\": \"red\",\n" +
+            "            \"price\": 19.95\n" +
+            "        }\n" +
+            "    },\n" +
+            "    \"expensive\": 10\n" +
+            "}";
+
+    @Test
+    public void testJsonExtract()
+    {
+        // simple expressions (should run on Presto engine)
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), JSON, "{\"x\":{\"a\":1,\"b\":2}}");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), JSON, "{\"a\":1,\"b\":2}");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), JSON, "1");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.c"), JSON, null);
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"), JSON, "3");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "[1,2,3]", "$[1]"), JSON, "2");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "[1,null,3]", "$[1]"), JSON, "null");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", "INVALID_JSON", "$"), JSON, null);
+        assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+
+        // complex expressions (should run on Jayway)
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.book[*].isbn"), JSON, "[\"0-553-21311-3\",\"0-395-19395-8\"]");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$..price"), JSON, "[8.95,12.99,8.99,22.99,19.95]");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.book[?(@.price < 10)].title"), JSON, "[\"Sayings of the Century\",\"Moby Dick\"]");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "max($..price)"), JSON, "22.99");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "concat($..category)"), JSON, "\"referencefictionfictionfiction\"");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.keys()"), JSON, "[\"book\",\"bicycle\"]");
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.book[1].author"), JSON, "\"Evelyn Waugh\"");
+
+        assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+    }
+
+    @Test
+    public void testJsonSize()
+    {
+        // simple expressions (should run on Presto engine)
+        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        assertFunction(format("JSON_SIZE('%s', CHAR '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "INVALID_JSON", "$"), BIGINT, null);
+        assertFunction(format("JSON_SIZE('%s', null)", "[1,2,3]"), BIGINT, null);
+        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
+        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
+        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
+        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
+        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
+        assertFunction(format("JSON_SIZE(JSON '%s', null)", "[1,2,3]"), BIGINT, null);
+
+        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+        assertInvalidFunction(format("JSON_SIZE('%s', CHAR '%s')", "{\"\":\"\"}", " "), "Invalid JSON path: ' '");
+        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "."), "Invalid JSON path: '.'");
+        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "..."), "Invalid JSON path: '...'");
+
+        // complex expressions (should run on Jayway)
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[*].isbn"), BIGINT, 2L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "$..price"), BIGINT, 5L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[?(@.price < 10)].title"), BIGINT, 2L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "max($..price)"), BIGINT, 0L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "concat($..category)"), BIGINT, 0L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.keys()"), BIGINT, 2L);
+        assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[1].author"), BIGINT, 0L);
+
+        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+    }
+
+    @Test
+    public void testJsonExtractScalar()
+    {
+        // simple expressions (should run on Presto)
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), VARCHAR, "1");
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"), VARCHAR, "3");
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "[1,2,3]", "$[1]"), VARCHAR, "2");
+        assertInvalidFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+
+        // complex expressions (should run on Jayway)
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[*].isbn"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$..price"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[?(@.price < 10)].title"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "max($..price)"), VARCHAR, "22.99");
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "concat($..category)"), VARCHAR, "referencefictionfictionfiction");
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.keys()"), VARCHAR, null);
+        assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[1].author"), VARCHAR, "Evelyn Waugh");
+
+        assertInvalidFunction(format("JSON_EXTRACT_SCALAR('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -285,30 +285,4 @@ public class TestJsonFunctions
     {
         assertFunction("JSON_FORMAT(JSON '[\"a\", \"b\"]')", VARCHAR, "[\"a\",\"b\"]");
     }
-
-    @Test
-    public void testJsonSize()
-    {
-        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
-        assertFunction(format("JSON_SIZE('%s', CHAR '%s')", "[1,2,3]", "$"), BIGINT, 3L);
-        assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "INVALID_JSON", "$"), BIGINT, null);
-        assertFunction(format("JSON_SIZE('%s', null)", "[1,2,3]"), BIGINT, null);
-        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
-        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
-        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
-        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
-        assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
-        assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
-        assertFunction(format("JSON_SIZE(JSON '%s', null)", "[1,2,3]"), BIGINT, null);
-        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
-        assertInvalidFunction(format("JSON_SIZE('%s', CHAR '%s')", "{\"\":\"\"}", " "), "Invalid JSON path: ' '");
-        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "."), "Invalid JSON path: '.'");
-        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "null"), "Invalid JSON path: 'null'");
-        assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", null), "Invalid JSON path: 'null'");
-    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -1434,21 +1434,22 @@ public class TestExpressionCompiler
     public void testFunctionCallJson()
             throws Exception
     {
+        ConnectorSession session = TEST_SESSION.toConnectorSession();
         for (String value : jsonValues) {
             for (String pattern : jsonPatterns) {
                 assertExecute(generateExpression("json_extract(%s, %s)", value, pattern),
                         JSON,
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), new JsonPath(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), JsonPath.build(pattern)));
                 assertExecute(generateExpression("json_extract_scalar(%s, %s)", value, pattern),
                         value == null ? createUnboundedVarcharType() : createVarcharType(value.length()),
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), new JsonPath(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), JsonPath.build(pattern)));
 
                 assertExecute(generateExpression("json_extract(%s, %s || '')", value, pattern),
                         JSON,
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), new JsonPath(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), JsonPath.build(pattern)));
                 assertExecute(generateExpression("json_extract_scalar(%s, %s || '')", value, pattern),
                         value == null ? createUnboundedVarcharType() : createVarcharType(value.length()),
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), new JsonPath(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), JsonPath.build(pattern)));
             }
         }
 


### PR DESCRIPTION
Adds support for arbitrarily complex JsonPath expressions in extraction functions (`JSON_EXTRACT`, `JSON_EXTRACT_SCALAR` and `JSON_SIZE`), by using the [Jayway JsonPath library](https://github.com/json-path/JsonPath).
The implemented behaviour is to try to parse the JsonPath using the current Presto JsonPathTokenizer. If that fails with an InvalidPathException (which is the case for complex JsonPath expressions), we then try to use Jayway to parse the JsonPath. There is thus no performance hit for simple JsonPath expressions (`$.path.to[2].nested`) since they will be run on the current extractor code.
The Jayway wrapper code replicates the current Presto behaviour for edge-cases (e.g. returning NULL instead of throwing an exception for invalid JSON, but throwing a PrestoException if the JsonPath is invalid).

This PR introduces a dependency to com.jayway.jsonpath:json-path:2.6.0.
Jayway is under Apache 2.0 license.

Test plan - 
```
mvn -Dtest="TestJsonExtract,TestJsonExtractFunctionsDynamic,TestJsonExtractFunctionsJayway,TestJsonExtractFunctionsPresto,TestJsonFunctions" test
```

I also ran a benchmark to ensure that performance is not impacted for simple JsonPath expressions (see [gist](https://gist.github.com/sviscaino/0a933fefa3374ff45a4ede5e3bcb6f64)), and a benchmark to compare the performance with a complex JsonPath expression (see [gist](https://gist.github.com/sviscaino/d653801de3480744e647c2fa6c568e33)).
Resolves #7005 

```
== RELEASE NOTES ==

General Changes
* Add support for complex JsonPath expressions in JSON_EXTRACT, JSON_EXTRACT_SCALAR and JSON_SIZE using Jayway

```
