### PR TITLE
Export spilling stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -699,6 +699,7 @@ public class ServerMainModule
         binder.bind(StandaloneSpillerFactory.class).to(TempStorageStandaloneSpillerFactory.class).in(Scopes.SINGLETON);
         binder.bind(PartitioningSpillerFactory.class).to(GenericPartitioningSpillerFactory.class).in(Scopes.SINGLETON);
         binder.bind(SpillerStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(SpillerStats.class).withGeneratedName();
         newExporter(binder).export(SpillerFactory.class).withGeneratedName();
         binder.bind(LocalSpillManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(NodeSpillConfig.class);


### PR DESCRIPTION
We currently define stats for spilled bytes, but we don't export it. As part of this PR, we are exporting spilling stats

Test plan - Verified by deploying to a test cluster

```
== NO RELEASE NOTE ==
```
