### PR TITLE
Show Estimate Stats on Graphviz

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -235,12 +235,12 @@ public class TextRenderer
         return output.toString();
     }
 
-    private static String formatEstimateAsDataSize(double value)
+    public static String formatEstimateAsDataSize(double value)
     {
         return isNaN(value) ? "?" : succinctBytes((long) value).toString();
     }
 
-    private static String formatAsLong(double value)
+    public static String formatAsLong(double value)
     {
         if (isFinite(value)) {
             return format(Locale.US, "%d", Math.round(value));
@@ -249,7 +249,7 @@ public class TextRenderer
         return "?";
     }
 
-    static String formatDouble(double value)
+    public static String formatDouble(double value)
     {
         if (isFinite(value)) {
             return format(Locale.US, "%.2f", value);

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -64,7 +64,8 @@ public class TestGraphvizPrinter
             TupleDomain.all(),
             TupleDomain.all());
     private static final String TEST_TABLE_SCAN_NODE_INNER_OUTPUT = format(
-            "label=\"{TableScan[TableHandle \\{connectorId='%s', connectorHandle='%s', layout='Optional.empty'\\}]}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue",
+            "label=\"{TableScan | [TableHandle \\{connectorId='%s', connectorHandle='%s', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                    "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue",
             TEST_CONNECTOR_ID,
             TEST_CONNECTOR_TABLE_HANDLE);
 
@@ -146,9 +147,12 @@ public class TestGraphvizPrinter
         String expected = "digraph logical_plan {\n" +
                 "subgraph cluster_0 {\n" +
                 "label = \"SOURCE\"\n" +
-                "plannode_1[label=\"{CrossJoin[REPLICATED]}\", style=\"rounded, filled\", shape=record, fillcolor=orange];\n" + //no Criteria + no filter + INNER Join => CrossJoin
-                "plannode_2[label=\"{TableScan[TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
-                "plannode_3[label=\"{Values}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "plannode_1[label=\"{CrossJoin[REPLICATED]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "}\", style=\"rounded, filled\", shape=record, fillcolor=orange];\n" +
+                "plannode_2[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "plannode_3[label=\"{Values|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
                 "}\n" +
                 "plannode_1 -> plannode_3 [label = \"Build\"];\n" + //valuesNode should be the Build side
                 "plannode_1 -> plannode_2 [label = \"Probe\"];\n" + //TEST_TABLE_SCAN_NODE should be the Probe side


### PR DESCRIPTION
Improve graphviz output with estimate stats.

Here is a sample output from tpch-q3
Before:
![q3_before](https://user-images.githubusercontent.com/32091981/181064727-69a7e73b-4623-41b3-b3fe-513c243b2152.png)


After:
![q3_after](https://user-images.githubusercontent.com/32091981/180713064-2c4b42c8-284f-4921-a35d-6528dc75c2cd.png)

```
== RELEASE NOTES ==

General Changes
* Improve graphviz output with estimate stats.
```
