### PR TITLE
Clarify serialization of maps in SerializedPage Wire Format doc

### DIFF
--- a/presto-docs/src/main/sphinx/develop/serialized-page.rst
+++ b/presto-docs/src/main/sphinx/develop/serialized-page.rst
@@ -177,8 +177,8 @@ MAP Encoding
 
 * Keys column
 * Values column
-* Hash table size - 4 bytes
-* [optional] Hash table
+* Hash table size (number of 4-byte chunks in the Hash table) - 4 bytes
+* [optional] Hash table: <Hash table size> * <4 bytes>
 * Number of rows - 4 bytes
 * Offsets - (number of rows + 1) * 4 bytes; 4 bytes per offset
 * Null flags


### PR DESCRIPTION
Add clarification to RST file about size of MAP's hash table in "SerializedPage Wire Format".