### PR TITLE
Introduce AlternativeArbitrary aggregation.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -289,6 +289,7 @@ import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharEnumParametricType.VARCHAR_ENUM;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
+import static com.facebook.presto.operator.aggregation.AlternativeArbitraryAggregationFunction.ALTERNATIVE_ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregationFunction.ALTERNATIVE_MAX;
 import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
@@ -898,6 +899,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
 
         // Replace some aggregations for Velox to override intermediate aggregation type.
         if (featuresConfig.isUseAlternativeFunctionSignatures()) {
+            builder.override(ARBITRARY_AGGREGATION, ALTERNATIVE_ARBITRARY_AGGREGATION);
             builder.override(MAX_AGGREGATION, ALTERNATIVE_MAX);
             builder.override(MIN_AGGREGATION, ALTERNATIVE_MIN);
             builder.override(MAX_BY, ALTERNATIVE_MAX_BY);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeArbitraryAggregationFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.type.Type;
+
+public class AlternativeArbitraryAggregationFunction
+        extends ArbitraryAggregationFunction
+{
+    public static final AlternativeArbitraryAggregationFunction ALTERNATIVE_ARBITRARY_AGGREGATION = new AlternativeArbitraryAggregationFunction();
+
+    public AlternativeArbitraryAggregationFunction()
+    {
+        super();
+    }
+
+    @Override
+    protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)
+    {
+        return inputType;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -90,7 +90,7 @@ public class ArbitraryAggregationFunction
         return generateAggregation(valueType);
     }
 
-    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
+    private BuiltInAggregationFunctionImplementation generateAggregation(Type type)
     {
         DynamicClassLoader classLoader = new DynamicClassLoader(ArbitraryAggregationFunction.class.getClassLoader());
 
@@ -133,7 +133,7 @@ public class ArbitraryAggregationFunction
         }
         inputFunction = inputFunction.bindTo(type);
 
-        Type intermediateType = stateSerializer.getSerializedType();
+        Type intermediateType = overrideIntermediateType(type, stateSerializer.getSerializedType());
         List<ParameterMetadata> inputParameterMetadata = createInputParameterMetadata(type);
         AggregationMetadata metadata = new AggregationMetadata(
                 generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
@@ -157,6 +157,11 @@ public class ArbitraryAggregationFunction
                 classLoader);
         return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), type,
                 true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)
+    {
+        return defaultIntermediateType;
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type value)


### PR DESCRIPTION
Introduce AlternativeArbitrary aggregation with the-same-as-input intermediate type instead of BIGINT, so we have it running properly on Velox. We'll use it for Prestissimo (C++ Velox-based Presto worker).

Test plan

Tested arbitrary() with Prestissimo in the local mac setup and observed proper results. Also will add E2E tests, but they will be later in Prestissimo repo.