### PR TITLE
Improve Graphviz output for JOIN nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -62,6 +62,7 @@ import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.optimizations.JoinNodeUtils;
+import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
@@ -484,11 +485,7 @@ public class PlanPrinter
 
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetailsLine("Distribution: %s", distributionType));
             if (!node.getDynamicFilters().isEmpty()) {
-                nodeOutput.appendDetails(
-                        "dynamicFilterAssignments = %s",
-                        node.getDynamicFilters().entrySet().stream()
-                                .map(filter -> filter.getValue() + " -> " + filter.getKey())
-                                .collect(Collectors.joining(", ", "{", "}")));
+                nodeOutput.appendDetails(getDynamicFilterAssignments(node));
             }
 
             node.getSortExpressionContext(functionAndTypeManager)
@@ -524,11 +521,7 @@ public class PlanPrinter
                             formatHash(node.getSourceHashVariable(), node.getFilteringSourceHashVariable())));
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetailsLine("Distribution: %s", distributionType));
             if (!node.getDynamicFilters().isEmpty()) {
-                nodeOutput.appendDetails(
-                        "dynamicFilterAssignments = %s",
-                        node.getDynamicFilters().entrySet().stream()
-                                .map(filter -> filter.getValue() + " -> " + filter.getKey())
-                                .collect(Collectors.joining(", ", "{", "}")));
+                nodeOutput.appendDetails(getDynamicFilterAssignments(node));
             }
             node.getSource().accept(this, context);
             node.getFilteringSource().accept(this, context);
@@ -1317,6 +1310,17 @@ public class PlanPrinter
             representation.addNode(nodeOutput);
             return nodeOutput;
         }
+    }
+
+    public static String getDynamicFilterAssignments(AbstractJoinNode node)
+    {
+        if (node.getDynamicFilters().isEmpty()) {
+            return "";
+        }
+        return format("dynamicFilterAssignments = %s",
+                node.getDynamicFilters().entrySet().stream()
+                        .map(filter -> filter.getValue() + " -> " + filter.getKey())
+                        .collect(Collectors.joining(", ", "{", "}")));
     }
 
     private static String castToVarchar(Type type, Object value, FunctionAndTypeManager functionAndTypeManager, Session session)

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.optimizations.JoinNodeUtils;
+import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -77,6 +78,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.getDynamicFilterAssignments;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Maps.immutableEnumMap;
 import static java.lang.String.format;
@@ -489,9 +491,18 @@ public final class GraphvizPrinter
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
                 joinExpressions.add(JoinNodeUtils.toExpression(clause));
             }
+            String joinCriteria = Joiner.on(" AND ").join(joinExpressions);
+            StringBuilder details = new StringBuilder(joinCriteria);
+            if (!node.getDynamicFilters().isEmpty()) {
+                details.append(", ");
+                details.append(getDynamicFilterAssignments(node));
+            }
 
-            String criteria = Joiner.on(" AND ").join(joinExpressions);
-            printNode(node, node.getType().getJoinLabel(), criteria, NODE_COLORS.get(NodeType.JOIN));
+            String distributionType = node.getDistributionType().isPresent() ? node.getDistributionType().get().toString() : "UNKNOWN";
+            final String joinType = node.isCrossJoin() ? "CrossJoin" : node.getType().getJoinLabel();
+            String label = format("%s[%s]", joinType, distributionType);
+
+            printNode(node, label, details.toString(), NODE_COLORS.get(NodeType.JOIN));
 
             node.getLeft().accept(this, context);
             node.getRight().accept(this, context);
@@ -502,7 +513,16 @@ public final class GraphvizPrinter
         @Override
         public Void visitSemiJoin(SemiJoinNode node, Void context)
         {
-            printNode(node, "SemiJoin", format("%s = %s", node.getSourceJoinVariable(), node.getFilteringSourceJoinVariable()), NODE_COLORS.get(NodeType.JOIN));
+            String joinExpression = format("%s = %s", node.getSourceJoinVariable(), node.getFilteringSourceJoinVariable());
+            StringBuilder details = new StringBuilder(joinExpression);
+            if (!node.getDynamicFilters().isEmpty()) {
+                details.append(", ");
+                details.append(getDynamicFilterAssignments(node));
+            }
+
+            String label = format("SemiJoin[%s]", node.getDistributionType().isPresent() ? node.getDistributionType().get().toString() : "UNKNOWN");
+
+            printNode(node, label, details.toString(), NODE_COLORS.get(NodeType.JOIN));
 
             node.getSource().accept(this, context);
             node.getFilteringSource().accept(this, context);
@@ -656,6 +676,29 @@ public final class GraphvizPrinter
         }
 
         @Override
+        public Void visitSemiJoin(SemiJoinNode node, Void context)
+        {
+            return visitBuildAndProbe(node, context, node.getBuild(), node.getProbe());
+        }
+
+        @Override
+        public Void visitJoin(JoinNode node, Void context)
+        {
+            return visitBuildAndProbe(node, context, node.getBuild(), node.getProbe());
+        }
+
+        private Void visitBuildAndProbe(AbstractJoinNode node, Void context, PlanNode build, PlanNode probe)
+        {
+            printEdge(node, build, "Build");
+            build.accept(this, context);
+
+            printEdge(node, probe, "Probe");
+            probe.accept(this, context);
+
+            return null;
+        }
+
+        @Override
         public Void visitPlan(PlanNode node, Void context)
         {
             for (PlanNode child : node.getSources()) {
@@ -680,12 +723,18 @@ public final class GraphvizPrinter
 
         private void printEdge(PlanNode from, PlanNode to)
         {
+            printEdge(from, to, "");
+        }
+
+        private void printEdge(PlanNode from, PlanNode to, String label)
+        {
             String fromId = idGenerator.getNodeId(from);
             String toId = idGenerator.getNodeId(to);
 
             output.append(fromId)
                     .append(" -> ")
                     .append(toId)
+                    .append(label.isEmpty() ? "" : String.format(" [label = \"%s\"]", label))
                     .append(';')
                     .append('\n');
         }

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -21,10 +21,13 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -33,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
@@ -110,6 +114,47 @@ public class TestGraphvizPrinter
                 "}",
                 "");
         assertEquals(actualNestedSubPlan, expectedNestedSubPlan);
+    }
+
+    @Test
+    public void testPrintLogicalForJoinNode()
+    {
+        ValuesNode valuesNode = new ValuesNode(Optional.empty(), new PlanNodeId("right"), ImmutableList.of(), ImmutableList.of());
+
+        PlanNode node = new JoinNode(
+                Optional.empty(),
+                new PlanNodeId("join"),
+                JoinNode.Type.INNER,
+                TEST_TABLE_SCAN_NODE, //Left : Probe side
+                valuesNode, //Right : Build side
+                Collections.emptyList(), //No Criteria
+                ImmutableList.<VariableReferenceExpression>builder()
+                        .addAll(TEST_TABLE_SCAN_NODE.getOutputVariables())
+                        .addAll(valuesNode.getOutputVariables())
+                        .build(),
+                Optional.empty(), //NO filter
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.REPLICATED),
+                ImmutableMap.of());
+
+        String actual = printLogical(
+                ImmutableList.of(createTestPlanFragment(0, node)),
+                testSessionBuilder().build(),
+                createTestFunctionAndTypeManager());
+
+        String expected = "digraph logical_plan {\n" +
+                "subgraph cluster_0 {\n" +
+                "label = \"SOURCE\"\n" +
+                "plannode_1[label=\"{CrossJoin[REPLICATED]}\", style=\"rounded, filled\", shape=record, fillcolor=orange];\n" + //no Criteria + no filter + INNER Join => CrossJoin
+                "plannode_2[label=\"{TableScan[TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "plannode_3[label=\"{Values}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "}\n" +
+                "plannode_1 -> plannode_3 [label = \"Build\"];\n" + //valuesNode should be the Build side
+                "plannode_1 -> plannode_2 [label = \"Probe\"];\n" + //TEST_TABLE_SCAN_NODE should be the Probe side
+                "}\n";
+
+        assertEquals(actual, expected);
     }
 
     private static PlanFragment createTestPlanFragment(int id, PlanNode node)


### PR DESCRIPTION
Make Graphviz output more readable for Join nodes by
1. Labeling edges with 'Build' or 'Probe'
1. Appending DistributionType to the node label
1. Appending 'dynamicFilterAssignments' to the node details

Test plan -
1. Tested EXPLAIN plans (both logical and distributed) generated for TPCH queries were parseable by dot (graphviz version 2.43.0)
1. Added a new unit test that asserts that build/probe nodes are labeled correctly

```
== RELEASE NOTES ==

General Changes
* Improve Graphviz output for JOIN nodes
```
