### PR TITLE
Reduce SelectiveReader memory usage

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -80,8 +80,7 @@ public class LongDictionarySelectiveStreamReader
     {
         super(context);
 
-        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(
-                LongDictionarySelectiveStreamReader.class.getSimpleName());
+        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(this.getClass().getSimpleName());
         this.isDictionaryOwner = true;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -16,9 +16,7 @@ package com.facebook.presto.orc.reader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockLease;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
-import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Stripe;
 import com.facebook.presto.orc.reader.LongDictionaryProvider.DictionaryResult;
 import com.facebook.presto.orc.stream.BooleanInputStream;
@@ -31,7 +29,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Optional;
 
 import static com.facebook.presto.common.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
@@ -44,7 +41,6 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.util.Objects.requireNonNull;
 
 public class LongDictionarySelectiveStreamReader
         extends AbstractLongSelectiveStreamReader
@@ -56,13 +52,7 @@ public class LongDictionarySelectiveStreamReader
     private static final byte FILTER_PASSED = 1;
     private static final byte FILTER_FAILED = 2;
 
-    private final StreamDescriptor streamDescriptor;
-    @Nullable
-    private final TupleDomainFilter filter;
-    private final boolean nonDeterministicFilter;
-    private final boolean nullsAllowed;
     private final OrcLocalMemoryContext systemMemoryContext;
-    private final boolean isLowMemory;
 
     private InputStreamSource<BooleanInputStream> presentStreamSource = getBooleanMissingStreamSource();
     @Nullable
@@ -86,24 +76,13 @@ public class LongDictionarySelectiveStreamReader
     private boolean rowGroupOpen;
     private int readOffset;
 
-    public LongDictionarySelectiveStreamReader(
-            StreamDescriptor streamDescriptor,
-            Optional<TupleDomainFilter> filter,
-            Optional<Type> outputType,
-            OrcLocalMemoryContext systemMemoryContext,
-            boolean isLowMemory)
+    public LongDictionarySelectiveStreamReader(SelectiveReaderContext context)
     {
-        super(outputType);
-        requireNonNull(filter, "filter is null");
-        checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
-        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.filter = filter.orElse(null);
-        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
-        this.isDictionaryOwner = true;
-        this.isLowMemory = isLowMemory;
+        super(context);
 
-        nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
-        nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
+        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(
+                LongDictionarySelectiveStreamReader.class.getSimpleName());
+        this.isDictionaryOwner = true;
     }
 
     @Override
@@ -116,7 +95,7 @@ public class LongDictionarySelectiveStreamReader
             openRowGroup();
         }
 
-        prepareNextRead(positionCount, presentStream != null && nullsAllowed);
+        prepareNextRead(positionCount, presentStream != null && context.isNullsAllowed());
 
         outputPositions = initializeOutputPositions(outputPositions, positions, positionCount);
 
@@ -129,7 +108,7 @@ public class LongDictionarySelectiveStreamReader
 
         // TODO In case of all nulls, the stream type will be LongDirect
         int streamPosition;
-        if (filter == null) {
+        if (context.getFilter() == null) {
             streamPosition = readNoFilter(positions, positionCount);
         }
         else {
@@ -180,6 +159,7 @@ public class LongDictionarySelectiveStreamReader
     {
         outputPositionCount = 0;
         int streamPosition = 0;
+        TupleDomainFilter filter = context.getFilter();
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
             if (position > streamPosition) {
@@ -188,8 +168,8 @@ public class LongDictionarySelectiveStreamReader
             }
 
             if (presentStream != null && !presentStream.nextBit()) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
-                    if (outputRequired) {
+                if ((context.isNonDeterministicFilter() && context.getFilter().testNull()) || context.isNullsAllowed()) {
+                    if (context.isOutputRequired()) {
                         nulls[outputPositionCount] = true;
                         values[outputPositionCount] = 0;
                     }
@@ -223,9 +203,9 @@ public class LongDictionarySelectiveStreamReader
                     filterPassed = filter.testLong(value);
                 }
                 if (filterPassed) {
-                    if (outputRequired) {
+                    if (context.isOutputRequired()) {
                         values[outputPositionCount] = value;
-                        if (presentStream != null && nullsAllowed) {
+                        if (presentStream != null && context.isNullsAllowed()) {
                             nulls[outputPositionCount] = false;
                         }
                     }
@@ -279,10 +259,10 @@ public class LongDictionarySelectiveStreamReader
     {
         // read the dictionary
         if (!dictionaryOpen && dictionarySize > 0) {
-            DictionaryResult dictionaryResult = dictionaryProvider.getDictionary(streamDescriptor, dictionary, dictionarySize);
+            DictionaryResult dictionaryResult = dictionaryProvider.getDictionary(context.getStreamDescriptor(), dictionary, dictionarySize);
             dictionary = dictionaryResult.dictionaryBuffer();
             isDictionaryOwner = dictionaryResult.isBufferOwner();
-            if (!isLowMemory && filter != null && !nonDeterministicFilter) {
+            if (!context.isLowMemory() && context.getFilter() != null && !context.isNonDeterministicFilter()) {
                 dictionaryFilterStatus = ensureCapacity(dictionaryFilterStatus, dictionarySize);
                 Arrays.fill(dictionaryFilterStatus, 0, dictionarySize, FILTER_NOT_EVALUATED);
             }
@@ -303,28 +283,28 @@ public class LongDictionarySelectiveStreamReader
     public Block getBlock(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
-        return buildOutputBlock(positions, positionCount, nullsAllowed && presentStream != null);
+        return buildOutputBlock(positions, positionCount, context.isNullsAllowed() && presentStream != null);
     }
 
     @Override
     public BlockLease getBlockView(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
-        return buildOutputBlockView(positions, positionCount, nullsAllowed && presentStream != null);
+        return buildOutputBlockView(positions, positionCount, context.isNullsAllowed() && presentStream != null);
     }
 
     @Override
     public void startStripe(Stripe stripe)
     {
         dictionaryProvider = stripe.getLongDictionaryProvider();
-        dictionarySize = stripe.getColumnEncodings().get(streamDescriptor.getStreamId())
-                .getColumnEncoding(streamDescriptor.getSequence())
+        dictionarySize = stripe.getColumnEncodings().get(context.getStreamDescriptor().getStreamId())
+                .getColumnEncoding(context.getStreamDescriptor().getSequence())
                 .getDictionarySize();
         dictionaryOpen = false;
 
@@ -344,9 +324,9 @@ public class LongDictionarySelectiveStreamReader
     @Override
     public void startRowGroup(InputStreamSources dataStreamSources)
     {
-        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
-        inDictionaryStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, IN_DICTIONARY, BooleanInputStream.class);
-        dataStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, DATA, LongInputStream.class);
+        presentStreamSource = dataStreamSources.getInputStreamSource(context.getStreamDescriptor(), PRESENT, BooleanInputStream.class);
+        inDictionaryStreamSource = dataStreamSources.getInputStreamSource(context.getStreamDescriptor(), IN_DICTIONARY, BooleanInputStream.class);
+        dataStreamSource = dataStreamSources.getInputStreamSource(context.getStreamDescriptor(), DATA, LongInputStream.class);
 
         readOffset = 0;
         presentStream = null;
@@ -360,7 +340,7 @@ public class LongDictionarySelectiveStreamReader
     public String toString()
     {
         return toStringHelper(this)
-                .addValue(streamDescriptor)
+                .addValue(context.getStreamDescriptor())
                 .toString();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -60,8 +60,7 @@ public class LongDirectSelectiveStreamReader
     public LongDirectSelectiveStreamReader(SelectiveReaderContext context)
     {
         super(context);
-        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(
-                LongDirectSelectiveStreamReader.class.getSimpleName());
+        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(this.getClass().getSimpleName());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -17,9 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockLease;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
-import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Stripe;
 import com.facebook.presto.orc.stream.BooleanInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
@@ -30,7 +28,6 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import static com.facebook.presto.common.block.ClosingBlockLease.newLease;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
@@ -40,18 +37,12 @@ import static com.facebook.presto.orc.stream.MissingInputStreamSource.getBoolean
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.getLongMissingStreamSource;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.requireNonNull;
 
 public class LongDirectSelectiveStreamReader
         extends AbstractLongSelectiveStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongDirectSelectiveStreamReader.class).instanceSize();
-
-    private final StreamDescriptor streamDescriptor;
-    @Nullable
-    private final TupleDomainFilter filter;
-    private final boolean nonDeterministicFilter;
-    private final boolean nullsAllowed;
+    private final OrcLocalMemoryContext systemMemoryContext;
 
     private InputStreamSource<BooleanInputStream> presentStreamSource = getBooleanMissingStreamSource();
     @Nullable
@@ -66,23 +57,11 @@ public class LongDirectSelectiveStreamReader
 
     private boolean allNulls;
 
-    private OrcLocalMemoryContext systemMemoryContext;
-
-    public LongDirectSelectiveStreamReader(
-            StreamDescriptor streamDescriptor,
-            Optional<TupleDomainFilter> filter,
-            Optional<Type> outputType,
-            OrcLocalMemoryContext systemMemoryContext)
+    public LongDirectSelectiveStreamReader(SelectiveReaderContext context)
     {
-        super(outputType);
-        requireNonNull(filter, "filter is null");
-        checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
-        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.filter = filter.orElse(null);
-        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
-
-        nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
-        nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
+        super(context);
+        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(
+                LongDirectSelectiveStreamReader.class.getSimpleName());
     }
 
     @Override
@@ -95,7 +74,7 @@ public class LongDirectSelectiveStreamReader
             openRowGroup();
         }
 
-        prepareNextRead(positionCount, nullsAllowed && presentStream != null);
+        prepareNextRead(positionCount, context.isNullsAllowed() && presentStream != null);
 
         allNulls = false;
 
@@ -113,7 +92,7 @@ public class LongDirectSelectiveStreamReader
         if (dataStream == null && presentStream != null) {
             streamPosition = readAllNulls(positions, positionCount);
         }
-        else if (filter == null) {
+        else if (context.getFilter() == null) {
             streamPosition = readNoFilter(positions, positionCount);
         }
         else {
@@ -130,7 +109,8 @@ public class LongDirectSelectiveStreamReader
     {
         presentStream.skip(positions[positionCount - 1]);
 
-        if (nonDeterministicFilter) {
+        TupleDomainFilter filter = context.getFilter();
+        if (context.isNonDeterministicFilter()) {
             outputPositionCount = 0;
             for (int i = 0; i < positionCount; i++) {
                 if (filter.testNull()) {
@@ -142,7 +122,7 @@ public class LongDirectSelectiveStreamReader
                 }
             }
         }
-        else if (nullsAllowed) {
+        else if (context.isNullsAllowed()) {
             outputPositionCount = positionCount;
         }
         else {
@@ -215,11 +195,12 @@ public class LongDirectSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
+        TupleDomainFilter filter = context.getFilter();
         if (positions[positionCount - 1] == positionCount - 1) {
             // no skipping
             if (presentStream == null) {
                 // no nulls
-                if (!outputRequired && !filter.isPositionalFilter()) {
+                if (!context.isOutputRequired() && !filter.isPositionalFilter()) {
                     // no output; just filter
                     for (int i = 0; i < positionCount; i++) {
                         long value = dataStream.next();
@@ -243,8 +224,8 @@ public class LongDirectSelectiveStreamReader
             }
 
             if (presentStream != null && !presentStream.nextBit()) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
-                    if (outputRequired) {
+                if ((context.isNonDeterministicFilter() && filter.testNull()) || context.isNullsAllowed()) {
+                    if (context.isOutputRequired()) {
                         nulls[outputPositionCount] = true;
                         values[outputPositionCount] = 0;
                     }
@@ -255,9 +236,9 @@ public class LongDirectSelectiveStreamReader
             else {
                 long value = dataStream.next();
                 if (filter.testLong(value)) {
-                    if (outputRequired) {
+                    if (context.isOutputRequired()) {
                         values[outputPositionCount] = value;
-                        if (nullsAllowed && presentStream != null) {
+                        if (context.isNullsAllowed() && presentStream != null) {
                             nulls[outputPositionCount] = false;
                         }
                     }
@@ -314,28 +295,28 @@ public class LongDirectSelectiveStreamReader
     public Block getBlock(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
+            return new RunLengthEncodedBlock(context.getOutputType().createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
-        return buildOutputBlock(positions, positionCount, nullsAllowed && presentStream != null);
+        return buildOutputBlock(positions, positionCount, context.isNullsAllowed() && presentStream != null);
     }
 
     @Override
     public BlockLease getBlockView(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
+            return newLease(new RunLengthEncodedBlock(context.getOutputType().createBlockBuilder(null, 1).appendNull().build(), positionCount));
         }
 
-        return buildOutputBlockView(positions, positionCount, nullsAllowed && presentStream != null);
+        return buildOutputBlockView(positions, positionCount, context.isNullsAllowed() && presentStream != null);
     }
 
     @Override
@@ -355,8 +336,8 @@ public class LongDirectSelectiveStreamReader
     @Override
     public void startRowGroup(InputStreamSources dataStreamSources)
     {
-        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
-        dataStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, DATA, LongInputStream.class);
+        presentStreamSource = dataStreamSources.getInputStreamSource(context.getStreamDescriptor(), PRESENT, BooleanInputStream.class);
+        dataStreamSource = dataStreamSources.getInputStreamSource(context.getStreamDescriptor(), DATA, LongInputStream.class);
 
         readOffset = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
@@ -25,21 +25,25 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.google.common.io.Closer;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.util.Objects.requireNonNull;
 
 public class LongSelectiveStreamReader
         implements SelectiveStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongSelectiveStreamReader.class).instanceSize();
 
-    private final StreamDescriptor streamDescriptor;
-    private final LongDirectSelectiveStreamReader directReader;
-    private final LongDictionarySelectiveStreamReader dictionaryReader;
+    private final SelectiveReaderContext context;
+
+    @Nullable
+    private LongDirectSelectiveStreamReader directReader;
+    @Nullable
+    private LongDictionarySelectiveStreamReader dictionaryReader;
     private SelectiveStreamReader currentReader;
 
     public LongSelectiveStreamReader(
@@ -49,20 +53,14 @@ public class LongSelectiveStreamReader
             OrcAggregatedMemoryContext systemMemoryContext,
             boolean isLowMemory)
     {
-        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        directReader = new LongDirectSelectiveStreamReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(LongSelectiveStreamReader.class.getSimpleName()));
-        dictionaryReader = new LongDictionarySelectiveStreamReader(
-                streamDescriptor,
-                filter,
-                outputType,
-                systemMemoryContext.newOrcLocalMemoryContext(LongSelectiveStreamReader.class.getSimpleName()),
-                isLowMemory);
+        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory);
     }
 
     @Override
     public void startStripe(Stripe stripe)
             throws IOException
     {
+        StreamDescriptor streamDescriptor = context.getStreamDescriptor();
         ColumnEncoding.ColumnEncodingKind kind = stripe.getColumnEncodings().get(streamDescriptor.getStreamId())
                 .getColumnEncoding(streamDescriptor.getSequence())
                 .getColumnEncodingKind();
@@ -70,9 +68,15 @@ public class LongSelectiveStreamReader
             case DIRECT:
             case DIRECT_V2:
             case DWRF_DIRECT:
+                if (directReader == null) {
+                    directReader = new LongDirectSelectiveStreamReader(context);
+                }
                 currentReader = directReader;
                 break;
             case DICTIONARY:
+                if (dictionaryReader == null) {
+                    dictionaryReader = new LongDictionarySelectiveStreamReader(context);
+                }
                 currentReader = dictionaryReader;
                 break;
             default:
@@ -93,7 +97,7 @@ public class LongSelectiveStreamReader
     public String toString()
     {
         return toStringHelper(this)
-                .addValue(streamDescriptor)
+                .addValue(context.getStreamDescriptor())
                 .toString();
     }
 
@@ -101,8 +105,12 @@ public class LongSelectiveStreamReader
     public void close()
     {
         try (Closer closer = Closer.create()) {
-            closer.register(directReader::close);
-            closer.register(dictionaryReader::close);
+            if (directReader != null) {
+                closer.register(directReader::close);
+            }
+            if (dictionaryReader != null) {
+                closer.register(dictionaryReader::close);
+            }
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -112,7 +120,9 @@ public class LongSelectiveStreamReader
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + directReader.getRetainedSizeInBytes() + dictionaryReader.getRetainedSizeInBytes();
+        return INSTANCE_SIZE +
+                (directReader == null ? 0L : directReader.getRetainedSizeInBytes()) +
+                (dictionaryReader == null ? 0L : dictionaryReader.getRetainedSizeInBytes());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.common.predicate.TupleDomainFilter;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.OrcAggregatedMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class SelectiveReaderContext
+{
+    private final StreamDescriptor streamDescriptor;
+    private final boolean outputRequired;
+    @Nullable
+    private final Type outputType;
+
+    @Nullable
+    private final TupleDomainFilter filter;
+    private final boolean nonDeterministicFilter;
+    private final boolean nullsAllowed;
+
+    private final OrcAggregatedMemoryContext systemMemoryContext;
+    private final boolean isLowMemory;
+
+    public SelectiveReaderContext(
+            StreamDescriptor streamDescriptor,
+            Optional<Type> outputType,
+            Optional<TupleDomainFilter> filter,
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory)
+    {
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
+        this.outputType = outputType.orElse(null);
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
+        this.filter = requireNonNull(filter, "filter is null").orElse(null);
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.isLowMemory = isLowMemory;
+        this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
+        this.nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
+    }
+
+    public StreamDescriptor getStreamDescriptor()
+    {
+        return streamDescriptor;
+    }
+
+    public boolean isOutputRequired()
+    {
+        return outputRequired;
+    }
+
+    @Nullable
+    public Type getOutputType()
+    {
+        return outputType;
+    }
+
+    @Nullable
+    public TupleDomainFilter getFilter()
+    {
+        return filter;
+    }
+
+    public OrcAggregatedMemoryContext getSystemMemoryContext()
+    {
+        return systemMemoryContext;
+    }
+
+    public boolean isLowMemory()
+    {
+        return isLowMemory;
+    }
+
+    public boolean isNonDeterministicFilter()
+    {
+        return nonDeterministicFilter;
+    }
+
+    public boolean isNullsAllowed()
+    {
+        return nullsAllowed;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -47,11 +47,11 @@ public class SelectiveReaderContext
             OrcAggregatedMemoryContext systemMemoryContext,
             boolean isLowMemory)
     {
+        this.filter = requireNonNull(filter, "filter is null").orElse(null);
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
         this.outputType = outputType.orElse(null);
         checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
-        this.filter = requireNonNull(filter, "filter is null").orElse(null);
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.isLowMemory = isLowMemory;
         this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.block.ClosingBlockLease;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.block.VariableWidthBlock;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Stripe;
@@ -67,15 +66,10 @@ public class SliceDirectSelectiveStreamReader
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDirectSelectiveStreamReader.class).instanceSize();
     private static final int ONE_GIGABYTE = toIntExact(new DataSize(1, GIGABYTE).toBytes());
 
-    private final TupleDomainFilter filter;
-    private final boolean nonDeterministicFilter;
-    private final boolean nullsAllowed;
-
-    private final StreamDescriptor streamDescriptor;
-    private final boolean outputRequired;
-    private final Type outputType;
+    private final SelectiveReaderContext context;
     private final boolean isCharType;
     private final int maxCodePointCount;
+    private final OrcLocalMemoryContext systemMemoryContext;
 
     private int readOffset;
 
@@ -87,7 +81,6 @@ public class SliceDirectSelectiveStreamReader
     private LongInputStream lengthStream;
 
     private boolean rowGroupOpen;
-    private OrcLocalMemoryContext systemMemoryContext;
     private boolean[] nulls;
 
     private int[] outputPositions;
@@ -102,18 +95,12 @@ public class SliceDirectSelectiveStreamReader
     private Slice dataAsSlice;          // data array wrapped in Slice
     private boolean valuesInUse;
 
-    public SliceDirectSelectiveStreamReader(StreamDescriptor streamDescriptor, Optional<TupleDomainFilter> filter, Optional<Type> outputType, OrcLocalMemoryContext newLocalMemoryContext)
+    public SliceDirectSelectiveStreamReader(SelectiveReaderContext context)
     {
-        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.filter = requireNonNull(filter, "filter is null").orElse(null);
-        this.systemMemoryContext = newLocalMemoryContext;
-        this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
-        this.nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
-        this.outputType = requireNonNull(outputType, "outputType is null").orElse(null);
-        this.outputRequired = outputType.isPresent();
-        this.isCharType = streamDescriptor.getOrcType().getOrcTypeKind() == OrcType.OrcTypeKind.CHAR;
-        this.maxCodePointCount = streamDescriptor.getOrcType().getLength().orElse(-1);
-        checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
+        this.context = requireNonNull(context, "context is null");
+        this.systemMemoryContext = context.getSystemMemoryContext().newOrcLocalMemoryContext(this.getClass().getSimpleName());
+        this.isCharType = context.getStreamDescriptor().getOrcType().getOrcTypeKind() == OrcType.OrcTypeKind.CHAR;
+        this.maxCodePointCount = context.getStreamDescriptor().getOrcType().getLength().orElse(-1);
     }
 
     @Override
@@ -143,7 +130,7 @@ public class SliceDirectSelectiveStreamReader
         if (lengthStream == null) {
             streamPosition = readAllNulls(positions, positionCount);
         }
-        else if (filter == null) {
+        else if (context.getFilter() == null) {
             streamPosition = readNoFilter(positions, positionCount, dataLength);
         }
         else {
@@ -181,7 +168,7 @@ public class SliceDirectSelectiveStreamReader
                     packByteArrayOffsetsAndNulls(data, offsets, isNullVector, positions, positionCount);
                 }
 
-                if (nullsAllowed) {
+                if (context.isNullsAllowed()) {
                     System.arraycopy(isNullVector, 0, nulls, 0, positionCount);
                 }
             }
@@ -226,6 +213,9 @@ public class SliceDirectSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount, int dataLength)
             throws IOException
     {
+        boolean outputRequired = context.isOutputRequired();
+        TupleDomainFilter filter = context.getFilter();
+
         int totalPositionCount = positions[positionCount - 1] + 1;
         if (useBatchMode(positionCount, totalPositionCount)) {
             if (dataStream != null) {
@@ -249,7 +239,7 @@ public class SliceDirectSelectiveStreamReader
                             packByteArrayOffsetsAndNulls(data, offsets, isNullVector, outputPositions, filteredPositionCount);
                         }
 
-                        if (nullsAllowed) {
+                        if (context.isNullsAllowed()) {
                             System.arraycopy(isNullVector, 0, nulls, 0, filteredPositionCount);
                         }
                     }
@@ -272,7 +262,7 @@ public class SliceDirectSelectiveStreamReader
 
             int offset = outputRequired ? offsets[outputPositionCount] : 0;
             if (presentStream != null && isNullVector[position]) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                if ((context.isNonDeterministicFilter() && filter.testNull()) || context.isNullsAllowed()) {
                     if (outputRequired) {
                         offsets[outputPositionCount + 1] = offset;
                         nulls[outputPositionCount] = true;
@@ -293,7 +283,7 @@ public class SliceDirectSelectiveStreamReader
                             if (outputRequired) {
                                 int truncatedLength = computeTruncatedLength(dataAsSlice, dataOffset, length, maxCodePointCount, isCharType);
                                 offsets[outputPositionCount + 1] = offset + truncatedLength;
-                                if (nullsAllowed && presentStream != null) {
+                                if (context.isNullsAllowed() && presentStream != null) {
                                     nulls[outputPositionCount] = false;
                                 }
                             }
@@ -306,7 +296,7 @@ public class SliceDirectSelectiveStreamReader
                         if (filter.testBytes("".getBytes(), 0, 0)) {
                             if (outputRequired) {
                                 offsets[outputPositionCount + 1] = offset;
-                                if (nullsAllowed && presentStream != null) {
+                                if (context.isNullsAllowed() && presentStream != null) {
                                     nulls[outputPositionCount] = false;
                                 }
                             }
@@ -346,19 +336,19 @@ public class SliceDirectSelectiveStreamReader
 
     private int readAllNulls(int[] positions, int positionCount)
     {
-        if (nonDeterministicFilter) {
+        if (context.isNonDeterministicFilter()) {
             outputPositionCount = 0;
             for (int i = 0; i < positionCount; i++) {
-                if (filter.testNull()) {
+                if (context.getFilter().testNull()) {
                     outputPositionCount++;
                 }
                 else {
-                    outputPositionCount -= filter.getPrecedingPositionsToFail();
-                    i += filter.getSucceedingPositionsToFail();
+                    outputPositionCount -= context.getFilter().getPrecedingPositionsToFail();
+                    i += context.getFilter().getSucceedingPositionsToFail();
                 }
             }
         }
-        else if (nullsAllowed) {
+        else if (context.isNullsAllowed()) {
             outputPositionCount = positionCount;
         }
         else {
@@ -410,12 +400,12 @@ public class SliceDirectSelectiveStreamReader
         int positionsIndex = 0;
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
-            if (filter.testLength(lengthVector[position])) {
+            if (context.getFilter().testLength(lengthVector[position])) {
                 outputPositions[positionsIndex++] = position;  // compact positions on the fly
             }
             else {
-                i += filter.getSucceedingPositionsToFail();
-                positionsIndex -= filter.getPrecedingPositionsToFail();
+                i += context.getFilter().getSucceedingPositionsToFail();
+                positionsIndex -= context.getFilter().getPrecedingPositionsToFail();
             }
         }
 
@@ -442,11 +432,12 @@ public class SliceDirectSelectiveStreamReader
         }
 
         int positionsIndex = 0;
+        TupleDomainFilter filter = context.getFilter();
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
 
             if (isNullVector[position]) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                if ((context.isNonDeterministicFilter() && filter.testNull()) || context.isNullsAllowed()) {
                     outputPositions[positionsIndex++] = position;
                 }
                 else {
@@ -473,7 +464,8 @@ public class SliceDirectSelectiveStreamReader
 
     private int testEmptyStrings(int[] positions, int positionCount)
     {
-        if (nonDeterministicFilter) {
+        TupleDomainFilter filter = context.getFilter();
+        if (context.isNonDeterministicFilter()) {
             int positionsIndex = 0;
             for (int i = 0; i < positionCount; i++) {
                 int position = positions[i];
@@ -498,6 +490,7 @@ public class SliceDirectSelectiveStreamReader
 
     private int testBytes(int[] positions, int positionCount)
     {
+        TupleDomainFilter filter = context.getFilter();
         int positionsIndex = 0;
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
@@ -525,15 +518,15 @@ public class SliceDirectSelectiveStreamReader
     public Block getBlock(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
+            return new RunLengthEncodedBlock(context.getOutputType().createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
-        boolean includeNulls = nullsAllowed && presentStream != null;
+        boolean includeNulls = context.isNullsAllowed() && presentStream != null;
 
         if (positionCount != outputPositionCount) {
             compactValues(positions, positionCount, includeNulls);
@@ -583,14 +576,14 @@ public class SliceDirectSelectiveStreamReader
     public BlockLease getBlockView(int[] positions, int positionCount)
     {
         checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
-        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(context.isOutputRequired(), "This stream reader doesn't produce output");
         checkState(positionCount <= outputPositionCount, "Not enough values");
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
+            return newLease(new RunLengthEncodedBlock(context.getOutputType().createBlockBuilder(null, 1).appendNull().build(), positionCount));
         }
-        boolean includeNulls = nullsAllowed && presentStream != null;
+        boolean includeNulls = context.isNullsAllowed() && presentStream != null;
         if (positionCount != outputPositionCount) {
             compactValues(positions, positionCount, includeNulls);
         }
@@ -649,6 +642,7 @@ public class SliceDirectSelectiveStreamReader
     @Override
     public void startRowGroup(InputStreamSources dataStreamSources)
     {
+        StreamDescriptor streamDescriptor = context.getStreamDescriptor();
         presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
         lengthStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, LENGTH, LongInputStream.class);
         dataStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, DATA, ByteArrayInputStream.class);
@@ -725,13 +719,13 @@ public class SliceDirectSelectiveStreamReader
             if (totalLength > ONE_GIGABYTE) {
                 throw new GenericInternalException(
                         format("Values in column \"%s\" are too large to process for Presto. %s column values are larger than 1GB [%s]",
-                                streamDescriptor.getFieldName(), positionCount,
-                                streamDescriptor.getOrcDataSourceId()));
+                                context.getStreamDescriptor().getFieldName(), positionCount,
+                                context.getStreamDescriptor().getOrcDataSourceId()));
             }
         }
 
-        if (outputRequired) {
-            if (presentStream != null && nullsAllowed) {
+        if (context.isOutputRequired()) {
+            if (presentStream != null && context.isNullsAllowed()) {
                 nulls = ensureCapacity(nulls, positionCount);
             }
             dataLength = totalLength;
@@ -741,7 +735,7 @@ public class SliceDirectSelectiveStreamReader
         else {
             if (useBatchMode(positionCount, totalPositions)) {
                 dataLength = totalLength;
-                if (filter != null) {
+                if (context.getFilter() != null) {
                     offsets = ensureCapacity(offsets, totalPositions + 1, SMALL, INITIALIZE);
                 }
             }
@@ -765,7 +759,7 @@ public class SliceDirectSelectiveStreamReader
         }
 
         double inputFilterRate = (double) (totalPositionCount - positionCount) / totalPositionCount;
-        if (filter == null) {  // readNoFilter
+        if (context.getFilter() == null) {  // readNoFilter
             // When there is no filter, batch mode performs better for almost all inputFilterRate.
             // But to limit data buffer size, we enable it for the range of [0.0f, 0.5f]
             if (inputFilterRate >= 0.0f && inputFilterRate <= 0.5f) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
@@ -29,45 +29,65 @@ import com.google.common.io.Closer;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.util.Objects.requireNonNull;
 
 public class SliceSelectiveStreamReader
         implements SelectiveStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceSelectiveStreamReader.class).instanceSize();
 
-    private final StreamDescriptor streamDescriptor;
-    private final SliceDirectSelectiveStreamReader directReader;
-    private final SliceDictionarySelectiveReader dictionaryReader;
+    private final SelectiveReaderContext context;
+
+    @Nullable
+    private SliceDirectSelectiveStreamReader directReader;
+    @Nullable
+    private SliceDictionarySelectiveReader dictionaryReader;
     private SelectiveStreamReader currentReader;
 
     public SliceSelectiveStreamReader(StreamDescriptor streamDescriptor, Optional<TupleDomainFilter> filter, Optional<Type> outputType, OrcAggregatedMemoryContext systemMemoryContext, boolean isLowMemory)
     {
-        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.directReader = new SliceDirectSelectiveStreamReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(SliceDirectSelectiveStreamReader.class.getSimpleName()));
-        this.dictionaryReader = new SliceDictionarySelectiveReader(streamDescriptor, filter, outputType, systemMemoryContext.newOrcLocalMemoryContext(SliceDictionarySelectiveReader.class.getSimpleName()), isLowMemory);
+        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory);
+    }
+
+    public static int computeTruncatedLength(Slice slice, int offset, int length, int maxCodePointCount, boolean isCharType)
+    {
+        if (isCharType) {
+            // truncate the characters and then remove the trailing white spaces
+            return Chars.byteCountWithoutTrailingSpace(slice, offset, length, maxCodePointCount);
+        }
+        if (maxCodePointCount >= 0 && length > maxCodePointCount) {
+            return Varchars.byteCount(slice, offset, length, maxCodePointCount);
+        }
+        return length;
     }
 
     @Override
     public void startStripe(Stripe stripe)
             throws IOException
     {
-        ColumnEncoding.ColumnEncodingKind kind = stripe.getColumnEncodings().get(streamDescriptor.getStreamId())
-                .getColumnEncoding(streamDescriptor.getSequence())
+        ColumnEncoding.ColumnEncodingKind kind = stripe.getColumnEncodings().get(context.getStreamDescriptor().getStreamId())
+                .getColumnEncoding(context.getStreamDescriptor().getSequence())
                 .getColumnEncodingKind();
         switch (kind) {
             case DIRECT:
             case DIRECT_V2:
             case DWRF_DIRECT:
+                if (directReader == null) {
+                    directReader = new SliceDirectSelectiveStreamReader(context);
+                }
                 currentReader = directReader;
                 break;
             case DICTIONARY:
             case DICTIONARY_V2:
+                if (dictionaryReader == null) {
+                    dictionaryReader = new SliceDictionarySelectiveReader(context);
+                }
                 currentReader = dictionaryReader;
                 break;
             default:
@@ -88,7 +108,7 @@ public class SliceSelectiveStreamReader
     public String toString()
     {
         return toStringHelper(this)
-                .addValue(streamDescriptor)
+                .addValue(context.getStreamDescriptor())
                 .toString();
     }
 
@@ -96,8 +116,12 @@ public class SliceSelectiveStreamReader
     public void close()
     {
         try (Closer closer = Closer.create()) {
-            closer.register(directReader::close);
-            closer.register(dictionaryReader::close);
+            if (directReader != null) {
+                closer.register(directReader::close);
+            }
+            if (dictionaryReader != null) {
+                closer.register(dictionaryReader::close);
+            }
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -107,7 +131,9 @@ public class SliceSelectiveStreamReader
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + directReader.getRetainedSizeInBytes() + dictionaryReader.getRetainedSizeInBytes();
+        return INSTANCE_SIZE +
+                (directReader == null ? 0L : directReader.getRetainedSizeInBytes()) +
+                (dictionaryReader == null ? 0L : dictionaryReader.getRetainedSizeInBytes());
     }
 
     @Override
@@ -141,22 +167,14 @@ public class SliceSelectiveStreamReader
         currentReader.throwAnyError(positions, positionCount);
     }
 
-    public static int computeTruncatedLength(Slice slice, int offset, int length, int maxCodePointCount, boolean isCharType)
-    {
-        if (isCharType) {
-            // truncate the characters and then remove the trailing white spaces
-            return Chars.byteCountWithoutTrailingSpace(slice, offset, length, maxCodePointCount);
-        }
-        if (maxCodePointCount >= 0 && length > maxCodePointCount) {
-            return Varchars.byteCount(slice, offset, length, maxCodePointCount);
-        }
-        return length;
-    }
-
     @VisibleForTesting
     public void resetDataStream()
     {
-        ((SliceDirectSelectiveStreamReader) directReader).resetDataStream();
-        ((SliceDictionarySelectiveReader) dictionaryReader).resetDataStream();
+        if (directReader != null) {
+            directReader.resetDataStream();
+        }
+        if (dictionaryReader != null) {
+            dictionaryReader.resetDataStream();
+        }
     }
 }


### PR DESCRIPTION
1. Refactor the common variables used into a context class.
2. Initialize the dictionary and direct reader lazily.

When the readers are embedded inside the flat maps, it will consume
less memory due to lazy initialization.

Test plan 
Existing tests. 

```
== NO RELEASE NOTE ==
```
