### PR TITLE
Fix Disagg Coordinator Memory Leak Check

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -242,7 +242,12 @@ public class ClusterMemoryManager
 
         // TODO revocable memory reservations can also leak and may need to be detected in the future
         // We are only concerned about the leaks in general pool.
-        memoryLeakDetector.checkForMemoryLeaks(allQueryInfoSupplier, pools.get(GENERAL_POOL).getQueryMemoryReservations());
+        if (memoryManagerService.isPresent()) {
+            memoryLeakDetector.checkForClusterMemoryLeaks(pools.get(GENERAL_POOL).getClusterInfo()::getRunningQueries, pools.get(GENERAL_POOL).getQueryMemoryReservations());
+        }
+        else {
+            memoryLeakDetector.checkForMemoryLeaks(allQueryInfoSupplier, pools.get(GENERAL_POOL).getQueryMemoryReservations());
+        }
 
         boolean outOfMemory = isClusterOutOfMemory();
         if (!outOfMemory) {

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
@@ -90,7 +90,12 @@ public class ClusterMemoryPool
 
     public synchronized ClusterMemoryPoolInfo getClusterInfo(Optional<QueryId> largestMemoryQuery)
     {
-        return new ClusterMemoryPoolInfo(getInfo(), blockedNodes, assignedQueries, largestMemoryQuery);
+        return new ClusterMemoryPoolInfo(getInfo(), blockedNodes, assignedQueries, largestMemoryQuery, Optional.empty());
+    }
+
+    public synchronized ClusterMemoryPoolInfo getClusterInfo(Optional<QueryId> largestMemoryQuery, Optional<List<QueryId>> runningQueries)
+    {
+        return new ClusterMemoryPoolInfo(getInfo(), blockedNodes, assignedQueries, largestMemoryQuery, runningQueries);
     }
 
     public MemoryPoolId getId()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/memory/ClusterMemoryPoolInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/memory/ClusterMemoryPoolInfo.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.QueryId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -31,13 +32,14 @@ public final class ClusterMemoryPoolInfo
     private final int blockedNodes;
     private final int assignedQueries;
     private final Optional<QueryId> largestMemoryQuery;
+    private final Optional<List<QueryId>> runningQueries;
 
     public ClusterMemoryPoolInfo(
             MemoryPoolInfo memoryPoolInfo,
             int blockedNodes,
             int assignedQueries)
     {
-        this(memoryPoolInfo, blockedNodes, assignedQueries, Optional.empty());
+        this(memoryPoolInfo, blockedNodes, assignedQueries, Optional.empty(), Optional.empty());
     }
 
     @ThriftConstructor
@@ -46,12 +48,14 @@ public final class ClusterMemoryPoolInfo
             @JsonProperty("memoryPoolInfo") MemoryPoolInfo memoryPoolInfo,
             int blockedNodes,
             int assignedQueries,
-            Optional<QueryId> largestMemoryQuery)
+            Optional<QueryId> largestMemoryQuery,
+            Optional<List<QueryId>> runningQueries)
     {
         this.memoryPoolInfo = requireNonNull(memoryPoolInfo, "memoryPoolInfo is null");
         this.blockedNodes = blockedNodes;
         this.assignedQueries = assignedQueries;
         this.largestMemoryQuery = largestMemoryQuery;
+        this.runningQueries = runningQueries;
     }
 
     @ThriftField(1)
@@ -80,5 +84,12 @@ public final class ClusterMemoryPoolInfo
     public Optional<QueryId> getLargestMemoryQuery()
     {
         return largestMemoryQuery;
+    }
+
+    @ThriftField(5)
+    @JsonProperty
+    public Optional<List<QueryId>> getRunningQueries()
+    {
+        return runningQueries;
     }
 }


### PR DESCRIPTION
ClusterMemoryLeakDetector identifies running query on different coordinator to be a leak.
As part of this fix, we are passing all running query information to all coordinator, so they
can identify the leaked queries correctly in multi coordinator setup.

Test plan - Unit test and verifier run

```
== RELEASE NOTES ==

General Changes
* Fixing Disaggregated Coordinator to not wrongly identifying running queries as leaked
```