### PR TITLE
Add schedulers in the Presto router

### DIFF
--- a/presto-router/etc/router-config.json
+++ b/presto-router/etc/router-config.json
@@ -9,5 +9,6 @@
     {
       "targetGroup": "all"
     }
-  ]
+  ],
+  "scheduler": "RANDOM_CHOICE"
 }

--- a/presto-router/pom.xml
+++ b/presto-router/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>node</artifactId>
         </dependency>

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
@@ -1,0 +1,39 @@
+package com.facebook.presto.router.scheduler;
+
+import com.facebook.airlift.log.Logger;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+public class RandomChoiceScheduler
+        implements Scheduler
+{
+    private List<URI> candidates;
+
+    private static final Random RANDOM = new Random();
+    private static final Logger log = Logger.get(RandomChoiceScheduler.class);
+
+    @Override
+    public Optional<URI> getDestination(String user)
+    {
+        try {
+            return Optional.ofNullable(candidates.get(RANDOM.nextInt(candidates.size())));
+        }
+        catch (Exception e) {
+            log.warn(e, "Error getting destination for user ", user);
+            return Optional.empty();
+        }
+    }
+
+    public void setCandidates(List<URI> candidates)
+    {
+        this.candidates = candidates;
+    }
+
+    public List<URI> getCandidates()
+    {
+        return candidates;
+    }
+}

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/Scheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/Scheduler.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.router.scheduler;
 
 import java.net.URI;
@@ -6,7 +19,14 @@ import java.util.Optional;
 
 public interface Scheduler
 {
+    /**
+     * Schedules a request from a user to a concrete candidate. Returns the
+     * URI of this candidate.
+     */
     Optional<URI> getDestination(String user);
 
+    /**
+     * Sets the candidates with the list of URIs for scheduling.
+     */
     void setCandidates(List<URI> candidates);
 }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/Scheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/Scheduler.java
@@ -1,0 +1,12 @@
+package com.facebook.presto.router.scheduler;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+public interface Scheduler
+{
+    Optional<URI> getDestination(String user);
+
+    void setCandidates(List<URI> candidates);
+}

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
@@ -1,0 +1,27 @@
+package com.facebook.presto.router.scheduler;
+
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class SchedulerFactory
+{
+    private final SchedulerType schedulerType;
+
+    public SchedulerFactory(SchedulerType schedulerType)
+    {
+        this.schedulerType = requireNonNull(schedulerType, "schedulerType is null");
+    }
+
+    public Scheduler create()
+    {
+        switch (schedulerType) {
+            case RANDOM_CHOICE:
+                return new RandomChoiceScheduler();
+            case USER_HASH:
+                return new UserHashScheduler();
+        }
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported router scheduler type " + schedulerType);
+    }
+}

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.presto.spi.PrestoException;

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerType.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.router.scheduler;
+
+public enum SchedulerType
+{
+    RANDOM_CHOICE,
+    USER_HASH,
+}

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
@@ -18,23 +18,21 @@ import com.facebook.airlift.log.Logger;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
-public class RandomChoiceScheduler
+public class UserHashScheduler
         implements Scheduler
 {
     private List<URI> candidates;
 
-    private static final Random RANDOM = new Random();
-    private static final Logger log = Logger.get(RandomChoiceScheduler.class);
+    private static final Logger log = Logger.get(UserHashScheduler.class);
 
     @Override
     public Optional<URI> getDestination(String user)
     {
         try {
-            return Optional.of(candidates.get(RANDOM.nextInt(candidates.size())));
+            return Optional.of(candidates.get(user.hashCode() % candidates.size()));
         }
-        catch (IllegalArgumentException e) {
+        catch (ArithmeticException e) {
             log.warn(e, "Error getting destination for user " + user);
             return Optional.empty();
         }

--- a/presto-router/src/main/java/com/facebook/presto/router/spec/RouterSpec.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/spec/RouterSpec.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.router.spec;
 
+import com.facebook.presto.router.scheduler.SchedulerType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -27,14 +28,17 @@ public class RouterSpec
 {
     private final List<GroupSpec> groups;
     private final List<SelectorRuleSpec> selectors;
+    private final SchedulerType schedulerType;
 
     @JsonCreator
     public RouterSpec(
             @JsonProperty("groups") List<GroupSpec> groups,
-            @JsonProperty("selectors") List<SelectorRuleSpec> selectors)
+            @JsonProperty("selectors") List<SelectorRuleSpec> selectors,
+            @JsonProperty("scheduler") SchedulerType schedulerType)
     {
         this.groups = ImmutableList.copyOf(requireNonNull(groups, "groups is null"));
-        this.selectors = ImmutableList.copyOf(requireNonNull(selectors, "groups is null"));
+        this.selectors = ImmutableList.copyOf(requireNonNull(selectors, "selectors is null"));
+        this.schedulerType = requireNonNull(schedulerType, "scheduler is null");
 
         // make sure no duplicate names in group definition
         checkArgument(groups.stream()
@@ -52,5 +56,11 @@ public class RouterSpec
     public List<SelectorRuleSpec> getSelectors()
     {
         return selectors;
+    }
+
+    @JsonProperty
+    public SchedulerType getSchedulerType()
+    {
+        return schedulerType;
     }
 }

--- a/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
@@ -1,13 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.router;
 
 import com.facebook.presto.router.scheduler.RandomChoiceScheduler;
 import com.facebook.presto.router.scheduler.Scheduler;
+import com.facebook.presto.router.scheduler.UserHashScheduler;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestScheduler
@@ -33,5 +48,21 @@ public class TestScheduler
 
         URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
         assertTrue(servers.contains(target));
+    }
+
+    @Test
+    public void testUserHashScheduler()
+            throws Exception
+    {
+        scheduler = new UserHashScheduler();
+        scheduler.setCandidates(servers);
+
+        URI target1 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        assertTrue(servers.contains(target1));
+
+        URI target2 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        assertTrue(servers.contains(target2));
+
+        assertEquals(target2, target1);
     }
 }

--- a/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
@@ -1,0 +1,37 @@
+package com.facebook.presto.router;
+
+import com.facebook.presto.router.scheduler.RandomChoiceScheduler;
+import com.facebook.presto.router.scheduler.Scheduler;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+
+import static org.testng.Assert.assertTrue;
+
+public class TestScheduler
+{
+    private final ArrayList<URI> servers = new ArrayList<>();
+    private Scheduler scheduler;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        servers.add(new URI("192.168.0.1"));
+        servers.add(new URI("192.168.0.2"));
+        servers.add(new URI("192.168.0.3"));
+    }
+
+    @Test
+    public void testRandomChoiceScheduler()
+            throws Exception
+    {
+        scheduler = new RandomChoiceScheduler();
+        scheduler.setCandidates(servers);
+
+        URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
+        assertTrue(servers.contains(target));
+    }
+}

--- a/presto-router/src/test/resources/simple-router-template.json
+++ b/presto-router/src/test/resources/simple-router-template.json
@@ -9,5 +9,6 @@
     {
       "targetGroup": "all"
     }
-  ]
+  ],
+  "scheduler": "RANDOM_CHOICE"
 }


### PR DESCRIPTION
This PR adds random choice and user hash schedulers in the Presto router. The scheduler type is loaded from the `scheduler` field in the config file.

Test plan - Added unit tests

```
== RELEASE NOTES ==

Router Changes
* Add a random choice scheduler in the Presto router
* Add a user hash scheduler in the Presto router
```

