### PR TITLE
Fix orc reader OOM in shared dictionaries

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -617,7 +617,8 @@ public class OrcSelectiveRecordReader
                         hiveStorageTimeZone,
                         options,
                         legacyMapSubscript,
-                        systemMemoryContext);
+                        systemMemoryContext,
+                        false);
             }
         }
         return streamReaders;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -123,7 +123,8 @@ public class ListSelectiveStreamReader
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
             boolean legacyMapSubscript,
-            OrcAggregatedMemoryContext systemMemoryContext)
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
     {
         requireNonNull(filters, "filters is null");
         requireNonNull(subfields, "subfields is null");
@@ -211,7 +212,8 @@ public class ListSelectiveStreamReader
                 hiveStorageTimeZone,
                 options,
                 legacyMapSubscript,
-                systemMemoryContext);
+                systemMemoryContext,
+                isLowMemory);
         this.systemMemoryContext = systemMemoryContext.newOrcLocalMemoryContext(ListSelectiveStreamReader.class.getSimpleName());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
@@ -46,11 +46,17 @@ public class LongSelectiveStreamReader
             StreamDescriptor streamDescriptor,
             Optional<TupleDomainFilter> filter,
             Optional<Type> outputType,
-            OrcAggregatedMemoryContext systemMemoryContext)
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         directReader = new LongDirectSelectiveStreamReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(LongSelectiveStreamReader.class.getSimpleName()));
-        dictionaryReader = new LongDictionarySelectiveStreamReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(LongSelectiveStreamReader.class.getSimpleName()));
+        dictionaryReader = new LongDictionarySelectiveStreamReader(
+                streamDescriptor,
+                filter,
+                outputType,
+                systemMemoryContext.newOrcLocalMemoryContext(LongSelectiveStreamReader.class.getSimpleName()),
+                isLowMemory);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -117,7 +117,8 @@ public class MapDirectSelectiveStreamReader
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
             boolean legacyMapSubscript,
-            OrcAggregatedMemoryContext systemMemoryContext)
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
     {
         checkArgument(filters.keySet().stream().map(Subfield::getPath).allMatch(List::isEmpty), "filters on nested columns are not supported yet");
 
@@ -149,8 +150,8 @@ public class MapDirectSelectiveStreamReader
                         .collect(toImmutableList());
             }
 
-            this.keyReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(0), keyFilter, keyOutputType, ImmutableList.of(), hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext.newOrcAggregatedMemoryContext());
-            this.valueReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(1), ImmutableMap.of(), valueOutputType, elementRequiredSubfields, hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext.newOrcAggregatedMemoryContext());
+            this.keyReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(0), keyFilter, keyOutputType, ImmutableList.of(), hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext.newOrcAggregatedMemoryContext(), isLowMemory);
+            this.valueReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(1), ImmutableMap.of(), valueOutputType, elementRequiredSubfields, hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext.newOrcAggregatedMemoryContext(), isLowMemory);
         }
         else {
             this.keyReader = null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -684,7 +684,8 @@ public class MapFlatSelectiveStreamReader
                     hiveStorageTimeZone,
                     options,
                     legacyMapSubscript,
-                    systemMemoryContext.newOrcAggregatedMemoryContext());
+                    systemMemoryContext.newOrcAggregatedMemoryContext(),
+                    true);
             valueStreamReader.startStripe(stripe);
             valueStreamReaders.add(valueStreamReader);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
@@ -57,10 +57,11 @@ public class MapSelectiveStreamReader
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
             boolean legacyMapSubscript,
-            OrcAggregatedMemoryContext systemMemoryContext)
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new MapDirectSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext);
+        directReader = new MapDirectSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext, isLowMemory);
         flatReader = new MapFlatSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, options, legacyMapSubscript, systemMemoryContext);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
@@ -46,11 +46,11 @@ public class SliceSelectiveStreamReader
     private final SliceDictionarySelectiveReader dictionaryReader;
     private SelectiveStreamReader currentReader;
 
-    public SliceSelectiveStreamReader(StreamDescriptor streamDescriptor, Optional<TupleDomainFilter> filter, Optional<Type> outputType, OrcAggregatedMemoryContext systemMemoryContext)
+    public SliceSelectiveStreamReader(StreamDescriptor streamDescriptor, Optional<TupleDomainFilter> filter, Optional<Type> outputType, OrcAggregatedMemoryContext systemMemoryContext, boolean isLowMemory)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.directReader = new SliceDirectSelectiveStreamReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(SliceDirectSelectiveStreamReader.class.getSimpleName()));
-        this.dictionaryReader = new SliceDictionarySelectiveReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(SliceDictionarySelectiveReader.class.getSimpleName()));
+        this.dictionaryReader = new SliceDictionarySelectiveReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(SliceDictionarySelectiveReader.class.getSimpleName()), isLowMemory);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -110,7 +110,8 @@ public class StructSelectiveStreamReader
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
             boolean legacyMapSubscript,
-            OrcAggregatedMemoryContext systemMemoryContext)
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null").newOrcLocalMemoryContext(StructSelectiveStreamReader.class.getSimpleName());
@@ -188,7 +189,8 @@ public class StructSelectiveStreamReader
                                 hiveStorageTimeZone,
                                 options,
                                 legacyMapSubscript,
-                                systemMemoryContext.newOrcAggregatedMemoryContext());
+                                systemMemoryContext.newOrcAggregatedMemoryContext(),
+                                isLowMemory);
                         nestedReaders.put(fieldName, nestedReader);
                     }
                     else {


### PR DESCRIPTION
Context:
1. DWRF FlatMap reader supports shared dictionary, where multiple flat
map columns share a dictionary. These dictionaries can be very large.

2. Filter pushdown  readers, caches deterministic filter results for
each entry in the dictionary.

3. Presto Map automatically removes the null keys from the map. By
using isNotNull key for Map.

Bug:
When flat map's value contains map type, filter pushdown readers today
tries to cache the result of isNotNull check. This allocates few GB of
memory per reader and causes the worker to OOM.

Fix:
Do not cache the dictionary results inside the flat map columns. As
there could be multiple 1000's of such columns.

Test plan
Existing tests. 
For the file that resulted in OOM

Before the fix:
Reader is 19GB (yes 19GB) and it took 23 seconds.
Checksum :4102702919787876459, metrics: ReaderMetrics{maxPageSize=11124719, maxRows=52, maxReaderBytes=19,195,841,771}, time_to_run: 23470

After the fix:
56MB and 9 seconds :)
Checksum :4102702919787876459, metrics: ReaderMetrics{maxPageSize=11124719, maxRows=52, maxReaderBytes=56,001,079}, time_to_run: 9809

```
== NO RELEASE NOTE ==
```
