### PR TITLE
Add release notes for 0.276

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.276
     release/release-0.275
     release/release-0.274
     release/release-0.273.3

--- a/presto-docs/src/main/sphinx/release/release-0.276.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.276.rst
@@ -1,0 +1,56 @@
+=============
+Release 0.276
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug where a query with an order by clause and an unpartitioned window function sometimes returned unordered results.
+* Improve Graphviz output for JOIN nodes and estimate stats.
+* Reduce the number of hdfsConfiguration copies in the worker. This feature is enabled by default and can be controlled by setting the ``hive.copy-on-first-write-configuration`` configuration property appropriately.
+* Add support for complex JsonPath expressions in :func:`json_extract`, :func:`json_extract_scalar` and :func:`json_size` using `Jayway JsonPath <https://github.com/json-path/JsonPath>`_.
+* Add support to nested SQL functions with lambdas when ``inline_sql_functions = false``.
+* Add the GeoPlugin by default. Previously it was an optional plugin.
+* Add documentation for :doc:`/functions/tdigest`.
+* Add ConnectorPlanRewriter utility to simplify writing Connector specific optimizer rules.
+* Make ``query.max-total-memory-per-node property`` optional with default value dependent on ``query.max-memory-per-node``.
+
+Hive Changes
+____________
+* Add support of function registration for interface `org.apache.hadoop.hive.ql.exec.UDF``.
+
+Hudi Changes
+____________
+* Add sized-based split weights for Hudi connector to improve query performance. This is enabled by default, controlled by configuration property ``hudi.size-based-split-weights-enabled`` and session property ``hudi.size_based_split_weights_enabled``. Two more configuration properties are added to adjust the weight: ``hudi.standard-split-weight-size`` to configure the split size corresponding to the standard split weight, and ``hudi.minimum-assigned-split-weight`` to configure the minimum split weight.
+
+Iceberg Changes
+_______________
+* Update Iceberg to 0.14.0.
+
+Pinot Changes
+_____________
+* Fix an incorrect result issue caused by cross-join query pushdown by throwing errors instead of providing the wrong answer.
+* Add new config ``pinot.attempt-broker-queries`` to attempt to pushdown queries to brokers.
+* Add support for pinot controller and broker authentication with user and password.
+* Add pushdown support for :func:`coalesce` function.
+
+Router Changes
+______________
+* Add a round-robin scheduler.
+* Add a weighted random choice scheduler.
+* Add an optional config for the query predictor uri.
+* Add presto router's doc.
+
+Spark Changes
+_____________
+* Add a new configuration property ``spark.retry-on-out-of-memory-with-increased-memory-settings-enabled`` to enable picking up presto and spark memory settings and retry the query within the same spark session with the new settings applied.  This can be overridden by ``spark_retry_on_out_of_memory_with_increased_memory_settings_enabled`` session property.
+* Add new configuration properties ``spark.retry-presto-session-properties`` and ``spark.retry-spark-configs`` to alter the Presto session properties and Spark settings during retry respectively. They can be overridden by ``out_of_memory_retry_presto_session_properties`` and ``out_of_memory_retry_spark_configs`` session properties.
+* Add a new configuration property ``spark.resource-allocation-strategy-enabled`` and its session property ``spark_resource_allocation_strategy_enabled`` to allow optimized resource allocation strategy. This enables automatic executor and hash partition count to be estimated during planning time. The estimation could be bounded by configurations including ``spark.average-input-datasize-per-executor``, ``spark.max-executor-count``, ``spark.min-executor-count``, ``spark.average-input-datasize-per-partition``, ``spark.max-hash-partition-count``, and ``spark.min-hash-partition-count``. There are also corresponding session properties for these estimations.
+
+
+**Credits**
+===========
+
+Amit Pandey, Anant Aneja, Andy Li, Arjun Gupta, Arunachalam Thirupathi, Beinan Wang, Chunxu Tang, Daniel Izcovich, Eduard Tudenhoefner, Feilong Liu, George Wang, Harsh Kevadia, James Sun, James Turner, Maria Basmanova, Michael Shang, Nikhil Collooru, Onder Kaya, Patrick Sullivan, Pranjal Shankhdhar, Rebecca Schlussel, Reetika Agrawal, Rongrong Zhong, Sacha Viscaino, Sergey Pershin, Sergii Druzkin, Sourav Pal, Swapnil Tailor, Timothy Meehan, Todd Gao, Vivek, Xiang Fu, Y Ethan Guo, abhiseksaikia, dnskr, ericyuliu, pratyakshsharma, shidayang, v-jizhang


### PR DESCRIPTION
# Missing Release Notes
## Andy Li
- [x] https://github.com/prestodb/presto/pull/18132 presto-pinot: COALESCE translation and pushdown (Merged by: James Sun)

## Pranjal Shankhdhar
- [x] https://github.com/prestodb/presto/pull/18194 Hbo rules (Merged by: Rebecca Schlussel)

## Reetika Agrawal
- [x] https://github.com/prestodb/presto/pull/18065 Handle Nullpointer when schema name is null (Merged by: Timothy Meehan)

## Sergey Pershin
- [x] https://github.com/prestodb/presto/pull/18156 Clarify serialization of maps in SerializedPage Wire Format documentation (Merged by: Maria Basmanova)
- [x] https://github.com/prestodb/presto/pull/18157 Introduce AlternativeArbitrary aggregation. (Merged by: Maria Basmanova)

## Sourav Pal
- [x] https://github.com/prestodb/presto/pull/17968 Setting Executor and Partition Count (Merged by: James Sun)

# Extracted Release Notes
- #17809 (Author: dnskr): Make query.max-total-memory-per-node optional with default value dependent on query.max-memory-per-node
  - Make query.max-total-memory-per-node property optional with default value dependent on query.max-memory-per-node.
- #17937 (Author: pratyakshsharma): Removed presto-geospatial module and moved the types and functions to presto-main
  - Removed presto-geospatial module.
  - Added the types and SqlFunctions defined by GeoPlugin to `BuiltInTypeAndFunctionNamespaceManager.java` for registering.
  - Moved the relevant classes to presto-main to avoid too many circular dependency issues which would have occurred if movement was done to presto-common rather.
  - Moved the relevant test classes to presto-main and presto-memory.
- #17956 (Author: Rongrong Zhong): Support nested sql functions with lambdas when not inlined
  - Add support to nested SQL functions with lambdas when ``inline_sql_functions = false``.
- #18025 (Author: Sacha Viscaino): Support complex JsonPath expressions using Jayway
  - Add support for complex JsonPath expressions in JSON_EXTRACT, JSON_EXTRACT_SCALAR and JSON_SIZE using Jayway.
- #18068 (Author: Anant Aneja): Improve Graphviz output for JOIN nodes
  - Improve Graphviz output for JOIN nodes.
- #18070 (Author: James Turner): Removed joda-time dependency from the iceberg package
  - Remove usage and package dependency of joda-time from presto-iceberg inline with JSR-310 suggestions to utilise java.time.* instead.
- #18073 (Author: Andy Li): presto-pinot pushdown pushdown attempt flag regardless of isShort
  - Add new config`pinot.attempt-broker-queries` to attempt to pushdown queries to brokers.
- #18076 (Author: Onder Kaya): [Bootcamp] T125823958 - Deprecate Joda library - Presto Clickhouse
  - Remove joda.time dependency at presco-clickhouse.
  - Replace joda.time codes with java.time counterparts.
  - Cover exception cases (DateTimeException) since joda.time does not throw exceptions.
- #18081 (Author: Eduard Tudenhoefner): Update Iceberg to 0.14.0
  - Update Iceberg to 0.14.0.
- #18085 (Author: Xiang Fu): Adding pinot auth support
  - Support pinot controller and broker authentication with user and password.
- #18096 (Author: George Wang): Show Estimate Stats on Graphviz
  - Improve graphviz output with estimate stats.
- #18105 (Author: Xiang Fu): Fixing cross-join query pushdown error for Pinot connector
  - Fixing an incorrect result issue caused by cross-join query pushdown by throwing errors instead of providing the wrong answer.
- #18110 (Author: Chunxu Tang): Add schedulers to the presto router
  - Add a weighted random choice scheduler.
  - Add a round-robin scheduler.
- #18115 (Author: Nikhil Collooru): Reduce number of hdfsConfiguration copies 
  - Optimized the number of hdfsConfiguration copies being done by using copy-on-first-write technique. This feature is enabled by default and can be controlled by setting the ``hive.copy-on-first-write-configuration`` configuration property appropriately.
- #18118 (Author: Chunxu Tang): Add presto router's doc
  - Add presto router's doc.
- #18121 (Author: Arjun Gupta): Retry EXCEEDED_MEMORY_LIMIT failures with higher memory settings
  - Add a new configuration property ``spark.retry-on-out-of-memory-with-increased-memory-settings-enabled`` to enable picking up presto and spark memory settings and retry the query within the same spark session with the new settings applied.  This can be overridden by ``spark_retry_on_out_of_memory_with_increased_memory_settings_enabled`` session property.
  - Add new configuration properties ``spark.retry-presto-session-properties`` and ``spark.retry-spark-configs`` to alter the Presto session properties and Spark settings during retry respectively. They can be overridden by ``out_of_memory_retry_presto_session_properties`` and ``out_of_memory_retry_spark_configs`` session properties.
- #18128 (Author: Chunxu Tang): Connects to the query predictor in the router
  - Add an optional config for the query predictor uri.
- #18130 (Author: James Sun): Allow non-generic UDF registration for Hive functions
  - Add support of function registration for interface `org.apache.hadoop.hive.ql.exec.UDF`.
- #18170 (Author: Daniel Izcovich): add docs for construct_tdigest
  - Adding documentation for construct_tdigest.
- #18177 (Author: Rebecca Schlussel): Fix sort for unpartitioned window with order by clause
  - Fix a bug where a query with an order by clause and an unpartitioned window function sometimes returned unordered results.
- #18184 (Author: Y Ethan Guo): Add sized-based split weights for Hudi connector
  - Add sized-based split weights for Hudi connector to improve query performance. This is enabled by default, controlled by configuration property ``hudi.size-based-split-weights-enabled`` and session property ``hudi.size_based_split_weights_enabled``. Two more configuration properties are added to adjust the weight: ``hudi.standard-split-weight-size`` to configure the split size corresponding to the standard split weight, and ``hudi.minimum-assigned-split-weight`` to configure the minimum split weight.

# All Commits
- b19dfbdcce18696652ac35a3b0e29f29edd59e13 Improve TPCH stats (Anant Aneja)
- 613d1f728d61a4ec6791ee9bd6883ae86fcd821f Optimize ORC StructSelectiveStreamReader.getRetainedSizeInBytes (Sergii Druzkin)
- fb50886e111fb45e1b824e553cdb53e35df9813b Add canonicalization for union nodes (Pranjal Shankhdhar)
- 014ecad20c3c1d1a80182e22af35b505f77382de Upgrade alluxio to 2.8.1 to fix security vulnerabilities (Beinan Wang)
- ea0a447b14bc83e5aa75ddf1cd1a961c1b6847cb Add native worker-specific github workflows (Michael Shang)
- 2353f9867b5049cd1f950fc21963d76628ae8bb0 Fix sort for unpartitioned window with order by clause (Rebecca Schlussel)
- 6873c7e31746ca2f7b7a30b5f7e84d958abba748 Handle null pointer when schema name is null (Reetika Agrawal)
- 19b7ba927871b123dacb5e8090a3c79baca06275 Optimize non null filter implementation in orc readers (Arunachalam Thirupathi)
- 29afafe9a549ba7fd734ab88a953ecfbd5eb2d3a Address review comments (Y Ethan Guo)
- 808c1ac34513cecba7df24b60f1dadbf7d8a36bc Fix TestHudiConfig (Y Ethan Guo)
- 6826a00c5c854fabbc5cbcbf4818aeebcb01f662 Add sized-based split weights for Hudi connector (Y Ethan Guo)
- e1c5a3df8a671765ae1f098551238bf6a308b811 Add history based stats tracker (Pranjal Shankhdhar)
- db0c4515cc97df126773aab68f6c0ba9ef6334b9 Last code move from presto_cpp to presto (Michael Shang)
- 61486b8c50dffebc695017d5113bf54884e9b934 Bump path-parse to 1.0.7 in the router ui (Chunxu Tang)
- 8a79d46c320b35091400fbdf7b4fd8f93f349865 Bump lodash to 4.17.21 in the router ui (Chunxu Tang)
- 9f92fd72003be2f9a469a6fb7d87159a761ee1db Bump tar to 4.4.19 in the router ui (Chunxu Tang)
- e51216df0811a1b0426480307d0af26a557a33a9 Speed up cpp gihub action workflow (Michael Shang)
- fe895af871646e9247cdd227fef2e794455b4855 Cleanup code from PR 16416 (Harsh Kevadia)
- eeaae9c2bb1eed14c938613fa1c31239b661bca2 moved presto-geospatial code to mainline logic (pratyakshsharma)
- da93d97a02dcc841ff8f721269c9beec91cd51b6 Add ConnectorPlanRewriter (Pranjal Shankhdhar)
- ba60834676a61c80023602960e786ba9d6af8de3 Make exchange/hash optimization rules work with HBO (Pranjal Shankhdhar)
- 2780f948374703894ed62e18566b62b8a66164a2 Reduce Slice Selective reader memory (Arunachalam Thirupathi)
- c623cc1779c2ef34a2fa2ee20fe94c3a6a7e4d61 Reduce LongSelectiveReader memory usage (Arunachalam Thirupathi)
- 90a3131403b5e35a17921321d2d521c5e9d7ffe9 Revert commit 8fc1be4cb4c2243ca5e36f8eef396ff9b6d5983d (Arun Thirupathi)
- 08cc78d3cd5779ca4b99ac5abe38604085e0a014 presto-pinot: COALESCE translation and pushdown (Andy Li)
- 6a71afc2c67ba0b08439fc47c3421e8ddbda2d46 Share CachingStatsProvider within multiple iterations of IterativeOptimizer (Pranjal Shankhdhar)
- 51c9b1cf5d5d6ca88b0c096e9d8bdad1bbb562a6 Add caching plan hasher (Pranjal Shankhdhar)
- 658e973c5d730d80c1cc09cd05d871058f3bc8d0 Make query.max-total-memory-per-node optional with default value dependent on query.max-memory-per-node (dnskr)
- 1e3cac791cb0eadad6b172fd8ed0c834d5f7c26a Fix accidentally merged session properties (James Sun)
- a03ac793e6722d7151dc5cde033fc7ed30994a84 Add Jayway extraction engine for JsonPath (Sacha Viscaino)
- e1b4fffcfa260c30759b1ff001b67ac49462e52f Do not intialize Flat Map readers inside Flat Map (Arunachalam Thirupathi)
- fe629581eecf82214a02daa7bba597f6339a4225 Fix runtime stats unit of local cache (Beinan Wang)
- e74f29a9c81cf3f2da6355bd3dbf46762d9bea7e Reduce memory usage of StreamDescriptor (Arunachalam Thirupathi)
- be2d44ef23958bbf42d1cc008538cf68fc9106fa Add github action workflow for native workers (Michael Shang)
- d7331745a728c6f667559ae97d54aa0b8b37134e Move router config parsing to RouterUtil (Chunxu Tang)
- fc9342fd9a672d995e0080848581902c1b50a766 add docs for construct_tdigest (Daniel Izcovich)
- 4a6c953601c26c0ef1689bf3d93e545bb72d79b7 Clarify serialization of maps in SerializedPage Wire Format doc (Sergey Pershin)
- 67055ab9e23431c14d2eeed402595573a44d3ba9 Add an option to fetch all table partitions from the catalog instead of by filtering by partition column predicates (Vivek)
- cbfec4130ff42649ae152581c78dda28731183d4 Do not cache bufferAdapter in OrcInputStream (Arunachalam Thirupathi)
- f68b1096ad61e40ee7bc8788c1ee82e22be3fa99 Introduce AlternativeArbitrary aggregation (Sergey Pershin)
- cb0ea45aaf49cd079de1200b34bafa7f5440a223 Fix orc reader OOM in shared dictionaries (Arunachalam Thirupathi)
- f6d0ed7fa19496aa34ae7fa851b4234920c30232 Reuse missing stream source (Arunachalam Thirupathi)
- 50116c15c882c70a619cd475386493e1ae786ec5 Automatically setting executor and hashpartition count (Sourav Pal)
- d0541b07d0cfe4f852f94b31706aabe7b7b99354 Deprecate Joda library - Presto Clickhouse (Onder Kaya)
- 5bccbe4e51ad229b842f3fe8d5a2c4f4e918c903 Rename ExternalPlanStatisticsProvider -> HistoryBasedPlanStatisticsProvider (Pranjal Shankhdhar)
- 77c53070324aa672d44de3c89398c8f85e12a33c Add skeleton of HBO framework (Pranjal Shankhdhar)
- e6470a934f21d8a69fbeef36f24af8c4d8706d1e Store statistically equivalent plan nodes (Pranjal Shankhdhar)
- be314f56a96117a5c7f2d2d078fb477294ec42bb Update the router's doc with the config for predictor (Chunxu Tang)
- ad597dec7bf5383e49f914b3504f3674f3667b21 Add an optional config for the predictor uri in the router (Chunxu Tang)
- 531a392c51de3cd7c960b56d268e16af9a2f3ac1 Support fetching query resource usage from the predictor (Chunxu Tang)
- ec06028c68d0644537a72179ea9ad05284d2db26 Revert "Improve ARRAY_FREQUENCY efficiency." (ericyuliu)
- 980a92c175164acc6f2a4fcdaf07963206ccefb5 fix release notes 0.275 (ericyuliu)
- d376b5e98d8af5697ce920d729caf4b516ebcb89 Allow committing empty transaction (shidayang)
- 43597f5ad6f76ef8c5d07ac23d9c65b2651162d3 Fix bounds check in MultiChannelGroupByHash and BigintGroupByHash (v-jizhang)
- 3545cf677dd1d6a3833291179fa75bb5e1501ac3 pinot pushdown attempt flag for session (Andy Li)
- d462681b72067c0d8365a7ea049f9edc19478999 Retry EXCEEDED_MEMORY_LIMIT failures with higher memory settings (Arjun Gupta)
- 2910a8818ffbd49cdb5ba411751c4c340ebe7c7d Add parameter to enable copy-on-first-write configuration by default (Nikhil Collooru)
- 01bf22cc5168c3b9c6d1a8251c5453e26319cf69 Add WrapperJobConf,CopyOnFirstWriteConfiguration to reduce config copies (Nikhil Collooru)
- 1f37a95c41eeffad9efb8b6b20c11987ce057b15 Reduce number of hdfsConfiguration copies (Nikhil Collooru)
- 0860390f71250725c73d7dd8c5af949268fdd75c Export spilling stats (abhiseksaikia)
- cf6ba638d6729e60c1dcc2faeef864cf0657daf5 Run router test with different schedulers (James Sun)
- 37fb97804bacc12a4f18a7ca1880b6f9dce9e6d2 Allow non-generic UDF registration for Hive functions (James Sun)
- b50cddc17e2743b8fb15a89ee5e5e14e8782e788 Fix bug in DWRF map stats builder for row groups with all nulls (Sergii Druzkin)
- 8440560b1f6bc625396b47497e209302a7038dd4 Fix bug in DWRF StreamOrderingLayout caused by the root node (Sergii Druzkin)
- 4fa754612a362ffc9661e0f5f7b80ff53496c47d Add presto router's doc (Chunxu Tang)
- 80bfb63cbc11acd474f7c079698b0a8bd2f5edd4 Support new functions in materialized view optimization (Patrick Sullivan)
- 7d167d5fe7c1128ef95eb2fbee0b2ac3e80d6337 Show Estimate Stats on Graphviz (George Wang)
- 2956437eb97ad0642381d1190560cf6565914608 Add comments on block equals/hashcode (Arunachalam Thirupathi)
- ff0757b00fff77822de25e785b754ce5aba9afa6 Rebuild presto everytime for C++ tests (James Sun)
- 1f626f92b055f51387518dd1349da4a868c20e5e Remove some of the raptor tests (James Sun)
- d4158e30d53fe0566de063e76508a1036a24be2a Remove usage of joda time dependency from the iceberg package (James Turner)
- fe38f160586f01a44592b7d198ca8b621d901832 Output warning if table scan converted to ValuesNode by HiveFilterPushdown (Feilong Liu)
- 18aaf2d5dc210d7ef74cc4be0f69525fe42855d7 Print table info if ValuesNode is converted from table scan by HiveFilterPushdown (Feilong Liu)
- eab744f72c7e2cf51f627eb6a3bc4262dd608531 Add a round-robin scheduler in the presto router (Chunxu Tang)
- 9872e30f7118117addbcfe2d3ac37768772bd780 Set random choice as the default scheduler in the router (Chunxu Tang)
- 040566241015c06d821f16a89b3ff4340934e55b Add a weighted random choice scheduler in the presto router (Chunxu Tang)
- 8fc1be4cb4c2243ca5e36f8eef396ff9b6d5983d DiscoveryNodeManager to not return Coordinator/Resource Manager if it's not in the allowed list (Swapnil Tailor)
- 106ae37369ed257fbf7d1b2696dc80bb73a27cdb Add history statistics storage service (Pranjal Shankhdhar)
- e45fbd1bb628ae24f459f1ba357de88c4e630aab Fix hashcode and equals on Block (Arunachalam Thirupathi)
- 4fabe9ac1d84926ed57d452de25b4e88ec15c231 Enable circleci check runs (Michael Shang)
- f40878dd0fe3d9db690d3c5cfaf7f5e181608461 Consider only partitions in query for materialized view optimization (Patrick Sullivan)
- d77273768fbcb7cf99c73f1c693418add9ad0060 Fix materialized view query optimization type mismatches (Patrick Sullivan)
- badac1dfee01494191805276d1b3d430a0421055 Fixing empty output expression in Pinot query generation (Xiang Fu)
- 57ca631eb03b79181977696bedcaa9a15f584036 Don't compute min/max statistics for orderable distinct types (Pranjal Shankhdhar)
- dd0403ef0b9e7952d03edbb9cc17b758becb20ee Improve materialized view integration tests (Patrick Sullivan)
- d3ce9e2fbd549aa82a9ec658df91cab96b35203f Disable flaky tests in presto-iceberg (Pranjal Shankhdhar)
- cde9ff1ebbeb531f41f8e7f1c36ed4acf7018b39 Improve Graphviz output for Join nodes (Anant Aneja)
- 66437fdfbb7f8dc44b2515ced5581f012cfcbade Update presto-native-execution (Michael Shang)
- 29204a88b5923894df28b816a9d4425c5ee5400d Adding pinot auth support (Xiang Fu)
- eab74ea6c7b83367353b8feb9aab46520d831211 Update Iceberg to 0.14.0 (Eduard Tudenhoefner)
- 1a6230d6efa9b780061a5976356cded6967afd28 Support nested sql functions with lambdas when not inlined (Rongrong Zhong)
- ffd0a49191840b9b99f2bc004bef7e297b1f3c34 Deprecate Joda library : Presto presto-kudu (Amit Pandey)
- 18a4547a0190fef0dea6afc27194b4834ab150a8 Refactor classes for materialized view partititon filtering (Patrick Sullivan)