### PR TITLE
Update Iceberg to 0.14.0

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.13.2</dep.iceberg.version>
+        <dep.iceberg.version>0.14.0</dep.iceberg.version>
         <dep.nessie.version>0.30.0</dep.nessie.version>
     </properties>
 
@@ -291,6 +291,14 @@
                     <groupId>org.roaringbitmap</groupId>
                     <artifactId>RoaringBitmap</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -330,6 +338,14 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -463,6 +479,8 @@
                             <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
                             <ignoredResourcePattern>about.html</ignoredResourcePattern>
                             <ignoredResourcePattern>org.apache.avro.data/Json.avsc</ignoredResourcePattern>
+                            <ignoredResourcePattern>iceberg-build.properties</ignoredResourcePattern>
+                            <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                         <ignoredClassPatterns>
                             <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -82,7 +82,6 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_PATH;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_METADATA_LOCATION;
-import static org.apache.iceberg.TableProperties.WRITE_NEW_DATA_LOCATION;
 import static org.apache.iceberg.Transactions.createTableTransaction;
 
 public class IcebergHiveMetadata
@@ -302,7 +301,7 @@ public class IcebergHiveMetadata
         // TODO: support path override in Iceberg table creation
         org.apache.iceberg.Table table = getHiveIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
         if (table.properties().containsKey(OBJECT_STORE_PATH) ||
-                table.properties().containsKey(WRITE_NEW_DATA_LOCATION) ||
+                table.properties().containsKey("write.folder-storage.path") || // Removed from Iceberg as of 0.14.0, but preserved for backward compatibility
                 table.properties().containsKey(WRITE_METADATA_LOCATION) ||
                 table.properties().containsKey(WRITE_DATA_LOCATION)) {
             throw new PrestoException(NOT_SUPPORTED, "Table " + handle.getSchemaTableName() + " contains Iceberg path override properties and cannot be dropped from Presto");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -76,7 +76,7 @@ public class TestNessieMultiBranching
     @Test
     public void testWithUnknownBranch()
     {
-        assertQueryFails(sessionOnRef("unknownRef"), "CREATE SCHEMA nessie_namespace", ".*Nessie ref 'unknownRef' does not exist. This ref must exist before creating a NessieCatalog.");
+        assertQueryFails(sessionOnRef("unknownRef"), "CREATE SCHEMA nessie_namespace", ".*Nessie ref 'unknownRef' does not exist.*");
     }
 
     @Test
@@ -88,15 +88,14 @@ public class TestNessieMultiBranching
         Session sessionOne = sessionOnRef(one.getName());
         Session sessionTwo = sessionOnRef(two.getName());
         assertQuerySucceeds(sessionOne, "CREATE SCHEMA namespace_one");
-        assertQuerySucceeds(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'");
+        assertThat(computeActual(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'").getMaterializedRows()).hasSize(1);
         assertQuerySucceeds(sessionTwo, "CREATE SCHEMA namespace_two");
-        assertQuerySucceeds(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'");
+        assertThat(computeActual(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'").getMaterializedRows()).hasSize(1);
 
-        // TODO: enable this after bump to Iceberg 0.14.0
         // namespace_two shouldn't be visible on branchOne
-        // assertQueryFails(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'", ".*Schema 'iceberg.namespace_two' does not exist");
+        assertThat(computeActual(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'").getMaterializedRows()).isEmpty();
         // namespace_one shouldn't be visible on branchTwo
-        // assertQueryFails(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'", ".*Schema 'iceberg.namespace_one' does not exist");
+        assertThat(computeActual(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'").getMaterializedRows()).isEmpty();
     }
 
     @Test
@@ -142,12 +141,11 @@ public class TestNessieMultiBranching
         String hash = logEntries.get(1).getCommitMeta().getHash();
         Session sessionTwoAtHash = sessionOnRef(two.getName(), hash);
 
-        // TODO: enable this after bump to Iceberg 0.14.0
         // at this hash there were only 3 rows
-        // assertThat(computeScalar(sessionTwoAtHash, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(3L);
-        // rows = computeActual(sessionTwoAtHash, "SELECT * FROM namespace_one.tbl");
-        // assertThat(rows.getMaterializedRows()).hasSize(3);
-        // assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionTwoAtHash, rows.getTypes()).row(1).row(2).row(5).build().getMaterializedRows());
+        assertThat(computeScalar(sessionTwoAtHash, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(3L);
+        rows = computeActual(sessionTwoAtHash, "SELECT * FROM namespace_one.tbl");
+        assertThat(rows.getMaterializedRows()).hasSize(3);
+        assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionTwoAtHash, rows.getTypes()).row(1).row(2).row(5).build().getMaterializedRows());
     }
 
     private Session sessionOnRef(String reference)

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -27,7 +27,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.28.0";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.30.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 


### PR DESCRIPTION
This PR updates the `presto-iceberg` connector to the latest Iceberg version 0.14.0 ([Release Notes](https://iceberg.apache.org/releases/#0140-release)).
Additionally, it updates a few places (tests around namespace/branch visibility and table properties) related to the `NessieCatalog` that have been fixed/improved in Iceberg 0.14.0.


```
== RELEASE NOTES ==

Iceberg Changes
* Update Iceberg to 0.14.0
```

