### PR TITLE
Classify spill errors properly.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/SpillingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SpillingUtils.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import java.util.concurrent.Future;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_SPILL_FAILURE;
 import static java.lang.String.format;
 
 public class SpillingUtils
@@ -40,7 +40,7 @@ public class SpillingUtils
             throw new PrestoException(prestoException::getErrorCode, prestoException.getMessage(), prestoException);
         }
         catch (RuntimeException runtimeException) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Spilling failed: %s", runtimeException.getMessage()), runtimeException);
+            throw new PrestoException(GENERIC_SPILL_FAILURE, format("Spilling failed: %s", runtimeException.getMessage()), runtimeException);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -45,12 +45,13 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static com.facebook.presto.execution.buffer.PageSplitterUtil.splitPage;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_SPILL_FAILURE;
 import static com.facebook.presto.spi.page.PagesSerdeUtil.writeSerializedPage;
 import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_PREFIX;
 import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_SUFFIX;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterators.transform;
+import static java.lang.String.format;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.util.Objects.requireNonNull;
 
@@ -108,7 +109,7 @@ public class FileSingleStreamSpiller
             this.targetFile = closer.register(new FileHolder(Files.createTempFile(spillPath, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX)));
         }
         catch (IOException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to create spill file", e);
+            throw new PrestoException(GENERIC_SPILL_FAILURE, format("Failed to create spill file: %s", e.getMessage()), e);
         }
     }
 
@@ -166,7 +167,7 @@ public class FileSingleStreamSpiller
             }
         }
         catch (UncheckedIOException | IOException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to spill pages", e);
+            throw new PrestoException(GENERIC_SPILL_FAILURE, format("Failed to spill pages: %s", e.getMessage()), e);
         }
     }
 
@@ -187,7 +188,7 @@ public class FileSingleStreamSpiller
             return closeWhenExhausted(compactPages, input);
         }
         catch (IOException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);
+            throw new PrestoException(GENERIC_SPILL_FAILURE, format("Failed to read spilled pages: %s", e.getMessage()), e);
         }
     }
 
@@ -200,7 +201,7 @@ public class FileSingleStreamSpiller
             closer.close();
         }
         catch (IOException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to close spiller", e);
+            throw new PrestoException(GENERIC_SPILL_FAILURE, format("Failed to close spiller: %s", e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
Classifying spilling errors with GENERIC_SPILL_FAILURE instead of GENERIC_INTERNAL_ERROR and improving error message for better user experience and monitoring. 
