### PR TITLE
[Bootcamp] T125823958 - Deprecate Joda library - Presto Clickhouse

### DIFF
--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -114,10 +114,6 @@
             <artifactId>bootstrap</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DateTimeUtil.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DateTimeUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clickhouse;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class DateTimeUtil
+{
+    private DateTimeUtil()
+    {
+    }
+
+    public static Date convertZonedDaysToDate(long zonedDays)
+    {
+        long epochMillis;
+
+        try {
+            ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.ofEpochDay(zonedDays), LocalTime.MIN, ZoneId.systemDefault());
+            epochMillis = SECONDS.toMillis(zonedDateTime.toEpochSecond());
+        }
+        catch (DateTimeException ex) {
+            epochMillis = zonedDays < 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+        }
+
+        return new Date(epochMillis);
+    }
+
+    public static long convertDateToZonedDays(Date date)
+    {
+        try {
+            ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(date.getTime()), ZoneId.systemDefault());
+            return zonedDateTime.toLocalDate().toEpochDay();
+        }
+        catch (DateTimeException ex) {
+            return date.getTime() < 0 ? LocalDate.MIN.toEpochDay() : LocalDate.MAX.toEpochDay();
+        }
+    }
+
+    public static long getMillisOfDay(Time time)
+    {
+        try {
+            LocalDateTime utcDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(time.getTime()), ZoneOffset.UTC);
+            return utcDateTime.get(ChronoField.MILLI_OF_DAY);
+        }
+        catch (DateTimeException ex) {
+            return time.getTime() < 0 ? LocalTime.MIN.get(ChronoField.MILLI_OF_DAY) : LocalTime.MAX.get(ChronoField.MILLI_OF_DAY);
+        }
+    }
+}

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/QueryBuilder.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/QueryBuilder.java
@@ -25,10 +25,8 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
-import org.joda.time.DateTimeZone;
 
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
@@ -50,6 +48,7 @@ import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIM
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.plugin.clickhouse.DateTimeUtil.convertZonedDaysToDate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -57,9 +56,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.Float.intBitsToFloat;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.stream.Collectors.joining;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class QueryBuilder
 {
@@ -179,8 +176,7 @@ public class QueryBuilder
                 statement.setBoolean(i + 1, (boolean) typeAndValue.getValue());
             }
             else if (typeAndValue.getType().equals(DATE)) {
-                long millis = DAYS.toMillis((long) typeAndValue.getValue());
-                statement.setDate(i + 1, new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis)));
+                statement.setDate(i + 1, convertZonedDaysToDate((long) typeAndValue.getValue()));
             }
             else if (typeAndValue.getType().equals(TIME)) {
                 statement.setTime(i + 1, new Time((long) typeAndValue.getValue()));


### PR DESCRIPTION
Test plan
- New `java.time` implementation are tested locally to see if they have same behavior with their Joda counterparts
- Testing with `presto-cli` locally with queries below after following [dev setup instructions](https://www.internalfb.com/intern/wiki/Presto_Internal/Presto_Development_Guide/Source/)
```
CREATE TABLE ds_customer WITH (format='dwrf', partitioned_by=array['ds']) AS SELECT *, '2021-07-11' as ds FROM customer LIMIT 1000;
INSERT INTO ds_customer SELECT *, '2021-07-12' as ds FROM customer LIMIT 1000;
SELECT custkey, name FROM ds_customer WHERE ds = '2021-07-12' LIMIT 100;
```
- Checking UI locally: http://127.0.0.1:8080/ui/

```
== RELEASE NOTES ==

General Changes
* Remove joda.time dependency at presco-clickhouse
* Replace joda.time codes with java.time counterparts
* Cover exception cases (DateTimeException) since joda.time does not throw exceptions
```
