### PR TITLE
Fix false positives in PERFORMANCE_WARNING for JOIN ON clause

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -268,6 +268,16 @@ public class AbstractAnalyzerTest
                         new ColumnMetadata("a&^[x", BIGINT))),
                 false));
 
+        // table with bigint, double, array of bigints and array of doubles column
+        SchemaTableName table13 = new SchemaTableName("s1", "t13");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table13, ImmutableList.of(
+                        new ColumnMetadata("w", BIGINT),
+                        new ColumnMetadata("x", BIGINT),
+                        new ColumnMetadata("y", BIGINT),
+                        new ColumnMetadata("z", BIGINT))),
+                false));
+
         // valid view referencing table in same schema
         String viewData1 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
                 new ViewDefinition(


### PR DESCRIPTION
Often times, while specifying the joining condition in JOIN ON clause,
users make mistakes and not referencing the joining table along side
with other table in join condition that result in performance issue due
to conditional join resulting in CROSS JOIN.

This change will reduce the number of cases when user is shown the
PERFORMANCE_WARNING when JOIN ON clause is actually correct.

See also: #17333, #17640

```
== NO RELEASE NOTE ==
```
