### PR TITLE
Enable circleci format/header check runs for presto-native-execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ workflows:
     jobs:
       - linux-build
       - linux-parquet-S3-build
+      - format-check
+      - header-check
 
 executors:
   build:
@@ -27,6 +29,9 @@ executors:
       MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
       MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+  check:
+    docker:
+      - image : prestocpp/velox-check:mikesh-20210609
 
 jobs:
   linux-build:
@@ -133,3 +138,33 @@ jobs:
           key: native-exe-linux-adapters-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
           paths:
             - .ccache/
+
+  format-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: Check formatting
+          command: |
+            cd presto-native-execution
+            make format-check
+
+  header-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: Check license headers
+          command: |
+            cd presto-native-execution
+            make header-check

--- a/presto-native-execution/license.header
+++ b/presto-native-execution/license.header
@@ -1,0 +1,11 @@
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.


### PR DESCRIPTION
Enable format and header checks for c++ code under presto-native-execution.

Test plan - (Please fill in how you tested your changes)
Make sure all circle ci runs are green.


```
== NO RELEASE NOTE ==
```
