### PR TITLE
Reduce number of hdfsConfiguration copies 

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -65,4 +65,11 @@ public class AlluxioCachingConfigurationProvider
             configuration.set("alluxio.user.client.cache.shadow.window", String.valueOf(alluxioCacheConfig.getShadowCacheWindow().toMillis()));
         }
     }
+
+    @Override
+    public boolean isUriIndependentConfigurationProvider()
+    {
+        // All the config set above are independent of the URI
+        return true;
+    }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoins.java
@@ -100,7 +100,7 @@ public class TestSpatialJoins
 
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
 
         FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/DynamicConfigurationProvider.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/DynamicConfigurationProvider.java
@@ -20,4 +20,9 @@ import java.net.URI;
 public interface DynamicConfigurationProvider
 {
     void updateConfiguration(Configuration configuration, HdfsContext context, URI uri);
+
+    default boolean isUriIndependentConfigurationProvider()
+    {
+        return false;
+    }
 }

--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystemS3.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystemS3.java
@@ -54,7 +54,7 @@ public abstract class AbstractTestHiveFileSystemS3
         S3ConfigurationUpdater s3Config = new PrestoS3ConfigurationUpdater(new HiveS3Config()
                 .setS3AwsAccessKey(awsAccessKey)
                 .setS3AwsSecretKey(awsSecretKey));
-        return new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreConfig, s3Config, ignored -> {}), ImmutableSet.of());
+        return new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreConfig, s3Config, ignored -> {}), ImmutableSet.of(), config);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CopyOnFirstWriteConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CopyOnFirstWriteConfiguration.java
@@ -1,0 +1,526 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+public class CopyOnFirstWriteConfiguration
+        extends Configuration
+{
+    private final Object lock = new Object();
+
+    private Configuration config;
+    private boolean isMutable;
+
+    // This a wrapper class around Configuration object, that creates a copy of Configuration object on write
+    public CopyOnFirstWriteConfiguration(Configuration config)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.isMutable = false;
+    }
+
+    public Configuration getConfig()
+    {
+        return config;
+    }
+
+    @Override
+    public void set(String name, String value)
+    {
+        checkAndSet(() -> config.set(name, value));
+    }
+
+    @Override
+    public void set(String name, String value, String source)
+    {
+        checkAndSet(() -> config.set(name, value, source));
+    }
+
+    @Override
+    public void setIfUnset(String name, String value)
+    {
+        checkAndSet(() -> config.setIfUnset(name, value));
+    }
+
+    @Override
+    public void setInt(String name, int value)
+    {
+        checkAndSet(() -> config.setInt(name, value));
+    }
+
+    @Override
+    public void setLong(String name, long value)
+    {
+        checkAndSet(() -> config.setLong(name, value));
+    }
+
+    @Override
+    public void setFloat(String name, float value)
+    {
+        checkAndSet(() -> config.setFloat(name, value));
+    }
+
+    @Override
+    public void setDouble(String name, double value)
+    {
+        checkAndSet(() -> config.setDouble(name, value));
+    }
+
+    @Override
+    public void setBoolean(String name, boolean value)
+    {
+        checkAndSet(() -> config.setBoolean(name, value));
+    }
+
+    @Override
+    public void setBooleanIfUnset(String name, boolean value)
+    {
+        checkAndSet(() -> config.setBooleanIfUnset(name, value));
+    }
+
+    @Override
+    public <T extends Enum<T>> void setEnum(String name, T value)
+    {
+        checkAndSet(() -> config.setEnum(name, value));
+    }
+
+    @Override
+    public void setTimeDuration(String name, long value, TimeUnit unit)
+    {
+        checkAndSet(() -> config.setTimeDuration(name, value, unit));
+    }
+
+    @Override
+    public void setPattern(String name, Pattern pattern)
+    {
+        checkAndSet(() -> config.setPattern(name, pattern));
+    }
+
+    @Override
+    public void setStrings(String name, String... values)
+    {
+        checkAndSet(() -> config.setStrings(name, values));
+    }
+
+    @Override
+    public void setSocketAddr(String name, InetSocketAddress addr)
+    {
+        checkAndSet(() -> config.setSocketAddr(name, addr));
+    }
+
+    @Override
+    public void setClass(String name, Class<?> theClass, Class<?> xface)
+    {
+        checkAndSet(() -> config.setClass(name, theClass, xface));
+    }
+
+    @Override
+    public void setClassLoader(ClassLoader classLoader)
+    {
+        checkAndSet(() -> config.setClassLoader(classLoader));
+    }
+
+    @Override
+    public void setQuietMode(boolean quietMode)
+    {
+        checkAndSet(() -> config.setQuietMode(quietMode));
+    }
+
+    @Override
+    public void setDeprecatedProperties()
+    {
+        checkAndSet(() -> config.setDeprecatedProperties());
+    }
+
+    @Override
+    public void unset(String name)
+    {
+        checkAndSet(() -> config.unset(name));
+    }
+
+    @Override
+    public String get(String name)
+    {
+        return config.get(name);
+    }
+
+    @Override
+    public String get(String name, String defaultValue)
+    {
+        return config.get(name, defaultValue);
+    }
+
+    @Override
+    public String getTrimmed(String name)
+    {
+        return config.getTrimmed(name);
+    }
+
+    @Override
+    public String getTrimmed(String name, String defaultValue)
+    {
+        return config.getTrimmed(name, defaultValue);
+    }
+
+    @Override
+    public String getRaw(String name)
+    {
+        return config.getRaw(name);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue)
+    {
+        return config.getInt(name, defaultValue);
+    }
+
+    @Override
+    public int[] getInts(String name)
+    {
+        return config.getInts(name);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue)
+    {
+        return config.getLong(name, defaultValue);
+    }
+
+    @Override
+    public long getLongBytes(String name, long defaultValue)
+    {
+        return config.getLongBytes(name, defaultValue);
+    }
+
+    @Override
+    public float getFloat(String name, float defaultValue)
+    {
+        return config.getFloat(name, defaultValue);
+    }
+
+    @Override
+    public double getDouble(String name, double defaultValue)
+    {
+        return config.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue)
+    {
+        return config.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public <T extends Enum<T>> T getEnum(String name, T defaultValue)
+    {
+        return config.getEnum(name, defaultValue);
+    }
+
+    @Override
+    public long getTimeDuration(String name, long defaultValue, TimeUnit unit)
+    {
+        return config.getTimeDuration(name, defaultValue, unit);
+    }
+
+    @Override
+    public Pattern getPattern(String name, Pattern defaultValue)
+    {
+        return config.getPattern(name, defaultValue);
+    }
+
+    @Override
+    public IntegerRanges getRange(String name, String defaultValue)
+    {
+        return config.getRange(name, defaultValue);
+    }
+
+    @Override
+    public Collection<String> getStringCollection(String name)
+    {
+        return config.getStringCollection(name);
+    }
+
+    @Override
+    public String[] getStrings(String name)
+    {
+        return config.getStrings(name);
+    }
+
+    @Override
+    public String[] getStrings(String name, String... defaultValue)
+    {
+        return config.getStrings(name, defaultValue);
+    }
+
+    @Override
+    public Collection<String> getTrimmedStringCollection(String name)
+    {
+        return config.getTrimmedStringCollection(name);
+    }
+
+    @Override
+    public String[] getTrimmedStrings(String name)
+    {
+        return config.getTrimmedStrings(name);
+    }
+
+    @Override
+    public String[] getTrimmedStrings(String name, String... defaultValue)
+    {
+        return config.getTrimmedStrings(name, defaultValue);
+    }
+
+    @Override
+    public char[] getPassword(String name)
+            throws IOException
+    {
+        return config.getPassword(name);
+    }
+
+    @Override
+    public InetSocketAddress getSocketAddr(String hostProperty, String addressProperty, String defaultAddressValue, int defaultPort)
+    {
+        return config.getSocketAddr(hostProperty, addressProperty, defaultAddressValue, defaultPort);
+    }
+
+    @Override
+    public InetSocketAddress getSocketAddr(String name, String defaultAddress, int defaultPort)
+    {
+        return config.getSocketAddr(name, defaultAddress, defaultPort);
+    }
+
+    @Override
+    public Class<?> getClassByName(String name)
+            throws ClassNotFoundException
+    {
+        return config.getClassByName(name);
+    }
+
+    @Override
+    public Class<?> getClassByNameOrNull(String name)
+    {
+        return config.getClassByNameOrNull(name);
+    }
+
+    @Override
+    public Class<?>[] getClasses(String name, Class<?>... defaultValue)
+    {
+        return config.getClasses(name, defaultValue);
+    }
+
+    @Override
+    public Class<?> getClass(String name, Class<?> defaultValue)
+    {
+        return config.getClass(name, defaultValue);
+    }
+
+    @Override
+    public <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface)
+    {
+        return config.getClass(name, defaultValue, xface);
+    }
+
+    @Override
+    public <U> List<U> getInstances(String name, Class<U> xface)
+    {
+        return config.getInstances(name, xface);
+    }
+
+    @Override
+    public Path getLocalPath(String dirsProp, String path)
+            throws IOException
+    {
+        return config.getLocalPath(dirsProp, path);
+    }
+
+    @Override
+    public File getFile(String dirsProp, String path)
+            throws IOException
+    {
+        return config.getFile(dirsProp, path);
+    }
+
+    @Override
+    public URL getResource(String name)
+    {
+        return config.getResource(name);
+    }
+
+    @Override
+    public InputStream getConfResourceAsInputStream(String name)
+    {
+        return config.getConfResourceAsInputStream(name);
+    }
+
+    @Override
+    public Reader getConfResourceAsReader(String name)
+    {
+        return config.getConfResourceAsReader(name);
+    }
+
+    @Override
+    public Set<String> getFinalParameters()
+    {
+        return config.getFinalParameters();
+    }
+
+    @Override
+    public int size()
+    {
+        return config.size();
+    }
+
+    @Override
+    public void clear()
+    {
+        config.clear();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator()
+    {
+        return config.iterator();
+    }
+
+    @Override
+    public ClassLoader getClassLoader()
+    {
+        return config.getClassLoader();
+    }
+
+    @Override
+    public void readFields(DataInput in)
+            throws IOException
+    {
+        config.readFields(in);
+    }
+
+    @Override
+    public void write(DataOutput out)
+            throws IOException
+    {
+        config.write(out);
+    }
+
+    @Override
+    public void writeXml(OutputStream out)
+            throws IOException
+    {
+        config.writeXml(out);
+    }
+
+    @Override
+    public void writeXml(Writer out)
+            throws IOException
+    {
+        config.writeXml(out);
+    }
+
+    @Override
+    public Map<String, String> getValByRegex(String regex)
+    {
+        return config.getValByRegex(regex);
+    }
+
+    @Override
+    public String toString()
+    {
+        return config.toString();
+    }
+
+    @Override
+    public void addResource(String name)
+    {
+        config.addResource(name);
+    }
+
+    @Override
+    public void addResource(URL url)
+    {
+        config.addResource(url);
+    }
+
+    @Override
+    public void addResource(Path file)
+    {
+        config.addResource(file);
+    }
+
+    @Override
+    public void addResource(InputStream in)
+    {
+        config.addResource(in);
+    }
+
+    @Override
+    public void addResource(InputStream in, String name)
+    {
+        config.addResource(in, name);
+    }
+
+    @Override
+    public void addResource(Configuration conf)
+    {
+        config.addResource(conf);
+    }
+
+    @Override
+    public void reloadConfiguration()
+    {
+        config.reloadConfiguration();
+    }
+
+    @Override
+    public String[] getPropertySources(String name)
+    {
+        return config.getPropertySources(name);
+    }
+
+    private void checkAndSet(Runnable action)
+    {
+        if (isMutable) {
+            action.run();
+            return;
+        }
+        synchronized (lock) {
+            if (!isMutable) {
+                Configuration originalConfig = config;
+                config = new Configuration(originalConfig);
+                isMutable = true;
+            }
+            action.run();
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -221,6 +221,8 @@ public class HiveClientConfig
     private Protocol thriftProtocol = Protocol.BINARY;
     private DataSize thriftBufferSize = new DataSize(128, BYTE);
 
+    private boolean copyOnFirstWriteConfigurationEnabled = true;
+
     @Min(0)
     public int getMaxInitialSplits()
     {
@@ -1854,5 +1856,18 @@ public class HiveClientConfig
     {
         this.thriftBufferSize = thriftBufferSize;
         return this;
+    }
+
+    @Config("hive.copy-on-first-write-configuration-enabled")
+    @ConfigDescription("Optimize the number of configuration copies by enabling copy-on-write technique")
+    public HiveClientConfig setCopyOnFirstWriteConfigurationEnabled(boolean copyOnFirstWriteConfigurationEnabled)
+    {
+        this.copyOnFirstWriteConfigurationEnabled = copyOnFirstWriteConfigurationEnabled;
+        return this;
+    }
+
+    public boolean isCopyOnFirstWriteConfigurationEnabled()
+    {
+        return copyOnFirstWriteConfigurationEnabled;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -46,11 +46,20 @@ public class HiveHdfsConfiguration
     private final HdfsConfigurationInitializer initializer;
     private final Set<DynamicConfigurationProvider> dynamicProviders;
 
+    // This is set to TRUE if the configuration providers are empty or they do NOT dependent on the URI
+    private final boolean isConfigReusable;
+    private Configuration uriAgnosticConfiguration;
+
     @Inject
     public HiveHdfsConfiguration(HdfsConfigurationInitializer initializer, Set<DynamicConfigurationProvider> dynamicProviders)
     {
         this.initializer = requireNonNull(initializer, "initializer is null");
         this.dynamicProviders = ImmutableSet.copyOf(requireNonNull(dynamicProviders, "dynamicProviders is null"));
+        boolean isUriIndependentConfig = true;
+        for (DynamicConfigurationProvider provider : dynamicProviders) {
+            isUriIndependentConfig = isUriIndependentConfig && provider.isUriIndependentConfigurationProvider();
+        }
+        this.isConfigReusable = isUriIndependentConfig;
     }
 
     @Override
@@ -61,10 +70,22 @@ public class HiveHdfsConfiguration
             return hadoopConfiguration.get();
         }
 
+        if (isConfigReusable && uriAgnosticConfiguration != null) {
+            // use the same configuration for everything
+            return new CopyOnFirstWriteConfiguration(uriAgnosticConfiguration);
+        }
+
         Configuration config = new Configuration(hadoopConfiguration.get());
         for (DynamicConfigurationProvider provider : dynamicProviders) {
             provider.updateConfiguration(config, context, uri);
         }
+
+        if (isConfigReusable && uriAgnosticConfiguration == null) {
+            uriAgnosticConfiguration = config;
+            // return a CopyOnFirstWrite configuration so that we make a copy before modifying it down the lane
+            return new CopyOnFirstWriteConfiguration(uriAgnosticConfiguration);
+        }
+
         return config;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -48,10 +48,11 @@ public class HiveHdfsConfiguration
 
     // This is set to TRUE if the configuration providers are empty or they do NOT dependent on the URI
     private final boolean isConfigReusable;
+    private final boolean isCopyOnFirstWriteConfigurationEnabled;
     private Configuration uriAgnosticConfiguration;
 
     @Inject
-    public HiveHdfsConfiguration(HdfsConfigurationInitializer initializer, Set<DynamicConfigurationProvider> dynamicProviders)
+    public HiveHdfsConfiguration(HdfsConfigurationInitializer initializer, Set<DynamicConfigurationProvider> dynamicProviders, HiveClientConfig hiveClientConfig)
     {
         this.initializer = requireNonNull(initializer, "initializer is null");
         this.dynamicProviders = ImmutableSet.copyOf(requireNonNull(dynamicProviders, "dynamicProviders is null"));
@@ -60,6 +61,7 @@ public class HiveHdfsConfiguration
             isUriIndependentConfig = isUriIndependentConfig && provider.isUriIndependentConfigurationProvider();
         }
         this.isConfigReusable = isUriIndependentConfig;
+        this.isCopyOnFirstWriteConfigurationEnabled = hiveClientConfig.isCopyOnFirstWriteConfigurationEnabled();
     }
 
     @Override
@@ -70,7 +72,7 @@ public class HiveHdfsConfiguration
             return hadoopConfiguration.get();
         }
 
-        if (isConfigReusable && uriAgnosticConfiguration != null) {
+        if (isCopyOnFirstWriteConfigurationEnabled && isConfigReusable && uriAgnosticConfiguration != null) {
             // use the same configuration for everything
             return new CopyOnFirstWriteConfiguration(uriAgnosticConfiguration);
         }
@@ -80,7 +82,7 @@ public class HiveHdfsConfiguration
             provider.updateConfiguration(config, context, uri);
         }
 
-        if (isConfigReusable && uriAgnosticConfiguration == null) {
+        if (isCopyOnFirstWriteConfigurationEnabled && isConfigReusable && uriAgnosticConfiguration == null) {
             uriAgnosticConfiguration = config;
             // return a CopyOnFirstWrite configuration so that we make a copy before modifying it down the lane
             return new CopyOnFirstWriteConfiguration(uriAgnosticConfiguration);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -166,7 +166,7 @@ public class StoragePartitionLoader
         Path path = new Path(location);
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
-        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext, path);
+        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext.getIdentity().getUser(), path, configuration);
         boolean s3SelectPushdownEnabled = shouldEnablePushdownForTable(session, table, path.toString(), partition.getPartition());
 
         if (inputFormat instanceof SymlinkTextInputFormat) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class WrapperJobConf
+        extends JobConf
+{
+    private final Configuration config;
+
+    public WrapperJobConf(Configuration config)
+    {
+        super();
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    public Configuration getConfig()
+    {
+        return config;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator()
+    {
+        return config.iterator();
+    }
+
+    @Override
+    public Class<?> getClassByName(String name)
+            throws ClassNotFoundException
+    {
+        return config.getClassByName(name);
+    }
+
+    @Override
+    public Class<?> getClassByNameOrNull(String name)
+    {
+        return config.getClassByNameOrNull(name);
+    }
+
+    @Override
+    public Class<?> getClass(String name, Class<?> defaultValue)
+    {
+        return config.getClass(name, defaultValue);
+    }
+
+    @Override
+    public <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface)
+    {
+        return config.getClass(name, defaultValue, xface);
+    }
+
+    @Override
+    public void setClassLoader(ClassLoader classLoader)
+    {
+        config.setClassLoader(classLoader);
+    }
+
+    @Override
+    public ClassLoader getClassLoader()
+    {
+        return config.getClassLoader();
+    }
+
+    @Override
+    public void set(String name, String value)
+    {
+        config.set(name, value);
+    }
+
+    @Override
+    public String get(String name, String defaultValue)
+    {
+        return config.get(name, defaultValue);
+    }
+
+    @Override
+    public String get(String name)
+    {
+        if (config == null) {
+            return super.get(name);
+        }
+        String result = config.get(name);
+        return result != null ? result : super.get(name);
+    }
+
+    @Override
+    public void setBoolean(String name, boolean value)
+    {
+        config.setBoolean(name, value);
+    }
+
+    @Override
+    public void setBooleanIfUnset(String name, boolean value)
+    {
+        config.setBooleanIfUnset(name, value);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue)
+    {
+        return config.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public void setInt(String name, int value)
+    {
+        config.setInt(name, value);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue)
+    {
+        return config.getInt(name, defaultValue);
+    }
+
+    @Override
+    public int[] getInts(String name)
+    {
+        return config.getInts(name);
+    }
+
+    @Override
+    public void setDouble(String name, double value)
+    {
+        config.setDouble(name, value);
+    }
+
+    @Override
+    public double getDouble(String name, double defaultValue)
+    {
+        return config.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public void setFloat(String name, float value)
+    {
+        config.setFloat(name, value);
+    }
+
+    @Override
+    public float getFloat(String name, float defaultValue)
+    {
+        return config.getFloat(name, defaultValue);
+    }
+
+    @Override
+    public void setLong(String name, long value)
+    {
+        config.setLong(name, value);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue)
+    {
+        return config.getLong(name, defaultValue);
+    }
+
+    @Override
+    public synchronized void unset(String name)
+    {
+        config.unset(name);
+    }
+
+    @Override
+    public synchronized void setIfUnset(String name, String value)
+    {
+        config.setIfUnset(name, value);
+    }
+
+    @Override
+    public void readFields(DataInput in)
+            throws IOException
+    {
+        config.readFields(in);
+    }
+
+    @Override
+    public void write(DataOutput out)
+            throws IOException
+    {
+        config.write(out);
+    }
+
+    @Override
+    public void clear()
+    {
+        super.clear();
+        config.clear();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -21,12 +21,12 @@ import com.facebook.presto.hadoop.FileSystemFactory;
 import com.facebook.presto.hive.HdfsConfiguration;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.WrapperJobConf;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.spi.PrestoException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
 
 import javax.inject.Inject;
 
@@ -89,21 +89,21 @@ public class HiveCachingHdfsConfiguration
     }
 
     private static class CachingJobConf
-            extends JobConf
+            extends WrapperJobConf
             implements FileSystemFactory
     {
         private final BiFunction<Configuration, URI, FileSystem> factory;
 
-        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration conf)
+        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration config)
         {
-            super(conf);
+            super(config);
             this.factory = requireNonNull(factory, "factory is null");
         }
 
         @Override
         public FileSystem createFileSystem(URI uri)
         {
-            return factory.apply(this, uri);
+            return factory.apply(getConfig(), uri);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.util;
 
 import com.facebook.presto.hadoop.FileSystemFactory;
+import com.facebook.presto.hive.CopyOnFirstWriteConfiguration;
 import com.facebook.presto.hive.HiveCompressionCodec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -53,6 +54,9 @@ public final class ConfigurationUtils
 
     public static Configuration copy(Configuration configuration)
     {
+        if (configuration instanceof CopyOnFirstWriteConfiguration) {
+            return new CopyOnFirstWriteConfiguration(copy(((CopyOnFirstWriteConfiguration) configuration).getConfig()));
+        }
         Configuration copy = new Configuration(false);
         copy(configuration, copy);
         return copy;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -960,7 +960,7 @@ public abstract class AbstractTestHiveClient
         }
 
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, host, port);
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         ExtendedHiveMetastore metastore = new CachingHiveMetastore(
                 new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator()),
@@ -986,7 +986,7 @@ public abstract class AbstractTestHiveClient
 
         hivePartitionManager = new HivePartitionManager(FUNCTION_AND_TYPE_MANAGER, hiveClientConfig);
         metastoreClient = hiveMetastore;
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         locationService = new HiveLocationService(hdfsEnvironment);
         metadataFactory = new HiveMetadataFactory(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -261,7 +261,7 @@ public final class HiveQueryRunner
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -216,7 +216,8 @@ public final class HiveTestUtils
                         metastoreClientConfig,
                         new PrestoS3ConfigurationUpdater(new HiveS3Config()),
                         new HiveGcsConfigurationInitializer(new HiveGcsConfig())),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                config);
         return new HdfsEnvironment(hdfsConfig, metastoreClientConfig, new NoHdfsAuthentication());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -657,7 +657,7 @@ public class TestBackgroundHiveSplitLoader
         public TestingHdfsEnvironment(List<LocatedFileStatus> files)
         {
             super(
-                    new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig(), new MetastoreClientConfig()), ImmutableSet.of()),
+                    new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig(), new MetastoreClientConfig()), ImmutableSet.of(), new HiveClientConfig()),
                     new MetastoreClientConfig(),
                     new NoHdfsAuthentication());
             this.files = ImmutableList.copyOf(files);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCopyOnFirstWriteConfiguration.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCopyOnFirstWriteConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+public class TestCopyOnFirstWriteConfiguration
+{
+    private static final String TEST_KEY = "test-key";
+    private static final String TEST_VALUE = "test-value";
+    private static final String TEST_UPDATED_VALUE = "test-updated-value";
+    private static final String TEST_KEY_INT = "test-key-int";
+    private static final int TEST_VALUE_INT = 1;
+
+    @Test
+    public void testCopyOnWriteConfiguration()
+    {
+        Configuration originalConfig = new Configuration();
+        originalConfig.set(TEST_KEY, TEST_VALUE);
+
+        CopyOnFirstWriteConfiguration copyOnWriteConfig = new CopyOnFirstWriteConfiguration(originalConfig);
+
+        // Assert the config remains same after a get call
+        assertEquals(originalConfig.get(TEST_KEY), copyOnWriteConfig.get(TEST_KEY));
+        assertEquals(TEST_VALUE, copyOnWriteConfig.get(TEST_KEY));
+        assertSame(originalConfig, copyOnWriteConfig.getConfig());
+
+        // Set the updated value
+        copyOnWriteConfig.set(TEST_KEY, TEST_UPDATED_VALUE);
+
+        // Assert value is different from the value in original config
+        assertEquals(TEST_UPDATED_VALUE, copyOnWriteConfig.get(TEST_KEY));
+        assertNotEquals(originalConfig.get(TEST_KEY), copyOnWriteConfig.get(TEST_KEY));
+
+        // Assert that the config object inside the CopyOnWriteConfiguration has changed
+        Configuration configAfterUpdate1 = copyOnWriteConfig.getConfig();
+        assertNotSame(originalConfig, configAfterUpdate1);
+
+        // Set a new key, value
+        copyOnWriteConfig.setInt(TEST_KEY_INT, TEST_VALUE_INT);
+
+        // Assert the config object after 2nd update is same as after 1st update
+        Configuration configAfterUpdate2 = copyOnWriteConfig.getConfig();
+        assertSame(configAfterUpdate1, configAfterUpdate2);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestFileSystemCache.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestFileSystemCache.java
@@ -33,9 +33,10 @@ public class TestFileSystemCache
             throws IOException
     {
         ImpersonatingHdfsAuthentication auth = new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication());
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
         HdfsEnvironment environment =
                 new HdfsEnvironment(
-                        new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig(), new MetastoreClientConfig()), ImmutableSet.of()),
+                        new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()), ImmutableSet.of(), hiveClientConfig),
                         new MetastoreClientConfig(),
                         auth);
         FileSystem fs1 = getFileSystem(environment, "user");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -168,7 +168,8 @@ public class TestHiveClientConfig
                 .setFileSplittable(true)
                 .setHudiMetadataEnabled(false)
                 .setThriftProtocol(Protocol.BINARY)
-                .setThriftBufferSize(new DataSize(128, BYTE)));
+                .setThriftBufferSize(new DataSize(128, BYTE))
+                .setCopyOnFirstWriteConfigurationEnabled(true));
     }
 
     @Test
@@ -296,6 +297,7 @@ public class TestHiveClientConfig
                 .put("hive.hudi-metadata-enabled", "true")
                 .put("hive.internal-communication.thrift-transport-protocol", "COMPACT")
                 .put("hive.internal-communication.thrift-transport-buffer-size", "256B")
+                .put("hive.copy-on-first-write-configuration-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -418,7 +420,8 @@ public class TestHiveClientConfig
                 .setFileSplittable(false)
                 .setHudiMetadataEnabled(true)
                 .setThriftProtocol(Protocol.COMPACT)
-                .setThriftBufferSize(new DataSize(256, BYTE));
+                .setThriftBufferSize(new DataSize(256, BYTE))
+                .setCopyOnFirstWriteConfigurationEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -74,7 +74,7 @@ public class TestHiveClientFileMetastore
         HiveClientConfig hiveConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
         HdfsConfigurationInitializer updater = new HdfsConfigurationInitializer(hiveConfig, metastoreClientConfig);
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updater, ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updater, ImmutableSet.of(), hiveConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -2012,7 +2012,7 @@ public class TestHiveLogicalPlanner
         URI baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toUri();
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toString(), "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -477,7 +477,7 @@ public class TestHiveSplitManager
 
         HiveClientConfig hiveClientConfig = new HiveClientConfig().setPartitionStatisticsBasedOptimizationEnabled(true);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(
-                new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()), ImmutableSet.of()),
+                new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()), ImmutableSet.of(), hiveClientConfig),
                 new MetastoreClientConfig(),
                 new NoHdfsAuthentication());
         HiveMetadataFactory metadataFactory = new HiveMetadataFactory(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableConstraints.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableConstraints.java
@@ -63,7 +63,7 @@ public class TestHiveTableConstraints
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
         PartitionMutator hivePartitionMutator = new HivePartitionMutator();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of(), config);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster, metastoreClientConfig, hdfsEnvironment);
         metastore = new SemiTransactionalHiveMetastore(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
@@ -71,7 +71,7 @@ public class TestHiveUtil
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, catalogDirectory.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -76,7 +76,7 @@ public class TestingSemiTransactionalHiveMetastore
         // none of these values matter, as we never use them
         HiveClientConfig config = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of(), config);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, HOST, PORT);
         ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/hudi/HudiTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/hudi/HudiTestUtils.java
@@ -80,7 +80,8 @@ public class HudiTestUtils
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(
                 new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, catalogDir, "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -93,7 +93,7 @@ public class TestHiveClientGlueMetastore
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
         glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -295,7 +295,7 @@ public class PrestoSparkQueryRunner
 
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
 
         this.metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/17625 was reverted because it caused latency regression.

This PR is same as above pr + regression fix. 
The `CopyOnWriteConfiguration` has a delegate configuration to which we delegate all the operations. Earlier we used the threadlocal configuration as delegate. We believe that has led to serious contention and hence the regression. As a fix, we created a local configuration object and then used that as delegate for the `CopyOnWriteConfiguration`. 

Also we have an open issue https://github.com/prestodb/presto/issues/17736 describing the problem with this approach when we copy configuration. This is only done in hudi as of today. So we added a flag to enable/disable this new feature of using CopyOnWriteConfiguration.

Test Plan:
- created custom presto version : 0.276-20220727.142226-14
- Shadowed the production traffic and confirmed that there is no regression in the query latency.

```
== RELEASE NOTES ==

General Changes
* Optimized the number of hdfsConfiguration copies being done by using copy-on-first-write technique. This feature is enabled by default and can be controlled by setting the ``hive.copy-on-first-write-configuration`` configuration property appropriately.
```
