### PR TITLE
Add asynchronous split generation in Hudi connector

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
@@ -32,8 +32,8 @@ public class HudiConfig
     private DataSize standardSplitWeightSize = new DataSize(128, MEGABYTE);
     private double minimumAssignedSplitWeight = 0.05;
     private int maxOutstandingSplits = 1000;
-    private int splitLoaderParallelism = 2;
-    private int splitGeneratorParallelism = 8;
+    private int splitLoaderParallelism = 4;
+    private int splitGeneratorParallelism = 4;
 
     public boolean isMetadataTableEnabled()
     {

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
@@ -98,7 +98,7 @@ public class HudiConfig
     }
 
     @Config("hudi.max-outstanding-splits")
-    @ConfigDescription("Maximum outstanding splits in a batch enqueued for processing.")
+    @ConfigDescription("Maximum outstanding splits per batch for query.")
     public HudiConfig setMaxOutstandingSplits(int maxOutstandingSplits)
     {
         this.maxOutstandingSplits = maxOutstandingSplits;
@@ -112,7 +112,7 @@ public class HudiConfig
     }
 
     @Config("hudi.split-generator-parallelism")
-    @ConfigDescription("Number of threads to generate splits from partitions.")
+    @ConfigDescription("Number of threads used to generate splits from partitions.")
     public HudiConfig setSplitGeneratorParallelism(int splitGeneratorParallelism)
     {
         this.splitGeneratorParallelism = splitGeneratorParallelism;
@@ -126,7 +126,7 @@ public class HudiConfig
     }
 
     @Config("hudi.split-loader-parallelism")
-    @ConfigDescription("Number of threads to run background split loader. "
+    @ConfigDescription("Number of threads used to run background split loader. "
             + "A single background split loader is needed per query.")
     public HudiConfig setSplitLoaderParallelism(int splitLoaderParallelism)
     {

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConfig.java
@@ -20,6 +20,7 @@ import io.airlift.units.DataSize;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -30,6 +31,9 @@ public class HudiConfig
     private boolean sizeBasedSplitWeightsEnabled = true;
     private DataSize standardSplitWeightSize = new DataSize(128, MEGABYTE);
     private double minimumAssignedSplitWeight = 0.05;
+    private int maxOutstandingSplits = 1000;
+    private int splitLoaderParallelism = 2;
+    private int splitGeneratorParallelism = 8;
 
     public boolean isMetadataTableEnabled()
     {
@@ -84,6 +88,49 @@ public class HudiConfig
     public HudiConfig setMinimumAssignedSplitWeight(double minimumAssignedSplitWeight)
     {
         this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxOutstandingSplits()
+    {
+        return maxOutstandingSplits;
+    }
+
+    @Config("hudi.max-outstanding-splits")
+    @ConfigDescription("Maximum outstanding splits in a batch enqueued for processing.")
+    public HudiConfig setMaxOutstandingSplits(int maxOutstandingSplits)
+    {
+        this.maxOutstandingSplits = maxOutstandingSplits;
+        return this;
+    }
+
+    @Min(1)
+    public int getSplitGeneratorParallelism()
+    {
+        return splitGeneratorParallelism;
+    }
+
+    @Config("hudi.split-generator-parallelism")
+    @ConfigDescription("Number of threads to generate splits from partitions.")
+    public HudiConfig setSplitGeneratorParallelism(int splitGeneratorParallelism)
+    {
+        this.splitGeneratorParallelism = splitGeneratorParallelism;
+        return this;
+    }
+
+    @Min(1)
+    public int getSplitLoaderParallelism()
+    {
+        return splitLoaderParallelism;
+    }
+
+    @Config("hudi.split-loader-parallelism")
+    @ConfigDescription("Number of threads to run background split loader. "
+            + "A single background split loader is needed per query.")
+    public HudiConfig setSplitLoaderParallelism(int splitLoaderParallelism)
+    {
+        this.splitLoaderParallelism = splitLoaderParallelism;
         return this;
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiErrorCode.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiErrorCode.java
@@ -30,6 +30,7 @@ public enum HudiErrorCode
     HUDI_FILESYSTEM_ERROR(0x40, EXTERNAL),
     HUDI_CANNOT_OPEN_SPLIT(0x41, EXTERNAL),
     HUDI_CURSOR_ERROR(0x42, EXTERNAL),
+    HUDI_CANNOT_GENERATE_SPLIT(0x43, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadata.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadata.java
@@ -255,7 +255,7 @@ public class HudiMetadata
         return builder.build();
     }
 
-    static MetastoreContext toMetastoreContext(ConnectorSession session)
+    public static MetastoreContext toMetastoreContext(ConnectorSession session)
     {
         return new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
     }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadataFactory.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadataFactory.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hudi;
 
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 
@@ -28,20 +30,30 @@ public class HudiMetadataFactory
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
+    private final long perTransactionCacheMaximumSize;
+    private final boolean metastoreImpersonationEnabled;
+    private final int metastorePartitionCacheMaxColumnCount;
 
     @Inject
     public HudiMetadataFactory(
             ExtendedHiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            MetastoreClientConfig metastoreClientConfig)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.perTransactionCacheMaximumSize = metastoreClientConfig.getPerTransactionMetastoreCacheMaximumSize();
+        this.metastoreImpersonationEnabled = metastoreClientConfig.isMetastoreImpersonationEnabled();
+        this.metastorePartitionCacheMaxColumnCount = metastoreClientConfig.getPartitionCacheColumnCountLimit();
     }
 
     public ConnectorMetadata create()
     {
-        return new HudiMetadata(metastore, hdfsEnvironment, typeManager);
+        return new HudiMetadata(
+                CachingHiveMetastore.memoizeMetastore(metastore, metastoreImpersonationEnabled, perTransactionCacheMaximumSize, metastorePartitionCacheMaxColumnCount),
+                hdfsEnvironment,
+                typeManager);
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.dataSizeSessionProp
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.dataSizeProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static java.lang.String.format;
 
 public class HudiSessionProperties
@@ -47,6 +48,8 @@ public class HudiSessionProperties
     private static final String STANDARD_SPLIT_WEIGHT_SIZE = "standard_split_weight_size";
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
+    private static final String MAX_OUTSTANDING_SPLITS = "max_outstanding_splits";
+    private static final String SPLIT_GENERATOR_PARALLELISM = "split_generator_parallelism";
 
     @Inject
     public HudiSessionProperties(HiveClientConfig hiveClientConfig, HudiConfig hudiConfig)
@@ -107,6 +110,16 @@ public class HudiSessionProperties
                         READ_MASKED_VALUE_ENABLED,
                         "Return null when access is denied for an encrypted parquet column",
                         hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
+                        false),
+                integerProperty(
+                        MAX_OUTSTANDING_SPLITS,
+                        "Maximum outstanding splits in a batch enqueued for processing",
+                        hudiConfig.getMaxOutstandingSplits(),
+                        false),
+                integerProperty(
+                        SPLIT_GENERATOR_PARALLELISM,
+                        "Number of threads to generate splits from partitions",
+                        hudiConfig.getSplitGeneratorParallelism(),
                         false));
     }
 
@@ -153,5 +166,15 @@ public class HudiSessionProperties
     public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
     {
         return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
+    }
+
+    public static int getMaxOutstandingSplits(ConnectorSession session)
+    {
+        return session.getProperty(MAX_OUTSTANDING_SPLITS, Integer.class);
+    }
+
+    public static int getSplitGeneratorParallelism(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_GENERATOR_PARALLELISM, Integer.class);
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSessionProperties.java
@@ -113,12 +113,12 @@ public class HudiSessionProperties
                         false),
                 integerProperty(
                         MAX_OUTSTANDING_SPLITS,
-                        "Maximum outstanding splits in a batch enqueued for processing",
+                        "Maximum outstanding splits per batch for query",
                         hudiConfig.getMaxOutstandingSplits(),
                         false),
                 integerProperty(
                         SPLIT_GENERATOR_PARALLELISM,
-                        "Number of threads to generate splits from partitions",
+                        "Number of threads used to generate splits from partitions",
                         hudiConfig.getSplitGeneratorParallelism(),
                         false));
     }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.hudi;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
@@ -21,8 +22,9 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
-import com.facebook.presto.hudi.split.HudiSplitWeightProvider;
-import com.facebook.presto.hudi.split.SizeBasedSplitWeightProvider;
+import com.facebook.presto.hudi.split.ForHudiBackgroundSplitLoader;
+import com.facebook.presto.hudi.split.ForHudiSplitAsyncQueue;
+import com.facebook.presto.hudi.split.ForHudiSplitSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -30,40 +32,34 @@ import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
-import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
-import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.HoodieTimer;
 
 import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_FILESYSTEM_ERROR;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_INVALID_METADATA;
 import static com.facebook.presto.hudi.HudiMetadata.fromDataColumns;
-import static com.facebook.presto.hudi.HudiMetadata.toMetastoreContext;
-import static com.facebook.presto.hudi.HudiSessionProperties.getMinimumAssignedSplitWeight;
-import static com.facebook.presto.hudi.HudiSessionProperties.getStandardSplitWeightSize;
+import static com.facebook.presto.hudi.HudiSessionProperties.getMaxOutstandingSplits;
 import static com.facebook.presto.hudi.HudiSessionProperties.isHudiMetadataTableEnabled;
-import static com.facebook.presto.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMemoryFileSystemViewWithTimeline;
@@ -71,19 +67,30 @@ import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMe
 public class HudiSplitManager
         implements ConnectorSplitManager
 {
+    private static final Logger log = Logger.get(HudiSplitManager.class);
+
     private final HdfsEnvironment hdfsEnvironment;
     private final HudiTransactionManager hudiTransactionManager;
     private final HudiPartitionManager hudiPartitionManager;
+    private final ExecutorService asyncQueueExecutor;
+    private final ScheduledExecutorService splitLoaderExecutorService;
+    private final ExecutorService splitGeneratorExecutorService;
 
     @Inject
     public HudiSplitManager(
             HdfsEnvironment hdfsEnvironment,
             HudiTransactionManager hudiTransactionManager,
-            HudiPartitionManager hudiPartitionManager)
+            HudiPartitionManager hudiPartitionManager,
+            @ForHudiSplitAsyncQueue ExecutorService asyncQueueExecutor,
+            @ForHudiSplitSource ScheduledExecutorService splitLoaderExecutorService,
+            @ForHudiBackgroundSplitLoader ExecutorService splitGeneratorExecutorService)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hudiTransactionManager = requireNonNull(hudiTransactionManager, "hudiTransactionManager is null");
         this.hudiPartitionManager = requireNonNull(hudiPartitionManager, "hudiPartitionManager is null");
+        this.asyncQueueExecutor = requireNonNull(asyncQueueExecutor, "asyncQueueExecutor is null");
+        this.splitLoaderExecutorService = requireNonNull(splitLoaderExecutorService, "splitLoaderExecutorService is null");
+        this.splitGeneratorExecutorService = requireNonNull(splitGeneratorExecutorService, "splitGeneratorExecutorService is null");
     }
 
     @Override
@@ -93,13 +100,14 @@ public class HudiSplitManager
             ConnectorTableLayoutHandle layoutHandle,
             SplitSchedulingContext splitSchedulingContext)
     {
-        HudiSplitWeightProvider splitWeightProvider = createSplitWeightProvider(session);
         ExtendedHiveMetastore metastore = ((HudiMetadata) hudiTransactionManager.get(transaction)).getMetastore();
         HudiTableLayoutHandle layout = (HudiTableLayoutHandle) layoutHandle;
         HudiTableHandle table = layout.getTable();
 
         // Retrieve and prune partitions
+        HoodieTimer timer = new HoodieTimer().startTimer();
         List<String> partitions = hudiPartitionManager.getEffectivePartitions(session, metastore, table.getSchemaName(), table.getTableName(), layout.getTupleDomain());
+        log.info("Took %d ms to get %d partitions", timer.endTimer(), partitions.size());
         if (partitions.isEmpty()) {
             return new FixedSplitSource(ImmutableList.of());
         }
@@ -118,21 +126,17 @@ public class HudiSplitManager
         HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(conf);
         HoodieTableFileSystemView fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
 
-        // Construct Presto splits
-        Path tablePath = new Path(table.getPath());
-        MetastoreContext metastoreContext = toMetastoreContext(session);
-        ImmutableList.Builder<HudiSplit> builder = ImmutableList.builder();
-        for (String partitionName : partitions) {
-            HudiPartition hudiPartition = getHudiPartition(metastore, metastoreContext, layout, partitionName);
-            Path partitionPath = new Path(hudiPartition.getStorage().getLocation());
-            String relativePartitionPath = FSUtils.getRelativePartitionPath(tablePath, partitionPath);
-            fsView.getLatestFileSlicesBeforeOrOn(relativePartitionPath, timestamp, false)
-                    .map(fileSlice -> createHudiSplit(table, fileSlice, timestamp, hudiPartition, splitWeightProvider))
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .forEach(builder::add);
-        }
-        return new FixedSplitSource(builder.build());
+        return new HudiSplitSource(
+                session,
+                metastore,
+                layout,
+                fsView,
+                partitions,
+                timestamp,
+                asyncQueueExecutor,
+                splitLoaderExecutorService,
+                splitGeneratorExecutorService,
+                getMaxOutstandingSplits(session));
     }
 
     private ExtendedFileSystem getFileSystem(ConnectorSession session, HudiTableHandle table)
@@ -151,35 +155,7 @@ public class HudiSplitManager
         }
     }
 
-    private Optional<HudiSplit> createHudiSplit(
-            HudiTableHandle table,
-            FileSlice slice,
-            String timestamp,
-            HudiPartition partition,
-            HudiSplitWeightProvider splitWeightProvider)
-    {
-        HudiFile hudiFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileLen())).orElse(null);
-        if (null == hudiFile && table.getTableType() == HudiTableType.COW) {
-            return Optional.empty();
-        }
-        List<HudiFile> logFiles = slice.getLogFiles()
-                .map(logFile -> new HudiFile(logFile.getPath().toString(), 0, logFile.getFileSize()))
-                .collect(toImmutableList());
-        long sizeInBytes = hudiFile != null ? hudiFile.getLength()
-                : (logFiles.size() > 0 ? logFiles.stream().map(HudiFile::getLength).reduce(0L, Long::sum) : 0L);
-
-        return Optional.of(new HudiSplit(
-                table,
-                timestamp,
-                partition,
-                Optional.ofNullable(hudiFile),
-                logFiles,
-                ImmutableList.of(),
-                NodeSelectionStrategy.NO_PREFERENCE,
-                splitWeightProvider.calculateSplitWeight(sizeInBytes)));
-    }
-
-    private static HudiPartition getHudiPartition(ExtendedHiveMetastore metastore, MetastoreContext context, HudiTableLayoutHandle tableLayout, String partitionName)
+    public static HudiPartition getHudiPartition(ExtendedHiveMetastore metastore, MetastoreContext context, HudiTableLayoutHandle tableLayout, String partitionName)
     {
         String databaseName = tableLayout.getTable().getSchemaName();
         String tableName = tableLayout.getTable().getTableName();
@@ -209,15 +185,5 @@ public class HudiSplitManager
         Streams.forEachPair(partitionColumns.stream(), partitionValues.stream(),
                 (column, value) -> builder.put(column.getName(), value));
         return builder.build();
-    }
-
-    private static HudiSplitWeightProvider createSplitWeightProvider(ConnectorSession session)
-    {
-        if (isSizeBasedSplitWeightsEnabled(session)) {
-            DataSize standardSplitWeightSize = getStandardSplitWeightSize(session);
-            double minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
-            return new SizeBasedSplitWeightProvider(minimumAssignedSplitWeight, standardSplitWeightSize);
-        }
-        return HudiSplitWeightProvider.uniformStandardWeightProvider();
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -107,7 +107,7 @@ public class HudiSplitManager
         // Retrieve and prune partitions
         HoodieTimer timer = new HoodieTimer().startTimer();
         List<String> partitions = hudiPartitionManager.getEffectivePartitions(session, metastore, table.getSchemaName(), table.getTableName(), layout.getTupleDomain());
-        log.info("Took %d ms to get %d partitions", timer.endTimer(), partitions.size());
+        log.debug("Took %d ms to get %d partitions", timer.endTimer(), partitions.size());
         if (partitions.isEmpty()) {
             return new FixedSplitSource(ImmutableList.of());
         }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitSource.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitSource.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi;
+
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.util.AsyncQueue;
+import com.facebook.presto.hudi.split.HudiBackgroundSplitLoader;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.google.common.util.concurrent.Futures;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.concurrent.MoreFutures.toCompletableFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
+public class HudiSplitSource
+        implements ConnectorSplitSource
+{
+    private final AsyncQueue<ConnectorSplit> queue;
+    private final HudiBackgroundSplitLoader splitLoader;
+    private final ScheduledFuture splitLoaderFuture;
+
+    public HudiSplitSource(
+            ConnectorSession session,
+            ExtendedHiveMetastore metastore,
+            HudiTableLayoutHandle layout,
+            HoodieTableFileSystemView fsView,
+            List<String> partitions,
+            String latestInstant,
+            ExecutorService asyncQueueExecutor,
+            ScheduledExecutorService splitLoaderExecutorService,
+            ExecutorService splitGeneratorExecutorService,
+            int maxOutstandingSplits)
+    {
+        this.queue = new AsyncQueue<>(maxOutstandingSplits, asyncQueueExecutor);
+        this.splitLoader = new HudiBackgroundSplitLoader(
+                session,
+                metastore,
+                splitGeneratorExecutorService,
+                layout,
+                fsView,
+                queue,
+                partitions,
+                latestInstant);
+        this.splitLoaderFuture = splitLoaderExecutorService.schedule(
+                this.splitLoader, 0, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(
+            ConnectorPartitionHandle partitionHandle,
+            int maxSize)
+    {
+        boolean noMoreSplits = isFinished();
+
+        return toCompletableFuture(Futures.transform(
+                queue.getBatchAsync(maxSize),
+                splits -> new ConnectorSplitBatch(splits, noMoreSplits),
+                directExecutor()));
+    }
+
+    @Override
+    public void close()
+    {
+        queue.finish();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return splitLoaderFuture.isDone() && queue.isFinished();
+    }
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiBackgroundSplitLoader.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiBackgroundSplitLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForHudiBackgroundSplitLoader
+{
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiSplitAsyncQueue.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiSplitAsyncQueue.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForHudiSplitAsyncQueue
+{
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiSplitSource.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/ForHudiSplitSource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForHudiSplitSource
+{
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiBackgroundSplitLoader.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiBackgroundSplitLoader.java
@@ -91,11 +91,6 @@ public class HudiBackgroundSplitLoader
             splitGeneratorFutures.add(splitGeneratorExecutorService.submit(generator));
         }
 
-        for (HudiPartitionSplitGenerator generator : splitGeneratorList) {
-            // Let the split generator stop once the partition queue is empty
-            generator.stopRunning();
-        }
-
         // Wait for all split generators to finish
         for (Future future : splitGeneratorFutures) {
             try {

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiBackgroundSplitLoader.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiBackgroundSplitLoader.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.util.AsyncQueue;
+import com.facebook.presto.hudi.HudiTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.exception.HoodieException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static com.facebook.presto.hudi.HudiSessionProperties.getSplitGeneratorParallelism;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A runnable to load Hudi splits asynchronously in the background
+ */
+public class HudiBackgroundSplitLoader
+        implements Runnable
+{
+    private static final Logger log = Logger.get(HudiBackgroundSplitLoader.class);
+
+    private final ConnectorSession session;
+    private final ExtendedHiveMetastore metastore;
+    private final HudiTableLayoutHandle layout;
+    private final HoodieTableFileSystemView fsView;
+    private final AsyncQueue<ConnectorSplit> asyncQueue;
+    private final List<String> partitions;
+    private final String latestInstant;
+    private final int splitGeneratorNumThreads;
+    private final ExecutorService splitGeneratorExecutorService;
+
+    public HudiBackgroundSplitLoader(
+            ConnectorSession session,
+            ExtendedHiveMetastore metastore,
+            ExecutorService splitGeneratorExecutorService,
+            HudiTableLayoutHandle layout,
+            HoodieTableFileSystemView fsView,
+            AsyncQueue<ConnectorSplit> asyncQueue,
+            List<String> partitions,
+            String latestInstant)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.layout = requireNonNull(layout, "layout is null");
+        this.fsView = requireNonNull(fsView, "fsView is null");
+        this.asyncQueue = requireNonNull(asyncQueue, "asyncQueue is null");
+        this.partitions = requireNonNull(partitions, "partitions is null");
+        this.latestInstant = requireNonNull(latestInstant, "latestInstant is null");
+
+        this.splitGeneratorNumThreads = getSplitGeneratorParallelism(session);
+        this.splitGeneratorExecutorService = requireNonNull(splitGeneratorExecutorService, "splitGeneratorExecutorService is null");
+    }
+
+    @Override
+    public void run()
+    {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        List<HudiPartitionSplitGenerator> splitGeneratorList = new ArrayList<>();
+        List<Future> splitGeneratorFutures = new ArrayList<>();
+        Queue<String> concurrentPartitionQueue = new ConcurrentLinkedQueue<>(partitions);
+
+        // Start a number of partition split generators to generate the splits in parallel
+        for (int i = 0; i < splitGeneratorNumThreads; i++) {
+            HudiPartitionSplitGenerator generator = new HudiPartitionSplitGenerator(
+                    session, metastore, layout, fsView, asyncQueue, concurrentPartitionQueue, latestInstant);
+            splitGeneratorList.add(generator);
+            splitGeneratorFutures.add(splitGeneratorExecutorService.submit(generator));
+        }
+
+        for (HudiPartitionSplitGenerator generator : splitGeneratorList) {
+            // Let the split generator stop once the partition queue is empty
+            generator.stopRunning();
+        }
+
+        // Wait for all split generators to finish
+        for (Future future : splitGeneratorFutures) {
+            try {
+                future.get();
+            }
+            catch (InterruptedException | ExecutionException e) {
+                throw new HoodieException("Error generating Hudi split", e);
+            }
+        }
+        asyncQueue.finish();
+        log.debug("Finish getting all splits in %d ms", timer.endTimer());
+    }
+}

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
@@ -67,7 +67,6 @@ public class HudiPartitionSplitGenerator
     private final Queue<String> concurrentPartitionQueue;
     private final String latestInstant;
     private final HudiSplitWeightProvider splitWeightProvider;
-    private boolean isRunning;
 
     public HudiPartitionSplitGenerator(
             ConnectorSession session,
@@ -88,7 +87,6 @@ public class HudiPartitionSplitGenerator
         this.concurrentPartitionQueue = requireNonNull(concurrentPartitionQueue, "concurrentPartitionQueue is null");
         this.latestInstant = requireNonNull(latestInstant, "latestInstant is null");
         this.splitWeightProvider = createSplitWeightProvider(requireNonNull(session, "session is null"));
-        this.isRunning = true;
     }
 
     @Override
@@ -96,7 +94,7 @@ public class HudiPartitionSplitGenerator
     {
         HoodieTimer timer = new HoodieTimer().startTimer();
 
-        while (isRunning || !concurrentPartitionQueue.isEmpty()) {
+        while (!concurrentPartitionQueue.isEmpty()) {
             String partitionName = concurrentPartitionQueue.poll();
 
             if (partitionName != null) {
@@ -104,11 +102,6 @@ public class HudiPartitionSplitGenerator
             }
         }
         log.debug("HudiPartitionSplitGenerator %s finishes in %d ms", this, timer.endTimer());
-    }
-
-    public void stopRunning()
-    {
-        this.isRunning = false;
     }
 
     private void generateSplitsFromPartition(String partitionName)

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi.split;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.util.AsyncQueue;
+import com.facebook.presto.hudi.HudiFile;
+import com.facebook.presto.hudi.HudiPartition;
+import com.facebook.presto.hudi.HudiSplit;
+import com.facebook.presto.hudi.HudiTableHandle;
+import com.facebook.presto.hudi.HudiTableLayoutHandle;
+import com.facebook.presto.hudi.HudiTableType;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.HoodieTimer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+
+import static com.facebook.presto.hudi.HudiMetadata.toMetastoreContext;
+import static com.facebook.presto.hudi.HudiSessionProperties.getMinimumAssignedSplitWeight;
+import static com.facebook.presto.hudi.HudiSessionProperties.getStandardSplitWeightSize;
+import static com.facebook.presto.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
+import static com.facebook.presto.hudi.HudiSplitManager.getHudiPartition;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A runnable to take partition names from a queue of partitions to process,
+ * generate Hudi splits from the partition, and add the splits to the async
+ * ConnectorSplit queue.
+ */
+public class HudiPartitionSplitGenerator
+        implements Runnable
+{
+    private static final Logger log = Logger.get(HudiPartitionSplitGenerator.class);
+
+    private final ExtendedHiveMetastore metastore;
+    private final MetastoreContext metastoreContext;
+    private final HudiTableLayoutHandle layout;
+    private final HudiTableHandle table;
+    private final Path tablePath;
+    private final HoodieTableFileSystemView fsView;
+    private final AsyncQueue<ConnectorSplit> asyncQueue;
+    private final Queue<String> concurrentPartitionQueue;
+    private final String latestInstant;
+    private final HudiSplitWeightProvider splitWeightProvider;
+    private boolean isRunning;
+
+    public HudiPartitionSplitGenerator(
+            ConnectorSession session,
+            ExtendedHiveMetastore metastore,
+            HudiTableLayoutHandle layout,
+            HoodieTableFileSystemView fsView,
+            AsyncQueue<ConnectorSplit> asyncQueue,
+            Queue<String> concurrentPartitionQueue,
+            String latestInstant)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.metastoreContext = toMetastoreContext(requireNonNull(session, "session is null"));
+        this.layout = requireNonNull(layout, "layout is null");
+        this.table = layout.getTable();
+        this.tablePath = new Path(table.getPath());
+        this.fsView = requireNonNull(fsView, "fsView is null");
+        this.asyncQueue = requireNonNull(asyncQueue, "asyncQueue is null");
+        this.concurrentPartitionQueue = requireNonNull(concurrentPartitionQueue, "concurrentPartitionQueue is null");
+        this.latestInstant = requireNonNull(latestInstant, "latestInstant is null");
+        this.splitWeightProvider = createSplitWeightProvider(requireNonNull(session, "session is null"));
+        this.isRunning = true;
+    }
+
+    @Override
+    public void run()
+    {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+
+        while (isRunning || !concurrentPartitionQueue.isEmpty()) {
+            String partitionName = concurrentPartitionQueue.poll();
+
+            if (partitionName != null) {
+                generateSplitsFromPartition(partitionName);
+            }
+        }
+        log.debug("HudiPartitionSplitGenerator %s finishes in %d ms", this, timer.endTimer());
+    }
+
+    public void stopRunning()
+    {
+        this.isRunning = false;
+    }
+
+    private void generateSplitsFromPartition(String partitionName)
+    {
+        HudiPartition hudiPartition = getHudiPartition(metastore, metastoreContext, layout, partitionName);
+        Path partitionPath = new Path(hudiPartition.getStorage().getLocation());
+        String relativePartitionPath = FSUtils.getRelativePartitionPath(tablePath, partitionPath);
+        fsView.getLatestFileSlicesBeforeOrOn(relativePartitionPath, latestInstant, false)
+                .map(fileSlice -> createHudiSplit(table, fileSlice, latestInstant, hudiPartition, splitWeightProvider))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(asyncQueue::offer);
+    }
+
+    private Optional<HudiSplit> createHudiSplit(
+            HudiTableHandle table,
+            FileSlice slice,
+            String timestamp,
+            HudiPartition partition,
+            HudiSplitWeightProvider splitWeightProvider)
+    {
+        HudiFile hudiFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileLen())).orElse(null);
+        if (null == hudiFile && table.getTableType() == HudiTableType.COW) {
+            return Optional.empty();
+        }
+        List<HudiFile> logFiles = slice.getLogFiles()
+                .map(logFile -> new HudiFile(logFile.getPath().toString(), 0, logFile.getFileSize()))
+                .collect(toImmutableList());
+        long sizeInBytes = hudiFile != null ? hudiFile.getLength()
+                : (logFiles.size() > 0 ? logFiles.stream().map(HudiFile::getLength).reduce(0L, Long::sum) : 0L);
+
+        return Optional.of(new HudiSplit(
+                table,
+                timestamp,
+                partition,
+                Optional.ofNullable(hudiFile),
+                logFiles,
+                ImmutableList.of(),
+                NodeSelectionStrategy.NO_PREFERENCE,
+                splitWeightProvider.calculateSplitWeight(sizeInBytes)));
+    }
+
+    private static HudiSplitWeightProvider createSplitWeightProvider(ConnectorSession session)
+    {
+        if (isSizeBasedSplitWeightsEnabled(session)) {
+            DataSize standardSplitWeightSize = getStandardSplitWeightSize(session);
+            double minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
+            return new SizeBasedSplitWeightProvider(minimumAssignedSplitWeight, standardSplitWeightSize);
+        }
+        return HudiSplitWeightProvider.uniformStandardWeightProvider();
+    }
+}

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
@@ -36,8 +36,8 @@ public class TestHudiConfig
                 .setStandardSplitWeightSize(new DataSize(128, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.05)
                 .setMaxOutstandingSplits(1000)
-                .setSplitLoaderParallelism(2)
-                .setSplitGeneratorParallelism(8));
+                .setSplitLoaderParallelism(4)
+                .setSplitGeneratorParallelism(4));
     }
 
     @Test
@@ -49,8 +49,8 @@ public class TestHudiConfig
                 .put("hudi.standard-split-weight-size", "500MB")
                 .put("hudi.minimum-assigned-split-weight", "0.1")
                 .put("hudi.max-outstanding-splits", "300")
-                .put("hudi.split-loader-parallelism", "6")
-                .put("hudi.split-generator-parallelism", "4")
+                .put("hudi.split-loader-parallelism", "2")
+                .put("hudi.split-generator-parallelism", "8")
                 .build();
 
         HudiConfig expected = new HudiConfig()
@@ -59,8 +59,8 @@ public class TestHudiConfig
                 .setStandardSplitWeightSize(new DataSize(500, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.1)
                 .setMaxOutstandingSplits(300)
-                .setSplitLoaderParallelism(6)
-                .setSplitGeneratorParallelism(4);
+                .setSplitLoaderParallelism(2)
+                .setSplitGeneratorParallelism(8);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiConfig.java
@@ -34,7 +34,10 @@ public class TestHudiConfig
                 .setMetadataTableEnabled(false)
                 .setSizeBasedSplitWeightsEnabled(true)
                 .setStandardSplitWeightSize(new DataSize(128, MEGABYTE))
-                .setMinimumAssignedSplitWeight(0.05));
+                .setMinimumAssignedSplitWeight(0.05)
+                .setMaxOutstandingSplits(1000)
+                .setSplitLoaderParallelism(2)
+                .setSplitGeneratorParallelism(8));
     }
 
     @Test
@@ -45,13 +48,19 @@ public class TestHudiConfig
                 .put("hudi.size-based-split-weights-enabled", "false")
                 .put("hudi.standard-split-weight-size", "500MB")
                 .put("hudi.minimum-assigned-split-weight", "0.1")
+                .put("hudi.max-outstanding-splits", "300")
+                .put("hudi.split-loader-parallelism", "6")
+                .put("hudi.split-generator-parallelism", "4")
                 .build();
 
         HudiConfig expected = new HudiConfig()
                 .setMetadataTableEnabled(true)
                 .setSizeBasedSplitWeightsEnabled(false)
                 .setStandardSplitWeightSize(new DataSize(500, MEGABYTE))
-                .setMinimumAssignedSplitWeight(0.1);
+                .setMinimumAssignedSplitWeight(0.1)
+                .setMaxOutstandingSplits(300)
+                .setSplitLoaderParallelism(6)
+                .setSplitGeneratorParallelism(4);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
### Change logs

This PR introduces the asynchronous split generation in Hudi connector to speed up the query execution and reduce overall query finishing time.  The asynchronous split generation is inspired by the background split loader in Hive connector, which asynchronously generates the splits into a queue in the background, while the query execution can proceed to process and read the splits as the split generation is still ongoing, so that the query execution is not completely blocked on the split generation for all partitions.

Two new configuration properties are added:
- `hudi.max-outstanding-splits` (`hudi.max_outstanding_splits` as session property): maximum outstanding splits in a batch enqueued for processing
- `hudi.split-generator-parallelism` (`hudi.split_generator_parallelism` as session property): number of threads to generate splits from partitions

### Test plan

The changes are benchmarked through TPC-DS queries using Hudi connector, with and without metadata table enabled. The Presto cluster consists of 1 coordinator and 10 workers in r5.4xlarge type. This PR significantly improves the query latency of selective representative TPC-DS 1TB queries by 2.8x (64% latency reduction) and 4.3x (77% latency reduction), for no metadata table and using metadata table, respectively.  With the asynchronous split generation in Hudi connector, the performance of a query in Hudi connector is similar to or better than that in Hive connector.

### Release notes

```
== RELEASE NOTES ==

General Changes
* Introduces the asynchronous split generation in Hudi connector to speed up the query execution and reduce overall query finishing time.
  Two new configuration properties are added.  `hudi.max-outstanding-splits` (`hudi.max_outstanding_splits` as session property) controls the maximum outstanding splits in a batch enqueued for processing.  `hudi.split-generator-parallelism` (`hudi.split_generator_parallelism` as session property) controls the number of threads to generate splits from partitions.