### PR TITLE
Fix runtime stats unit of local cache

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -19,7 +19,7 @@ import alluxio.client.quota.CacheScope;
 import com.facebook.presto.hive.HiveFileContext;
 import com.google.common.collect.ImmutableMap;
 
-import static com.facebook.presto.common.RuntimeUnit.NANO;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoCacheContext
@@ -51,7 +51,7 @@ public class PrestoCacheContext
     @Override
     public void incrementCounter(String name, long value)
     {
-        hiveFileContext.incrementCounter(name, NANO, value);
+        hiveFileContext.incrementCounter(name, NONE, value);
     }
 
     public HiveFileContext getHiveFileContext()


### PR DESCRIPTION
The stats unit could be either nano or bytes from  local cache, so I just put the unit to be NONE temporarily.  I will change the code on alluxio side soon to pass a real unit to runtime stats.


```
== NO RELEASE NOTE ==
```
