### PR TITLE
Do not cache bufferAdapter in OrcInputStream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -67,7 +67,6 @@ public final class OrcInputStream
     private int currentCompressedBlockOffset;
 
     private byte[] buffer;
-    private OrcDecompressor.OutputBuffer bufferAdapter;
     private int position;
     private int length;
     private int uncompressedOffset;
@@ -108,7 +107,6 @@ public final class OrcInputStream
             this.compressedSliceInput = sliceInput;
             this.buffer = new byte[0];
             this.compressedSliceInputRetainedSizeInBytes = sliceInputRetainedSizeInBytes;
-            this.bufferAdapter = createDecompressorOutputBufferAdapter();
         }
 
         memoryUsage.setBytes(getRetainedSizeInBytes());
@@ -493,7 +491,7 @@ public final class OrcInputStream
                 readCompressed = compressedBuffer.length;
             }
 
-            length = decompressor.get().decompress(compressedBuffer, 0, readCompressed, bufferAdapter);
+            length = decompressor.get().decompress(compressedBuffer, 0, readCompressed, createDecompressorOutputBufferAdapter());
             position = 0;
         }
         uncompressedOffset = position;


### PR DESCRIPTION
Flat map creates lot of OrcInputStream. Each bufferAdapter
is 24 bytes size and has a 8 byte reference from OrcInputStream. 
For a flat map reader it can add up to 10MB.

Test plan -
Existing tests.

```
== NO RELEASE NOTE ==
```
