### PR TITLE
Re-enable Nessie namespace/table visibility tests

### DIFF
--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -27,7 +27,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.30.0";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.43.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 


### PR DESCRIPTION
`testTableDataVisibility()` and `testNamespaceVisibility` are both using the same namespace names (where `namespace_one` is created on the `main` branch), so it's possible that those tests interfere with each other if the tests run in parallel