### PR TITLE
Fix bug in DWRF map stats builder for row groups with all nulls

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class MapColumnStatisticsBuilder
@@ -73,7 +72,6 @@ public class MapColumnStatisticsBuilder
     private Optional<MapStatistics> buildMapStatistics()
     {
         if (hasEntries && collectKeyStats) {
-            checkState(nonNullValueCount > 0, "MapColumnStatisticsBuilder has map entries, but nonNullValueCount is 0");
             MapStatistics mapStatistics = new MapStatistics(entries.build());
             return Optional.of(mapStatistics);
         }
@@ -84,7 +82,6 @@ public class MapColumnStatisticsBuilder
     public ColumnStatistics buildColumnStatistics()
     {
         if (hasEntries && collectKeyStats) {
-            checkState(nonNullValueCount > 0, "MapColumnStatisticsBuilder has map entries, but nonNullValueCount is 0");
             MapStatistics mapStatistics = new MapStatistics(entries.build());
             return new MapColumnStatistics(nonNullValueCount, null, mapStatistics);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
@@ -83,6 +83,34 @@ public class TestMapColumnStatisticsBuilder
         assertEquals(entries.get(1).getColumnStatistics(), columnStatistics2);
     }
 
+    // test a case when keys are carried of from one row group, to another row
+    // group having all null entries
+    @Test(dataProvider = "keySupplier")
+    public void testAddMapStatisticsNoValues(KeyInfo[] keys)
+    {
+        KeyInfo key1 = keys[0];
+        KeyInfo key2 = keys[1];
+
+        ColumnStatistics columnStatistics1 = new ColumnStatistics(3L, null);
+        ColumnStatistics columnStatistics2 = new ColumnStatistics(5L, null);
+
+        MapColumnStatisticsBuilder builder = new MapColumnStatisticsBuilder(true);
+        builder.addMapStatistics(key1, columnStatistics1);
+        builder.addMapStatistics(key2, columnStatistics2);
+        builder.increaseValueCount(0);
+
+        MapColumnStatistics columnStatistics = (MapColumnStatistics) builder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), 0);
+
+        MapStatistics mapStatistics = columnStatistics.getMapStatistics();
+        List<MapStatisticsEntry> entries = mapStatistics.getEntries();
+        assertEquals(entries.size(), 2);
+        assertEquals(entries.get(0).getKey(), key1);
+        assertEquals(entries.get(0).getColumnStatistics(), columnStatistics1);
+        assertEquals(entries.get(1).getKey(), key2);
+        assertEquals(entries.get(1).getColumnStatistics(), columnStatistics2);
+    }
+
     @Test(dataProvider = "keySupplier")
     public void testMergeMapStatistics(KeyInfo[] keys)
     {


### PR DESCRIPTION
Initial implementation of the Map stats builder had an assumption that the number of non null values should be greater than zero for cases when stats builder has any map entries. This assumption works fine for the first row group stats and file stats, but doesn't quite work for the subsequent row group stats in one edge case.

The tricky part is that all map keys are carried over across all row group stats in a stripe, which will trigger the constraint in the initial implementation if first row group has valid entries, but second row group has all nulls.

Example:
Entries for Row group 1: A->A. Expected stats: Keys=(A), nonNullValues = 1
Entries for Row group 2: null. Expected stats: Keys=(A - carried over from row group 1), nonNullValues = 0

This fix removes the constraint requiring nonNullValues to be greater than zero if stats has any entries. 

Test plan:
- new unit tests

```
== NO RELEASE NOTE ==
```
