### PR TITLE
Fix sort for unpartitioned window with order by clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -535,6 +535,10 @@ public final class StreamPropertyDerivations
         @Override
         public StreamProperties visitWindow(WindowNode node, List<StreamProperties> inputProperties)
         {
+            StreamProperties childProperties = Iterables.getOnlyElement(inputProperties);
+            if (childProperties.isSingleStream() && node.getPartitionBy().isEmpty() && node.getOrderingScheme().isPresent()) {
+                return StreamProperties.ordered();
+            }
             return Iterables.getOnlyElement(inputProperties);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
@@ -33,30 +34,42 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
+import static com.facebook.presto.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.specification;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 
 public class TestEliminateSorts
         extends BasePlanTest
 {
     private static final String QUANTITY_ALIAS = "QUANTITY";
+    private static final String TAX_ALIAS = "TAX";
 
     private static final ExpectedValueProvider<WindowNode.Specification> windowSpec = specification(
             ImmutableList.of(),
             ImmutableList.of(QUANTITY_ALIAS),
             ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));
 
-    private static final PlanMatchPattern LINEITEM_TABLESCAN_Q = tableScan(
+    private static final PlanMatchPattern LINEITEM_TABLESCAN_Q_BASIC = tableScan(
             "lineitem",
             ImmutableMap.of(QUANTITY_ALIAS, "quantity"));
 
+    private static final PlanMatchPattern LINEITEM_TABLESCAN_Q = tableScan(
+            "lineitem",
+            ImmutableMap.of(QUANTITY_ALIAS, "quantity", TAX_ALIAS, "tax"));
+
     @Test
-    public void testEliminateSorts()
+    public void testEliminateSortsBasic()
     {
         @Language("SQL") String sql = "SELECT quantity, row_number() OVER (ORDER BY quantity) FROM lineitem ORDER BY quantity";
 
@@ -65,7 +78,38 @@ public class TestEliminateSorts
                         window(windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(windowSpec)
                                         .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
-                                anyTree(LINEITEM_TABLESCAN_Q)));
+                                anyTree(LINEITEM_TABLESCAN_Q_BASIC)));
+
+        assertUnitPlan(sql, pattern);
+    }
+
+    /**
+     * Cannot eliminate sorts when there is a filter or project above the window as a local exchange
+     * will be added to repartition the data before the filter or project node
+     */
+    @Test
+    public void testDoesNotEliminateSortsWithFilter()
+    {
+        @Language("SQL") String sql = "SELECT * FROM " +
+                "(SELECT quantity, count(tax) OVER (ORDER BY quantity) AS c  FROM lineitem) " +
+                "WHERE c > 3 ORDER BY quantity";
+
+        PlanMatchPattern pattern =
+                output(
+                        exchange(
+                                LOCAL,
+                                GATHER,
+                                sort(
+                                        filter("C > 3",
+                                                exchange(
+                                                        LOCAL,
+                                                        REPARTITION,
+                                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                        .specification(windowSpec)
+                                                                        .addFunction(
+                                                                                "C",
+                                                                                functionCall("count", Optional.empty(), ImmutableList.of(TAX_ALIAS))),
+                                                                anyTree(LINEITEM_TABLESCAN_Q)))))));
 
         assertUnitPlan(sql, pattern);
     }
@@ -95,7 +139,15 @@ public class TestEliminateSorts
                         getQueryRunner().getStatsCalculator(),
                         getQueryRunner().getCostCalculator(),
                         new TranslateExpressions(getMetadata(), new SqlParser()).rules()),
+                new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
+                new PruneUnreferencedOutputs(),
+                new IterativeOptimizer(
+                        new RuleStatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getCostCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new AddExchanges(getQueryRunner().getMetadata(), new SqlParser(), new PartitioningProviderManager()),
+                new AddLocalExchanges(getMetadata(), new SqlParser()),
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
@@ -103,7 +155,9 @@ public class TestEliminateSorts
                         getQueryRunner().getStatsCalculator(),
                         getQueryRunner().getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())));
-
-        assertPlan(sql, pattern, optimizers);
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(TASK_CONCURRENCY, "4")
+                .build();
+        assertPlan(sql, session, OPTIMIZED, pattern, optimizers);
     }
 }


### PR DESCRIPTION
There is an optimization to remove sorts if the data is already sorted and
single node.
This applies if there is an unpartitioned window function with an order by in
the window function and the query has a general order by on the same columns.
However, sometimes a round robin local exchange was being added after the
window, causing the output to be incorrectly ordered.  For example, this would
happen if there was a project after the window functio. This PR fixes those
cases by not adding a local exchange.

Example affected query:
SELECT regionkey, count(name) OVER (order by regionkey)
FROM region
ORDER BY regionkey;

Previous plan:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[regionkey, _col1] => [regionkey:bigint, count:bigint]
         _col1 := count (1:27)
     - Project[projectLocality = LOCAL] => [regionkey:bigint, count:bigint]
         - LocalExchange[ROUND_ROBIN] () => [regionkey:bigint, name:varchar(25), count:bigint]
             - Window[order by (regionkey ASC_NULLS_LAST)] => [regionkey:bigint, name:varchar(25), count:bigint]
                     count := count(name) RANGE UNBOUNDED_PRECEDING CURRENT_ROW (1:27)
                 - LocalExchange[SINGLE] () => [regionkey:bigint, name:varchar(25)]
                         Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 104.00}
                     - RemoteStreamingExchange[GATHER] => [regionkey:bigint, name:varchar(25)]
                             Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 104.00}
                         - TableScan[TableHandle {connectorId='tpch', connectorHandle='region:sf1.0', layout='Optional[region:sf1.0]'}] => [regionkey:bigint, name:varchar(25)]
                                 Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 0.00}
                                 name := tpch:name (1:70)
                                 regionkey := tpch:regionkey (1:70)

New Plan:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[regionkey, _col1] => [regionkey:bigint, count:bigint]
         _col1 := count (1:27)
     - LocalMerge[regionkey ASC_NULLS_LAST] => [regionkey:bigint, count:bigint]
         - Sort[regionkey ASC_NULLS_LAST] => [regionkey:bigint, count:bigint]
             - Project[projectLocality = LOCAL] => [regionkey:bigint, count:bigint]
                 - LocalExchange[ROUND_ROBIN] () => [regionkey:bigint, name:varchar(25), count:bigint]
                     - Window[order by (regionkey ASC_NULLS_LAST)] => [regionkey:bigint, name:varchar(25), count:bigint]
                             count := count(name) RANGE UNBOUNDED_PRECEDING CURRENT_ROW (1:27)
                         - LocalExchange[SINGLE] () => [regionkey:bigint, name:varchar(25)]
                                 Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 104.00}
                             - RemoteStreamingExchange[GATHER] => [regionkey:bigint, name:varchar(25)]
                                     Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 104.00}
                                 - TableScan[TableHandle {connectorId='tpch', connectorHandle='region:sf1.0', layout='Optional[region:sf1.0]'}] => [regionkey:bigint, name:varchar(25)]
                                         Estimates: {rows: 5 (104B), cpu: 104.00, memory: 0.00, network: 0.00}
                                         name := tpch:name (2:6)
                                         regionkey := tpch:regionkey (2:6)

Test plan - (Please fill in how you tested your changes)


```
== RELEASE NOTES ==

General Changes
* Fix a bug where a query with an order by clause and an unpartitioned window function sometimes returned unordered results.
```

