### PR TITLE
Optimize ORC StructSelectiveStreamReader.getRetainedSizeInBytes

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -665,10 +665,11 @@ public class StructSelectiveStreamReader
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + sizeOf(outputPositions) + sizeOf(nestedPositions) + sizeOf(nestedOutputPositions) + sizeOf(nulls) +
-                nestedReaders.values().stream()
-                        .mapToLong(SelectiveStreamReader::getRetainedSizeInBytes)
-                        .sum();
+        long size = INSTANCE_SIZE + sizeOf(outputPositions) + sizeOf(nestedPositions) + sizeOf(nestedOutputPositions) + sizeOf(nulls);
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            size += reader.getRetainedSizeInBytes();
+        }
+        return size;
     }
 
     private static Optional<TupleDomainFilter> getTopLevelFilter(Map<Subfield, TupleDomainFilter> filters)


### PR DESCRIPTION
Replace stream pipelining to calculate a sum with a simple loop.

This is a tiny improvement for a case when reading all nulls struct.

Test plan:
Repurposed a SelectiveReadersBenchmark to test the struct reader. The benchmark was running with 30M all null rows.

**Before:**
```
Before:
Benchmark                  (filterRateSignature)                             (typeSignature)  (withNulls)  Mode  Cnt    Score   Error  Units
BenchmarkMy.readAllBlocks                     -1                                      bigint          ALL  avgt   20   31.190 ± 2.895  ms/op
BenchmarkMy.readAllBlocks                     -1                             row("a" bigint)          ALL  avgt   20  119.863 ± 4.314  ms/op
BenchmarkMy.readAllBlocks                     -1                    row("a" row("b" bigint))          ALL  avgt   20  133.254 ± 6.982  ms/op
BenchmarkMy.readAllBlocks                     -1           row("a" row("b" row("c" bigint)))          ALL  avgt   20  139.932 ± 4.562  ms/op
BenchmarkMy.readAllBlocks                     -1  row("a" row("b" row("c" row("d" bigint))))          ALL  avgt   20  143.196 ± 2.723  ms/op
```

**After:**
```
Optimized retainedSize
Benchmark                  (filterRateSignature)                             (typeSignature)  (withNulls)  Mode  Cnt    Score   Error  Units
BenchmarkMy.readAllBlocks                     -1                                      bigint          ALL  avgt   20   35.247 ± 4.827  ms/op
BenchmarkMy.readAllBlocks                     -1                             row("a" bigint)          ALL  avgt   20  112.171 ± 3.904  ms/op
BenchmarkMy.readAllBlocks                     -1                    row("a" row("b" bigint))          ALL  avgt   20  114.777 ± 4.500  ms/op
BenchmarkMy.readAllBlocks                     -1           row("a" row("b" row("c" bigint)))          ALL  avgt   20  113.223 ± 3.657  ms/op
BenchmarkMy.readAllBlocks                     -1  row("a" row("b" row("c" row("d" bigint))))          ALL  avgt   20  116.939 ± 9.514  ms/op
```


```
== NO RELEASE NOTE ==
```
