### PR TITLE
Reduce memory usage of StreamDescriptor in Flat Maps

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -785,7 +785,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             nestedStreams.add(createStreamDescriptor(parentStreamName, "key", type.getFieldTypeIndex(0), types, dataSource));
             nestedStreams.add(createStreamDescriptor(parentStreamName, "value", type.getFieldTypeIndex(1), types, dataSource));
         }
-        return new StreamDescriptor(parentStreamName, typeId, fieldName, type, dataSource, nestedStreams.build());
+        return new StreamDescriptorWithoutSequence(parentStreamName, typeId, fieldName, type, dataSource, nestedStreams.build());
     }
 
     protected boolean shouldValidateWritePageChecksum()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
@@ -15,99 +15,34 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.util.Objects.requireNonNull;
-
-public final class StreamDescriptor
+public interface StreamDescriptor
 {
-    private final String streamName;
-    private final int streamId;
-    private final int sequence;
-    private final OrcType orcType;
-    private final String fieldName;
-    private final OrcDataSource orcDataSource;
-    private final List<StreamDescriptor> nestedStreams;
+    StreamDescriptor duplicate(int sequence);
 
-    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcType orcType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams)
+    String getStreamName();
+
+    int getStreamId();
+
+    int getSequence();
+
+    default OrcTypeKind getOrcTypeKind()
     {
-        this(streamName, streamId, fieldName, orcType, orcDataSource, nestedStreams, DEFAULT_SEQUENCE_ID);
+        return getOrcType().getOrcTypeKind();
     }
 
-    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcType orcType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams, int sequence)
+    OrcType getOrcType();
+
+    String getFieldName();
+
+    default OrcDataSourceId getOrcDataSourceId()
     {
-        this.streamName = requireNonNull(streamName, "streamName is null");
-        this.streamId = streamId;
-        this.sequence = sequence;
-        this.fieldName = requireNonNull(fieldName, "fieldName is null");
-        this.orcType = requireNonNull(orcType, "orcType is null");
-        this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
-        this.nestedStreams = ImmutableList.copyOf(requireNonNull(nestedStreams, "nestedStreams is null"));
+        return getOrcDataSource().getId();
     }
 
-    public StreamDescriptor duplicate(int sequence)
-    {
-        return new StreamDescriptor(streamName, streamId, fieldName, orcType, orcDataSource, nestedStreams, sequence);
-    }
+    OrcDataSource getOrcDataSource();
 
-    public String getStreamName()
-    {
-        return streamName;
-    }
-
-    public int getStreamId()
-    {
-        return streamId;
-    }
-
-    public int getSequence()
-    {
-        return sequence;
-    }
-
-    public OrcTypeKind getOrcTypeKind()
-    {
-        return orcType.getOrcTypeKind();
-    }
-
-    public OrcType getOrcType()
-    {
-        return this.orcType;
-    }
-
-    public String getFieldName()
-    {
-        return fieldName;
-    }
-
-    public OrcDataSourceId getOrcDataSourceId()
-    {
-        return orcDataSource.getId();
-    }
-
-    public OrcDataSource getOrcDataSource()
-    {
-        return orcDataSource;
-    }
-
-    public List<StreamDescriptor> getNestedStreams()
-    {
-        return nestedStreams;
-    }
-
-    @Override
-    public String toString()
-    {
-        return toStringHelper(this)
-                .add("streamName", streamName)
-                .add("streamId", streamId)
-                .add("sequence", sequence)
-                .add("orcType", orcType)
-                .add("dataSource", orcDataSource.getId())
-                .toString();
-    }
+    List<StreamDescriptor> getNestedStreams();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorWithSequence.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorWithSequence.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.OrcType;
+import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class StreamDescriptorWithSequence
+        implements StreamDescriptor
+{
+    private final StreamDescriptor streamDescriptor;
+    private final int sequence;
+
+    public StreamDescriptorWithSequence(StreamDescriptor streamDescriptor, int sequence)
+    {
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.sequence = sequence;
+    }
+
+    public StreamDescriptorWithSequence duplicate(int sequence)
+    {
+        return new StreamDescriptorWithSequence(streamDescriptor, sequence);
+    }
+
+    public String getStreamName()
+    {
+        return streamDescriptor.getStreamName();
+    }
+
+    public int getStreamId()
+    {
+        return streamDescriptor.getStreamId();
+    }
+
+    public int getSequence()
+    {
+        return sequence;
+    }
+
+    public OrcTypeKind getOrcTypeKind()
+    {
+        return getOrcType().getOrcTypeKind();
+    }
+
+    public OrcType getOrcType()
+    {
+        return streamDescriptor.getOrcType();
+    }
+
+    public String getFieldName()
+    {
+        return streamDescriptor.getFieldName();
+    }
+
+    public OrcDataSourceId getOrcDataSourceId()
+    {
+        return getOrcDataSource().getId();
+    }
+
+    public OrcDataSource getOrcDataSource()
+    {
+        return streamDescriptor.getOrcDataSource();
+    }
+
+    public List<StreamDescriptor> getNestedStreams()
+    {
+        return streamDescriptor.getNestedStreams().stream()
+                .map(stream -> copyStreamDescriptorWithSequence(stream, sequence))
+                .collect(toImmutableList());
+    }
+
+    private static StreamDescriptor copyStreamDescriptorWithSequence(StreamDescriptor streamDescriptor, int sequence)
+    {
+        if (!streamDescriptor.getNestedStreams().isEmpty()) {
+            List<StreamDescriptor> nestedStreams = streamDescriptor.getNestedStreams().stream()
+                    .map(stream -> copyStreamDescriptorWithSequence(stream, sequence))
+                    .collect(toImmutableList());
+            streamDescriptor = new StreamDescriptorWithoutSequence(
+                    streamDescriptor.getStreamName(),
+                    streamDescriptor.getStreamId(),
+                    streamDescriptor.getFieldName(),
+                    streamDescriptor.getOrcType(),
+                    streamDescriptor.getOrcDataSource(),
+                    nestedStreams);
+        }
+
+        return new StreamDescriptorWithSequence(streamDescriptor, sequence);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorWithoutSequence.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorWithoutSequence.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.OrcType;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class StreamDescriptorWithoutSequence
+        implements StreamDescriptor
+{
+    private final String streamName;
+    private final int streamId;
+    private final OrcType orcType;
+    private final String fieldName;
+    private final OrcDataSource orcDataSource;
+    private final List<StreamDescriptor> nestedStreams;
+
+    public StreamDescriptorWithoutSequence(String streamName, int streamId, String fieldName, OrcType orcType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams)
+    {
+        this.streamName = requireNonNull(streamName, "streamName is null");
+        this.streamId = streamId;
+        this.fieldName = requireNonNull(fieldName, "fieldName is null");
+        this.orcType = requireNonNull(orcType, "orcType is null");
+        this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
+        this.nestedStreams = ImmutableList.copyOf(requireNonNull(nestedStreams, "nestedStreams is null"));
+    }
+
+    @Override
+    public StreamDescriptor duplicate(int sequence)
+    {
+        return new StreamDescriptorWithSequence(this, sequence);
+    }
+
+    public String getStreamName()
+    {
+        return streamName;
+    }
+
+    public int getStreamId()
+    {
+        return streamId;
+    }
+
+    public int getSequence()
+    {
+        return DEFAULT_SEQUENCE_ID;
+    }
+
+    public OrcType getOrcType()
+    {
+        return this.orcType;
+    }
+
+    public String getFieldName()
+    {
+        return fieldName;
+    }
+
+    public OrcDataSource getOrcDataSource()
+    {
+        return orcDataSource;
+    }
+
+    public List<StreamDescriptor> getNestedStreams()
+    {
+        return nestedStreams;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("streamName", streamName)
+                .add("streamId", streamId)
+                .add("sequence", getSequence())
+                .add("orcType", orcType)
+                .add("dataSource", orcDataSource.getId())
+                .toString();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -33,6 +33,7 @@ import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
 import com.facebook.presto.orc.OrcRecordReaderOptions;
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.StreamDescriptorWithSequence;
 import com.facebook.presto.orc.Stripe;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
@@ -73,7 +74,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
@@ -673,7 +673,7 @@ public class MapFlatSelectiveStreamReader
 
             inMapStreamSources.add(getBooleanMissingStreamSource());
 
-            StreamDescriptor valueStreamDescriptor = copyStreamDescriptorWithSequence(baseValueStreamDescriptor, sequence);
+            StreamDescriptor valueStreamDescriptor = new StreamDescriptorWithSequence(baseValueStreamDescriptor, sequence);
             valueStreamDescriptors.add(valueStreamDescriptor);
 
             SelectiveStreamReader valueStreamReader = SelectiveStreamReaders.createStreamReader(
@@ -705,26 +705,6 @@ public class MapFlatSelectiveStreamReader
         }
 
         return requiredStringKeys.isEmpty() || requiredStringKeys.contains(value.getKey().getBytesKey().toStringUtf8());
-    }
-
-    /**
-     * Creates StreamDescriptor which is a copy of this one with the value of sequence changed to
-     * the value passed in.  Recursively calls itself on the nested streams.
-     */
-    private static StreamDescriptor copyStreamDescriptorWithSequence(StreamDescriptor streamDescriptor, int sequence)
-    {
-        List<StreamDescriptor> streamDescriptors = streamDescriptor.getNestedStreams().stream()
-                .map(stream -> copyStreamDescriptorWithSequence(stream, sequence))
-                .collect(toImmutableList());
-
-        return new StreamDescriptor(
-                streamDescriptor.getStreamName(),
-                streamDescriptor.getStreamId(),
-                streamDescriptor.getFieldName(),
-                streamDescriptor.getOrcType(),
-                streamDescriptor.getOrcDataSource(),
-                streamDescriptors,
-                sequence);
     }
 
     private Block getKeysBlock(List<DwrfSequenceEncoding> sequenceEncodings)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -224,9 +224,9 @@ public class TestListFilter
         OrcType intType = new OrcType(INT, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
         OrcType listType = new OrcType(LIST, ImmutableList.of(1), ImmutableList.of("item"), Optional.empty(), Optional.empty(), Optional.empty());
 
-        StreamDescriptor streamDescriptor = new StreamDescriptor("a", 0, "a", intType, orcDataSource, ImmutableList.of());
+        StreamDescriptor streamDescriptor = new StreamDescriptorWithoutSequence("a", 0, "a", intType, orcDataSource, ImmutableList.of());
         for (int i = 0; i < levels; i++) {
-            streamDescriptor = new StreamDescriptor("a", 0, "a", listType, orcDataSource, ImmutableList.of(streamDescriptor));
+            streamDescriptor = new StreamDescriptorWithoutSequence("a", 0, "a", listType, orcDataSource, ImmutableList.of(streamDescriptor));
         }
 
         return streamDescriptor;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
@@ -287,8 +287,9 @@ public class TestLongDictionaryProvider
 
     private StreamDescriptor createFlatStreamDescriptor(StreamId streamId)
     {
-        return new StreamDescriptor("test_dictionary_stream", streamId.getColumn(),
-                String.format("field_%d", streamId.getColumn()), LONG_TYPE, DUMMY_ORC_DATA_SOURCE, ImmutableList.of(), streamId.getSequence());
+        StreamDescriptor streamDescriptor = new StreamDescriptorWithoutSequence("test_dictionary_stream", streamId.getColumn(),
+                String.format("field_%d", streamId.getColumn()), LONG_TYPE, DUMMY_ORC_DATA_SOURCE, ImmutableList.of());
+        return new StreamDescriptorWithSequence(streamDescriptor, streamId.getSequence());
     }
 
     private InputStreamSources createLongDictionaryStreamSources(Map<NodeId, long[]> streams, OrcAggregatedMemoryContext aggregatedMemoryContext)


### PR DESCRIPTION
Flat Maps StreamDescriptor consume large amount of memory.
1. Make additional sequences point to the base sequence to
avoid duplicating references.
2. Do not store nested streams, as they are computed, stored
and retrieved only once in the constructor of the reader.

Should reduce typical flat map reader memory consumption by about
10-15 MB.

Test plan -
Will add new tests in a modified commit.

```
== NO RELEASE NOTE ==
```
