### PR TITLE
Revert commit 8fc1be4cb4c2243ca5e36f8eef396ff9b6d5983d

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -443,18 +443,6 @@ public final class DiscoveryNodeManager
         return getAllNodes().getShuttingDownNodes().size();
     }
 
-    @Managed
-    public int getActiveResourceManagerCount()
-    {
-        return getAllNodes().getActiveResourceManagers().size();
-    }
-
-    @Managed
-    public int getActiveCoordinatorCount()
-    {
-        return getAllNodes().getActiveCoordinators().size();
-    }
-
     @Override
     public Set<InternalNode> getNodes(NodeState state)
     {
@@ -603,6 +591,8 @@ public final class DiscoveryNodeManager
             return service ->
                     !nodeStatusService.isPresent()
                             || nodeStatusService.get().isAllowed(service.getLocation())
+                            || isCoordinator(service)
+                            || isResourceManager(service)
                             || isCatalogServer(service);
         }
 


### PR DESCRIPTION
After this change SHOW COLUMNS FROM Table;
fails with the error

```
Caused by: com.facebook.presto.spi.PrestoException: No nodes available to run query
	at com.facebook.presto.execution.scheduler.nodeSelection.SimpleNodeSelector.computeAssignments(SimpleNodeSelector.java:186)
	at com.facebook.presto.execution.scheduler.DynamicSplitPlacementPolicy.computeAssignments(DynamicSplitPlacementPolicy.java:42)
	at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.schedule(SourcePartitionedScheduler.java:273)
	at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler$1.schedule(SourcePartitionedScheduler.java:147)
	at com.facebook.presto.execution.scheduler.LegacySqlQueryScheduler.schedule(LegacySqlQueryScheduler.java:433)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
```

Test plan 
After the revert the query succeeds. There are several tests of similar pattern, but none of them failed though.

```
== NO RELEASE NOTE ==
```
