### PR TITLE
Fix hashcode and equals on Block

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -21,7 +21,6 @@ import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -499,26 +498,6 @@ public abstract class AbstractMapBlock
                         keyCount * HASH_MULTIPLIER);
             }
             set(hashTables);
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            HashTables other = (HashTables) obj;
-            return Arrays.equals(this.hashTables, other.hashTables) &&
-                    this.expectedHashTableCount == other.expectedHashTableCount;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(Arrays.hashCode(hashTables), expectedHashTableCount);
         }
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -37,10 +37,10 @@ public class ArrayBlock
     private final boolean[] valueIsNull;
     private final Block values;
     private final int[] offsets;
+    private final long retainedSizeInBytes;
 
     private volatile long sizeInBytes;
     private volatile long logicalSizeInBytes;
-    private final long retainedSizeInBytes;
 
     /**
      * Create an array block directly from columnar nulls, values, and offsets into the values.
@@ -258,8 +258,6 @@ public class ArrayBlock
                 Arrays.equals(this.valueIsNull, other.valueIsNull) &&
                 Objects.equals(this.values, other.values) &&
                 Arrays.equals(this.offsets, other.offsets) &&
-                this.sizeInBytes == other.sizeInBytes &&
-                this.logicalSizeInBytes == other.logicalSizeInBytes &&
                 this.retainedSizeInBytes == other.retainedSizeInBytes;
     }
 
@@ -271,8 +269,6 @@ public class ArrayBlock
                 Arrays.hashCode(valueIsNull),
                 values,
                 Arrays.hashCode(offsets),
-                sizeInBytes,
-                logicalSizeInBytes,
                 retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -47,10 +47,11 @@ public class DictionaryBlock
     private final int idsOffset;
     private final int[] ids;
     private final long retainedSizeInBytes;
+    private final DictionaryId dictionarySourceId;
+
     private volatile long sizeInBytes = -1;
     private volatile long logicalSizeInBytes = -1;
     private volatile int uniqueIds = -1;
-    private final DictionaryId dictionarySourceId;
 
     public DictionaryBlock(Block dictionary, int[] ids)
     {
@@ -688,9 +689,6 @@ public class DictionaryBlock
                 this.idsOffset == other.idsOffset &&
                 Arrays.equals(this.ids, other.ids) &&
                 this.retainedSizeInBytes == other.retainedSizeInBytes &&
-                this.sizeInBytes == other.sizeInBytes &&
-                this.logicalSizeInBytes == other.logicalSizeInBytes &&
-                this.uniqueIds == other.uniqueIds &&
                 Objects.equals(this.dictionarySourceId, other.dictionarySourceId);
     }
 
@@ -702,9 +700,6 @@ public class DictionaryBlock
                 idsOffset,
                 Arrays.hashCode(ids),
                 retainedSizeInBytes,
-                sizeInBytes,
-                logicalSizeInBytes,
-                uniqueIds,
                 dictionarySourceId);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -322,9 +322,7 @@ public class MapBlock
                 Arrays.equals(this.offsets, other.offsets) &&
                 Objects.equals(this.keyBlock, other.keyBlock) &&
                 Objects.equals(this.valueBlock, other.valueBlock) &&
-                Objects.equals(this.hashTables, other.hashTables) &&
-                this.retainedSizeInBytesExceptHashtable == other.retainedSizeInBytesExceptHashtable &&
-                this.sizeInBytes == other.sizeInBytes;
+                this.retainedSizeInBytesExceptHashtable == other.retainedSizeInBytesExceptHashtable;
     }
 
     @Override
@@ -336,8 +334,6 @@ public class MapBlock
                 Arrays.hashCode(offsets),
                 keyBlock,
                 valueBlock,
-                hashTables,
-                retainedSizeInBytesExceptHashtable,
-                sizeInBytes);
+                retainedSizeInBytesExceptHashtable);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -40,10 +40,10 @@ public class RowBlock
     private final boolean[] rowIsNull;
     private final int[] fieldBlockOffsets;
     private final Block[] fieldBlocks;
+    private final long retainedSizeInBytes;
 
     private volatile long sizeInBytes;
     private volatile long logicalSizeInBytes;
-    private final long retainedSizeInBytes;
 
     /**
      * Create a row block directly from columnar nulls and field blocks.
@@ -286,8 +286,6 @@ public class RowBlock
                 Arrays.equals(this.rowIsNull, other.rowIsNull) &&
                 Arrays.equals(this.fieldBlockOffsets, other.fieldBlockOffsets) &&
                 Arrays.equals(this.fieldBlocks, other.fieldBlocks) &&
-                this.sizeInBytes == other.sizeInBytes &&
-                this.logicalSizeInBytes == other.logicalSizeInBytes &&
                 this.retainedSizeInBytes == other.retainedSizeInBytes;
     }
 
@@ -299,8 +297,6 @@ public class RowBlock
                 Arrays.hashCode(rowIsNull),
                 Arrays.hashCode(fieldBlockOffsets),
                 Arrays.hashCode(fieldBlocks),
-                sizeInBytes,
-                logicalSizeInBytes,
                 retainedSizeInBytes);
     }
 }


### PR DESCRIPTION
Hashcode and equals on blocks are non deterministic, this caused NPE in Planner.
They used mutable fields in the computation which made the Map's buggy.

```
java.lang.NullPointerException
	at com.facebook.presto.sql.planner.optimizations.ApplyConnectorOptimization.optimize(ApplyConnectorOptimization.java:154)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:196)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:184)
```

FilterNode -> RowExpression(ConstantExpression) -> value is a block.
Went through all blocks implementation of the hashcode and equals and fixed it.

Will work on improving the ApplyConnectorOptimization to use identityHashCode as
PlanNodes are immutable objects.

Test plan
Existing tests.

```
== NO RELEASE NOTE ==
```
