### PR TITLE
remove joda time usage from presto-redis module

### DIFF
--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -63,11 +63,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-redis/src/main/java/com/facebook/presto/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
@@ -16,10 +16,11 @@ package com.facebook.presto.redis.decoder.hash;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.decoder.DecoderColumnHandle;
 import com.facebook.presto.decoder.FieldValueProvider;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
-import java.util.Locale;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.common.type.DateType.DATE;
@@ -32,7 +33,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 class ISO8601HashRedisFieldDecoder
         extends HashRedisFieldDecoder
 {
-    private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.dateTimeParser().withLocale(Locale.ENGLISH).withZoneUTC();
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneId.of("UTC"));
 
     @Override
     public FieldValueProvider decode(String value, DecoderColumnHandle columnHandle)
@@ -51,7 +52,7 @@ class ISO8601HashRedisFieldDecoder
         @Override
         public long getLong()
         {
-            long millis = FORMATTER.parseMillis(getSlice().toStringAscii());
+            long millis = LocalDate.from(FORMATTER.parse(getSlice().toStringAscii())).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
 
             Type type = columnHandle.getType();
             if (type.equals(DATE)) {

--- a/presto-redis/src/test/java/com/facebook/presto/redis/util/RedisLoader.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/util/RedisLoader.java
@@ -25,11 +25,11 @@ import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.tests.AbstractTestingPrestoClient;
 import com.facebook.presto.tests.ResultsSession;
 import com.google.common.collect.ImmutableMap;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class RedisLoader
         extends AbstractTestingPrestoClient<Void>
 {
-    private static final DateTimeFormatter ISO8601_FORMATTER = ISODateTimeFormat.dateTime();
+    private static final DateTimeFormatter ISO8601_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     private final JedisPool jedisPool;
     private final String tableName;
@@ -170,13 +170,13 @@ public class RedisLoader
                 return value;
             }
             if (TIME.equals(type)) {
-                return ISO8601_FORMATTER.print(parseTimeLiteral(timeZoneKey, (String) value));
+                return ISO8601_FORMATTER.parse(Instant.ofEpochMilli(parseTimeLiteral(timeZoneKey, (String) value)).toString());
             }
             if (TIMESTAMP.equals(type)) {
-                return ISO8601_FORMATTER.print(parseTimestampWithoutTimeZone(timeZoneKey, (String) value));
+                return ISO8601_FORMATTER.parse(Instant.ofEpochMilli(parseTimestampWithoutTimeZone(timeZoneKey, (String) value)).toString());
             }
             if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
-                return ISO8601_FORMATTER.print(unpackMillisUtc(parseTimestampWithTimeZone(timeZoneKey, (String) value)));
+                return ISO8601_FORMATTER.parse(Instant.ofEpochMilli(unpackMillisUtc(parseTimestampWithTimeZone(timeZoneKey, (String) value))).toString());
             }
             throw new AssertionError("unhandled type: " + type);
         }


### PR DESCRIPTION
Test plan - mvn clean test from command line:
[INFO] Tests run: 857, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,307.459 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 857, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22:19 min
[INFO] Finished at: 2022-07-12T17:23:28-04:00
[INFO] ------------------------------------------------------------------------ 

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
