### PR TITLE
Support new functions in materialized view optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -25,10 +25,14 @@ import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.planner.LiteralEncoder;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
@@ -36,6 +40,7 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,6 +52,10 @@ import java.util.Set;
 import java.util.Stack;
 
 import static com.facebook.presto.common.predicate.TupleDomain.extractFixedValues;
+import static com.facebook.presto.common.type.StandardTypes.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.sql.tree.ArithmeticBinaryExpression.Operator.DIVIDE;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.AND;
@@ -60,7 +69,20 @@ public final class MaterializedViewUtils
     public static final QualifiedName MAX = QualifiedName.of("MAX");
     public static final QualifiedName SUM = QualifiedName.of("SUM");
     public static final QualifiedName COUNT = QualifiedName.of("COUNT");
-    public static final Set<QualifiedName> SUPPORTED_FUNCTION_CALLS = ImmutableSet.of(MIN, MAX, SUM, COUNT);
+    public static final QualifiedName AVG = QualifiedName.of("AVG");
+    public static final QualifiedName CARDINALITY = QualifiedName.of("CARDINALITY");
+    public static final QualifiedName MERGE = QualifiedName.of("MERGE");
+    public static final QualifiedName APPROX_DISTINCT = QualifiedName.of("APPROX_DISTINCT");
+    public static final QualifiedName APPROX_SET = QualifiedName.of("APPROX_SET");
+
+    public static final Set<QualifiedName> ASSOCIATIVE_REWRITE_FUNCTIONS = ImmutableSet.of(MIN, MAX, SUM, COUNT);
+
+    // TODO: Add count to NonAssociativeFunctionHandler, add more functions
+    public static final Map<QualifiedName, MaterializedViewUtils.NonAssociativeFunctionHandler> NON_ASSOCIATIVE_REWRITE_FUNCTIONS = ImmutableMap.of(
+            AVG, new MaterializedViewUtils.AvgRewriteHandler(),
+            APPROX_DISTINCT, new MaterializedViewUtils.ApproxDistinctRewriteHandler());
+
+    public static final Set<QualifiedName> SUPPORTED_FUNCTION_CALLS = Sets.union(ASSOCIATIVE_REWRITE_FUNCTIONS, NON_ASSOCIATIVE_REWRITE_FUNCTIONS.keySet());
 
     private MaterializedViewUtils() {}
 
@@ -174,5 +196,122 @@ public final class MaterializedViewUtils
                         : Optional.empty());
 
         return predicateFromBaseQuery.getTupleDomain();
+    }
+
+    /**
+     * Rewrites the provided argument if it is non-associative (e.g. it cannot be handled by simply re-applying function to derived columns)
+     */
+    public static Expression rewriteNonAssociativeFunction(FunctionCall functionCall, Map<Expression, Identifier> baseToViewColumnMap)
+    {
+        if (!validateNonAssociativeFunctionCallFields(functionCall)) {
+            throw new SemanticException(NOT_SUPPORTED, functionCall, "Nonassociative function call rewrite not supported function calls with fields other than name and arguments");
+        }
+
+        QualifiedName functionName = functionCall.getName();
+        List<Expression> expressions = functionCall.getArguments();
+
+        if (!validateNonAssociativeFunctionCallArguments(functionName, expressions)) {
+            throw new SemanticException(NOT_SUPPORTED, functionCall, "Nonassociative function call rewrite not supported without single identifier as argument");
+        }
+
+        Identifier baseTableColumn = (Identifier) expressions.get(0);
+
+        return NON_ASSOCIATIVE_REWRITE_FUNCTIONS.get(functionName).rewrite(baseTableColumn, baseToViewColumnMap);
+    }
+
+    public static boolean validateNonAssociativeFunctionRewrite(FunctionCall functionCall, Map<Expression, Identifier> baseToViewColumnMap)
+    {
+        QualifiedName functionName = functionCall.getName();
+        List<Expression> expressions = functionCall.getArguments();
+
+        return validateNonAssociativeFunctionCallFields(functionCall)
+                && validateNonAssociativeFunctionCallArguments(functionName, expressions)
+                && NON_ASSOCIATIVE_REWRITE_FUNCTIONS.get(functionName).validate((Identifier) functionCall.getArguments().get(0), baseToViewColumnMap);
+    }
+
+    private static boolean validateNonAssociativeFunctionCallFields(FunctionCall functionCall)
+    {
+        return !(functionCall.isDistinct() || functionCall.getWindow().isPresent() || functionCall.getOrderBy().isPresent()
+                || functionCall.isIgnoreNulls() || functionCall.getFilter().isPresent());
+    }
+
+    private static boolean validateNonAssociativeFunctionCallArguments(QualifiedName functionName, List<Expression> expressions)
+    {
+        return NON_ASSOCIATIVE_REWRITE_FUNCTIONS.containsKey(functionName) && expressions.size() == 1 && expressions.get(0) instanceof Identifier;
+    }
+
+    /**
+     * Handles rewrites for functions which are non-associative, e.g. cannot be simply re-written like sum(sum_result).
+     * Uses base table column name as well as a map of base to view columns to return a rewritten Expression, or
+     * Optional.empty() if rewrite is not possible.
+     */
+    private interface NonAssociativeFunctionHandler
+    {
+        Expression rewrite(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap);
+
+        boolean validate(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap);
+    }
+
+    private static class AvgRewriteHandler
+            implements NonAssociativeFunctionHandler
+    {
+        @Override
+        public Expression rewrite(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap)
+        {
+            Optional<Identifier> sumDerived = getDerivedFromFunctionCall(SUM, baseTableColumn, baseToViewColumnMap);
+            Optional<Identifier> countDerived = getDerivedFromFunctionCall(COUNT, baseTableColumn, baseToViewColumnMap);
+
+            if (!sumDerived.isPresent() || !countDerived.isPresent()) {
+                throw new SemanticException(NOT_SUPPORTED, baseTableColumn, "Avg rewrite not supported without COUNT and SUM");
+            }
+
+            // Rewrite avg as sum(sum_result) / sum(count_result)
+            FunctionCall sum = new FunctionCall(SUM, ImmutableList.of(sumDerived.get()));
+            FunctionCall count = new FunctionCall(SUM, ImmutableList.of(countDerived.get()));
+            return new ArithmeticBinaryExpression(DIVIDE, sum, count);
+        }
+
+        @Override
+        public boolean validate(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap)
+        {
+            Optional<Identifier> sumDerived = getDerivedFromFunctionCall(SUM, baseTableColumn, baseToViewColumnMap);
+            Optional<Identifier> countDerived = getDerivedFromFunctionCall(COUNT, baseTableColumn, baseToViewColumnMap);
+
+            return sumDerived.isPresent() && countDerived.isPresent();
+        }
+
+        /**
+         * Gets the column from the materialized view derived from provided function name and argument
+         */
+        private Optional<Identifier> getDerivedFromFunctionCall(QualifiedName functionName, Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap)
+        {
+            return Optional.ofNullable(baseToViewColumnMap.get(new FunctionCall(functionName, ImmutableList.of(baseTableColumn))));
+        }
+    }
+
+    private static class ApproxDistinctRewriteHandler
+            implements NonAssociativeFunctionHandler
+    {
+        @Override
+        public Expression rewrite(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap)
+        {
+            Cast cast = new Cast(new FunctionCall(APPROX_SET, ImmutableList.of(baseTableColumn)), VARBINARY);
+
+            if (!baseToViewColumnMap.containsKey(cast)) {
+                throw new SemanticException(NOT_SUPPORTED, baseTableColumn, "APPROX_DISTINCT rewrite not supported without approx set in base to view column map");
+            }
+
+            Identifier identifier = baseToViewColumnMap.get(cast);
+            Cast varbinaryToHll = new Cast(identifier, HYPER_LOG_LOG);
+
+            FunctionCall mergedHll = new FunctionCall(MERGE, ImmutableList.of(varbinaryToHll));
+            return new FunctionCall(CARDINALITY, ImmutableList.of(mergedHll));
+        }
+
+        @Override
+        public boolean validate(Identifier baseTableColumn, Map<Expression, Identifier> baseToViewColumnMap)
+        {
+            return baseToViewColumnMap.containsKey(new Cast(new FunctionCall(APPROX_SET, ImmutableList.of(baseTableColumn)), VARBINARY));
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -337,10 +337,11 @@ public class TestMaterializedViewQueryOptimizer
         expectedRewrittenSql = format("SELECT SUM(a), SUM(bc), d, e FROM %s GROUP BY d, e", VIEW_1);
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
-        baseQuerySql = format("SELECT d, e FROM %s", BASE_TABLE_1);
-        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
-
         baseQuerySql = format("SELECT SUM(d) FROM %s GROUP BY e", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(d) FROM %s GROUP BY e", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT d, e FROM %s", BASE_TABLE_1);
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
         baseQuerySql = format("SELECT SUM(a) FROM %s WHERE x > 10", BASE_TABLE_1);
@@ -388,13 +389,27 @@ public class TestMaterializedViewQueryOptimizer
     @Test
     public void testWithUnsupportedFunction()
     {
+        String originalViewSql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testAssociativeRewriteOfNonAssociativeFunctions()
+    {
         String originalViewSql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
         String baseQuerySql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
 
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
-        originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
-        baseQuerySql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
+        originalViewSql = format("SELECT APPROX_DISTINCT(a) FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT APPROX_DISTINCT(a) FROM %s", BASE_TABLE_1);
 
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
@@ -1138,6 +1153,82 @@ public class TestMaterializedViewQueryOptimizer
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, ImmutableMap.of(
                 BASE_TABLE_1, ImmutableMap.of(VIEW_1, viewSql1),
                 BASE_TABLE_2, ImmutableMap.of(VIEW_2, viewSql2)));
+    }
+
+    @Test
+    public void testAvgRewriteWithSumAndCount()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS mv_sum, COUNT(a) AS mv_count FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT AVG(a) AS base_avg FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT (SUM(mv_sum) / SUM(mv_count)) AS base_avg FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT SUM(a, b) AS mv_sum, COUNT(a, b) AS mv_count FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT AVG(a, b) AS base_avg FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT SUM(a+b) AS mv_sum, COUNT(a+b) AS mv_count FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT AVG(a+b) AS base_avg FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testAvgRewriteWithSumAndCountC()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS mv_sum, COUNT(a) AS mv_count FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT AVG(a) AS base_avg FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT (SUM(mv_sum) / SUM(mv_count)) AS base_avg FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testAvgRewriteWithSumAndCountGroupByJoin()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS mv_sum, COUNT(a) AS mv_count, b, c FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT AVG(a), b FROM %s GROUP BY b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT (SUM(mv_sum) / SUM(mv_count)), b FROM %s GROUP BY b", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT SUM(a) AS mv_sum, COUNT(a) AS mv_count, b FROM %s GROUP BY b", BASE_TABLE_1);
+
+        baseQuerySql = format("SELECT filtered_avg, b, a_count FROM " +
+                "(SELECT base_avg as filtered_avg, b FROM (SELECT AVG(a) AS base_avg, b FROM %s GROUP BY b ORDER BY b) WHERE base_avg < 5.25) s1 " +
+                "INNER JOIN " +
+                "(SELECT COUNT(a) AS a_count, b FROM %s GROUP BY b) s2 " +
+                "ON s1.b = s2.b", BASE_TABLE_1, BASE_TABLE_1);
+
+        expectedRewrittenSql = format("SELECT filtered_avg, b, a_count FROM " +
+                "(SELECT base_avg as filtered_avg, b FROM (SELECT (SUM(mv_sum) / SUM(mv_count)) AS base_avg, b FROM %s GROUP BY b ORDER BY b) WHERE base_avg < 5.25) s1 " +
+                "INNER JOIN " +
+                "(SELECT SUM(mv_count) AS a_count, b FROM %s GROUP BY b) s2 " +
+                "ON s1.b = s2.b", VIEW_1, VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testApproxDistinctRewrite()
+    {
+        String originalViewSql = format("SELECT cast(APPROX_SET(a) as varbinary) AS mv_approx_set FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT APPROX_DISTINCT(a) AS base_approx_distinct FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT (CARDINALITY(MERGE(CAST(mv_approx_set AS hyperloglog)))) AS base_approx_distinct FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testApproxDistinctRewriteGroupBy()
+    {
+        String originalViewSql = format("SELECT cast(APPROX_SET(a) as varbinary) AS mv_approx_set, b, c FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT APPROX_DISTINCT(a) AS base_approx_distinct, b FROM %s GROUP BY b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT (CARDINALITY(MERGE(CAST(mv_approx_set AS hyperloglog)))) AS base_approx_distinct, b FROM %s GROUP BY b", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
@@ -37,8 +37,8 @@ public class TestMaterializedViewRewriteQueryShapeValidator
     public void unsupportedFunction()
     {
         assertFails(
-                "SELECT AVG(x) AS avg_x, y FROM tbl GROUP BY y",
-                "Query shape invalid: avg function is not supported for materialized view optimizations");
+                "SELECT GEOMETRIC_MEAN(x) AS geomean_x, y FROM tbl GROUP BY y",
+                "Query shape invalid: geometric_mean function is not supported for materialized view optimizations");
     }
 
     @Test


### PR DESCRIPTION
Adds support for `avg` and `approx_distinct` in materialized view query rewrite, and creates a framework for supporting further functions which cannot be rewritten by simply applying the same function over derived columns in view.

Test plan - Unit, manual, and integration testing for new functions

```
== NO RELEASE NOTE ==
```
