### PR TITLE
Fix TestSeverInfoResource timeout by constructing TestingPrestoSever once.

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestServerInfoResource.java
@@ -35,7 +35,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test(singleThreaded = true)
 public class TestServerInfoResource
 {
     private static final long SHUTDOWN_TIMEOUT_MILLIS = 240_000;


### PR DESCRIPTION
Fix TestSeverInfoResource timeout by parallelizing the tasks.

Test plan - (Please fill in how you tested your changes)
Improved by 16% for all tests in this class.
![image](https://user-images.githubusercontent.com/55011456/179086555-74f6cccf-4cde-41e5-b03c-c5620ce1e942.png)


![image](https://user-images.githubusercontent.com/55011456/179080658-b6df2698-364b-46a9-8394-5dc9b7f6da18.png)

Here are different tries we have done.

We first perf the test method and found out that the inject initialization process is the most time-consuming.
![image](https://user-images.githubusercontent.com/55011456/179084437-5e246066-5155-4bfb-a39b-e8f1cd46ad16.png)

1. Constructing the DistributedQueryRunner instance once in the @BeforeClass method. Problem is that the cases are sharing states, which might not be suitable for the testing scenario.
2. Reactivate the server after each tests in single thread scenario. But it does not work since ServerInfoResource does not support reactivate operations.
3. We plan to strip the injector of every server out. But injector is a part of the bootstrap mechanism and is local to a server instance.

So lastly, we decided to parallelize the whole test cases and prove that the states of every cases are not interfering with each other.


```
== NO RELEASE NOTE ==
```
