### PR TITLE
Provide an option to toggle between partition filter cache and caching all table partitions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -223,6 +223,8 @@ public class HiveClientConfig
 
     private boolean copyOnFirstWriteConfigurationEnabled = true;
 
+    private boolean partitionFilteringFromMetastoreEnabled = true;
+
     @Min(0)
     public int getMaxInitialSplits()
     {
@@ -1869,5 +1871,18 @@ public class HiveClientConfig
     public boolean isCopyOnFirstWriteConfigurationEnabled()
     {
         return copyOnFirstWriteConfigurationEnabled;
+    }
+
+    public boolean isPartitionFilteringFromMetastoreEnabled()
+    {
+        return partitionFilteringFromMetastoreEnabled;
+    }
+
+    @Config("hive.partition-filtering-from-metastore-enabled")
+    @ConfigDescription("When enabled attempts to retrieve partition metadata only for partitions that satisfy the query predicates")
+    public HiveClientConfig setPartitionFilteringFromMetastoreEnabled(boolean partitionFilteringFromMetastoreEnabled)
+    {
+        this.partitionFilteringFromMetastoreEnabled = partitionFilteringFromMetastoreEnabled;
+        return this;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -169,7 +169,8 @@ public class TestHiveClientConfig
                 .setHudiMetadataEnabled(false)
                 .setThriftProtocol(Protocol.BINARY)
                 .setThriftBufferSize(new DataSize(128, BYTE))
-                .setCopyOnFirstWriteConfigurationEnabled(true));
+                .setCopyOnFirstWriteConfigurationEnabled(true)
+                .setPartitionFilteringFromMetastoreEnabled(true));
     }
 
     @Test
@@ -298,6 +299,7 @@ public class TestHiveClientConfig
                 .put("hive.internal-communication.thrift-transport-protocol", "COMPACT")
                 .put("hive.internal-communication.thrift-transport-buffer-size", "256B")
                 .put("hive.copy-on-first-write-configuration-enabled", "false")
+                .put("hive.partition-filtering-from-metastore-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -421,7 +423,8 @@ public class TestHiveClientConfig
                 .setHudiMetadataEnabled(true)
                 .setThriftProtocol(Protocol.COMPACT)
                 .setThriftBufferSize(new DataSize(256, BYTE))
-                .setCopyOnFirstWriteConfigurationEnabled(false);
+                .setCopyOnFirstWriteConfigurationEnabled(false)
+                .setPartitionFilteringFromMetastoreEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -92,6 +92,7 @@ public class TestingSemiTransactionalHiveMetastore
         HiveTableName hiveTableName = new HiveTableName(database, tableName);
         tablesMap.put(hiveTableName, table);
         partitionsMap.put(hiveTableName, partitions);
+        partitionNames = partitions;
     }
 
     @Override


### PR DESCRIPTION
Add an option to fetch all table partitions from the catalog instead of by filters on partition columns

This amortizes the overhead of the remote call and improves overall planning performance with AWS Glue when there are tables with a large number of partitions

Resolves #18107

```
== NO RELEASE NOTE ==
```
