### PR TITLE
PruneUnreferencedOutputs to not generate invalid SELECT when query has an equality w/ subquery

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -587,10 +587,14 @@ public class PruneUnreferencedOutputs
                     builder.put(variable, expression);
                 }
             });
+            Assignments assignments = builder.build();
+            if (assignments.size() == 0) {
+                // Project node should have at least one assignment. avoid pruning if all assignments are removed.
+                return node;
+            }
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
-
-            return new ProjectNode(node.getSourceLocation(), node.getId(), source, builder.build(), node.getLocality());
+            return new ProjectNode(node.getSourceLocation(), node.getId(), source, assignments, node.getLocality());
         }
 
         @Override


### PR DESCRIPTION
Github Issue: https://github.com/prestodb/presto/issues/17998

`PruneUnreferencedOutputs:: visitProject` plan optimizer ends up removing all projected columns in the case when input SELECT has an equality w/ a subquery:

Example:
```
SELECT * FROM table WHERE id = (SELECT id FROM table WHERE id = '123' AND col2 > 0)
```


Different connectors have different ways of coping with the issue:
- TPCH connector (uses `LocalExecutionPlanner::visitScanFilterAndProject`) populates projected columns from the underlying `tableScanNode.getOutputVariables()`.
- Pinot connector fails since the generated SELECT statement has no projection columns.
