### PR TITLE
DiscoveryNodeManager to not return Coordinator/Resource Manager if not allowed by NodeStatusService

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -443,6 +443,18 @@ public final class DiscoveryNodeManager
         return getAllNodes().getShuttingDownNodes().size();
     }
 
+    @Managed
+    public int getActiveResourceManagerCount()
+    {
+        return getAllNodes().getActiveResourceManagers().size();
+    }
+
+    @Managed
+    public int getActiveCoordinatorCount()
+    {
+        return getAllNodes().getActiveCoordinators().size();
+    }
+
     @Override
     public Set<InternalNode> getNodes(NodeState state)
     {
@@ -591,8 +603,6 @@ public final class DiscoveryNodeManager
             return service ->
                     !nodeStatusService.isPresent()
                             || nodeStatusService.get().isAllowed(service.getLocation())
-                            || isCoordinator(service)
-                            || isResourceManager(service)
                             || isCatalogServer(service);
         }
 


### PR DESCRIPTION

In some mysterious conditions, we noticed coordinators are showing up in discovery service for disagg coordinator setup, this lead to a bad state where resource managed start failing getResourceGroupInfo call due to incosistency in the coordinator count. we won't to mitigate it by removing this checks which are no longer needed given NodeStatusService should filter
them.

Test plan - unit tests

```
== NO RELEASE NOTE ==
```
