### PR TITLE
Fixing cross-join query pushdown error for Pinot connector

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -202,6 +202,7 @@ public class PinotQueryGeneratorContext
         if (!useSqlSyntax) {
             checkSupported(!hasGroupBy(), "Pinot doesn't yet support new selections on top of the grouped by data");
         }
+        checkSupported(!newOutputs.isEmpty(), "Missing output expression in Pinot query context");
         return new PinotQueryGeneratorContext(
                 newSelections,
                 newOutputs,
@@ -428,6 +429,8 @@ public class PinotQueryGeneratorContext
         String groupByExpressions = groupByColumns.stream()
                 .map(x -> selections.get(x).getDefinition())
                 .collect(Collectors.joining(", "));
+
+        checkSupported(!outputs.isEmpty(), "Unable to generate Pinot query without output expression");
         String selectExpressions = outputs.stream()
                 .filter(o -> !groupByColumns.contains(o))
                 .map(o -> updateSelection(selections.get(o).getDefinition(), session))


### PR DESCRIPTION
Fix the issue that Pinot push down empty query during cross join queries. Ref: https://github.com/prestodb/presto/issues/17998

In a certain cross-join scenario, the right side PlanNode has a ProjectNode with empty outputVariables. It causes Pinot generates a pushdown query with an empty selection expression.

Fix this issue by throwing exceptions in PinotQueryPlanVistor.visitProject(...) method.

Test plan - (Please fill in how you tested your changes)
Tested locally with pinot quickstart:

Before:
```
presto:default> select teamid from baseballstats where teamid = (select teamid from baseballStats where G_old = 11 and yearID=2004 and teamID='SFN' limit 10);

Query 20220726_040246_00002_7iw58, FAILED, 1 node
Splits: 52 total, 0 done (0.00%)
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20220726_040246_00002_7iw58 failed: Query SELECT  FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10 encountered exception {"errorCode":150,"message":"SQLParsingError:\norg.apache.pinot.sql.parsers.SqlCompilationException: Caught exception while parsing query: SELECT  FROM baseballStats WHERE (((\"G_old\" = 11) AND (\"yearID\" = 2004)) AND (\"teamID\" = 'SFN')) LIMIT 10\n\tat org.apache.pinot.sql.parsers.CalciteSqlParser.compileToSqlNodeAndOptions(CalciteSqlParser.java:133)\n\tat org.apache.pinot.broker.api.resources.PinotClientRequest.executeSqlQuery(PinotClientRequest.java:153)\n\tat org.apache.pinot.broker.api.resources.PinotClientRequest.processSqlQueryPost(PinotClientRequest.java:139)\n\tat jdk.internal.reflect.GeneratedMethodAccessor138.invoke(Unknown Source)\n...\nCaused by: org.apache.pinot.sql.parsers.parser.ParseException: Encountered \"\" at line 1, column 9.\n\tat org.apache.pinot.sql.parsers.parser.SqlParserImpl.generateParseException(SqlParserImpl.java:38531)\n\tat org.apache.pinot.sql.parsers.parser.SqlParserImpl.jj_consume_token(SqlParserImpl.java:38328)\n\tat org.apache.pinot.sql.parsers.parser.SqlParserImpl.SelectExpression(SqlParserImpl.java:1858)\n\tat org.apache.pinot.sql.parsers.parser.SqlParserImpl.SelectItem(SqlParserImpl.java:1818)"} with pinot query "SELECT  FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10"
```
Query plan: 
```
presto:default explain select teamid from baseballstats where teamid = (select teamid from baseballStats where G_old = 11 and yearID=2004 and teamID='SFN' limit 10);
                                                                                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[teamid] = [teamid:varchar]                                                                                                                                                                                                       
         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}                                                                                                                                                                         
     - RemoteStreamingExchange[GATHER] = [teamid:varchar]                                                                                                                                                                                  
             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}                                                                                                                                                                     
         - CrossJoin = [teamid:varchar]                                                                                                                                                                                                    
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}                                                                                                                                                              
                 Distribution: REPLICATED                                                                                                                                                                                                   
             - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID" FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE ("teamID" = 'SFN')__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[0], groupByClauses=0, haveFilter=true, isQueryShort=false}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID" FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__WHERE ("teamID" = 'SFN')__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[0], groupByClauses=0, haveFilter=true, isQueryShort=false}]}]'}] => [teamid:varchar]
                     Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}                                                                                                                                                          
                     teamid := PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR} (1:28)                                                                                                                                
             - LocalExchange[SINGLE] () = []                                                                                                                                                                                               
                     Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                      
                 - RemoteStreamingExchange[REPLICATE] = []                                                                                                                                                                                 
                         Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                  
                     - EnforceSingleRow = []                                                                                                                                                                                               
                             Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                              
                         - LocalExchange[SINGLE] () = []                                                                                                                                                                                   
                                 Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                          
                             - RemoteStreamingExchange[GATHER] = []                                                                                                                                                                        
                                     Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                      
                                 - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT  FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0,haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT  FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=true}]}]'}] => []
                                         Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                  
                                                                                                                                                                                                                                            
(1 row)
```
After the change, generated query plan is:
```
presto:default> select teamid from baseballstats where teamid = (select teamid from baseballStats where G_old = 11 and yearID=2004 and teamID='SFN' limit 10);
 teamid
--------
 SFN
 .......
 SFN

Query 20220726_040939_00002_d7pvh, FINISHED, 1 node
Splits: 52 total, 52 done (100.00%)
0:01 [2.21K rows, 6.46KB] [2.23K rows/s, 6.54KB/s]

```

The query plan:

```
presto:default> explain select teamid from baseballstats where teamid = (select teamid from baseballStats where G_old = 11 and yearID=2004 and teamID='SFN' limit 10);
                                                                                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[teamid] => [teamid:varchar]                                                                                                                                                                                                       
         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}                                                                                                                                                                         
     - RemoteStreamingExchange[GATHER] => [teamid:varchar]                                                                                                                                                                                  
             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}                                                                                                                                                                     
         - CrossJoin => [teamid:varchar]                                                                                                                                                                                                    
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}                                                                                                                                                              
                 Distribution: REPLICATED                                                                                                                                                                                                   
             - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID" FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE ("teamID" = 'SFN')__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[0], groupByClauses=0, haveFilter=true, isQueryShort=false}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID" FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__WHERE ("teamID" = 'SFN')__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[0], groupByClauses=0, haveFilter=true, isQueryShort=false}]}]'}] => [teamid:varchar]
                     Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}                                                                                                                                                          
                     teamid := PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR} (1:28)                                                                                                                                
             - LocalExchange[SINGLE] () => []                                                                                                                                                                                               
                     Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                      
                 - RemoteStreamingExchange[REPLICATE] => []                                                                                                                                                                                 
                         Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                                  
                     - EnforceSingleRow => []                                                                                                                                                                                               
                             Estimates: {rows: 1 (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                              
                         - LocalExchange[SINGLE] () => []                                                                                                                                                                                   
                                 Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                          
                             - RemoteStreamingExchange[GATHER] => []                                                                                                                                                                        
                                     Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                      
                                 - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName="yearID", dataType=integer, type=REGULAR}, PinotColumnHandle{columnName="G_old", dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID", "yearID", "G_old" FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10, format=SQL, table=baseballStats, expectedColumnIndices=[0, 1, 2], groupByClauses=0, haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName="teamID", dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName="yearID", dataType=integer, type=REGULAR}, PinotColumnHandle{columnName="G_old", dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT "teamID", "yearID", "G_old" FROM baseballStats WHERE ((("G_old" = 11) AND ("yearID" = 2004)) AND ("teamID" = 'SFN')) LIMIT 10, format=SQL, table=baseballStats, expectedColumnIndices=[0, 1, 2], groupByClauses=0, haveFilter=true,isQueryShort=true}]}]'}] => []
                                         Estimates: {rows: ? (0B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                                                  
```


```
== RELEASE NOTES ==

Pinot Changes
* Fixing an incorrect result issue caused by cross-join query pushdown by throwing errors instead of providing the wrong answer.
```