### PR TITLE
Fix the exception when querying the hudi MOR table

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
@@ -162,6 +162,11 @@ class HudiRecordCursors
     private static HudiFile getHudiBaseFile(HudiSplit hudiSplit)
     {
         // use first log file as base file for MOR table if it hasn't base file
-        return hudiSplit.getBaseFile().orElse(hudiSplit.getLogFiles().get(0));
+        if (hudiSplit.getBaseFile().isPresent()) {
+            return hudiSplit.getBaseFile().get();
+        }
+        else {
+            return hudiSplit.getLogFiles().get(0);
+        }
     }
 }


### PR DESCRIPTION
The IndexOutOfBoundsException will be thrown when querying the hudi MOR table if logs of hudi file slice is empty (parquet file only).

```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(ArrayList.java:659)
        at java.util.ArrayList.get(ArrayList.java:435)
        at com.facebook.presto.hudi.HudiRecordCursors.getHudiBaseFile(HudiRecordCursors.java:168)
        at com.facebook.presto.hudi.HudiRecordCursors.createRealtimeRecordCursor(HudiRecordCursors.java:73)
        at com.facebook.presto.hudi.HudiPageSourceProvider.createPageSource(HudiPageSourceProvider.java:127)
        at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:63)
        at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:80)
        at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:261)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:426)
        at com.facebook.presto.operator.Driver.lambda$processFor$9(Driver.java:309)
        at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:730)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:302)
        at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
        at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:166)
        at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:599)
        at com.facebook.presto.$gen.Presto_0_277_SNAPSHOT_3f19e33____20220824_033741_1.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

```
== NO RELEASE NOTE ==
```
