### PR TITLE
Optimize non null filter implementation

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomainFilter;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.stream.BooleanInputStream;
 
 import javax.annotation.Nullable;
 
@@ -75,8 +76,14 @@ public class SelectiveReaderContext
     }
 
     @Nullable
-    public TupleDomainFilter getFilter()
+    public TupleDomainFilter getRowGroupFilter(BooleanInputStream presentStream)
     {
+        if (isOutputRequired() && presentStream == null && filter == TupleDomainFilter.IS_NOT_NULL) {
+            // Readers don't handle the outputRequired == false and filter = null. When that is fixed
+            // outputRequired can be removed from the above condition.
+            // When present stream is null, there are no nulls in the Column. The filter is no-op
+            return null;
+        }
         return filter;
     }
 


### PR DESCRIPTION
Orc reader filters map entries if the keys are null. Selective map
readers combine the key readers with non null filters. When key column
does not have a present stream, then this filter can be ignored as
the key does not have any null.

This change replaces the file level filter with rowGroup filter.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
