### PR TITLE
Improve ARRAY_FREQUENCY efficiency

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlArrayFrequencyBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlArrayFrequencyBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlArrayFrequencyBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlArrayFrequencyBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 10, 10, query);
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlArrayTransformBenchmark(createLocalQueryRunner(), "SELECT ARRAY_FREQUENCY(SHUFFLE(SEQUENCE(1, 10000)))", "sql_array_frequencey_all1_10k").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        new SqlArrayTransformBenchmark(createLocalQueryRunner(), "SELECT ARRAY_FREQUENCY(TRANSFORM(SEQUENCE(1, 10000), x->random(100)))", "sql_array_frequencey_10k").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -59,11 +59,9 @@ public class ArraySqlFunctions
     @SqlType("map(bigint, int)")
     public static String arrayFrequencyBigint()
     {
-        return "RETURN reduce(" +
-                "input," +
-                "MAP()," +
-                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m,MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
-                "m -> m)";
+        return "RETURN TRANSFORM_VALUES(" +
+                "MULTIMAP_FROM_ENTRIES(TRANSFORM(FILTER(input, x -> x IS NOT NULL), x->(x, NULL))), " +
+                "(k, v) -> CAST(CARDINALITY(v) AS INTEGER))";
     }
 
     @SqlInvokedScalarFunction(value = "array_frequency", deterministic = true, calledOnNullInput = false)
@@ -72,11 +70,9 @@ public class ArraySqlFunctions
     @SqlType("map(varchar, int)")
     public static String arrayFrequencyVarchar()
     {
-        return "RETURN reduce(" +
-                "input," +
-                "MAP()," +
-                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m,MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
-                "m -> m)";
+        return "RETURN TRANSFORM_VALUES(" +
+                "MULTIMAP_FROM_ENTRIES(TRANSFORM(FILTER(input, x -> x IS NOT NULL), x->(x, NULL))), " +
+                "(k, v) -> CAST(CARDINALITY(v) AS INTEGER))";
     }
 
     @SqlInvokedScalarFunction(value = "array_duplicates", alias = {"array_dupes"}, deterministic = true, calledOnNullInput = false)


### PR DESCRIPTION
Benchmark:

New:
input_bytes:0,output_rows:1,output_bytes:2205
           sql_array_frequencey_10k ::   91.253 cpu ms ::    0B peak memory :: in     1,      0B,      10/s,      0B/s :: out     1,  2.15KB,      10/s,  23.6KB/s
input_bytes:0,output_rows:1,output_bytes:220005
      sql_array_frequencey_all1_10k ::  106.202 cpu ms ::    0B peak memory :: in     1,      0B,       9/s,      0B/s :: out     1,   215KB,       9/s,  1.98MB/s

Old:
input_bytes:0,output_rows:1,output_bytes:2205
           sql_array_frequencey_10k ::  144.473 cpu ms ::    0B peak memory :: in     1,      0B,       6/s,      0B/s :: out     1,  2.15KB,       6/s,  14.9KB/s
input_rows:1,input_bytes:0,output_rows:1,output_bytes:220005
      sql_array_frequencey_all1_10k :: 2006.523 cpu ms ::    0B peak memory :: in     1,      0B,       0/s,      0B/s :: out     1,   215KB,       0/s,   107KB/s
 

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.


```
== NO RELEASE NOTE ==
```
