### PR TITLE
Reduce memory usage of StreamDescriptor

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -764,30 +764,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         return systemMemoryUsage.getBytes();
     }
 
-    protected static StreamDescriptor createStreamDescriptor(String parentStreamName, String fieldName, int typeId, List<OrcType> types, OrcDataSource dataSource)
-    {
-        OrcType type = types.get(typeId);
-
-        if (!fieldName.isEmpty()) {
-            parentStreamName += "." + fieldName;
-        }
-
-        ImmutableList.Builder<StreamDescriptor> nestedStreams = ImmutableList.builder();
-        if (type.getOrcTypeKind() == STRUCT) {
-            for (int i = 0; i < type.getFieldCount(); ++i) {
-                nestedStreams.add(createStreamDescriptor(parentStreamName, type.getFieldName(i), type.getFieldTypeIndex(i), types, dataSource));
-            }
-        }
-        else if (type.getOrcTypeKind() == OrcType.OrcTypeKind.LIST) {
-            nestedStreams.add(createStreamDescriptor(parentStreamName, "item", type.getFieldTypeIndex(0), types, dataSource));
-        }
-        else if (type.getOrcTypeKind() == OrcType.OrcTypeKind.MAP) {
-            nestedStreams.add(createStreamDescriptor(parentStreamName, "key", type.getFieldTypeIndex(0), types, dataSource));
-            nestedStreams.add(createStreamDescriptor(parentStreamName, "value", type.getFieldTypeIndex(1), types, dataSource));
-        }
-        return new StreamDescriptor(parentStreamName, typeId, fieldName, type, dataSource, nestedStreams.build());
-    }
-
     protected boolean shouldValidateWritePageChecksum()
     {
         return writeChecksumBuilder.isPresent();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.StreamDescriptorFactory.createStreamDescriptor;
+
 public class OrcBatchRecordReader
         extends AbstractOrcRecordReader<BatchStreamReader>
 {
@@ -157,7 +159,7 @@ public class OrcBatchRecordReader
             OrcAggregatedMemoryContext systemMemoryContext)
             throws OrcCorruptionException
     {
-        List<StreamDescriptor> streamDescriptors = createStreamDescriptor("", "", 0, types, orcDataSource).getNestedStreams();
+        List<StreamDescriptor> streamDescriptors = createStreamDescriptor(types, orcDataSource).getNestedStreams();
 
         OrcType rowType = types.get(0);
         BatchStreamReader[] streamReaders = new BatchStreamReader[rowType.getFieldCount()];

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
+import static com.facebook.presto.orc.StreamDescriptorFactory.createStreamDescriptor;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.createStreamReader;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
@@ -592,7 +593,7 @@ public class OrcSelectiveRecordReader
             Map<Integer, List<Subfield>> requiredSubfields,
             OrcAggregatedMemoryContext systemMemoryContext)
     {
-        List<StreamDescriptor> streamDescriptors = createStreamDescriptor("", "", 0, types, orcDataSource).getNestedStreams();
+        List<StreamDescriptor> streamDescriptors = createStreamDescriptor(types, orcDataSource).getNestedStreams();
 
         requireNonNull(filterFunctions, "filterFunctions is null");
         requireNonNull(filterFunctionInputMapping, "filterFunctionInputMapping is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorFactory.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptorFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.OrcType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.STRUCT;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public final class StreamDescriptorFactory
+{
+    private static final int ROOT_ID = 0;
+
+    private StreamDescriptorFactory()
+    {
+    }
+
+    public static StreamDescriptor createStreamDescriptor(List<OrcType> types, OrcDataSource dataSource)
+    {
+        ImmutableMap.Builder<Integer, StreamProperty> propertiesBuilder = ImmutableMap.builderWithExpectedSize(types.size());
+        addOrcType("", "", ROOT_ID, types, propertiesBuilder);
+        AllStreams allStreams = new AllStreams(dataSource, propertiesBuilder.build());
+        return new StreamDescriptor(ROOT_ID, DEFAULT_SEQUENCE_ID, allStreams);
+    }
+
+    private static void addOrcType(String parentStreamName, String fieldName, int typeId, List<OrcType> types, ImmutableMap.Builder<Integer, StreamProperty> propertiesBuilder)
+    {
+        OrcType type = types.get(typeId);
+
+        if (!fieldName.isEmpty()) {
+            parentStreamName += "." + fieldName;
+        }
+
+        ImmutableList.Builder<Integer> nestedStreamIdsBuilder = ImmutableList.builderWithExpectedSize(type.getFieldCount());
+        if (type.getOrcTypeKind() == STRUCT) {
+            for (int i = 0; i < type.getFieldCount(); i++) {
+                nestedStreamIdsBuilder.add(type.getFieldTypeIndex(i));
+                addOrcType(parentStreamName, type.getFieldName(i), type.getFieldTypeIndex(i), types, propertiesBuilder);
+            }
+        }
+        else if (type.getOrcTypeKind() == OrcType.OrcTypeKind.LIST) {
+            nestedStreamIdsBuilder.add(type.getFieldTypeIndex(0));
+            addOrcType(parentStreamName, "item", type.getFieldTypeIndex(0), types, propertiesBuilder);
+        }
+        else if (type.getOrcTypeKind() == OrcType.OrcTypeKind.MAP) {
+            nestedStreamIdsBuilder.add(type.getFieldTypeIndex(0));
+            nestedStreamIdsBuilder.add(type.getFieldTypeIndex(1));
+            addOrcType(parentStreamName, "key", type.getFieldTypeIndex(0), types, propertiesBuilder);
+            addOrcType(parentStreamName, "value", type.getFieldTypeIndex(1), types, propertiesBuilder);
+        }
+        StreamProperty streamProperty = new StreamProperty(parentStreamName, type, fieldName, nestedStreamIdsBuilder.build());
+        propertiesBuilder.put(typeId, streamProperty);
+    }
+
+    public static class StreamProperty
+    {
+        private final String streamName;
+        private final OrcType orcType;
+        private final String fieldName;
+        private final List<Integer> nestedStreamIds;
+
+        public StreamProperty(String streamName, OrcType orcType, String fieldName, List<Integer> nestedStreamIds)
+        {
+            this.streamName = requireNonNull(streamName, "streamName is null");
+            this.orcType = requireNonNull(orcType, "orcType is null");
+            this.fieldName = requireNonNull(fieldName, "fieldName is null");
+            this.nestedStreamIds = ImmutableList.copyOf(requireNonNull(nestedStreamIds, "nestedStreamIds is null"));
+        }
+
+        public String getStreamName()
+        {
+            return streamName;
+        }
+
+        public OrcType getOrcType()
+        {
+            return orcType;
+        }
+
+        public String getFieldName()
+        {
+            return fieldName;
+        }
+
+        public List<Integer> getNestedStreamIds()
+        {
+            return nestedStreamIds;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            StreamProperty that = (StreamProperty) o;
+            return Objects.equals(streamName, that.streamName)
+                    && Objects.equals(orcType, that.orcType)
+                    && Objects.equals(fieldName, that.fieldName)
+                    && Objects.equals(nestedStreamIds, that.nestedStreamIds);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(streamName, orcType, fieldName, nestedStreamIds);
+        }
+    }
+
+    public static class AllStreams
+    {
+        private final OrcDataSource orcDataSource;
+        private final Map<Integer, StreamProperty> streamIdToProperties;
+
+        public AllStreams(OrcDataSource orcDataSource, Map<Integer, StreamProperty> streamIdToProperties)
+        {
+            this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
+            this.streamIdToProperties = ImmutableMap.copyOf(requireNonNull(streamIdToProperties, "streamProperties is null"));
+        }
+
+        public OrcDataSource getOrcDataSource()
+        {
+            return orcDataSource;
+        }
+
+        public StreamProperty getStreamProperty(int streamId)
+        {
+            StreamProperty streamProperty = streamIdToProperties.get(streamId);
+            checkState(streamProperty != null, "StreamId %s is missing", streamId);
+            return streamProperty;
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -73,7 +73,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
@@ -673,7 +672,7 @@ public class MapFlatSelectiveStreamReader
 
             inMapStreamSources.add(getBooleanMissingStreamSource());
 
-            StreamDescriptor valueStreamDescriptor = copyStreamDescriptorWithSequence(baseValueStreamDescriptor, sequence);
+            StreamDescriptor valueStreamDescriptor = baseValueStreamDescriptor.duplicate(sequence);
             valueStreamDescriptors.add(valueStreamDescriptor);
 
             SelectiveStreamReader valueStreamReader = SelectiveStreamReaders.createStreamReader(
@@ -705,26 +704,6 @@ public class MapFlatSelectiveStreamReader
         }
 
         return requiredStringKeys.isEmpty() || requiredStringKeys.contains(value.getKey().getBytesKey().toStringUtf8());
-    }
-
-    /**
-     * Creates StreamDescriptor which is a copy of this one with the value of sequence changed to
-     * the value passed in.  Recursively calls itself on the nested streams.
-     */
-    private static StreamDescriptor copyStreamDescriptorWithSequence(StreamDescriptor streamDescriptor, int sequence)
-    {
-        List<StreamDescriptor> streamDescriptors = streamDescriptor.getNestedStreams().stream()
-                .map(stream -> copyStreamDescriptorWithSequence(stream, sequence))
-                .collect(toImmutableList());
-
-        return new StreamDescriptor(
-                streamDescriptor.getStreamName(),
-                streamDescriptor.getStreamId(),
-                streamDescriptor.getFieldName(),
-                streamDescriptor.getOrcType(),
-                streamDescriptor.getOrcDataSource(),
-                streamDescriptors,
-                sequence);
     }
 
     private Block getKeysBlock(List<DwrfSequenceEncoding> sequenceEncodings)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -17,20 +17,22 @@ import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
 import com.facebook.presto.common.predicate.TupleDomainFilter.BigintRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.PositionalFilter;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.reader.ListFilter;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 
-import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.INT;
-import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LIST;
+import static com.facebook.presto.orc.StreamDescriptorFactory.createStreamDescriptor;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -221,15 +223,13 @@ public class TestListFilter
     {
         NoopOrcDataSource orcDataSource = NoopOrcDataSource.INSTANCE;
 
-        OrcType intType = new OrcType(INT, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
-        OrcType listType = new OrcType(LIST, ImmutableList.of(1), ImmutableList.of("item"), Optional.empty(), Optional.empty(), Optional.empty());
-
-        StreamDescriptor streamDescriptor = new StreamDescriptor("a", 0, "a", intType, orcDataSource, ImmutableList.of());
+        Type elementType = IntegerType.INTEGER;
         for (int i = 0; i < levels; i++) {
-            streamDescriptor = new StreamDescriptor("a", 0, "a", listType, orcDataSource, ImmutableList.of(streamDescriptor));
+            elementType = new ArrayType(elementType);
         }
+        List<OrcType> orcTypes = OrcType.toOrcType(0, elementType);
 
-        return streamDescriptor;
+        return createStreamDescriptor(orcTypes, orcDataSource);
     }
 
     private static Subfield toSubfield(RowAndColumn indices)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.orc.StreamDescriptorFactory.AllStreams;
+import com.facebook.presto.orc.StreamDescriptorFactory.StreamProperty;
 import com.facebook.presto.orc.checkpoint.StreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.OrcType;
@@ -287,8 +289,12 @@ public class TestLongDictionaryProvider
 
     private StreamDescriptor createFlatStreamDescriptor(StreamId streamId)
     {
-        return new StreamDescriptor("test_dictionary_stream", streamId.getColumn(),
-                String.format("field_%d", streamId.getColumn()), LONG_TYPE, DUMMY_ORC_DATA_SOURCE, ImmutableList.of(), streamId.getSequence());
+        Map<Integer, StreamProperty> streamProperties = ImmutableMap.of(
+                streamId.getColumn(),
+                new StreamProperty("test_dictionary_stream", LONG_TYPE, "field_" + streamId.getColumn(), ImmutableList.of()));
+        AllStreams allStreams = new AllStreams(DUMMY_ORC_DATA_SOURCE, streamProperties);
+
+        return new StreamDescriptor(streamId.getColumn(), streamId.getSequence(), allStreams);
     }
 
     private InputStreamSources createLongDictionaryStreamSources(Map<NodeId, long[]> streams, OrcAggregatedMemoryContext aggregatedMemoryContext)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamDescriptorFactory.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamDescriptorFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.StreamDescriptorFactory.AllStreams;
+import com.facebook.presto.orc.StreamDescriptorFactory.StreamProperty;
+import com.facebook.presto.orc.metadata.OrcType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.OrcTester.arrayType;
+import static com.facebook.presto.orc.OrcTester.mapType;
+import static com.facebook.presto.orc.StreamDescriptorFactory.createStreamDescriptor;
+import static com.facebook.presto.orc.metadata.OrcType.toOrcType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+public class TestStreamDescriptorFactory
+{
+    private static final OrcDataSource DUMMY_ORC_DATA_SOURCE = new NoopOrcDataSource();
+
+    private static void verifyStreamDescriptor(StreamDescriptor streamDescriptor, int expectedStreamId, int expectedSequence, Map<Integer, StreamProperty> streamPropertyMap)
+    {
+        assertEquals(streamDescriptor.getStreamId(), expectedStreamId, "streamId");
+        assertEquals(streamDescriptor.getSequence(), expectedSequence, "sequence");
+
+        assertEquals(streamDescriptor.getOrcDataSource(), DUMMY_ORC_DATA_SOURCE, "sequence");
+
+        StreamProperty streamProperty = streamPropertyMap.get(expectedStreamId);
+        assertEquals(streamDescriptor.getStreamName(), streamProperty.getStreamName(), "stream name");
+        assertEquals(streamDescriptor.getFieldName(), streamProperty.getFieldName(), "field name");
+        assertEquals(streamDescriptor.getOrcType(), streamProperty.getOrcType(), "orc type");
+
+        List<StreamDescriptor> nestedStreamDescriptors = streamDescriptor.getNestedStreams();
+        assertEquals(nestedStreamDescriptors.size(), streamProperty.getNestedStreamIds().size(), "nested streams for stream Id " + expectedStreamId);
+        for (int i = 0; i < nestedStreamDescriptors.size(); i++) {
+            verifyStreamDescriptor(nestedStreamDescriptors.get(i), streamProperty.getNestedStreamIds().get(i), expectedSequence, streamPropertyMap);
+        }
+    }
+
+    public static void throwUnsupportedOperation()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private static List<OrcType> getOrcTypes()
+    {
+        // Create schema with 2 columns
+        // 1st column with name column1 and type Long
+        // 2nd column with name column2 and type Map{ Long : List<Struct{inner1: Float, inner2: VARCHAR}}
+        RowType.Field inner1 = new RowType.Field(Optional.of("inner1"), REAL);
+        RowType.Field inner2 = new RowType.Field(Optional.of("inner2"), VARCHAR);
+        RowType rowType = RowType.from(ImmutableList.of(inner1, inner2));
+
+        Type arrayType = arrayType(rowType);
+        Type mapType = mapType(BIGINT, arrayType);
+
+        RowType.Field column1 = new RowType.Field(Optional.of("column1"), BIGINT);
+        RowType.Field column2 = new RowType.Field(Optional.of("column2"), mapType);
+        RowType rootType = RowType.from(ImmutableList.of(column1, column2));
+        return toOrcType(0, rootType);
+    }
+
+    @Test
+    public void testBuilder()
+    {
+        List<OrcType> orcTypes = getOrcTypes();
+        StreamDescriptor streamDescriptor = createStreamDescriptor(orcTypes, DUMMY_ORC_DATA_SOURCE);
+
+        StreamProperty rootProperty = new StreamProperty("", orcTypes.get(0), "", ImmutableList.of(1, 2));
+        StreamProperty column1Property = new StreamProperty(".column1", orcTypes.get(1), "column1", ImmutableList.of());
+        StreamProperty column2Property = new StreamProperty(".column2", orcTypes.get(2), "column2", ImmutableList.of(3, 4));
+        StreamProperty mapKeyProperty = new StreamProperty(".column2.key", orcTypes.get(3), "key", ImmutableList.of());
+        StreamProperty mapValueProperty = new StreamProperty(".column2.value", orcTypes.get(4), "value", ImmutableList.of(5));
+        StreamProperty listElementProperty = new StreamProperty(".column2.value.item", orcTypes.get(5), "item", ImmutableList.of(6, 7));
+        StreamProperty inner1Property = new StreamProperty(".column2.value.item.inner1", orcTypes.get(6), "inner1", ImmutableList.of());
+        StreamProperty inner2Property = new StreamProperty(".column2.value.item.inner2", orcTypes.get(7), "inner2", ImmutableList.of());
+
+        ImmutableMap.Builder<Integer, StreamProperty> streamToPropertyMapBuilder = ImmutableMap.builder();
+        streamToPropertyMapBuilder.put(0, rootProperty);
+        streamToPropertyMapBuilder.put(1, column1Property);
+        streamToPropertyMapBuilder.put(2, column2Property);
+        streamToPropertyMapBuilder.put(3, mapKeyProperty);
+        streamToPropertyMapBuilder.put(4, mapValueProperty);
+        streamToPropertyMapBuilder.put(5, listElementProperty);
+        streamToPropertyMapBuilder.put(6, inner1Property);
+        streamToPropertyMapBuilder.put(7, inner2Property);
+
+        Map<Integer, StreamProperty> streamPropertyMap = streamToPropertyMapBuilder.build();
+        verifyStreamDescriptor(streamDescriptor, 0, 0, streamPropertyMap);
+
+        StreamDescriptor sequenceStreamDescriptor = streamDescriptor.duplicate(10);
+        verifyStreamDescriptor(sequenceStreamDescriptor, 0, 10, streamPropertyMap);
+    }
+
+    @Test
+    public void testAllStreamsNonExistent()
+    {
+        OrcType varcharType = toOrcType(0, VARCHAR).get(0);
+        StreamProperty streamProperty = new StreamProperty("", varcharType, "", ImmutableList.of(1, 2));
+        ImmutableMap<Integer, StreamProperty> streamIdToPropertyMap = ImmutableMap.of(0, streamProperty);
+        AllStreams allStreams = new AllStreams(DUMMY_ORC_DATA_SOURCE, streamIdToPropertyMap);
+
+        StreamProperty retrieved = allStreams.getStreamProperty(0);
+        assertEquals(retrieved, streamProperty, "streamProperty");
+        expectThrows(IllegalStateException.class, () -> allStreams.getStreamProperty(1));
+    }
+}


### PR DESCRIPTION
StreamDescriptor stores stream name, field name, type, datasource, list
of nested stream descriptors. For Flat Maps, this information is duplicated
over and over again with only different sequence ids and wastes space.

This change applies the database schema normalization and refactors the
code so that only streamId and sequence id are stored in the stream
descriptors. Others are stored in common all streams so that the
data will be shared.

This might slightly regress the memory for normal tables, but will save
a lot for flat map tables.

Test plan -
Existing tests for StreamDescriptor usage
Added new test for StreamDescriptorBuilder

```
== NO RELEASE NOTE ==
```
