### PR TITLE
Add sized-based split weights for Hudi connector

### DIFF
--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -125,6 +125,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-presto-bundle</artifactId>
         </dependency>

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
@@ -15,10 +15,21 @@
 package com.facebook.presto.hudi;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class HudiConfig
 {
     private boolean metadataTableEnabled;
+    private boolean sizeBasedSplitWeightsEnabled = true;
+    private DataSize standardSplitWeightSize = new DataSize(128, MEGABYTE);
+    private double minimumAssignedSplitWeight = 0.05;
 
     public boolean isMetadataTableEnabled()
     {
@@ -29,6 +40,50 @@ public class HudiConfig
     public HudiConfig setMetadataTableEnabled(boolean metadataTableEnabled)
     {
         this.metadataTableEnabled = metadataTableEnabled;
+        return this;
+    }
+
+    public boolean isSizeBasedSplitWeightsEnabled()
+    {
+        return sizeBasedSplitWeightsEnabled;
+    }
+
+    @Config("hudi.size-based-split-weights-enabled")
+    @ConfigDescription("Unlike uniform splitting, size-based splitting ensures that each batch of splits has enough data to process. " +
+            "By default, it is enabled to improve performance.")
+    public HudiConfig setSizeBasedSplitWeightsEnabled(boolean sizeBasedSplitWeightsEnabled)
+    {
+        this.sizeBasedSplitWeightsEnabled = sizeBasedSplitWeightsEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getStandardSplitWeightSize()
+    {
+        return standardSplitWeightSize;
+    }
+
+    @Config("hudi.standard-split-weight-size")
+    @ConfigDescription("The split size corresponding to the standard weight (1.0) "
+            + "when size based split weights are enabled.")
+    public HudiConfig setStandardSplitWeightSize(DataSize standardSplitWeightSize)
+    {
+        this.standardSplitWeightSize = standardSplitWeightSize;
+        return this;
+    }
+
+    @DecimalMax("1")
+    @DecimalMin(value = "0", inclusive = false)
+    public double getMinimumAssignedSplitWeight()
+    {
+        return minimumAssignedSplitWeight;
+    }
+
+    @Config("hudi.minimum-assigned-split-weight")
+    @ConfigDescription("Minimum weight that a split can be assigned when size based split weights are enabled.")
+    public HudiConfig setMinimumAssignedSplitWeight(double minimumAssignedSplitWeight)
+    {
+        this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
         return this;
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
@@ -43,9 +43,9 @@ public class HudiSessionProperties
     private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
 
-    public static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
+    private static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     private static final String STANDARD_SPLIT_WEIGHT_SIZE = "standard_split_weight_size";
-    public static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
+    private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
 
     @Inject
     public HudiSessionProperties(HiveClientConfig hiveClientConfig, HudiConfig hudiConfig)

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplit.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplit.java
@@ -40,6 +40,7 @@ public class HudiSplit
     private final List<HudiFile> logFiles;
     private final List<HostAddress> addresses;
     private final NodeSelectionStrategy nodeSelectionStrategy;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
     public HudiSplit(
@@ -49,7 +50,8 @@ public class HudiSplit
             @JsonProperty("baseFile") Optional<HudiFile> baseFile,
             @JsonProperty("logFiles") List<HudiFile> logFiles,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy)
+            @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy,
+            @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         this.table = requireNonNull(table, "table is null");
         this.instantTime = requireNonNull(instantTime, "instantTime is null");
@@ -58,6 +60,7 @@ public class HudiSplit
         this.logFiles = requireNonNull(logFiles, "logFiles is null");
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.nodeSelectionStrategy = requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @JsonProperty
@@ -130,10 +133,11 @@ public class HudiSplit
         return OptionalLong.empty();
     }
 
+    @JsonProperty
     @Override
     public SplitWeight getSplitWeight()
     {
-        return ConnectorSplit.super.getSplitWeight();
+        return splitWeight;
     }
 
     @Override

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -129,8 +129,7 @@ public class HudiSplitManager
             Path partitionPath = new Path(hudiPartition.getStorage().getLocation());
             String relativePartitionPath = FSUtils.getRelativePartitionPath(tablePath, partitionPath);
             fsView.getLatestFileSlicesBeforeOrOn(relativePartitionPath, timestamp, false)
-                    .map(fileSlice -> createHudiSplit(
-                            table, fileSlice, timestamp, hudiPartition, splitWeightProvider))
+                    .map(fileSlice -> createHudiSplit(table, fileSlice, timestamp, hudiPartition, splitWeightProvider))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .forEach(builder::add);
@@ -155,7 +154,10 @@ public class HudiSplitManager
     }
 
     private Optional<HudiSplit> createHudiSplit(
-            HudiTableHandle table, FileSlice slice, String timestamp, HudiPartition partition,
+            HudiTableHandle table,
+            FileSlice slice,
+            String timestamp,
+            HudiPartition partition,
             HudiSplitWeightProvider splitWeightProvider)
     {
         HudiFile hudiFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileLen())).orElse(null);

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.hudi;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
@@ -21,6 +22,8 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hudi.split.HudiSplitWeightProvider;
+import com.facebook.presto.hudi.split.SizeBasedSplitWeightProvider;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -32,6 +35,7 @@ import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
+import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -55,7 +59,10 @@ import static com.facebook.presto.hudi.HudiErrorCode.HUDI_FILESYSTEM_ERROR;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_INVALID_METADATA;
 import static com.facebook.presto.hudi.HudiMetadata.fromDataColumns;
 import static com.facebook.presto.hudi.HudiMetadata.toMetastoreContext;
+import static com.facebook.presto.hudi.HudiSessionProperties.getMinimumAssignedSplitWeight;
+import static com.facebook.presto.hudi.HudiSessionProperties.getStandardSplitWeightSize;
 import static com.facebook.presto.hudi.HudiSessionProperties.isHudiMetadataTableEnabled;
+import static com.facebook.presto.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
@@ -65,6 +72,7 @@ import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMe
 public class HudiSplitManager
         implements ConnectorSplitManager
 {
+    private static final Logger log = Logger.get(HudiSplitManager.class);
     private final HdfsEnvironment hdfsEnvironment;
     private final HudiTransactionManager hudiTransactionManager;
     private final HudiPartitionManager hudiPartitionManager;
@@ -87,6 +95,7 @@ public class HudiSplitManager
             ConnectorTableLayoutHandle layoutHandle,
             SplitSchedulingContext splitSchedulingContext)
     {
+        HudiSplitWeightProvider splitWeightProvider = createSplitWeightProvider(session);
         ExtendedHiveMetastore metastore = ((HudiMetadata) hudiTransactionManager.get(transaction)).getMetastore();
         HudiTableLayoutHandle layout = (HudiTableLayoutHandle) layoutHandle;
         HudiTableHandle table = layout.getTable();
@@ -120,7 +129,8 @@ public class HudiSplitManager
             Path partitionPath = new Path(hudiPartition.getStorage().getLocation());
             String relativePartitionPath = FSUtils.getRelativePartitionPath(tablePath, partitionPath);
             fsView.getLatestFileSlicesBeforeOrOn(relativePartitionPath, timestamp, false)
-                    .map(fileSlice -> createHudiSplit(table, fileSlice, timestamp, hudiPartition))
+                    .map(fileSlice -> createHudiSplit(
+                            table, fileSlice, timestamp, hudiPartition, splitWeightProvider))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .forEach(builder::add);
@@ -144,7 +154,9 @@ public class HudiSplitManager
         }
     }
 
-    private Optional<HudiSplit> createHudiSplit(HudiTableHandle table, FileSlice slice, String timestamp, HudiPartition partition)
+    private Optional<HudiSplit> createHudiSplit(
+            HudiTableHandle table, FileSlice slice, String timestamp, HudiPartition partition,
+            HudiSplitWeightProvider splitWeightProvider)
     {
         HudiFile hudiFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileLen())).orElse(null);
         if (null == hudiFile && table.getTableType() == HudiTableType.COW) {
@@ -153,6 +165,9 @@ public class HudiSplitManager
         List<HudiFile> logFiles = slice.getLogFiles()
                 .map(logFile -> new HudiFile(logFile.getPath().toString(), 0, logFile.getFileSize()))
                 .collect(toImmutableList());
+        long sizeInBytes = hudiFile != null ? hudiFile.getLength()
+                : (logFiles.size() > 0 ? logFiles.stream().map(HudiFile::getLength).reduce(0L, Long::sum) : 0L);
+
         return Optional.of(new HudiSplit(
                 table,
                 timestamp,
@@ -160,7 +175,8 @@ public class HudiSplitManager
                 Optional.ofNullable(hudiFile),
                 logFiles,
                 ImmutableList.of(),
-                NodeSelectionStrategy.NO_PREFERENCE));
+                NodeSelectionStrategy.NO_PREFERENCE,
+                splitWeightProvider.calculateSplitWeight(sizeInBytes)));
     }
 
     public static HudiPartition getHudiPartition(ExtendedHiveMetastore metastore, MetastoreContext context, HudiTableLayoutHandle tableLayout, String partitionName)
@@ -193,5 +209,15 @@ public class HudiSplitManager
         Streams.forEachPair(partitionColumns.stream(), partitionValues.stream(),
                 (column, value) -> builder.put(column.getName(), value));
         return builder.build();
+    }
+
+    private static HudiSplitWeightProvider createSplitWeightProvider(ConnectorSession session)
+    {
+        if (isSizeBasedSplitWeightsEnabled(session)) {
+            DataSize standardSplitWeightSize = getStandardSplitWeightSize(session);
+            double minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
+            return new SizeBasedSplitWeightProvider(minimumAssignedSplitWeight, standardSplitWeightSize);
+        }
+        return HudiSplitWeightProvider.uniformStandardWeightProvider();
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiSplitWeightProvider.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiSplitWeightProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import com.facebook.presto.spi.SplitWeight;
+
+/**
+ * An interface to provide the logic to calculate Hudi split weight
+ */
+public interface HudiSplitWeightProvider
+{
+    SplitWeight calculateSplitWeight(long splitSizeInBytes);
+
+    static HudiSplitWeightProvider uniformStandardWeightProvider()
+    {
+        return splitSizeInBytes -> SplitWeight.standard();
+    }
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/SizeBasedSplitWeightProvider.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/SizeBasedSplitWeightProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import com.facebook.presto.spi.SplitWeight;
+import io.airlift.units.DataSize;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.primitives.Doubles.constrainToRange;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Hudi split weight provider based on the split size.
+ *
+ * The standard split size, `standardSplitSize` in bytes, corresponding split weight "1" and the minimum weight
+ * `minimumWeight` are given during the initialization.
+ *
+ * Given the split size in bytes as `splitSizeInBytes`, the raw weight is calculated as
+ * `splitSizeInBytes / standardSplitSize`.  If the weight is smaller than `minimumWeight`, `minimumWeight` is used.
+ * If the weight is larger than 1, 1 is used as the weight.  The split weight is always in the range of
+ * [`minimumWeight`, 1].
+ */
+public class SizeBasedSplitWeightProvider
+        implements HudiSplitWeightProvider
+{
+    private final double minimumWeight;
+    private final double standardSplitSizeInBytes;
+
+    public SizeBasedSplitWeightProvider(double minimumWeight, DataSize standardSplitSize)
+    {
+        checkArgument(
+                Double.isFinite(minimumWeight) && minimumWeight > 0 && minimumWeight <= 1,
+                "minimumWeight must be > 0 and <= 1, found: %s", minimumWeight);
+        this.minimumWeight = minimumWeight;
+        long standardSplitSizeInBytesLong = requireNonNull(standardSplitSize, "standardSplitSize is null").toBytes();
+        checkArgument(standardSplitSizeInBytesLong > 0, "standardSplitSize must be > 0, found: %s", standardSplitSize);
+        this.standardSplitSizeInBytes = (double) standardSplitSizeInBytesLong;
+    }
+
+    @Override
+    public SplitWeight calculateSplitWeight(long splitSizeInBytes)
+    {
+        double computedWeight = splitSizeInBytes / standardSplitSizeInBytes;
+        // Clamp the value between the minimum weight and 1.0 (standard weight)
+        return SplitWeight.fromProportion(constrainToRange(computedWeight, minimumWeight, 1.0));
+    }
+}

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.hudi;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -22,13 +23,18 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestHudiConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(HudiConfig.class).setMetadataTableEnabled(false));
+        assertRecordedDefaults(recordDefaults(HudiConfig.class)
+                .setMetadataTableEnabled(false)
+                .setSizeBasedSplitWeightsEnabled(true)
+                .setStandardSplitWeightSize(new DataSize(128, MEGABYTE))
+                .setMinimumAssignedSplitWeight(0.05));
     }
 
     @Test
@@ -36,9 +42,16 @@ public class TestHudiConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hudi.metadata-table-enabled", "true")
+                .put("hudi.size-based-split-weights-enabled", "false")
+                .put("hudi.standard-split-weight-size", "500MB")
+                .put("hudi.minimum-assigned-split-weight", "0.1")
                 .build();
 
-        HudiConfig expected = new HudiConfig().setMetadataTableEnabled(true);
+        HudiConfig expected = new HudiConfig()
+                .setMetadataTableEnabled(true)
+                .setSizeBasedSplitWeightsEnabled(false)
+                .setStandardSplitWeightSize(new DataSize(500, MEGABYTE))
+                .setMinimumAssignedSplitWeight(0.1);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/split/TestSizeBasedSplitWeightProvider.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/split/TestSizeBasedSplitWeightProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import com.facebook.presto.spi.SplitWeight;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static org.testng.Assert.assertEquals;
+
+public class TestSizeBasedSplitWeightProvider
+{
+    @Test
+    public void testCalculateSplitWeight()
+    {
+        double minimumWeight = 0.2;
+        DataSize standardSplitSize = new DataSize(100, MEGABYTE);
+        HudiSplitWeightProvider weightProvider = new SizeBasedSplitWeightProvider(minimumWeight, standardSplitSize);
+        assertWeight(weightProvider, 0, minimumWeight);
+        assertWeight(weightProvider, 200 * 1024 * 1024, 1.0);
+        assertWeight(weightProvider, 50 * 1024 * 1024, 0.5);
+        assertWeight(weightProvider, 10 * 1024 * 1024, minimumWeight);
+    }
+
+    private void assertWeight(HudiSplitWeightProvider weightProvider, long splitSizeInBytes, double expectedWeight)
+    {
+        assertEquals(weightProvider.calculateSplitWeight(splitSizeInBytes), SplitWeight.fromProportion(expectedWeight));
+    }
+}


### PR DESCRIPTION
### Change Logs

This PR adds split weight to HudiSplit based on the split size in Hudi connector.  Before this change, the Hudi split weight is uniform, set to default 1.0, which limits the number of splits scheduled to be processed (queued + running) to 100. This becomes the bottleneck for the query performance when the splits are small (e.g. a few MB). The dynamic weight assignment allows much more splits to be scheduled to run, better using the compute and memory resources.

When using size-based split weight, the weight value is between a minimum configured weight and 1.  Given the split size in bytes as `splitSizeInBytes`, the raw weight is calculated as `splitSizeInBytes / standardSplitSize` and then capped in the above range.  There are three new properties introduced (defaults should work well):
- `hudi.size-based-split-weights-enabled` (default: `true`): whether to enable size-based split weight in Hudi connector
- `hudi.standard-split-weight-size` (default: `128MB`): the split size corresponding to the standard split weight when size-based split weight is enabled
- `hudi.minimum-assigned-split-weight` (default: `0.05`): the minimum split weight when size-based split weight is enabled

The concept of using size-based split weight for Hudi split in Presto is similar to Trino Hudi connector, implemented [here](https://github.com/codope/trino/pull/15).

### Test plan

The changes are benchmarked through TPC-DS queries using Hudi connector.  The Presto cluster consists of 1 coordinator and 10 workers in `r5.4xlarge` type.  This PR improves the query latency of selective TPC-DS 1TB queries by ~10%.

```
== RELEASE NOTES ==

General Changes
- Add sized-based split weights for Hudi connector to improve query performance
```
