### PR TITLE
Add plan canonicalization strategies

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/plan/PlanCanonicalizationStrategy.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/plan/PlanCanonicalizationStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.plan;
+
+public enum PlanCanonicalizationStrategy
+{
+    /**
+     * DEFAULT strategy is used to canonicalize plans with minimal changes.
+     *
+     * We remove any unimportant information like source location, make the variable
+     * names consistent, and order them.
+     * For example:
+     * `SELECT * FROM table WHERE id IN (1, 2)` will be equivalent to `SELECT * FROM table WHERE id IN (2, 1)`
+     *
+     * This is used in context of fragment result caching
+     */
+    DEFAULT,
+    /**
+     * CONNECTOR strategy will canonicalize plan according to DEFAULT strategy, and additionally
+     * canoncialize `TableScanNode` by giving a connector specific implementation.
+     *
+     * With this approach, we call ConnectorTableLayoutHandle.getIdentifier() for all `TableScanNode`.
+     * Each connector can have a specific implementation to canonicalize table layout handles however they want.
+     *
+     * For example, Hive connector removes constants from constraints on partition keys:
+     * `SELECT * FROM table WHERE ds = '2020-01-01'` will be equivalent to `SELECT * FROM table WHERE ds = '2020-01-02'`
+     * where `ds` is a partition column in `table`
+     *
+     * This is used in context of history based optimizations.
+     */
+    CONNECTOR,
+    /**
+     * REMOVE_SAFE_CONSTANTS strategy is used to canonicalize plan with
+     * CONNECTOR strategy and will additionally remove constants from plan
+     * which are not bound to have impact on plan statistics.
+     *
+     * This includes removing constants from ProjectNode, but keeps constants
+     * in FilterNode since they can have major impact on plan statistics.
+     *
+     * For example:
+     * `SELECT *, 1 FROM table` will be equivalent to `SELECT *, 2 FROM table`
+     * `SELECT * FROM table WHERE id > 1` will NOT be equivalent to `SELECT * FROM table WHERE id > 1000`
+     *
+     * This is used in context of history based optimizations.
+     */
+    REMOVE_SAFE_CONSTANTS,
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
@@ -142,6 +142,12 @@ public class AllOrNoneValueSet
     }
 
     @Override
+    public ValueSet canonicalize(boolean removeSafeConstants)
+    {
+        return this;
+    }
+
+    @Override
     public int hashCode()
     {
         return Objects.hash(type, all);

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -276,6 +276,22 @@ public final class Domain
         return Domain.create(simplifiedValueSet, nullAllowed);
     }
 
+    /**
+     * @return A canonicalized Domain with a consistent representation.
+     *
+     * When removeSafeConstants is true, we return a Domain with all point constants removed,
+     * and range constants are kept.
+     * Example:
+     * `x = 1` is equivalent to `x = 1000`
+     * `x >= 1` is NOT equivalent to `x >= 1000`
+     *
+     * All types and bounds information is preserved.
+     */
+    public Domain canonicalize(boolean removeConstants)
+    {
+        return new Domain(values.canonicalize(removeConstants), nullAllowed);
+    }
+
     public String toString(SqlFunctionProperties properties)
     {
         return "[ " + (nullAllowed ? "NULL, " : "") + values.toString(properties) + " ]";

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Marker.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Marker.java
@@ -300,4 +300,13 @@ public final class Marker
         buffer.append("}");
         return buffer.toString();
     }
+
+    public Marker canonicalize(boolean removeConstants)
+    {
+        if (valueBlock.isPresent() && removeConstants) {
+            // For REMOVE_CONSTANTS, we replace this with null
+            return new Marker(type, Optional.of(Utils.nativeValueToBlock(type, null)), bound);
+        }
+        return this;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomain.java
@@ -36,6 +36,8 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Comparator.comparing;
+import static java.util.Map.Entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -481,6 +483,13 @@ public final class TupleDomain<T>
             }
         });
         return TupleDomain.withColumnDomains(unmodifiableMap(compactedDomains));
+    }
+
+    public TupleDomain<T> canonicalize(boolean removeConstants)
+    {
+        return new TupleDomain<>(domains.map(d -> unmodifiableMap(d.entrySet().stream()
+                .sorted(comparing(domain -> domain.getKey().toString()))
+                .collect(toLinkedMap(Entry::getKey, entry -> entry.getValue().canonicalize(removeConstants))))));
     }
 
     public static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper)

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
@@ -155,4 +155,17 @@ public interface ValueSet
     }
 
     String toString(SqlFunctionProperties properties);
+
+    /**
+     * @return A canonicalized ValueSet with a consistent representation.
+     *
+     * When removeSafeConstants is true, we return a ValueSet with all point constants removed,
+     * and range constants are kept.
+     * Example:
+     * `x = 1` is equivalent to `x = 1000`
+     * `x >= 1` is NOT equivalent to `x >= 1000`
+     *
+     * All types and bounds information is preserved.
+     */
+    ValueSet canonicalize(boolean removeSafeConstants);
 }

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/CanonicalRowExpressionRewriter.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/CanonicalRowExpressionRewriter.java
@@ -31,13 +31,16 @@ import java.util.Optional;
 public class CanonicalRowExpressionRewriter
         extends RowExpressionRewriter<Void>
 {
-    private static final CanonicalRowExpressionRewriter SINGLETON = new CanonicalRowExpressionRewriter();
+    private final boolean removeConstants;
 
-    private CanonicalRowExpressionRewriter() {}
-
-    public static RowExpression canonicalizeRowExpression(RowExpression expression)
+    private CanonicalRowExpressionRewriter(boolean removeConstants)
     {
-        return RowExpressionTreeRewriter.rewriteWith(SINGLETON, expression, null);
+        this.removeConstants = removeConstants;
+    }
+
+    public static RowExpression canonicalizeRowExpression(RowExpression expression, boolean removeConstants)
+    {
+        return RowExpressionTreeRewriter.rewriteWith(new CanonicalRowExpressionRewriter(removeConstants), expression, null);
     }
 
     @Override
@@ -60,7 +63,11 @@ public class CanonicalRowExpressionRewriter
     @Override
     public RowExpression rewriteConstant(ConstantExpression literal, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
     {
-        return literal.canonicalize();
+        if (!removeConstants) {
+            return literal.canonicalize();
+        }
+        // We replace the constant value with null.
+        return new ConstantExpression(null, literal.getType());
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.REMOV
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlan;
+import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlanFragment;
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -230,7 +231,7 @@ public class TestHiveCanonicalPlanGenerator
         SubPlan subplan = subplan(format("( %s ) UNION ALL ( %s )", sql1, sql2), session);
         List<CanonicalPlanFragment> leafCanonicalPlans = getLeafSubPlans(subplan).stream()
                 .map(SubPlan::getFragment)
-                .map(fragment -> generateCanonicalPlan(fragment.getRoot(), fragment.getPartitioningScheme()))
+                .map(fragment -> generateCanonicalPlanFragment(fragment.getRoot(), fragment.getPartitioningScheme()))
                 .map(Optional::get)
                 .collect(Collectors.toList());
         assertEquals(leafCanonicalPlans.size(), 2);
@@ -244,8 +245,8 @@ public class TestHiveCanonicalPlanGenerator
     {
         PlanFragment fragment1 = getOnlyElement(getLeafSubPlans(subplan(sql1, session))).getFragment();
         PlanFragment fragment2 = getOnlyElement(getLeafSubPlans(subplan(sql2, session))).getFragment();
-        Optional<CanonicalPlanFragment> canonicalPlan1 = generateCanonicalPlan(fragment1.getRoot(), fragment1.getPartitioningScheme());
-        Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), fragment2.getPartitioningScheme());
+        Optional<CanonicalPlanFragment> canonicalPlan1 = generateCanonicalPlanFragment(fragment1.getRoot(), fragment1.getPartitioningScheme());
+        Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlanFragment(fragment2.getRoot(), fragment2.getPartitioningScheme());
         assertTrue(canonicalPlan1.isPresent());
         assertTrue(canonicalPlan2.isPresent());
         assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
@@ -57,7 +57,7 @@ public class HistoryBasedPlanStatisticsCalculator
     private PlanNode removeGroupReferences(PlanNode planNode, Lookup lookup)
     {
         if (planNode instanceof GroupReference) {
-            return lookup.resolve(planNode);
+            return removeGroupReferences(lookup.resolve(planNode), lookup);
         }
         List<PlanNode> children = planNode.getSources().stream().map(node -> removeGroupReferences(node, lookup)).collect(toImmutableList());
         return planNode.replaceChildren(children);

--- a/presto-main/src/main/java/com/facebook/presto/execution/FragmentResultCacheContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FragmentResultCacheContext.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
-import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlan;
+import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlanFragment;
 import static com.google.common.hash.Hashing.sha256;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -66,7 +66,7 @@ public class FragmentResultCacheContext
             return Optional.empty();
         }
 
-        Optional<CanonicalPlanFragment> canonicalPlanFragment = generateCanonicalPlan(root, partitioningScheme);
+        Optional<CanonicalPlanFragment> canonicalPlanFragment = generateCanonicalPlanFragment(root, partitioningScheme);
         if (!canonicalPlanFragment.isPresent()) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlan.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class CanonicalPlan
+{
+    private final PlanNode plan;
+    private final PlanCanonicalizationStrategy strategy;
+
+    @JsonCreator
+    public CanonicalPlan(
+            @JsonProperty("plan") PlanNode plan,
+            @JsonProperty("strategy") PlanCanonicalizationStrategy strategy)
+    {
+        this.plan = requireNonNull(plan, "plan is null");
+        this.strategy = requireNonNull(strategy, "plan is null");
+    }
+
+    @JsonProperty
+    public PlanNode getPlan()
+    {
+        return plan;
+    }
+
+    @JsonProperty
+    public PlanCanonicalizationStrategy getStrategy()
+    {
+        return strategy;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CanonicalPlan that = (CanonicalPlan) o;
+        return Objects.equals(plan, that.plan) &&
+                Objects.equals(strategy, that.strategy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(plan, strategy);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("plan", plan)
+                .add("strategy", strategy)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -65,7 +65,7 @@ public class CanonicalPlanGenerator
         this.strategy = strategy;
     }
 
-    public static Optional<CanonicalPlanFragment> generateCanonicalPlan(PlanNode root, PartitioningScheme partitioningScheme)
+    public static Optional<CanonicalPlanFragment> generateCanonicalPlanFragment(PlanNode root, PartitioningScheme partitioningScheme)
     {
         Map<VariableReferenceExpression, VariableReferenceExpression> originalToNewVariableNames = new HashMap<>();
         Optional<PlanNode> canonicalPlan = root.accept(new CanonicalPlanGenerator(DEFAULT), originalToNewVariableNames);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableHandle;
@@ -130,12 +131,12 @@ public class CanonicalTableScanNode
         // we do not serialize this field.
         private final Optional<ConnectorTableLayoutHandle> layoutHandle;
 
-        public static CanonicalTableHandle getCanonicalTableHandle(TableHandle tableHandle)
+        public static CanonicalTableHandle getCanonicalTableHandle(TableHandle tableHandle, PlanCanonicalizationStrategy strategy)
         {
             return new CanonicalTableHandle(
                     tableHandle.getConnectorId(),
                     tableHandle.getConnectorHandle(),
-                    tableHandle.getLayout().map(layout -> layout.getIdentifier(Optional.empty())),
+                    tableHandle.getLayout().map(layout -> layout.getIdentifier(Optional.empty(), strategy)),
                     tableHandle.getLayout());
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.TestingBlockEncodingSerde;
 import com.facebook.presto.common.block.TestingBlockJsonSerde;
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.common.type.TestingTypeDeserializer;
 import com.facebook.presto.common.type.TestingTypeManager;
 import com.facebook.presto.common.type.Type;
@@ -36,6 +37,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
+import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.REMOVE_SAFE_CONSTANTS;
 import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlan;
 import static com.facebook.presto.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
@@ -171,6 +174,59 @@ public class TestCanonicalPlanGenerator
         assertDifferentCanonicalLeafSubPlan("SELECT totalprice FROM orders", "SELECT orderkey, totalprice FROM orders");
         assertDifferentCanonicalLeafSubPlan("SELECT * FROM orders", "SELECT orderkey, totalprice FROM orders");
     }
+    @Test
+    public void testTableScanAndProjectWithStrategy()
+            throws Exception
+    {
+        assertSameCanonicalLeafPlan("SELECT 1 from orders", "SELECT 1 from orders", CONNECTOR);
+        assertDifferentCanonicalLeafPlan("SELECT 1 from orders", "SELECT 2 from orders", CONNECTOR);
+        assertSameCanonicalLeafPlan("SELECT 1 from orders", "SELECT 2 from orders", REMOVE_SAFE_CONSTANTS);
+        assertSameCanonicalLeafPlan("SELECT CAST(1 AS VARCHAR) from orders", "SELECT CAST(2 AS VARCHAR) from orders", REMOVE_SAFE_CONSTANTS);
+
+        assertSameCanonicalLeafPlan(
+                "SELECT totalprice, custkey + (totalprice / 10) from orders",
+                "SELECT custkey + (totalprice / 10), totalprice from orders",
+                CONNECTOR);
+        assertDifferentCanonicalLeafPlan(
+                "SELECT totalprice, custkey + (totalprice / 10) from orders",
+                "SELECT custkey + (totalprice / 5), totalprice from orders",
+                CONNECTOR);
+        assertSameCanonicalLeafPlan(
+                "SELECT totalprice, custkey + (totalprice / 10) from orders",
+                "SELECT custkey + (totalprice / 5), totalprice from orders",
+                REMOVE_SAFE_CONSTANTS);
+    }
+
+    @Test
+    public void testFilterWithStrategy()
+            throws Exception
+    {
+        assertSameCanonicalLeafPlan(
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 120",
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 120",
+                CONNECTOR);
+        assertDifferentCanonicalLeafPlan(
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 110",
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 120",
+                CONNECTOR);
+        assertDifferentCanonicalLeafPlan(
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 120",
+                "SELECT totalprice from orders WHERE custkey > 100 AND custkey < 110",
+                REMOVE_SAFE_CONSTANTS);
+
+        assertSameCanonicalLeafPlan(
+                "SELECT totalprice from orders WHERE custkey IN (10,20,30)",
+                "SELECT totalprice from orders WHERE custkey IN (10,30,20)",
+                CONNECTOR);
+        assertDifferentCanonicalLeafPlan(
+                "SELECT totalprice from orders WHERE custkey IN (10,20,30)",
+                "SELECT totalprice from orders WHERE custkey IN (10,30,40)",
+                REMOVE_SAFE_CONSTANTS);
+        assertSameCanonicalLeafPlan(
+                "SELECT totalprice, CAST(3 AS VARCHAR) from orders WHERE custkey > 100 AND custkey < 120",
+                "SELECT totalprice, CAST(2 AS VARCHAR) as x from orders WHERE custkey > 100 AND custkey < 120",
+                REMOVE_SAFE_CONSTANTS);
+    }
 
     private static List<SubPlan> getLeafSubPlans(SubPlan subPlan)
     {
@@ -205,7 +261,9 @@ public class TestCanonicalPlanGenerator
                 .collect(Collectors.toList());
         assertEquals(leafCanonicalPlans.size(), 2);
         assertEquals(leafCanonicalPlans.get(0), leafCanonicalPlans.get(1));
-        assertEquals(objectMapper.writeValueAsString(leafCanonicalPlans.get(0)), objectMapper.writeValueAsString(leafCanonicalPlans.get(1)));
+        String s1 = objectMapper.writeValueAsString(leafCanonicalPlans.get(0));
+        String s2 = objectMapper.writeValueAsString(leafCanonicalPlans.get(0));
+        assertEquals(s1, s2);
     }
 
     private void assertDifferentCanonicalLeafSubPlan(String sql1, String sql2)
@@ -215,6 +273,37 @@ public class TestCanonicalPlanGenerator
         PlanFragment fragment2 = getOnlyElement(getLeafSubPlans(subplan(sql2, OPTIMIZED_AND_VALIDATED, false))).getFragment();
         Optional<CanonicalPlanFragment> canonicalPlan1 = generateCanonicalPlan(fragment1.getRoot(), fragment1.getPartitioningScheme());
         Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), fragment2.getPartitioningScheme());
+        assertTrue(canonicalPlan1.isPresent());
+        assertTrue(canonicalPlan2.isPresent());
+        assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));
+    }
+
+    private void assertSameCanonicalLeafPlan(String sql1, String sql2, PlanCanonicalizationStrategy strategy)
+            throws Exception
+    {
+        SubPlan subplan = subplan(
+                format("( %s ) UNION ALL ( %s )", sql1, sql2),
+                OPTIMIZED_AND_VALIDATED,
+                false);
+        List<CanonicalPlan> leafCanonicalPlans = getLeafSubPlans(subplan).stream()
+                .map(SubPlan::getFragment)
+                .map(fragment -> generateCanonicalPlan(fragment.getRoot(), strategy))
+                .map(Optional::get)
+                .collect(Collectors.toList());
+        assertEquals(leafCanonicalPlans.size(), 2);
+        assertEquals(leafCanonicalPlans.get(0), leafCanonicalPlans.get(1));
+        String s1 = objectMapper.writeValueAsString(leafCanonicalPlans.get(0));
+        String s2 = objectMapper.writeValueAsString(leafCanonicalPlans.get(0));
+        assertEquals(s1, s2);
+    }
+
+    private void assertDifferentCanonicalLeafPlan(String sql1, String sql2, PlanCanonicalizationStrategy strategy)
+            throws Exception
+    {
+        PlanFragment fragment1 = getOnlyElement(getLeafSubPlans(subplan(sql1, OPTIMIZED_AND_VALIDATED, false))).getFragment();
+        PlanFragment fragment2 = getOnlyElement(getLeafSubPlans(subplan(sql2, OPTIMIZED_AND_VALIDATED, false))).getFragment();
+        Optional<CanonicalPlan> canonicalPlan1 = generateCanonicalPlan(fragment1.getRoot(), strategy);
+        Optional<CanonicalPlan> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), strategy);
         assertTrue(canonicalPlan1.isPresent());
         assertTrue(canonicalPlan2.isPresent());
         assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.REMOVE_SAFE_CONSTANTS;
 import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlan;
+import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlanFragment;
 import static com.facebook.presto.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -256,7 +257,7 @@ public class TestCanonicalPlanGenerator
                 false);
         List<CanonicalPlanFragment> leafCanonicalPlans = getLeafSubPlans(subplan).stream()
                 .map(SubPlan::getFragment)
-                .map(fragment -> generateCanonicalPlan(fragment.getRoot(), fragment.getPartitioningScheme()))
+                .map(fragment -> generateCanonicalPlanFragment(fragment.getRoot(), fragment.getPartitioningScheme()))
                 .map(Optional::get)
                 .collect(Collectors.toList());
         assertEquals(leafCanonicalPlans.size(), 2);
@@ -271,8 +272,8 @@ public class TestCanonicalPlanGenerator
     {
         PlanFragment fragment1 = getOnlyElement(getLeafSubPlans(subplan(sql1, OPTIMIZED_AND_VALIDATED, false))).getFragment();
         PlanFragment fragment2 = getOnlyElement(getLeafSubPlans(subplan(sql2, OPTIMIZED_AND_VALIDATED, false))).getFragment();
-        Optional<CanonicalPlanFragment> canonicalPlan1 = generateCanonicalPlan(fragment1.getRoot(), fragment1.getPartitioningScheme());
-        Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlan(fragment2.getRoot(), fragment2.getPartitioningScheme());
+        Optional<CanonicalPlanFragment> canonicalPlan1 = generateCanonicalPlanFragment(fragment1.getRoot(), fragment1.getPartitioningScheme());
+        Optional<CanonicalPlanFragment> canonicalPlan2 = generateCanonicalPlanFragment(fragment2.getRoot(), fragment2.getPartitioningScheme());
         assertTrue(canonicalPlan1.isPresent());
         assertTrue(canonicalPlan2.isPresent());
         assertNotEquals(objectMapper.writeValueAsString(canonicalPlan1), objectMapper.writeValueAsString(canonicalPlan2));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayoutHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayoutHandle.java
@@ -13,11 +13,20 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+
 import java.util.Optional;
 
 public interface ConnectorTableLayoutHandle
 {
-    default Object getIdentifier(Optional<ConnectorSplit> split)
+    /**
+     * Identifier is used to identify if the table layout is providing the same set of data.
+     *
+     * Split is used to update the identifier based on runtime information.
+     *
+     * Returns an identifier with consistent representation according to canonicalizationStrategy
+     */
+    default Object getIdentifier(Optional<ConnectorSplit> split, PlanCanonicalizationStrategy canonicalizationStrategy)
     {
         return this;
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -396,6 +396,21 @@ public abstract class AbstractTestQueryFramework
                 });
     }
 
+    protected Plan plan(@Language("SQL") String sql, Session session)
+    {
+        QueryExplainer explainer = getQueryExplainer();
+        try {
+            return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+                    .singleStatement()
+                    .execute(session, transactionSession -> {
+                        return explainer.getLogicalPlan(transactionSession, sqlParser.createStatement(sql, createParsingOptions(transactionSession)), emptyList(), WarningCollector.NOOP);
+                    });
+        }
+        catch (RuntimeException e) {
+            throw new AssertionError("Planning failed for SQL: " + sql, e);
+        }
+    }
+
     protected SubPlan subplan(String sql)
     {
         return subplan(sql, queryRunner.getDefaultSession());

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableLayoutHandle.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableLayoutHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tpch;
 
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
@@ -55,11 +56,11 @@ public class TpchTableLayoutHandle
     }
 
     @Override
-    public Object getIdentifier(Optional<ConnectorSplit> split)
+    public Object getIdentifier(Optional<ConnectorSplit> split, PlanCanonicalizationStrategy strategy)
     {
         return ImmutableMap.builder()
                 .put("table", table)
-                .put("predicate", predicate)
+                .put("predicate", predicate.canonicalize(false))
                 .build();
     }
 }


### PR DESCRIPTION
This PR introduces different plan canonicalization strategies to be used by HBO framework

Commit 1: Add canonicalization strategies to canonicalize plans. Add a connector specific strategy, and remove_constants strategy. It only works on scan, filter, project, agg plan nodes. Some basic tests were added which test plan canonicalization, but does not reflect an actual run, since HBO will try to canonicalize plans in between the optimizer.

Commit 2: Refactor