### PR TITLE
Cache plan hashes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -15,6 +15,8 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.spi.statistics.EmptyPlanStatisticsProvider;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.sql.planner.CachingPlanHasher;
+import com.facebook.presto.sql.planner.PlanHasher;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 
@@ -22,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 
 public class HistoryBasedPlanStatisticsManager
 {
-    private final ObjectMapper objectMapper;
+    private final PlanHasher planHasher;
 
     private HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider = EmptyPlanStatisticsProvider.getInstance();
     private boolean statisticsProviderAdded;
@@ -30,7 +32,8 @@ public class HistoryBasedPlanStatisticsManager
     @Inject
     public HistoryBasedPlanStatisticsManager(ObjectMapper objectMapper)
     {
-        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        requireNonNull(objectMapper, "objectMapper is null");
+        this.planHasher = new CachingPlanHasher(objectMapper);
     }
 
     public void addHistoryBasedPlanStatisticsProviderFactory(HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider)
@@ -44,6 +47,6 @@ public class HistoryBasedPlanStatisticsManager
 
     public HistoryBasedPlanStatisticsCalculator getHistoryBasedPlanStatisticsCalculator(StatsCalculator delegate)
     {
-        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, delegate, objectMapper);
+        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, delegate, planHasher);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanHasher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanHasher.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Weigher;
+import io.airlift.units.DataSize;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.StandardErrorCode.PLAN_SERIALIZATION_ERROR;
+import static com.google.common.hash.Hashing.sha256;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class CachingPlanHasher
+        implements PlanHasher
+{
+    private static final DataSize CACHE_SIZE_BYTES = new DataSize(1, DataSize.Unit.MEGABYTE);
+
+    // Create a cache, instead of a LoadingCache, because we can load multiple keys at once.
+    // For weight, we only consider size of hash, as PlanNodes are already in memory for running queries.
+    // We use length of hash + 20 bytes as overhead for storing references, string size and strategy.
+    private final Cache<CacheKey, String> cache = CacheBuilder.newBuilder()
+            .maximumWeight(CACHE_SIZE_BYTES.toBytes())
+            .weigher((Weigher<CacheKey, String>) (key, hash) -> hash.length() + 20)
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .build();
+    private final ObjectMapper objectMapper;
+
+    public CachingPlanHasher(ObjectMapper objectMapper)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @Override
+    public Optional<String> hash(PlanNode planNode, PlanCanonicalizationStrategy strategy)
+    {
+        // TODO: Use QueryManager to unload keys rather relying on LoadingCache
+        CacheKey key = new CacheKey(planNode, strategy);
+        String result = cache.getIfPresent(key);
+        if (result != null) {
+            return Optional.of(result);
+        }
+
+        CanonicalPlanGenerator.Context context = new CanonicalPlanGenerator.Context();
+        key.getNode().accept(new CanonicalPlanGenerator(key.getStrategy()), context);
+        context.getCanonicalPlans().forEach((plan, canonicalPlan) -> {
+            String hashValue = hashCanonicalPlan(canonicalPlan, objectMapper);
+            cache.put(new CacheKey(plan, strategy), hashValue);
+        });
+        return Optional.ofNullable(cache.getIfPresent(key));
+    }
+
+    @VisibleForTesting
+    public long getCacheSize()
+    {
+        return cache.size();
+    }
+
+    private String hashCanonicalPlan(CanonicalPlan plan, ObjectMapper objectMapper)
+    {
+        try {
+            return sha256().hashString(objectMapper.writeValueAsString(plan), UTF_8).toString();
+        }
+        catch (JsonProcessingException e) {
+            throw new PrestoException(PLAN_SERIALIZATION_ERROR, "Cannot serialize plan to JSON", e);
+        }
+    }
+
+    private static class CacheKey
+    {
+        private final PlanNode node;
+        private final PlanCanonicalizationStrategy strategy;
+
+        public CacheKey(PlanNode node, PlanCanonicalizationStrategy strategy)
+        {
+            this.node = requireNonNull(node, "node is null");
+            this.strategy = requireNonNull(strategy, "strategy is null");
+        }
+
+        public PlanNode getNode()
+        {
+            return node;
+        }
+
+        public PlanCanonicalizationStrategy getStrategy()
+        {
+            return strategy;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return node == cacheKey.node && strategy.equals(cacheKey.strategy);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(System.identityHashCode(node), strategy);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -54,7 +55,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
 public class CanonicalPlanGenerator
-        extends InternalPlanVisitor<Optional<PlanNode>, Map<VariableReferenceExpression, VariableReferenceExpression>>
+        extends InternalPlanVisitor<Optional<PlanNode>, CanonicalPlanGenerator.Context>
 {
     private final PlanNodeIdAllocator planNodeidAllocator = new PlanNodeIdAllocator();
     private final PlanVariableAllocator variableAllocator = new PlanVariableAllocator();
@@ -67,28 +68,28 @@ public class CanonicalPlanGenerator
 
     public static Optional<CanonicalPlanFragment> generateCanonicalPlanFragment(PlanNode root, PartitioningScheme partitioningScheme)
     {
-        Map<VariableReferenceExpression, VariableReferenceExpression> originalToNewVariableNames = new HashMap<>();
-        Optional<PlanNode> canonicalPlan = root.accept(new CanonicalPlanGenerator(DEFAULT), originalToNewVariableNames);
-        if (!originalToNewVariableNames.keySet().containsAll(partitioningScheme.getOutputLayout())) {
+        Context context = new Context();
+        Optional<PlanNode> canonicalPlan = root.accept(new CanonicalPlanGenerator(PlanCanonicalizationStrategy.DEFAULT), context);
+        if (!context.getExpressions().keySet().containsAll(partitioningScheme.getOutputLayout())) {
             return Optional.empty();
         }
-        return canonicalPlan.map(planNode -> new CanonicalPlanFragment(new CanonicalPlan(planNode, DEFAULT), getCanonicalPartitioningScheme(partitioningScheme, originalToNewVariableNames)));
+        return canonicalPlan.map(planNode -> new CanonicalPlanFragment(new CanonicalPlan(planNode, DEFAULT), getCanonicalPartitioningScheme(partitioningScheme, context.getExpressions())));
     }
 
     public static Optional<CanonicalPlan> generateCanonicalPlan(PlanNode root, PlanCanonicalizationStrategy strategy)
     {
-        Optional<PlanNode> canonicalPlanNode = root.accept(new CanonicalPlanGenerator(strategy), new HashMap<>());
+        Optional<PlanNode> canonicalPlanNode = root.accept(new CanonicalPlanGenerator(strategy), new CanonicalPlanGenerator.Context());
         return canonicalPlanNode.map(planNode -> new CanonicalPlan(planNode, strategy));
     }
 
     @Override
-    public Optional<PlanNode> visitPlan(PlanNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitPlan(PlanNode node, Context context)
     {
         return Optional.empty();
     }
 
     @Override
-    public Optional<PlanNode> visitOutput(OutputNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitOutput(OutputNode node, Context context)
     {
         if (strategy == DEFAULT) {
             return Optional.empty();
@@ -100,13 +101,14 @@ public class CanonicalPlanGenerator
         }
 
         List<RowExpressionReference> rowExpressionReferences = node.getOutputVariables().stream()
-                .map(variable -> new RowExpressionReference(inlineAndCanonicalize(context, variable, strategy == REMOVE_SAFE_CONSTANTS), variable))
+                .map(variable -> new RowExpressionReference(inlineAndCanonicalize(context.getExpressions(), variable, strategy == REMOVE_SAFE_CONSTANTS), variable))
                 .sorted(comparing(rowExpressionReference -> rowExpressionReference.getRowExpression().toString()))
                 .collect(toImmutableList());
 
         ImmutableMap.Builder<VariableReferenceExpression, RowExpression> assignments = ImmutableMap.builder();
         for (RowExpressionReference rowExpressionReference : rowExpressionReferences) {
             VariableReferenceExpression reference = variableAllocator.newVariable(rowExpressionReference.getRowExpression());
+            context.mapExpression(rowExpressionReference.getVariableReferenceExpression(), reference);
             assignments.put(reference, rowExpressionReference.getRowExpression());
         }
         // Rewrite OutputNode as ProjectNode
@@ -116,12 +118,13 @@ public class CanonicalPlanGenerator
                 source.get(),
                 new Assignments(assignments.build()),
                 ProjectNode.Locality.LOCAL);
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
 
         return Optional.of(canonicalPlan);
     }
 
     @Override
-    public Optional<PlanNode> visitAggregation(AggregationNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitAggregation(AggregationNode node, Context context)
     {
         Optional<PlanNode> source = node.getSource().accept(this, context);
         if (!source.isPresent()) {
@@ -134,28 +137,31 @@ public class CanonicalPlanGenerator
         //   3. Get new variable reference for aggregation expression
         //   4. Record mapping from original variable reference to the new one
         List<AggregationReference> aggregationReferences = node.getAggregations().entrySet().stream()
-                .map(entry -> new AggregationReference(getCanonicalAggregation(entry.getValue(), context), entry.getKey()))
+                .map(entry -> new AggregationReference(getCanonicalAggregation(entry.getValue(), context.getExpressions()), entry.getKey()))
                 .sorted(comparing(aggregationReference -> aggregationReference.getAggregation().getCall().toString()))
                 .collect(toImmutableList());
         ImmutableMap.Builder<VariableReferenceExpression, Aggregation> aggregations = ImmutableMap.builder();
         for (AggregationReference aggregationReference : aggregationReferences) {
             VariableReferenceExpression reference = variableAllocator.newVariable(aggregationReference.getAggregation().getCall());
-            context.put(aggregationReference.getVariableReferenceExpression(), reference);
+            context.mapExpression(aggregationReference.getVariableReferenceExpression(), reference);
             aggregations.put(reference, aggregationReference.getAggregation());
         }
 
-        return Optional.of(new AggregationNode(
+        PlanNode canonicalPlan = new AggregationNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
                 aggregations.build(),
-                getCanonicalGroupingSetDescriptor(node.getGroupingSets(), context),
+                getCanonicalGroupingSetDescriptor(node.getGroupingSets(), context.getExpressions()),
                 node.getPreGroupedVariables().stream()
-                        .map(context::get)
+                        .map(variable -> context.getExpressions().get(variable))
                         .collect(toImmutableList()),
                 node.getStep(),
                 node.getHashVariable().map(ignored -> variableAllocator.newHashVariable()),
-                node.getGroupIdVariable().map(context::get)));
+                node.getGroupIdVariable().map(variable -> context.getExpressions().get(variable)));
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     private Aggregation getCanonicalAggregation(Aggregation aggregation, Map<VariableReferenceExpression, VariableReferenceExpression> context)
@@ -209,7 +215,7 @@ public class CanonicalPlanGenerator
     }
 
     @Override
-    public Optional<PlanNode> visitGroupId(GroupIdNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitGroupId(GroupIdNode node, Context context)
     {
         Optional<PlanNode> source = node.getSource().accept(this, context);
         if (!source.isPresent()) {
@@ -218,36 +224,39 @@ public class CanonicalPlanGenerator
 
         ImmutableMap.Builder<VariableReferenceExpression, VariableReferenceExpression> groupingColumns = ImmutableMap.builder();
         for (Entry<VariableReferenceExpression, VariableReferenceExpression> entry : node.getGroupingColumns().entrySet()) {
-            VariableReferenceExpression column = context.get(entry.getValue());
+            VariableReferenceExpression column = context.getExpressions().get(entry.getValue());
             VariableReferenceExpression reference = variableAllocator.newVariable(column, "gid");
-            context.put(entry.getKey(), reference);
+            context.mapExpression(entry.getKey(), reference);
             groupingColumns.put(reference, column);
         }
 
         ImmutableList.Builder<List<VariableReferenceExpression>> groupingSets = ImmutableList.builder();
         for (List<VariableReferenceExpression> groupingSet : node.getGroupingSets()) {
             groupingSets.add(groupingSet.stream()
-                    .map(context::get)
+                    .map(variable -> context.getExpressions().get(variable))
                     .collect(toImmutableList()));
         }
 
         VariableReferenceExpression groupId = variableAllocator.newVariable("groupid", INTEGER);
-        context.put(node.getGroupIdVariable(), groupId);
+        context.mapExpression(node.getGroupIdVariable(), groupId);
 
-        return Optional.of(new GroupIdNode(
+        PlanNode canonicalPlan = new GroupIdNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
                 groupingSets.build(),
                 groupingColumns.build(),
                 node.getAggregationArguments().stream()
-                        .map(context::get)
+                        .map(variable -> context.getExpressions().get(variable))
                         .collect(toImmutableList()),
-                groupId));
+                groupId);
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     @Override
-    public Optional<PlanNode> visitUnnest(UnnestNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitUnnest(UnnestNode node, Context context)
     {
         Optional<PlanNode> source = node.getSource().accept(this, context);
         if (!source.isPresent()) {
@@ -257,11 +266,11 @@ public class CanonicalPlanGenerator
         // Generate canonical unnestVariables.
         ImmutableMap.Builder<VariableReferenceExpression, List<VariableReferenceExpression>> newUnnestVariables = ImmutableMap.builder();
         for (Map.Entry<VariableReferenceExpression, List<VariableReferenceExpression>> unnestVariable : node.getUnnestVariables().entrySet()) {
-            VariableReferenceExpression input = (VariableReferenceExpression) inlineAndCanonicalize(context, unnestVariable.getKey());
+            VariableReferenceExpression input = (VariableReferenceExpression) inlineAndCanonicalize(context.getExpressions(), unnestVariable.getKey());
             ImmutableList.Builder<VariableReferenceExpression> newVariables = ImmutableList.builder();
             for (VariableReferenceExpression variable : unnestVariable.getValue()) {
                 VariableReferenceExpression newVariable = variableAllocator.newVariable(Optional.empty(), "unnest_field", variable.getType());
-                context.put(variable, newVariable);
+                context.mapExpression(variable, newVariable);
                 newVariables.add(newVariable);
             }
             newUnnestVariables.put(input, newVariables.build());
@@ -271,23 +280,26 @@ public class CanonicalPlanGenerator
         Optional<VariableReferenceExpression> ordinalityVariable = node.getOrdinalityVariable()
                 .map(variable -> {
                     VariableReferenceExpression newVariable = variableAllocator.newVariable(Optional.empty(), "unnest_ordinality", variable.getType());
-                    context.put(variable, newVariable);
+                    context.mapExpression(variable, newVariable);
                     return newVariable;
                 });
 
-        return Optional.of(new UnnestNode(
+        PlanNode canonicalPlan = new UnnestNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
                 node.getReplicateVariables().stream()
-                        .map(variable -> (VariableReferenceExpression) inlineAndCanonicalize(context, variable))
+                        .map(variable -> (VariableReferenceExpression) inlineAndCanonicalize(context.getExpressions(), variable))
                         .collect(toImmutableList()),
                 newUnnestVariables.build(),
-                ordinalityVariable));
+                ordinalityVariable);
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     @Override
-    public Optional<PlanNode> visitProject(ProjectNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitProject(ProjectNode node, Context context)
     {
         Optional<PlanNode> source = node.getSource().accept(this, context);
         if (!source.isPresent()) {
@@ -295,22 +307,25 @@ public class CanonicalPlanGenerator
         }
 
         List<RowExpressionReference> rowExpressionReferences = node.getAssignments().entrySet().stream()
-                .map(entry -> new RowExpressionReference(inlineAndCanonicalize(context, entry.getValue(), strategy == REMOVE_SAFE_CONSTANTS), entry.getKey()))
+                .map(entry -> new RowExpressionReference(inlineAndCanonicalize(context.getExpressions(), entry.getValue(), strategy == REMOVE_SAFE_CONSTANTS), entry.getKey()))
                 .sorted(comparing(rowExpressionReference -> rowExpressionReference.getRowExpression().toString()))
                 .collect(toImmutableList());
         ImmutableMap.Builder<VariableReferenceExpression, RowExpression> assignments = ImmutableMap.builder();
         for (RowExpressionReference rowExpressionReference : rowExpressionReferences) {
             VariableReferenceExpression reference = variableAllocator.newVariable(rowExpressionReference.getRowExpression());
-            context.put(rowExpressionReference.getVariableReferenceExpression(), reference);
+            context.mapExpression(rowExpressionReference.getVariableReferenceExpression(), reference);
             assignments.put(reference, rowExpressionReference.getRowExpression());
         }
 
-        return Optional.of(new ProjectNode(
+        PlanNode canonicalPlan = new ProjectNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
                 new Assignments(assignments.build()),
-                node.getLocality()));
+                node.getLocality());
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     private static class RowExpressionReference
@@ -336,18 +351,25 @@ public class CanonicalPlanGenerator
     }
 
     @Override
-    public Optional<PlanNode> visitFilter(FilterNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitFilter(FilterNode node, Context context)
     {
         Optional<PlanNode> source = node.getSource().accept(this, context);
-        return source.map(planNode -> new FilterNode(
+        if (!source.isPresent()) {
+            return Optional.empty();
+        }
+
+        PlanNode canonicalPlan = new FilterNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
-                inlineAndCanonicalize(context, node.getPredicate())));
+                inlineAndCanonicalize(context.getExpressions(), node.getPredicate()));
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     @Override
-    public Optional<PlanNode> visitTableScan(TableScanNode node, Map<VariableReferenceExpression, VariableReferenceExpression> context)
+    public Optional<PlanNode> visitTableScan(TableScanNode node, Context context)
     {
         List<ColumnReference> columnReferences = node.getAssignments().entrySet().stream()
                 .map(entry -> new ColumnReference(entry.getValue(), entry.getKey()))
@@ -357,17 +379,20 @@ public class CanonicalPlanGenerator
         ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> assignments = ImmutableMap.builder();
         for (ColumnReference columnReference : columnReferences) {
             VariableReferenceExpression reference = variableAllocator.newVariable(Optional.empty(), columnReference.getColumnHandle().toString(), columnReference.getVariableReferenceExpression().getType());
-            context.put(columnReference.getVariableReferenceExpression(), reference);
+            context.mapExpression(columnReference.getVariableReferenceExpression(), reference);
             outputVariables.add(reference);
             assignments.put(reference, columnReference.getColumnHandle());
         }
 
-        return Optional.of(new CanonicalTableScanNode(
+        PlanNode canonicalPlan = new CanonicalTableScanNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 getCanonicalTableHandle(node.getTable(), strategy),
                 outputVariables.build(),
-                assignments.build()));
+                assignments.build());
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
     }
 
     private static RowExpression inlineAndCanonicalize(
@@ -404,6 +429,32 @@ public class CanonicalPlanGenerator
         public VariableReferenceExpression getVariableReferenceExpression()
         {
             return variableReferenceExpression;
+        }
+    }
+
+    public static class Context
+    {
+        private final Map<VariableReferenceExpression, VariableReferenceExpression> expressions = new HashMap<>();
+        private final Map<PlanNode, CanonicalPlan> canonicalPlans = new IdentityHashMap<>();
+
+        public Map<VariableReferenceExpression, VariableReferenceExpression> getExpressions()
+        {
+            return expressions;
+        }
+
+        public Map<PlanNode, CanonicalPlan> getCanonicalPlans()
+        {
+            return canonicalPlans;
+        }
+
+        public void mapExpression(VariableReferenceExpression from, VariableReferenceExpression to)
+        {
+            expressions.put(from, to);
+        }
+
+        public void addPlan(PlanNode plan, CanonicalPlan canonicalPlan)
+        {
+            canonicalPlans.put(plan, canonicalPlan);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanHasher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanHasher.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.spi.plan.PlanNode;
+
+import java.util.Optional;
+
+/**
+ * Interface to hash a PlanNode according to PlanCanonicalizationStrategy `strategy`.
+ */
+public interface PlanHasher
+{
+    /**
+     * Canonicalize the plan using `CanonicalPlanGenerator` with given strategy, and returns a hash representation
+     * of the canonicalized plan.
+     * @param planNode Plan node to hash
+     * @param strategy Strategy to canonicalize the plan node
+     * @return Hash of the plan node. Returns Optional.empty() if unable to hash.
+     */
+    Optional<String> hash(PlanNode planNode, PlanCanonicalizationStrategy strategy);
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCachingPlanHasher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCachingPlanHasher.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.cost.HistoryBasedPlanStatisticsCalculator;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.USE_HISTORY_BASED_PLAN_STATISTICS;
+import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestCachingPlanHasher
+        extends BasePlanTest
+{
+    @Test
+    public void testCache()
+    {
+        getPlanHash("SELECT COUNT_IF(totalprice > 0) from orders WHERE custkey > 100 GROUP BY orderkey", CONNECTOR);
+        PlanHasher planHasher = ((HistoryBasedPlanStatisticsCalculator) getQueryRunner().getStatsCalculator()).getPlanHasher();
+        // We cache hashes for all intermediate plan nodes
+        assertEquals(((CachingPlanHasher) planHasher).getCacheSize(), 6);
+    }
+
+    private Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty("task_concurrency", "1")
+                .build();
+    }
+
+    private String getPlanHash(String sql, PlanCanonicalizationStrategy strategy)
+    {
+        Session session = createSession();
+        PlanNode plan = plan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, session).getRoot();
+        assertTrue(plan.getStatsEquivalentPlanNode().isPresent());
+        PlanHasher planHasher = ((HistoryBasedPlanStatisticsCalculator) getQueryRunner().getStatsCalculator()).getPlanHasher();
+        return planHasher.hash(plan, strategy).get();
+    }
+}


### PR DESCRIPTION
Commit 1: Cache plan hashes so they are shared with repeated calls of IterativePlanOptimizer

Commit 2: Previously, CachingStatsProvider was recreated multiple times within a single iterative rule. Fixed it to instantiate it once only
```
== NO RELEASE NOTE ==
```
