### PR TITLE
Fix bug in DWRF StreamOrderingLayout caused by the root node

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcFileIntrospector.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcFileIntrospector.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.orc.metadata.Footer;
 import com.facebook.presto.orc.metadata.OrcFileTail;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
+import com.facebook.presto.orc.metadata.StripeFooter;
 import com.facebook.presto.orc.metadata.StripeInformation;
 
 import java.util.List;
@@ -28,6 +29,8 @@ public interface OrcFileIntrospector
     default void onFileTail(OrcFileTail fileTail) {}
 
     default void onStripe(StripeInformation stripeInformation, Stripe stripe) {}
+
+    default void onStripeFooter(StripeInformation stripeInformation, StripeFooter stripeFooter) {}
 
     default void onRowGroupIndexes(StripeInformation stripe, Map<StreamId, List<RowGroupIndex>> columnIndexes) {}
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -157,6 +157,7 @@ public class StripeReader
 
         // read the stripe footer
         StripeFooter stripeFooter = readStripeFooter(stripeId, stripe, systemMemoryUsage);
+        fileIntrospector.ifPresent(introspector -> introspector.onStripeFooter(stripe, stripeFooter));
 
         // get streams for selected columns
         List<List<Stream>> allStreams = new ArrayList<>();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamOrderingLayout.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamOrderingLayout.java
@@ -141,6 +141,12 @@ public class StreamOrderingLayout
         // iterate through all the encodings and if the encoding has additional sequence encodings put it in the map
         for (Map.Entry<Integer, ColumnEncoding> entry : nodeIdToColumnEncodings.entrySet()) {
             int nodeId = entry.getKey();
+
+            // skip the root node, because it doesn't have a column
+            if (nodeId == 0) {
+                continue;
+            }
+
             int column = nodeIdToColumn.get(nodeId);
             if (entry.getValue().getAdditionalSequenceEncodings().isPresent() && columnToKeySet.containsKey(column) && !columnsVisited.contains(column)) {
                 // add entries only if stream ordering contains the column ID

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -13,23 +13,38 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.MapBlockBuilder;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.metadata.StripeFooter;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.orc.writer.StreamLayout.ByColumnSize;
 import com.facebook.presto.orc.writer.StreamLayout.ByStreamSize;
+import com.facebook.presto.orc.writer.StreamLayoutFactory;
 import com.facebook.presto.orc.writer.StreamOrderingLayout;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -38,9 +53,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
+import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
+import static com.facebook.presto.orc.OrcTester.arrayType;
+import static com.facebook.presto.orc.OrcTester.createOrcWriter;
+import static com.facebook.presto.orc.OrcTester.mapType;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_MAP_FLAT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -320,7 +343,7 @@ public class TestStreamLayout
 
     private static List<StreamDataOutput> createStreams(boolean isEmptyMap)
     {
-        // Assume the file has following schema
+        // Assume the file has the following schema
         // column 0: INT (Node 0)
         // column 1: MAP<INT, LIST<INT>> // non flat map
         // column 2: MAP<INT, FLOAT> // flat map
@@ -368,5 +391,204 @@ public class TestStreamLayout
             streams.add(createStream(12, 5, StreamKind.DATA, 15));
         }
         return streams;
+    }
+
+    @DataProvider
+    public static Object[][] streamOrderingLayoutProvider()
+    {
+        // stream ordering test writes the following keys: 0, 1, 2
+        return new Object[][] {
+                {2L, 0L, 1L}, // full match
+                {new Long[0]}, // no keys
+                {0L}, // partially matching keys
+
+                {10L, 20L}, // full mismatch
+                {2L, 10L} // partial match + mismatch
+        };
+    }
+
+    @Test(dataProvider = "streamOrderingLayoutProvider")
+    public void testStreamOrderingLayoutEndToEndPrimitive(Object[] orderedKeys)
+            throws Exception
+    {
+        MapType mapType = (MapType) mapType(INTEGER, INTEGER);
+
+        // create a map with a single row and three keys 0, 1, 2
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, 10);
+        BlockBuilder mapKeyBuilder = mapBlockBuilder.getKeyBlockBuilder();
+        BlockBuilder mapValueBuilder = mapBlockBuilder.getValueBlockBuilder();
+        mapBlockBuilder.beginDirectEntry();
+        for (int k = 0; k < 3; k++) {
+            INTEGER.writeLong(mapKeyBuilder, k);
+            INTEGER.writeLong(mapValueBuilder, k);
+        }
+        mapBlockBuilder.closeEntry();
+        Page page = new Page(mapBlockBuilder.build());
+
+        // inject a custom layout factory
+        StreamLayoutFactory streamLayoutFactory = createLongKeysStreamLayoutFactory(0, orderedKeys);
+        OrcWriterOptions writerOptions = OrcWriterOptions.builder()
+                .withFlattenedColumns(ImmutableSet.of(0))
+                .withStreamLayoutFactory(streamLayoutFactory)
+                .build();
+
+        try (TempFile tempFile = new TempFile()) {
+            try (OrcWriter orcWriter = createOrcWriter(
+                    tempFile.getFile(),
+                    OrcEncoding.DWRF,
+                    CompressionKind.ZLIB,
+                    Optional.empty(),
+                    ImmutableList.of(mapType),
+                    writerOptions,
+                    NOOP_WRITER_STATS)) {
+                orcWriter.write(page);
+            }
+
+            assertFileStreamsOrder(orderedKeys, mapType, tempFile);
+        }
+    }
+
+    @Test(dataProvider = "streamOrderingLayoutProvider")
+    public void testStreamOrderingLayoutEndToEndComplexEmpty(Object[] orderedKeys)
+            throws Exception
+    {
+        MapType mapType = (MapType) mapType(INTEGER, arrayType(INTEGER));
+
+        // create an empty map
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, 10);
+        mapBlockBuilder.beginDirectEntry();
+        mapBlockBuilder.closeEntry();
+        Page page = new Page(mapBlockBuilder.build());
+
+        // inject a custom layout factory
+        StreamLayoutFactory streamLayoutFactory = createLongKeysStreamLayoutFactory(0, orderedKeys);
+        OrcWriterOptions writerOptions = OrcWriterOptions.builder()
+                .withFlattenedColumns(ImmutableSet.of(0))
+                .withStreamLayoutFactory(streamLayoutFactory)
+                .build();
+
+        try (TempFile tempFile = new TempFile()) {
+            try (OrcWriter orcWriter = createOrcWriter(
+                    tempFile.getFile(),
+                    OrcEncoding.DWRF,
+                    CompressionKind.ZLIB,
+                    Optional.empty(),
+                    ImmutableList.of(mapType),
+                    writerOptions,
+                    NOOP_WRITER_STATS)) {
+                orcWriter.write(page);
+                // no need to verify empty map
+            }
+        }
+    }
+
+    private static void assertFileStreamsOrder(Object[] orderedKeys, MapType mapType, TempFile tempFile)
+            throws IOException
+    {
+        // introspect the file to get access to the file meta information
+        CapturingOrcFileIntrospector introspector = new CapturingOrcFileIntrospector();
+        readFileWithIntrospector(mapType, introspector, tempFile);
+        assertEquals(introspector.getStripeFooterByStripeOffset().size(), 1);
+
+        StripeFooter stripeFooter = introspector.getStripeFooterByStripeOffset().values().iterator().next();
+
+        // get data streams, because only data streams are ordered
+        List<Stream> dataStreams = stripeFooter.getStreams().stream()
+                .filter(s -> s.getStreamKind() != StreamKind.ROW_INDEX)
+                .collect(toImmutableList());
+
+        // get sequence to key mapping for flat map value node
+        int node = 3; // map value node
+        ColumnEncoding columnEncoding = stripeFooter.getColumnEncodings().get(node);
+        SortedMap<Integer, DwrfSequenceEncoding> nodeSequences = columnEncoding.getAdditionalSequenceEncodings().get();
+        ImmutableMap.Builder<Long, Integer> keyToSequenceBuilder = ImmutableMap.builder();
+        for (Map.Entry<Integer, DwrfSequenceEncoding> entry : nodeSequences.entrySet()) {
+            long key = entry.getValue().getKey().getIntKey();
+            int sequence = entry.getKey();
+            keyToSequenceBuilder.put(key, sequence);
+        }
+        Map<Long, Integer> keyToSequence = keyToSequenceBuilder.build();
+
+        // remove mismatching keys that are not written by the writer
+        List<Long> filteredKeys = Arrays.stream(orderedKeys)
+                .map(k -> (Long) k)
+                .filter(k -> k >= 0 && k < 3)
+                .collect(toImmutableList());
+
+        // assert that the streams are indeed ordered
+        // ordered streams come at the head of the all data streams
+        Iterator<Stream> dataStreamsIterator = dataStreams.iterator();
+        for (Long key : filteredKeys) {
+            // there should be IN_MAP + DATA streams for each sequence, we don't care about what stream kind comes first
+            int sequence = keyToSequence.get(key);
+            assertEquals(dataStreamsIterator.next().getSequence(), sequence);
+            assertEquals(dataStreamsIterator.next().getSequence(), sequence);
+        }
+    }
+
+    private static void readFileWithIntrospector(Type type, CapturingOrcFileIntrospector introspector, TempFile tempFile)
+            throws IOException
+    {
+        OrcDataSource dataSource = new FileOrcDataSource(tempFile.getFile(),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                true);
+
+        OrcReaderOptions readerOptions = OrcReaderOptions.builder()
+                .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                .build();
+
+        OrcReader reader = new OrcReader(
+                dataSource,
+                OrcEncoding.DWRF,
+                new StorageOrcFileTailSource(),
+                StripeMetadataSourceFactory.of(new StorageStripeMetadataSource()),
+                Optional.empty(),
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                readerOptions,
+                false,
+                DwrfEncryptionProvider.NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats(),
+                Optional.of(introspector));
+
+        OrcSelectiveRecordReader recordReader = reader.createSelectiveRecordReader(
+                ImmutableMap.of(0, type),
+                ImmutableList.of(0),
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                OrcPredicate.TRUE,
+                0,
+                dataSource.getSize(),
+                DateTimeZone.UTC,
+                false,
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                Optional.empty(),
+                1000);
+        while (recordReader.getNextPage() != null) {
+            // ignore
+        }
+        recordReader.close();
+    }
+
+    private static StreamLayoutFactory createLongKeysStreamLayoutFactory(int column, Object[] orderedKeys)
+    {
+        List<DwrfProto.KeyInfo> keyInfos = Arrays.stream(orderedKeys)
+                .map(key -> DwrfProto.KeyInfo.newBuilder()
+                        .setIntKey((Long) key)
+                        .build())
+                .collect(toImmutableList());
+        Map<Integer, List<DwrfProto.KeyInfo>> columnToKeys = ImmutableMap.of(column, keyInfos);
+
+        DwrfStreamOrderingConfig streamOrderingConfig = new DwrfStreamOrderingConfig(columnToKeys);
+        StreamLayoutFactory baseStreamLayoutFactory = new StreamLayoutFactory.ColumnSizeLayoutFactory();
+        return () -> new StreamOrderingLayout(streamOrderingConfig, baseStreamLayoutFactory.create());
     }
 }


### PR DESCRIPTION
There is a small mismatch between the nodes passed into the `StreamLayout.reorder` that is causing a crash (S282964). 

`nodeIdToColumnEncodings` has the root node 0, but `nodeIdToColumn` does not have the root node 0. So, when the code iterates over the nodes from nodeIdToColumnEncodings it fails to get the column number for the root node 0.
 
Here is the stack trace of the failure:
```
java.lang.NullPointerException
  at com.facebook.presto.orc.writer.StreamOrderingLayout.getStreamMetadata(StreamOrderingLayout.java:144) 
  at com.facebook.presto.orc.writer.StreamOrderingLayout.reorder(StreamOrderingLayout.java:170)
  at com.facebook.presto.orc.OrcWriter.bufferStripeData(OrcWriter.java:583)
  at com.facebook.presto.orc.OrcWriter.flushStripe(OrcWriter.java:487)
  at com.facebook.presto.orc.OrcWriter.writeChunk(OrcWriter.java:460)
```

Test plan:
- new unit tests

```
== NO RELEASE NOTE ==
```
