### PR TITLE
Add null masking for parquet decryption

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaPageSourceProvider.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaPageSourceProvider.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.delta.DeltaErrorCode.DELTA_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.delta.DeltaErrorCode.DELTA_MISSING_DATA;
 import static com.facebook.presto.delta.DeltaErrorCode.DELTA_PARQUET_SCHEMA_MISMATCH;
 import static com.facebook.presto.delta.DeltaSessionProperties.getParquetMaxReadBlockSize;
+import static com.facebook.presto.delta.DeltaSessionProperties.getReadNullMaskedParquetEncryptedValue;
 import static com.facebook.presto.delta.DeltaSessionProperties.isParquetBatchReaderVerificationEnabled;
 import static com.facebook.presto.delta.DeltaSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.delta.DeltaTypeUtils.convertPartitionValue;
@@ -211,6 +212,7 @@ public class DeltaPageSourceProvider
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
         String user = session.getUser();
+        boolean readMaskedValue = getReadNullMaskedParquetEncryptedValue(session);
 
         ParquetDataSource dataSource = null;
         try {
@@ -219,7 +221,7 @@ public class DeltaPageSourceProvider
             final ParquetDataSource parquetDataSource = buildHdfsParquetDataSource(inputStream, path, stats);
             dataSource = parquetDataSource;
             Optional<InternalFileDecryptor> fileDecryptor = createDecryptor(configuration, path);
-            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(user, () -> MetadataReader.readFooter(parquetDataSource, fileSize, fileDecryptor).getParquetMetadata());
+            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(user, () -> MetadataReader.readFooter(parquetDataSource, fileSize, fileDecryptor, readMaskedValue).getParquetMetadata());
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSessionProperties.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSessionProperties.java
@@ -34,6 +34,7 @@ public final class DeltaSessionProperties
     private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
+    public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -68,6 +69,11 @@ public final class DeltaSessionProperties
                         PARQUET_DEREFERENCE_PUSHDOWN_ENABLED,
                         "Is dereference pushdown expression pushdown into Parquet reader enabled?",
                         deltaConfigConfig.isParquetDereferencePushdownEnabled(),
+                        false),
+                booleanProperty(
+                        READ_MASKED_VALUE_ENABLED,
+                        "Return null when access is denied for an encrypted parquet column",
+                        hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
                         false));
     }
 
@@ -99,5 +105,10 @@ public final class DeltaSessionProperties
     public static boolean isParquetDereferencePushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_DEREFERENCE_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
+    {
+        return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -220,6 +220,7 @@ public class HiveClientConfig
     private boolean fileSplittable = true;
     private Protocol thriftProtocol = Protocol.BINARY;
     private DataSize thriftBufferSize = new DataSize(128, BYTE);
+    private boolean isReadNullMaskedParquetEncryptedValueEnabled;
 
     private boolean copyOnFirstWriteConfigurationEnabled = true;
 
@@ -1884,5 +1885,18 @@ public class HiveClientConfig
     {
         this.partitionFilteringFromMetastoreEnabled = partitionFilteringFromMetastoreEnabled;
         return this;
+    }
+
+    @Config("hive.read-null-masked-parquet-encrypted-value-enabled")
+    @ConfigDescription("Read null masked value when access is denied for an encrypted parquet column")
+    public HiveClientConfig setReadNullMaskedParquetEncryptedValue(boolean isReadNullMaskedParquetEncryptedValueEnabled)
+    {
+        this.isReadNullMaskedParquetEncryptedValueEnabled = isReadNullMaskedParquetEncryptedValueEnabled;
+        return this;
+    }
+
+    public boolean getReadNullMaskedParquetEncryptedValue()
+    {
+        return this.isReadNullMaskedParquetEncryptedValueEnabled;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -143,7 +143,7 @@ public final class HiveSessionProperties
     public static final String FILE_SPLITTABLE = "file_splittable";
     private static final String HUDI_METADATA_ENABLED = "hudi_metadata_enabled";
     private static final String READ_TABLE_CONSTRAINTS = "read_table_constraints";
-
+    public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -689,6 +689,11 @@ public final class HiveSessionProperties
                         HUDI_METADATA_ENABLED,
                         "For Hudi tables prefer to fetch the list of file names, sizes and other metadata from the internal metadata table rather than storage",
                         hiveClientConfig.isHudiMetadataEnabled(),
+                        false),
+                booleanProperty(
+                        READ_MASKED_VALUE_ENABLED,
+                        "Return null when access is denied for an encrypted parquet column",
+                        hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
                         false));
     }
 
@@ -1208,5 +1213,10 @@ public final class HiveSessionProperties
     public static boolean isReadTableConstraints(ConnectorSession session)
     {
         return session.getProperty(READ_TABLE_CONSTRAINTS, Boolean.class);
+    }
+
+    public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
+    {
+        return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -169,6 +169,7 @@ public class TestHiveClientConfig
                 .setHudiMetadataEnabled(false)
                 .setThriftProtocol(Protocol.BINARY)
                 .setThriftBufferSize(new DataSize(128, BYTE))
+                .setReadNullMaskedParquetEncryptedValue(false)
                 .setCopyOnFirstWriteConfigurationEnabled(true)
                 .setPartitionFilteringFromMetastoreEnabled(true));
     }
@@ -298,6 +299,7 @@ public class TestHiveClientConfig
                 .put("hive.hudi-metadata-enabled", "true")
                 .put("hive.internal-communication.thrift-transport-protocol", "COMPACT")
                 .put("hive.internal-communication.thrift-transport-buffer-size", "256B")
+                .put("hive.read-null-masked-parquet-encrypted-value-enabled", "true")
                 .put("hive.copy-on-first-write-configuration-enabled", "false")
                 .put("hive.partition-filtering-from-metastore-enabled", "false")
                 .build();
@@ -423,6 +425,7 @@ public class TestHiveClientConfig
                 .setHudiMetadataEnabled(true)
                 .setThriftProtocol(Protocol.COMPACT)
                 .setThriftBufferSize(new DataSize(256, BYTE))
+                .setReadNullMaskedParquetEncryptedValue(true)
                 .setCopyOnFirstWriteConfigurationEnabled(false)
                 .setPartitionFilteringFromMetastoreEnabled(false);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -267,7 +267,7 @@ public class BenchmarkParquetPageSource
             PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
             pageProcessor = new ExpressionCompiler(metadata, pageFunctionCompiler).compilePageProcessor(testSession.getSqlFunctionProperties(), filterConjunction(), projections).get();
 
-            parquetMetadata = MetadataReader.readFooter(new FileParquetDataSource(parquetFile), parquetFile.length(), Optional.empty()).getParquetMetadata();
+            parquetMetadata = MetadataReader.readFooter(new FileParquetDataSource(parquetFile), parquetFile.length(), Optional.empty(), false).getParquetMetadata();
         }
 
         @TearDown

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
@@ -46,6 +46,7 @@ public class HudiSessionProperties
     private static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     private static final String STANDARD_SPLIT_WEIGHT_SIZE = "standard_split_weight_size";
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
+    public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
 
     @Inject
     public HudiSessionProperties(HiveClientConfig hiveClientConfig, HudiConfig hudiConfig)
@@ -101,7 +102,12 @@ public class HudiSessionProperties
                             }
                             return doubleValue;
                         },
-                        value -> value));
+                        value -> value),
+                booleanProperty(
+                        READ_MASKED_VALUE_ENABLED,
+                        "Return null when access is denied for an encrypted parquet column",
+                        hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -142,5 +148,10 @@ public class HudiSessionProperties
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)
     {
         return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
+    {
+        return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -112,6 +112,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxRead
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetMaxReadBlockSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getReadNullMaskedParquetEncryptedValue;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
@@ -182,6 +183,7 @@ public class IcebergPageSourceProvider
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
         String user = session.getUser();
+        boolean readMaskedValue = getReadNullMaskedParquetEncryptedValue(session);
 
         ParquetDataSource dataSource = null;
         try {
@@ -203,7 +205,7 @@ public class IcebergPageSourceProvider
             final ParquetDataSource parquetDataSource = buildHdfsParquetDataSource(inputStream, path, fileFormatDataSourceStats);
             dataSource = parquetDataSource;
             Optional<InternalFileDecryptor> fileDecryptor = createDecryptor(configuration, path);
-            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(user, () -> MetadataReader.readFooter(parquetDataSource, fileSize, fileDecryptor).getParquetMetadata());
+            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(user, () -> MetadataReader.readFooter(parquetDataSource, fileSize, fileDecryptor, readMaskedValue).getParquetMetadata());
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -76,6 +76,7 @@ public final class IcebergSessionProperties
     private static final String NODE_SELECTION_STRATEGY = "node_selection_strategy";
     private static final String NESSIE_REFERENCE_NAME = "nessie_reference_name";
     private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
+    public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -261,6 +262,11 @@ public final class IcebergSessionProperties
                         NESSIE_REFERENCE_HASH,
                         "Nessie reference hash to use",
                         null,
+                        false),
+                booleanProperty(
+                        READ_MASKED_VALUE_ENABLED,
+                        "Return null when access is denied for an encrypted parquet column",
+                        hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
                         false));
     }
 
@@ -422,5 +428,10 @@ public final class IcebergSessionProperties
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)
     {
         return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
+    {
+        return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
@@ -45,14 +45,15 @@ public class CachingParquetMetadataSource
             long fileSize,
             boolean cacheable,
             long modificationTime,
-            Optional<InternalFileDecryptor> fileDecryptor)
+            Optional<InternalFileDecryptor> fileDecryptor,
+            boolean readMaskedValue)
             throws IOException
     {
         try {
             if (cacheable) {
                 ParquetFileMetadata fileMetadataCache = cache.get(
                         parquetDataSource.getId(),
-                        () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor));
+                        () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor, readMaskedValue));
                 if (fileMetadataCache.getModificationTime() == modificationTime) {
                     return fileMetadataCache;
                 }
@@ -60,7 +61,7 @@ public class CachingParquetMetadataSource
                     cache.invalidate(parquetDataSource.getId());
                 }
             }
-            return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor);
+            return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor, readMaskedValue);
         }
         catch (ExecutionException | UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), IOException.class);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
@@ -26,6 +26,7 @@ public interface ParquetMetadataSource
             long fileSize,
             boolean cacheable,
             long modificationTime,
-            Optional<InternalFileDecryptor> fileDecryptor)
+            Optional<InternalFileDecryptor> fileDecryptor,
+            boolean readMaskedValue)
             throws IOException;
 }

--- a/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnException.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnException.java
@@ -21,9 +21,17 @@ public class HiddenColumnException
         extends ParquetRuntimeException
 {
     private static final long serialVersionUID = 1L;
+    private final String column;
 
     public HiddenColumnException(String[] columnPath, String filePath)
     {
         super(String.format("User does not have access to the encryption key for encrypted column = %s for file: %s", Arrays.toString(columnPath), filePath));
+        // We have to duplicate the toString() call because super() won't allow anything else before it
+        column = Arrays.toString(columnPath);
+    }
+
+    public String getColumn()
+    {
+        return column;
     }
 }

--- a/presto-parquet/src/main/java/org/apache/parquet/crypto/ParquetCryptoMetaDataUtils.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/crypto/ParquetCryptoMetaDataUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.crypto;
+
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public final class ParquetCryptoMetaDataUtils
+{
+    private ParquetCryptoMetaDataUtils()
+    {
+    }
+
+    public static MessageType removeColumnsInSchema(MessageType schema, Set<ColumnPath> paths)
+    {
+        List<String> currentPath = new ArrayList<>();
+        List<Type> prunedFields = removeColumnsInFields(schema.getFields(), currentPath, paths);
+        return new MessageType(schema.getName(), prunedFields);
+    }
+
+    private static List<Type> removeColumnsInFields(List<Type> fields, List<String> currentPath, Set<ColumnPath> paths)
+    {
+        List<Type> prunedFields = new ArrayList<>();
+        for (Type childField : fields) {
+            Type prunedChildField = removeColumnsInField(childField, currentPath, paths);
+            if (prunedChildField != null) {
+                prunedFields.add(prunedChildField);
+            }
+        }
+        return prunedFields;
+    }
+
+    private static Type removeColumnsInField(Type field, List<String> currentPath, Set<ColumnPath> paths)
+    {
+        String fieldName = field.getName();
+        currentPath.add(fieldName);
+        ColumnPath path = ColumnPath.get(currentPath.toArray(new String[0]));
+        Type prunedField = null;
+        if (!paths.contains(path)) {
+            if (field.isPrimitive()) {
+                prunedField = field;
+            }
+            else {
+                List<Type> childFields = ((GroupType) field).getFields();
+                List<Type> prunedFields = removeColumnsInFields(childFields, currentPath, paths);
+                if (prunedFields.size() > 0) {
+                    prunedField = ((GroupType) field).withNewFields(prunedFields);
+                }
+            }
+        }
+
+        checkState(currentPath.size() > 0,
+                "The length of currentPath is empty but trying to remove element in it");
+        checkState(currentPath.get(currentPath.size() - 1) != null,
+                "The last element of currentPath is null");
+        checkState(currentPath.get(currentPath.size() - 1).equals(fieldName),
+                "The last element of currentPath " + currentPath.get(currentPath.size() - 1) + " not equal to " + fieldName);
+
+        currentPath.remove(currentPath.size() - 1);
+
+        return prunedField;
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
@@ -273,7 +273,7 @@ public class BenchmarkParquetReader
                 throws IOException
         {
             FileParquetDataSource dataSource = new FileParquetDataSource(file);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, file.length(), Optional.empty()).getParquetMetadata();
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, file.length(), Optional.empty(), false).getParquetMetadata();
             MessageType schema = parquetMetadata.getFileMetaData().getSchema();
             MessageColumnIO messageColumnIO = getColumnIO(schema, schema);
 

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFileBuilder.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFileBuilder.java
@@ -52,6 +52,7 @@ public class EncryptionTestFileBuilder
     private String[] encryptColumns = {};
     private ParquetCipher cipher = ParquetCipher.AES_GCM_V1;
     private Boolean footerEncryption = false;
+    private Boolean dataMaskingTest = false;
 
     public EncryptionTestFileBuilder(Configuration conf, MessageType schema)
     {
@@ -108,12 +109,18 @@ public class EncryptionTestFileBuilder
         return this;
     }
 
+    public EncryptionTestFileBuilder withDataMaskingTest()
+    {
+        this.dataMaskingTest = true;
+        return this;
+    }
+
     public EncryptionTestFile build()
             throws IOException
     {
         String fileName = createTempFile("test");
         SimpleGroup[] fileContent = createFileContent(schema);
-        FileEncryptionProperties encryptionProperties = EncryptDecryptUtil.getFileEncryptionProperties(Arrays.asList(encryptColumns), cipher, footerEncryption);
+        FileEncryptionProperties encryptionProperties = EncryptDecryptUtil.getFileEncryptionProperties(Arrays.asList(encryptColumns), cipher, footerEncryption, dataMaskingTest);
         ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(fileName))
                 .withConf(conf)
                 .withWriterVersion(writerVersion)

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestParquetCryptoMetaDataUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestParquetCryptoMetaDataUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.parquet.crypto.ParquetCryptoMetaDataUtils.removeColumnsInSchema;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestParquetCryptoMetaDataUtils
+{
+    @Test
+    public void testRemoveColumnsInSchema()
+    {
+        MessageType schema = new MessageType("schema",
+                new PrimitiveType(REQUIRED, INT64, "DocId"),
+                new PrimitiveType(REQUIRED, BINARY, "Name"),
+                new PrimitiveType(REQUIRED, BINARY, "Gender"),
+                new GroupType(OPTIONAL, "Links",
+                        new PrimitiveType(REPEATED, INT64, "Backward"),
+                        new PrimitiveType(REPEATED, INT64, "Forward")));
+        Set<ColumnPath> paths = new HashSet<>();
+        paths.add(ColumnPath.fromDotString("Name"));
+
+        MessageType newSchema = removeColumnsInSchema(schema, paths);
+
+        String[] docId = {"DocId"};
+        assertTrue(newSchema.containsPath(docId));
+        String[] gender = {"Gender"};
+        assertTrue(newSchema.containsPath(gender));
+        String[] linkForward = {"Links", "Forward"};
+        assertTrue(newSchema.containsPath(linkForward));
+        String[] name = {"Name"};
+        assertFalse(newSchema.containsPath(name));
+    }
+
+    @Test
+    public void testRemoveNestedColumnsInSchema()
+    {
+        MessageType schema = new MessageType("schema",
+                new PrimitiveType(REQUIRED, INT64, "DocId"),
+                new PrimitiveType(REQUIRED, BINARY, "Name"),
+                new PrimitiveType(REQUIRED, BINARY, "Gender"),
+                new GroupType(OPTIONAL, "Links",
+                        new PrimitiveType(REPEATED, INT64, "Backward"),
+                        new PrimitiveType(REPEATED, INT64, "Forward")));
+        Set<ColumnPath> paths = new HashSet<>();
+        paths.add(ColumnPath.fromDotString("Links.Backward"));
+
+        MessageType newSchema = removeColumnsInSchema(schema, paths);
+
+        String[] docId = {"DocId"};
+        assertTrue(newSchema.containsPath(docId));
+        String[] gender = {"Gender"};
+        assertTrue(newSchema.containsPath(gender));
+        String[] name = {"Name"};
+        assertTrue(newSchema.containsPath(name));
+        String[] linkForward = {"Links", "Forward"};
+        assertTrue(newSchema.containsPath(linkForward));
+        String[] linkBackward = {"Links", "Backward"};
+        assertFalse(newSchema.containsPath(linkBackward));
+    }
+}


### PR DESCRIPTION
Summary: Without this change, when the user queries an encrypted parquet file but doesn't have permission for the encryption key, the query will throw an 'access denied' exception. This change is to return a masked value (NULL in the current implementation) for the no-permission-encrypted columns if the added flag is enabled (by default it is disabled). This feature is useful because in some use cases, the user is not allowed to be granted permission for reading some encrypted sensitive column. Another use case is the user doesn't really need the real value of those encrypted columns, but it is to cumbersome forcing user to explicitly write each column they want. Instead, the user just writes 'select * from xxx'. 


Test plan: 

This feature was tested in the Uber environment and then rolled out to production for 2+ years.


```
== RELEASE NOTES ==

General Changes
* Add null masking for the Parquet decryption feature. When this feature is enabled and the user is denied access encrypted column, the columns will be removed in the requested schema sent to Parquet. Then it is filled out with 'NULL'  when the result is returned. 

Hive Changes
* A new session property - read_null_masked_parquet_encrypted_value_enabled is introduced. When this session property is enabled, the Parquet null masking feature is enabled. By default, it is disabled.  
```
