### PR TITLE
Cache testing on catalog server

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -26,6 +26,7 @@ import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tests.tpcds.TpcdsTableName;
 import com.facebook.presto.tpcds.TpcdsPlugin;
@@ -89,6 +90,12 @@ public final class HiveQueryRunner
         return createQueryRunner(tables, ImmutableMap.of(), Optional.empty());
     }
 
+    public static DistributedQueryRunner createQueryRunner(boolean catalogServerEnabled, Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createQueryRunner(tables, ImmutableList.of(), ImmutableMap.of(), ImmutableMap.of(), "sql-standard", ImmutableMap.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), catalogServerEnabled);
+    }
+
     public static DistributedQueryRunner createQueryRunner(
             Iterable<TpchTable<?>> tpchTables,
             Map<String, String> extraProperties,
@@ -134,7 +141,7 @@ public final class HiveQueryRunner
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher)
             throws Exception
     {
-        return createQueryRunner(tpchTables, tpcdsTableNames, extraProperties, extraCoordinatorProperties, security, extraHiveProperties, workerCount, baseDataDir, externalWorkerLauncher, Optional.empty());
+        return createQueryRunner(tpchTables, tpcdsTableNames, extraProperties, extraCoordinatorProperties, security, extraHiveProperties, workerCount, baseDataDir, externalWorkerLauncher, Optional.empty(), false);
     }
 
     public static DistributedQueryRunner createQueryRunner(
@@ -147,7 +154,8 @@ public final class HiveQueryRunner
             Optional<Integer> workerCount,
             Optional<Path> baseDataDir,
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            Optional<ExtendedHiveMetastore> externalMetastore)
+            Optional<ExtendedHiveMetastore> externalMetastore,
+            boolean catalogServerEnabled)
             throws Exception
     {
         assertEquals(DateTimeZone.getDefault(), TIME_ZONE, "Timezone not configured correctly. Add -Duser.timezone=America/Bahia_Banderas to your JVM arguments");
@@ -166,6 +174,7 @@ public final class HiveQueryRunner
                         .setNodeCount(workerCount.orElse(4))
                         .setExtraProperties(systemProperties)
                         .setCoordinatorProperties(extraCoordinatorProperties)
+                        .setCatalogServerEnabled(catalogServerEnabled)
                         .setBaseDataDir(baseDataDir)
                         .setExternalWorkerLauncher(externalWorkerLauncher)
                         .build();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveQueriesWithCatalogServer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveQueriesWithCatalogServer.java
@@ -1,0 +1,131 @@
+package com.facebook.presto.hive;
+
+import com.facebook.presto.catalogserver.RemoteMetadataManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.tpch.TpchTable.getTables;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveQueriesWithCatalogServer
+{
+    private QueryRunner queryRunner;
+    private QueryRunner queryRunnerWithCatalogServer;
+
+    @BeforeClass
+    public void init()
+            throws Exception
+    {
+        queryRunner = HiveQueryRunner.createQueryRunner(false, getTables());
+        queryRunnerWithCatalogServer = HiveQueryRunner.createQueryRunner(true, getTables());
+    }
+
+    @Test
+    public void testCatalogServerInitialization()
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        DistributedQueryRunner queryRunnerWithCatalogServer = (DistributedQueryRunner) getQueryRunnerWithCatalogServer();
+
+        assertFalse(queryRunner.getCatalogServer().isPresent());
+        assertTrue(queryRunnerWithCatalogServer.getCatalogServer().isPresent());
+
+        assertEquals(queryRunner.getMetadata().getClass(), MetadataManager.class);
+        assertEquals(queryRunnerWithCatalogServer.getMetadata().getClass(), RemoteMetadataManager.class);
+    }
+
+    @Test
+    public void testTableQueryComparison()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+
+        String query1 = "SELECT name FROM tpch.sf1.nation";
+        String query2 = "SELECT * FROM system.information_schema.schemata";
+
+        assertEquals(queryRunner.execute(query1), queryRunnerWithCatalogServer.execute(query1));
+        assertEquals(queryRunner.execute(query2), queryRunnerWithCatalogServer.execute(query2));
+    }
+
+    @Test
+    public void testViewQueryComparison()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+
+        String view = "columns_view";
+        try {
+            String createView = format("CREATE VIEW %s AS SELECT * FROM system.information_schema.columns", view);
+            String query = format("SELECT * FROM %s", view);
+
+            queryRunner.execute(createView);
+            queryRunnerWithCatalogServer.execute(createView);
+
+            assertEquals(queryRunner.execute(query), queryRunnerWithCatalogServer.execute(query));
+        }
+        finally {
+            queryRunner.execute(format("DROP VIEW IF EXISTS %s", view));
+            queryRunnerWithCatalogServer.execute(format("DROP VIEW IF EXISTS %s", view));
+        }
+    }
+
+    @Test
+    public void testMaterializedViewQueryComparison()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+
+        String materializedView = "customer_materialized_view";
+        String table = "partitioned_customer";
+        try {
+            String createTable = format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) AS" +
+                    " SELECT custkey, name, address, nationkey FROM customer", table);
+            String createMaterializedView = format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['nationkey']) AS" +
+                    " SELECT name, nationkey FROM %s", materializedView, table);
+            String query = format("SELECT * FROM %s", materializedView);
+
+            queryRunner.execute(createTable);
+            queryRunnerWithCatalogServer.execute(createTable);
+
+            queryRunner.execute(createMaterializedView);
+            queryRunnerWithCatalogServer.execute(createMaterializedView);
+
+            MaterializedResult result1 = queryRunner.execute(query);
+            MaterializedResult result2 = queryRunnerWithCatalogServer.execute(query);
+
+            assertEquals(result1.getTypes(), result2.getTypes());
+            assertTrue(result1.getMaterializedRows().containsAll(result2.getMaterializedRows()) && result2.getMaterializedRows().containsAll(result1.getMaterializedRows()));
+            assertEquals(result1.getRowCount(), result2.getRowCount());
+            assertEquals(result1.getSetSessionProperties(), result2.getSetSessionProperties());
+            assertEquals(result1.getResetSessionProperties(), result2.getResetSessionProperties());
+            assertEquals(result1.getUpdateType(), result2.getUpdateType());
+            assertEquals(result1.getUpdateCount(), result2.getUpdateCount());
+        }
+        finally {
+            queryRunner.execute(format("DROP MATERIALIZED VIEW IF EXISTS %s", materializedView));
+            queryRunnerWithCatalogServer.execute(format("DROP MATERIALIZED VIEW IF EXISTS %s", materializedView));
+
+            queryRunner.execute(format("DROP TABLE IF EXISTS %s", table));
+            queryRunnerWithCatalogServer.execute(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    private QueryRunner getQueryRunner()
+    {
+        checkState(queryRunner != null, "queryRunner not set");
+        return queryRunner;
+    }
+
+    private QueryRunner getQueryRunnerWithCatalogServer()
+    {
+        checkState(queryRunnerWithCatalogServer != null, "queryRunnerWithCatalogServer not set");
+        return queryRunnerWithCatalogServer;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveQueriesWithCatalogServer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveQueriesWithCatalogServer.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.catalogserver.CatalogServerCacheStats;
 import com.facebook.presto.catalogserver.RemoteMetadataManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.testing.MaterializedResult;
@@ -29,14 +45,45 @@ public class TestHiveQueriesWithCatalogServer
     }
 
     @Test
-    public void testCatalogServerInitialization()
+    public void testCatalogServerInitializationCacheStats()
+    {
+        CatalogServerCacheStats cacheStats = getMetadataManager().getCacheStats();
+
+        // Assert the hit/miss count stats upon query runner initialization
+        assertEquals(cacheStats.getSchemaExistsCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getCatalogExistsCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getListSchemaNamesCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheHitCount(), 8);
+        assertEquals(cacheStats.getListTablesCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getListViewsCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getGetViewsCacheStats().getCacheHitCount(), 0);
+        assertEquals(cacheStats.getGetViewCacheStats().getCacheHitCount(), 8);
+        assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheHitCount(), 8);
+        assertEquals(cacheStats.getGetReferencedMaterializedViewsCacheStats().getCacheHitCount(), 0);
+
+        assertEquals(cacheStats.getCatalogExistsCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getSchemaExistsCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getListSchemaNamesCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheMissCount(), 24);
+        assertEquals(cacheStats.getListTablesCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getListViewsCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getGetViewsCacheStats().getCacheMissCount(), 0);
+        assertEquals(cacheStats.getGetViewCacheStats().getCacheMissCount(), 8);
+        assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheMissCount(), 8);
+        assertEquals(cacheStats.getGetReferencedMaterializedViewsCacheStats().getCacheMissCount(), 0);
+    }
+
+    @Test
+    public void testCatalogServerConfiguration()
     {
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
         DistributedQueryRunner queryRunnerWithCatalogServer = (DistributedQueryRunner) getQueryRunnerWithCatalogServer();
 
+        // Assert catalog server node creation
         assertFalse(queryRunner.getCatalogServer().isPresent());
         assertTrue(queryRunnerWithCatalogServer.getCatalogServer().isPresent());
 
+        // Assert correct metadata binding
         assertEquals(queryRunner.getMetadata().getClass(), MetadataManager.class);
         assertEquals(queryRunnerWithCatalogServer.getMetadata().getClass(), RemoteMetadataManager.class);
     }
@@ -46,12 +93,31 @@ public class TestHiveQueriesWithCatalogServer
     {
         QueryRunner queryRunner = getQueryRunner();
         QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+        RemoteMetadataManager metadataManager = getMetadataManager();
+        metadataManager.refreshCache();
 
         String query1 = "SELECT name FROM tpch.sf1.nation";
         String query2 = "SELECT * FROM system.information_schema.schemata";
 
+        // Assert query equality and cache miss for first run
         assertEquals(queryRunner.execute(query1), queryRunnerWithCatalogServer.execute(query1));
         assertEquals(queryRunner.execute(query2), queryRunnerWithCatalogServer.execute(query2));
+
+        CatalogServerCacheStats cacheStats = metadataManager.getCacheStats();
+
+        assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheMissCount(), 2);
+        assertEquals(cacheStats.getGetViewCacheStats().getCacheMissCount(), 2);
+        assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheMissCount(), 2);
+
+        // Assert query equality and cache hit for duplicate run
+        assertEquals(queryRunner.execute(query1), queryRunnerWithCatalogServer.execute(query1));
+        assertEquals(queryRunner.execute(query2), queryRunnerWithCatalogServer.execute(query2));
+
+        cacheStats = metadataManager.getCacheStats();
+
+        assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheHitCount(), 2);
+        assertEquals(cacheStats.getGetViewCacheStats().getCacheHitCount(), 2);
+        assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheHitCount(), 2);
     }
 
     @Test
@@ -59,16 +125,35 @@ public class TestHiveQueriesWithCatalogServer
     {
         QueryRunner queryRunner = getQueryRunner();
         QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+        RemoteMetadataManager metadataManager = getMetadataManager();
+        metadataManager.refreshCache();
 
         String view = "columns_view";
         try {
             String createView = format("CREATE VIEW %s AS SELECT * FROM system.information_schema.columns", view);
             String query = format("SELECT * FROM %s", view);
 
+            // Create view from existing table
             queryRunner.execute(createView);
             queryRunnerWithCatalogServer.execute(createView);
 
+            // Assert query equality and cache miss for first run
             assertEquals(queryRunner.execute(query), queryRunnerWithCatalogServer.execute(query));
+
+            CatalogServerCacheStats cacheStats = metadataManager.getCacheStats();
+
+            assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheMissCount(), 1);
+            assertEquals(cacheStats.getGetViewCacheStats().getCacheMissCount(), 2);
+            assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheMissCount(), 1);
+
+            // Assert query equality and cache hit for duplicate run
+            assertEquals(queryRunner.execute(query), queryRunnerWithCatalogServer.execute(query));
+
+            cacheStats = metadataManager.getCacheStats();
+
+            assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheHitCount(), 1);
+            assertEquals(cacheStats.getGetViewCacheStats().getCacheHitCount(), 2);
+            assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheHitCount(), 1);
         }
         finally {
             queryRunner.execute(format("DROP VIEW IF EXISTS %s", view));
@@ -81,6 +166,8 @@ public class TestHiveQueriesWithCatalogServer
     {
         QueryRunner queryRunner = getQueryRunner();
         QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+        RemoteMetadataManager metadataManager = getMetadataManager();
+        metadataManager.refreshCache();
 
         String materializedView = "customer_materialized_view";
         String table = "partitioned_customer";
@@ -91,12 +178,14 @@ public class TestHiveQueriesWithCatalogServer
                     " SELECT name, nationkey FROM %s", materializedView, table);
             String query = format("SELECT * FROM %s", materializedView);
 
+            // Create table for materialized view
             queryRunner.execute(createTable);
             queryRunnerWithCatalogServer.execute(createTable);
 
             queryRunner.execute(createMaterializedView);
             queryRunnerWithCatalogServer.execute(createMaterializedView);
 
+            // Assert query equality and cache miss for first run
             MaterializedResult result1 = queryRunner.execute(query);
             MaterializedResult result2 = queryRunnerWithCatalogServer.execute(query);
 
@@ -107,6 +196,30 @@ public class TestHiveQueriesWithCatalogServer
             assertEquals(result1.getResetSessionProperties(), result2.getResetSessionProperties());
             assertEquals(result1.getUpdateType(), result2.getUpdateType());
             assertEquals(result1.getUpdateCount(), result2.getUpdateCount());
+
+            CatalogServerCacheStats cacheStats = metadataManager.getCacheStats();
+
+            assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheMissCount(), 2);
+            assertEquals(cacheStats.getGetViewCacheStats().getCacheMissCount(), 3);
+            assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheMissCount(), 3);
+
+            // Assert query equality and cache hit for duplicate run
+            result1 = queryRunner.execute(query);
+            result2 = queryRunnerWithCatalogServer.execute(query);
+
+            assertEquals(result1.getTypes(), result2.getTypes());
+            assertTrue(result1.getMaterializedRows().containsAll(result2.getMaterializedRows()) && result2.getMaterializedRows().containsAll(result1.getMaterializedRows()));
+            assertEquals(result1.getRowCount(), result2.getRowCount());
+            assertEquals(result1.getSetSessionProperties(), result2.getSetSessionProperties());
+            assertEquals(result1.getResetSessionProperties(), result2.getResetSessionProperties());
+            assertEquals(result1.getUpdateType(), result2.getUpdateType());
+            assertEquals(result1.getUpdateCount(), result2.getUpdateCount());
+
+            cacheStats = metadataManager.getCacheStats();
+
+            assertEquals(cacheStats.getGetTableHandleCacheStats().getCacheHitCount(), 2);
+            assertEquals(cacheStats.getGetViewCacheStats().getCacheHitCount(), 2);
+            assertEquals(cacheStats.getGetMaterializedViewCacheStats().getCacheHitCount(), 2);
         }
         finally {
             queryRunner.execute(format("DROP MATERIALIZED VIEW IF EXISTS %s", materializedView));
@@ -127,5 +240,11 @@ public class TestHiveQueriesWithCatalogServer
     {
         checkState(queryRunnerWithCatalogServer != null, "queryRunnerWithCatalogServer not set");
         return queryRunnerWithCatalogServer;
+    }
+
+    private RemoteMetadataManager getMetadataManager()
+    {
+        QueryRunner queryRunnerWithCatalogServer = getQueryRunnerWithCatalogServer();
+        return (RemoteMetadataManager) queryRunnerWithCatalogServer.getMetadata();
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
@@ -60,6 +60,7 @@ public final class S3HiveQueryRunner
                                         hiveEndpoint.getPort()),
                                 new MetastoreClientConfig(),
                                 HDFS_ENVIRONMENT),
-                        new HivePartitionMutator())));
+                        new HivePartitionMutator())),
+                false);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
@@ -24,29 +24,53 @@ import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import javax.inject.Inject;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThriftService(value = "presto-catalog-server", idlName = "PrestoCatalogServer")
 public class CatalogServer
 {
     private static final String EMPTY_STRING = "";
+    // TODO make cache constants configurable
+    private static final Duration CACHE_EXPIRES_AFTER_WRITE_MILLIS = Duration.of(10, MINUTES);
+    private static final long CACHE_MAXIMUM_SIZE = 1000;
 
     private final Metadata metadataProvider;
     private final SessionPropertyManager sessionPropertyManager;
     private final TransactionManager transactionManager;
     private final ObjectMapper objectMapper;
+
+    private final LoadingCache<CacheKey, Boolean> catalogExistsCache;
+    private final LoadingCache<CacheKey, Boolean> schemaExistsCache;
+    private final LoadingCache<CacheKey, List<String>> listSchemaNamesCache;
+    private final LoadingCache<CacheKey, Optional<TableHandle>> getTableHandleCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> listTablesCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> listViewsCache;
+    private final LoadingCache<CacheKey, Map<QualifiedObjectName, ViewDefinition>> getViewsCache;
+    private final LoadingCache<CacheKey, Optional<ViewDefinition>> getViewCache;
+    private final LoadingCache<CacheKey, Optional<ConnectorMaterializedViewDefinition>> getMaterializedViewCache;
+    private final LoadingCache<CacheKey, List<QualifiedObjectName>> getReferencedMaterializedViewsCache;
 
     @Inject
     public CatalogServer(MetadataManager metadataProvider, SessionPropertyManager sessionPropertyManager, TransactionManager transactionManager, ObjectMapper objectMapper)
@@ -55,38 +79,61 @@ public class CatalogServer
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.objectMapper = requireNonNull(objectMapper, "handleResolver is null");
+
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                .maximumSize(CACHE_MAXIMUM_SIZE)
+                .expireAfterWrite(CACHE_EXPIRES_AFTER_WRITE_MILLIS.toMillis(), MILLISECONDS);
+
+        this.catalogExistsCache = cacheBuilder.build(CacheLoader.from(this::loadCatalogExists));
+        this.schemaExistsCache = cacheBuilder.build(CacheLoader.from(this::loadSchemaExists));
+        this.listSchemaNamesCache = cacheBuilder.build(CacheLoader.from(this::loadListSchemaNames));
+        this.getTableHandleCache = cacheBuilder.build(CacheLoader.from(this::loadGetTableHandle));
+        this.listTablesCache = cacheBuilder.build(CacheLoader.from(this::loadListTables));
+        this.listViewsCache = cacheBuilder.build(CacheLoader.from(this::loadListViews));
+        this.getViewsCache = cacheBuilder.build(CacheLoader.from(this::loadGetViews));
+        this.getViewCache = cacheBuilder.build(CacheLoader.from(this::loadGetView));
+        this.getMaterializedViewCache = cacheBuilder.build(CacheLoader.from(this::loadGetMaterializedView));
+        this.getReferencedMaterializedViewsCache = cacheBuilder.build(CacheLoader.from(this::loadGetReferencedMaterializedViews));
     }
+
+    /*
+        Metadata Manager Methods
+     */
 
     @ThriftMethod
     public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        return metadataProvider.schemaExists(session.toSession(sessionPropertyManager), schema);
+        return get(schemaExistsCache, new CacheKey<>(session, schema));
     }
 
     @ThriftMethod
     public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        return metadataProvider.catalogExists(session.toSession(sessionPropertyManager), catalogName);
+        return get(catalogExistsCache, new CacheKey(session, catalogName));
     }
 
     @ThriftMethod
     public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<String> schemaNames = metadataProvider.listSchemaNames(session.toSession(sessionPropertyManager), catalogName);
-        if (!schemaNames.isEmpty()) {
-            return writeValueAsString(schemaNames, objectMapper);
-        }
-        return EMPTY_STRING;
+        List<String> schemaNames = get(listSchemaNamesCache, new CacheKey(session, catalogName));
+        return schemaNames.isEmpty()
+                ? EMPTY_STRING
+                : writeValueAsString(schemaNames, objectMapper);
     }
 
     @ThriftMethod
     public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<TableHandle> tableHandle = metadataProvider.getTableHandle(session.toSession(sessionPropertyManager), table);
+        CacheKey cacheKey = new CacheKey(session, table);
+        Optional<TableHandle> tableHandle = get(getTableHandleCache, cacheKey);
+        if (!tableHandle.isPresent()) {
+            getTableHandleCache.refresh(cacheKey);
+            tableHandle = get(getTableHandleCache, cacheKey);
+        }
         return tableHandle.map(handle -> writeValueAsString(handle, objectMapper))
                 .orElse(EMPTY_STRING);
     }
@@ -95,40 +142,37 @@ public class CatalogServer
     public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> tableList = metadataProvider.listTables(session.toSession(sessionPropertyManager), prefix);
-        if (!tableList.isEmpty()) {
-            return writeValueAsString(tableList, objectMapper);
-        }
-        return EMPTY_STRING;
+        List<QualifiedObjectName> tableList = get(listTablesCache, new CacheKey(session, prefix));
+        return tableList.isEmpty()
+                ? EMPTY_STRING
+                : writeValueAsString(tableList, objectMapper);
     }
 
     @ThriftMethod
     public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> viewsList = metadataProvider.listViews(session.toSession(sessionPropertyManager), prefix);
-        if (!viewsList.isEmpty()) {
-            writeValueAsString(viewsList, objectMapper);
-        }
-        return EMPTY_STRING;
+        List<QualifiedObjectName> viewsList = get(listViewsCache, new CacheKey(session, prefix));
+        return viewsList.isEmpty()
+                ? EMPTY_STRING
+                : writeValueAsString(viewsList, objectMapper);
     }
 
     @ThriftMethod
     public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Map<QualifiedObjectName, ViewDefinition> viewsMap = metadataProvider.getViews(session.toSession(sessionPropertyManager), prefix);
-        if (!viewsMap.isEmpty()) {
-            return writeValueAsString(viewsMap, objectMapper);
-        }
-        return EMPTY_STRING;
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = get(getViewsCache, new CacheKey(session, prefix));
+        return viewsMap.isEmpty()
+                ? EMPTY_STRING
+                : writeValueAsString(viewsMap, objectMapper);
     }
 
     @ThriftMethod
     public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<ViewDefinition> viewDefinition = metadataProvider.getView(session.toSession(sessionPropertyManager), viewName);
+        Optional<ViewDefinition> viewDefinition = get(getViewCache, new CacheKey(session, viewName));
         return viewDefinition.map(view -> writeValueAsString(view, objectMapper))
                 .orElse(EMPTY_STRING);
     }
@@ -137,8 +181,7 @@ public class CatalogServer
     public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition =
-                metadataProvider.getMaterializedView(session.toSession(sessionPropertyManager), viewName);
+        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition = get(getMaterializedViewCache, new CacheKey(session, viewName));
         return connectorMaterializedViewDefinition.map(materializedView -> writeValueAsString(materializedView, objectMapper))
                 .orElse(EMPTY_STRING);
     }
@@ -147,20 +190,128 @@ public class CatalogServer
     public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
     {
         transactionManager.tryRegisterTransaction(transactionInfo);
-        List<QualifiedObjectName> referencedMaterializedViewsList = metadataProvider.getReferencedMaterializedViews(session.toSession(sessionPropertyManager), tableName);
-        if (!referencedMaterializedViewsList.isEmpty()) {
-            return writeValueAsString(referencedMaterializedViewsList, objectMapper);
-        }
-        return EMPTY_STRING;
+        List<QualifiedObjectName> referencedMaterializedViewsList = get(getReferencedMaterializedViewsCache, new CacheKey(session, tableName));
+        return referencedMaterializedViewsList.isEmpty()
+                ? EMPTY_STRING
+                : writeValueAsString(referencedMaterializedViewsList, objectMapper);
     }
 
-    private static String writeValueAsString(Object value, ObjectMapper objectMapper)
+    /*
+        Loading Cache Methods
+     */
+
+    private Boolean loadCatalogExists(CacheKey key)
+    {
+        return metadataProvider.catalogExists(key.getSession().toSession(sessionPropertyManager), (String) key.getKey());
+    }
+
+    private Boolean loadSchemaExists(CacheKey key)
+    {
+        return metadataProvider.schemaExists(key.getSession().toSession(sessionPropertyManager), (CatalogSchemaName) key.getKey());
+    }
+
+    private List<String> loadListSchemaNames(CacheKey key)
+    {
+        return metadataProvider.listSchemaNames(key.getSession().toSession(sessionPropertyManager), (String) key.getKey());
+    }
+
+    private Optional<TableHandle> loadGetTableHandle(CacheKey key)
+    {
+        return metadataProvider.getTableHandle(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadListTables(CacheKey key)
+    {
+        return metadataProvider.listTables(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadListViews(CacheKey key)
+    {
+        return metadataProvider.listViews(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private Map<QualifiedObjectName, ViewDefinition> loadGetViews(CacheKey key)
+    {
+        return metadataProvider.getViews(key.getSession().toSession(sessionPropertyManager), (QualifiedTablePrefix) key.getKey());
+    }
+
+    private Optional<ViewDefinition> loadGetView(CacheKey key)
+    {
+        return metadataProvider.getView(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private Optional<ConnectorMaterializedViewDefinition> loadGetMaterializedView(CacheKey key)
+    {
+        return metadataProvider.getMaterializedView(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private List<QualifiedObjectName> loadGetReferencedMaterializedViews(CacheKey key)
+    {
+        return metadataProvider.getReferencedMaterializedViews(key.getSession().toSession(sessionPropertyManager), (QualifiedObjectName) key.getKey());
+    }
+
+    private String writeValueAsString(Object value, ObjectMapper objectMapper)
     {
         try {
             return objectMapper.writeValueAsString(value);
         }
         catch (JsonProcessingException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private <K, V> V get(LoadingCache<K, V> cache, K key)
+    {
+        try {
+            return cache.getUnchecked(key);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+    }
+
+    private static class CacheKey<T>
+    {
+        private final SessionRepresentation session;
+        private final T key;
+
+        private CacheKey(SessionRepresentation session, T key)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.key = requireNonNull(key, "key is null");
+        }
+
+        public SessionRepresentation getSession()
+        {
+            return session;
+        }
+
+        public T getKey()
+        {
+            return key;
+        }
+
+        // Session changes across different queries. For caching to be effective across multiple queries,
+        // we should NOT include session in equals() and hashCode() methods below.
+        // Only the key value is to be considered in determining whether a cacheKey is unique or not
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(key, cacheKey.key);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(key);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerCacheStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerCacheStats.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@ThriftStruct
+public class CatalogServerCacheStats
+{
+    private final CacheStats catalogExistsCacheStats;
+    private final CacheStats schemaExistsCacheStats;
+    private final CacheStats listSchemaNamesCacheStats;
+    private final CacheStats getTableHandleCacheStats;
+    private final CacheStats listTablesCacheStats;
+    private final CacheStats listViewsCacheStats;
+    private final CacheStats getViewsCacheStats;
+    private final CacheStats getViewCacheStats;
+    private final CacheStats getMaterializedViewCacheStats;
+    private final CacheStats getReferencedMaterializedViewsCacheStats;
+
+    @ThriftConstructor
+    public CatalogServerCacheStats(
+            CacheStats catalogExistsCacheStats,
+            CacheStats schemaExistsCacheStats,
+            CacheStats listSchemaNamesCacheStats,
+            CacheStats getTableHandleCacheStats,
+            CacheStats listTablesCacheStats,
+            CacheStats listViewsCacheStats,
+            CacheStats getViewsCacheStats,
+            CacheStats getViewCacheStats,
+            CacheStats getMaterializedViewCacheStats,
+            CacheStats getReferencedMaterializedViewsCacheStats
+    ) {
+        this.catalogExistsCacheStats = catalogExistsCacheStats;
+        this.schemaExistsCacheStats = schemaExistsCacheStats;
+        this.listSchemaNamesCacheStats = listSchemaNamesCacheStats;
+        this.getTableHandleCacheStats = getTableHandleCacheStats;
+        this.listTablesCacheStats = listTablesCacheStats;
+        this.listViewsCacheStats = listViewsCacheStats;
+        this.getViewsCacheStats = getViewsCacheStats;
+        this.getViewCacheStats = getViewCacheStats;
+        this.getMaterializedViewCacheStats = getMaterializedViewCacheStats;
+        this.getReferencedMaterializedViewsCacheStats = getReferencedMaterializedViewsCacheStats;
+    }
+
+    public CatalogServerCacheStats()
+    {
+        this.catalogExistsCacheStats = new CacheStats();
+        this.schemaExistsCacheStats = new CacheStats();
+        this.listSchemaNamesCacheStats = new CacheStats();
+        this.getTableHandleCacheStats = new CacheStats();
+        this.listTablesCacheStats = new CacheStats();
+        this.listViewsCacheStats = new CacheStats();
+        this.getViewsCacheStats = new CacheStats();
+        this.getViewCacheStats = new CacheStats();
+        this.getMaterializedViewCacheStats = new CacheStats();
+        this.getReferencedMaterializedViewsCacheStats = new CacheStats();
+    }
+
+    @ThriftField(1)
+    public CacheStats getCatalogExistsCacheStats()
+    {
+        return catalogExistsCacheStats;
+    }
+
+    @ThriftField(2)
+    public CacheStats getSchemaExistsCacheStats()
+    {
+        return schemaExistsCacheStats;
+    }
+
+    @ThriftField(3)
+    public CacheStats getListSchemaNamesCacheStats()
+    {
+        return listSchemaNamesCacheStats;
+    }
+
+    @ThriftField(4)
+    public CacheStats getGetTableHandleCacheStats()
+    {
+        return getTableHandleCacheStats;
+    }
+
+    @ThriftField(5)
+    public CacheStats getListTablesCacheStats()
+    {
+        return listTablesCacheStats;
+    }
+
+    @ThriftField(6)
+    public CacheStats getListViewsCacheStats()
+    {
+        return listViewsCacheStats;
+    }
+
+    @ThriftField(7)
+    public CacheStats getGetViewsCacheStats()
+    {
+        return getViewsCacheStats;
+    }
+
+    @ThriftField(8)
+    public CacheStats getGetViewCacheStats()
+    {
+        return getViewCacheStats;
+    }
+
+    @ThriftField(9)
+    public CacheStats getGetMaterializedViewCacheStats()
+    {
+        return getMaterializedViewCacheStats;
+    }
+
+    @ThriftField(10)
+    public CacheStats getGetReferencedMaterializedViewsCacheStats()
+    {
+        return getReferencedMaterializedViewsCacheStats;
+    }
+
+    public void clearAll()
+    {
+        this.catalogExistsCacheStats.clear();
+        this.schemaExistsCacheStats.clear();
+        this.listSchemaNamesCacheStats.clear();
+        this.getTableHandleCacheStats.clear();
+        this.listTablesCacheStats.clear();
+        this.listViewsCacheStats.clear();
+        this.getViewsCacheStats.clear();
+        this.getViewCacheStats.clear();
+        this.getMaterializedViewCacheStats.clear();
+        this.getReferencedMaterializedViewsCacheStats.clear();
+    }
+
+    @ThriftStruct
+    public static class CacheStats
+    {
+        private final AtomicLong cacheHitCount;
+        private final AtomicLong cacheMissCount;
+
+        @ThriftConstructor
+        public CacheStats(long cacheHitCount, long cacheMissCount)
+        {
+            this.cacheHitCount = new AtomicLong(cacheHitCount);
+            this.cacheMissCount = new AtomicLong(cacheMissCount);
+        }
+
+        public CacheStats()
+        {
+            this.cacheHitCount = new AtomicLong();
+            this.cacheMissCount = new AtomicLong();
+        }
+
+        public void incrementCacheHit()
+        {
+            cacheHitCount.getAndIncrement();
+        }
+
+        public void incrementCacheMiss()
+        {
+            cacheMissCount.getAndIncrement();
+        }
+
+        public void clear()
+        {
+            this.cacheHitCount.set(0);
+            this.cacheMissCount.set(0);
+        }
+
+        @ThriftField(1)
+        public long getCacheHitCount()
+        {
+            return cacheHitCount.get();
+        }
+
+        @ThriftField(2)
+        public long getCacheMissCount()
+        {
+            return cacheMissCount.get();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
@@ -53,4 +53,10 @@ public interface CatalogServerClient
 
     @ThriftMethod
     String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName);
+
+    @ThriftMethod
+    CatalogServerCacheStats getCacheStats();
+
+    @ThriftMethod
+    void refreshCache();
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -185,6 +185,16 @@ public class RemoteMetadataManager
                 : readValue(referencedMaterializedViewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
     }
 
+    public CatalogServerCacheStats getCacheStats()
+    {
+        return catalogServerClient.get().getCacheStats();
+    }
+
+    public void refreshCache()
+    {
+        catalogServerClient.get().refreshCache();
+    }
+
     private <T> T readValue(String content, TypeReference<T> valueTypeRef)
     {
         try {

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
@@ -87,4 +87,13 @@ class TestingCatalogServerClient
     {
         return "[\"hive.tpch.test_customer_base\"]";
     }
+
+    @Override
+    public CatalogServerCacheStats getCacheStats()
+    {
+        return new CatalogServerCacheStats();
+    }
+
+    @Override
+    public void refreshCache(){}
 }


### PR DESCRIPTION
# Stacked on top of #17940 & #18011
## Add tests for catalog server caching
- Added cache stats to be able to test the caching hit rate
- Tested the amount of calls and hit/miss count for different queries and compared to what we expected

Test plan
- Run tests on TestHiveQueriesWithCatalogServer

== NO RELEASE NOTE ==
```
