### PR TITLE
Removed joda-time dependency from the iceberg package

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
@@ -39,9 +39,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
@@ -97,6 +99,43 @@ public class OrcFileWriter
                 fileInputColumnIndexes,
                 metadata,
                 hiveStorageTimeZone,
+                validationInputFactory,
+                validationMode,
+                stats,
+                dwrfEncryptionProvider,
+                dwrfWriterEncryption);
+    }
+
+    public OrcFileWriter(
+            DataSink dataSink,
+            Callable<Void> rollbackAction,
+            OrcEncoding orcEncoding,
+            List<String> columnNames,
+            List<Type> fileColumnTypes,
+            Optional<List<OrcType>> fileColumnOrcTypes,
+            CompressionKind compression,
+            OrcWriterOptions options,
+            int[] fileInputColumnIndexes,
+            Map<String, String> metadata,
+            ZoneId hiveStorageTimeZone,
+            Optional<Supplier<OrcDataSource>> validationInputFactory,
+            OrcWriteValidationMode validationMode,
+            WriterStats stats,
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            Optional<DwrfWriterEncryption> dwrfWriterEncryption)
+    {
+        this(
+                dataSink,
+                rollbackAction,
+                orcEncoding,
+                columnNames,
+                fileColumnTypes,
+                fileColumnOrcTypes,
+                compression,
+                options,
+                fileInputColumnIndexes,
+                metadata,
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(hiveStorageTimeZone.getId()))),
                 validationInputFactory,
                 validationMode,
                 stats,

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -225,11 +225,6 @@
             <artifactId>validation-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
         <!-- Iceberg -->
         <dependency>
             <groupId>org.apache.iceberg</groupId>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -69,9 +69,9 @@ import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class IcebergFileWriterFactory
 {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
@@ -37,10 +37,10 @@ import io.airlift.slice.Slice;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Conversions;
-import org.joda.time.DateTimeZone;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -74,7 +74,7 @@ public class IcebergOrcFileWriter
             OrcWriterOptions options,
             int[] fileInputColumnIndexes,
             Map<String, String> metadata,
-            DateTimeZone hiveStorageTimeZone,
+            ZoneId hiveStorageTimeZone,
             Optional<Supplier<OrcDataSource>> validationInputFactory,
             OrcWriteValidation.OrcWriteValidationMode validationMode,
             NoOpOrcWriterStats stats,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -132,11 +132,11 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.parquet.io.ColumnIOConverter.constructField;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class IcebergPageSourceProvider
         implements ConnectorPageSourceProvider

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -22,8 +22,6 @@ import io.airlift.slice.Murmur3Hash32;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.iceberg.PartitionField;
-import org.joda.time.DateTimeField;
-import org.joda.time.chrono.ISOChronology;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,11 +48,6 @@ public final class PartitionTransforms
 {
     private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
     private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
-
-    private static final DateTimeField YEAR_FIELD = ISOChronology.getInstanceUTC().year();
-    private static final DateTimeField MONTH_FIELD = ISOChronology.getInstanceUTC().monthOfYear();
-    private static final DateTimeField DAY_OF_YEAR_FIELD = ISOChronology.getInstanceUTC().dayOfYear();
-    private static final DateTimeField DAY_OF_MONTH_FIELD = ISOChronology.getInstanceUTC().dayOfMonth();
 
     private PartitionTransforms() {}
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -43,9 +43,11 @@ import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -304,6 +306,26 @@ public class OrcReader
             throws OrcCorruptionException
     {
         return createBatchRecordReader(includedColumns, predicate, 0, getOrcDataSource().getSize(), hiveStorageTimeZone, systemMemoryUsage, initialBatchSize);
+    }
+
+    public OrcBatchRecordReader createBatchRecordReader(
+            Map<Integer, Type> includedColumns,
+            OrcPredicate predicate,
+            long offset,
+            long length,
+            ZoneId hiveStorageTimeZone,
+            OrcAggregatedMemoryContext systemMemoryUsage,
+            int initialBatchSize)
+            throws OrcCorruptionException
+    {
+        return createBatchRecordReader(
+                includedColumns,
+                predicate,
+                offset,
+                length,
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(hiveStorageTimeZone.getId()))),
+                systemMemoryUsage,
+                initialBatchSize);
     }
 
     public OrcBatchRecordReader createBatchRecordReader(


### PR DESCRIPTION
This PR removes the dependency of joda-time from the iceberg package ONLY. It does not go deeper than this (as a larger refactor is required).

Test plan - Successful compilation and tests

```
== RELEASE NOTES ==

General Changes
* Remove usage and package dependency of joda-time from presto-iceberg inline with JSR-310 suggestions to utilise java.time.* instead

```