### PR TITLE
Upgrade Apache Hudi version to 0.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dep.pinot.version>0.10.0</dep.pinot.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>0.11.0</dep.hudi.version>
+        <dep.hudi.version>0.12.0</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.jayway.version>2.6.0</dep.jayway.version>


### PR DESCRIPTION
### Change Logs

This PR upgrades the Apache Hudi version to 0.12.0 as the dependency.

### Test plan

Presto Hudi connector can execute queries without problems.

### Release Note Update

```
== RELEASE NOTES ==

Hudi Changes
* Upgrade the Apache Hudi version to 0.12.0

```
