### PR TITLE
refactor methods in presto-hive module

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -293,6 +293,17 @@ public class HiveSplitManager
                 splitSchedulingContext.schedulerUsesHostAddresses(),
                 layout.isPartialAggregationsPushedDown());
 
+        HiveSplitSource splitSource = computeSplitSource(splitSchedulingContext, table, session, hiveSplitLoader);
+        hiveSplitLoader.start(splitSource);
+
+        return splitSource;
+    }
+
+    private HiveSplitSource computeSplitSource(SplitSchedulingContext splitSchedulingContext,
+                                               Table table,
+                                               ConnectorSession session,
+                                               HiveSplitLoader hiveSplitLoader)
+    {
         HiveSplitSource splitSource;
         CacheQuotaRequirement cacheQuotaRequirement = cacheQuotaRequirementProvider.getCacheQuotaRequirement(table.getDatabaseName(), table.getTableName());
         switch (splitSchedulingContext.getSplitSchedulingStrategy()) {
@@ -337,7 +348,6 @@ public class HiveSplitManager
             default:
                 throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingContext.getSplitSchedulingStrategy());
         }
-        hiveSplitLoader.start(splitSource);
 
         return splitSource;
     }
@@ -403,6 +413,23 @@ public class HiveSplitManager
         }
 
         Iterable<List<HivePartition>> partitionNameBatches = partitionExponentially(hivePartitions, minPartitionBatchSize, maxPartitionBatchSize);
+        Iterable<List<HivePartitionMetadata>> partitionBatches = computePartitionMetadata(partitionNameBatches, session, table, metastore,
+                tableName, predicateColumns, domains, allRequestedColumns, hiveBucketHandle, resolvedHiveStorageFormat, warningCollector);
+        return concat(partitionBatches);
+    }
+
+    private Iterable<List<HivePartitionMetadata>> computePartitionMetadata(Iterable<List<HivePartition>> partitionNameBatches,
+                                                                           ConnectorSession session,
+                                                                           Table table,
+                                                                           SemiTransactionalHiveMetastore metastore,
+                                                                           SchemaTableName tableName,
+                                                                           Map<String, HiveColumnHandle> predicateColumns,
+                                                                           Optional<Map<Subfield, Domain>> domains,
+                                                                           Optional<Set<HiveColumnHandle>> allRequestedColumns,
+                                                                           Optional<HiveBucketHandle> hiveBucketHandle,
+                                                                           Optional<HiveStorageFormat> resolvedHiveStorageFormat,
+                                                                           WarningCollector warningCollector)
+    {
         Iterable<List<HivePartitionMetadata>> partitionBatches = transform(partitionNameBatches, partitionBatch -> {
             Map<String, PartitionSplitInfo> partitionSplitInfo = getPartitionSplitInfo(session, metastore, tableName, partitionBatch, predicateColumns, domains);
             if (partitionBatch.size() != partitionSplitInfo.size()) {
@@ -508,7 +535,7 @@ public class HiveSplitManager
             }
             return results.build();
         });
-        return concat(partitionBatches);
+        return partitionBatches;
     }
 
     /**


### PR DESCRIPTION
There are many methods in presto-hive module which span few hundreds of lines and as a result, it is very difficult to go through them. Also these methods do not comply with the standard practices of coding. This PR is a small effort to refactor the code and break such long methods into smaller ones.

I believe this should be an ongoing effort to make the codebase more readable. Suggestions are welcome to point to other classes/methods which need refactoring as well.


Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Code refactoring - break long methods into small readable ones
* 

Hive Changes
* HiveSplitManager.java refactored
* StoragePartitionLoader.java refactored
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
