### PR TITLE
Prefix DECIMAL value structs with Unscaled

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -708,16 +708,16 @@ void setCellFromConstantVector(
   }
   switch (valueVector->typeKind()) {
     case TypeKind::SHORT_DECIMAL: {
-      auto flatVector = columnVector->as<FlatVector<velox::ShortDecimal>>();
+      auto flatVector = columnVector->as<FlatVector<velox::UnscaledShortDecimal>>();
       flatVector->set(
           row,
-          valueVector->as<ConstantVector<velox::ShortDecimal>>()->valueAt(0));
+          valueVector->as<ConstantVector<velox::UnscaledShortDecimal>>()->valueAt(0));
     } break;
     case TypeKind::LONG_DECIMAL: {
-      auto flatVector = columnVector->as<FlatVector<velox::LongDecimal>>();
+      auto flatVector = columnVector->as<FlatVector<velox::UnscaledLongDecimal>>();
       flatVector->set(
           row,
-          valueVector->as<ConstantVector<velox::LongDecimal>>()->valueAt(0));
+          valueVector->as<ConstantVector<velox::UnscaledLongDecimal>>()->valueAt(0));
     } break;
     default:
       VELOX_UNSUPPORTED();


### PR DESCRIPTION
ShortDecimal and LongDecimal only store the unscaled decimal values.
To clarify this semantic, we add the prefix "Unscaled".

ShortDecimal -> UnscaledShortDecimal
LongDecimal -> UnscaledLongDecimal

**Test plan**
The existing tests must pass. This just a rename of structs change. No functional changes introduced.


```
== NO RELEASE NOTE ==
```
