### PR TITLE
Introduce selectAuthorizedIdentity security API

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -339,7 +339,8 @@ public final class HiveQueryRunner
                         role.map(selectedRole -> ImmutableMap.of(HIVE_CATALOG, selectedRole))
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .setCatalog(HIVE_CATALOG)
                 .setSchema(schema)
                 .build();
@@ -359,7 +360,8 @@ public final class HiveQueryRunner
                         role.map(selectedRole -> ImmutableMap.of(HIVE_BUCKETED_CATALOG, selectedRole))
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .setCatalog(HIVE_BUCKETED_CATALOG)
                 .setSchema(schema)
                 .build();
@@ -374,7 +376,8 @@ public final class HiveQueryRunner
                         role.map(selectedRole -> ImmutableMap.of("hive", selectedRole))
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .setSystemProperty(PARTITIONING_PROVIDER_CATALOG, HIVE_CATALOG)
                 .setSystemProperty(EXCHANGE_MATERIALIZATION_STRATEGY, ExchangeMaterializationStrategy.ALL.name())
                 .setSystemProperty(HASH_PARTITION_COUNT, "13")

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -212,7 +212,8 @@ public class TestHiveIntegrationSmokeTest
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
 
         assertUpdate(admin, "CREATE SCHEMA new_schema");
@@ -235,7 +236,8 @@ public class TestHiveIntegrationSmokeTest
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
 
         assertUpdate(admin, "CREATE SCHEMA new_schema");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -439,7 +439,8 @@ public class TestHiveRecoverableExecution
                         .map(selectedRole -> ImmutableMap.of("hive", selectedRole))
                         .orElse(ImmutableMap.of()),
                 ImmutableMap.of(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                Optional.empty());
 
         return testSessionBuilder()
                 .setIdentity(identity)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRoles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRoles.java
@@ -384,7 +384,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ALL, Optional.empty())),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         Session setRoleNone = Session.builder(getQueryRunner().getDefaultSession())
                 .setIdentity(new Identity(
@@ -392,7 +393,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.NONE, Optional.empty())),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         Session setRole1 = Session.builder(getQueryRunner().getDefaultSession())
                 .setIdentity(new Identity(
@@ -400,7 +402,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_1"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         Session setRole2 = Session.builder(getQueryRunner().getDefaultSession())
                 .setIdentity(new Identity(
@@ -408,7 +411,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_2"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         Session setRole3 = Session.builder(getQueryRunner().getDefaultSession())
                 .setIdentity(new Identity(
@@ -416,7 +420,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_3"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         Session setRole4 = Session.builder(getQueryRunner().getDefaultSession())
                 .setIdentity(new Identity(
@@ -424,7 +429,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_4"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
 
         MaterializedResult actual = getQueryRunner().execute(unsetRole, "SELECT * FROM hive.information_schema.applicable_roles");
@@ -547,7 +553,8 @@ public class TestHiveRoles
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -46,7 +46,8 @@ public class TestIcebergMetadataListing
                         Optional.empty(),
                         ImmutableMap.of("hive", new SelectedRole(ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
-                        ImmutableMap.of()))
+                        ImmutableMap.of(),
+                        Optional.empty()))
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.session.ResourceEstimates;
 import com.facebook.presto.transaction.TransactionId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
@@ -313,7 +314,9 @@ public final class SessionRepresentation
                         principal.map(BasicPrincipal::new),
                         roles,
                         extraCredentials,
-                        extraAuthenticators),
+                        extraAuthenticators,
+                        Optional.empty()),
+                ImmutableList.of(),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -22,6 +22,7 @@ import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.execution.warnings.WarningHandlingLevel;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spiller.NodeSpillConfig;
@@ -261,7 +262,8 @@ public final class SystemSessionProperties
                 new NodeSchedulerConfig(),
                 new NodeSpillConfig(),
                 new TracingConfig(),
-                new CompilerConfig());
+                new CompilerConfig(),
+                new SecurityConfig());
     }
 
     @Inject
@@ -275,7 +277,8 @@ public final class SystemSessionProperties
             NodeSchedulerConfig nodeSchedulerConfig,
             NodeSpillConfig nodeSpillConfig,
             TracingConfig tracingConfig,
-            CompilerConfig compilerConfig)
+            CompilerConfig compilerConfig,
+            SecurityConfig securityConfig)
     {
         sessionProperties = ImmutableList.of(
                 stringProperty(

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -31,11 +31,14 @@ import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.SessionContext;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.SessionSupplier;
+import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -83,6 +86,8 @@ public class DispatchManager
 
     private final QueryManagerStats stats = new QueryManagerStats();
 
+    private final SecurityConfig securityConfig;
+
     @Inject
     public DispatchManager(
             QueryIdGenerator queryIdGenerator,
@@ -97,7 +102,8 @@ public class DispatchManager
             SessionPropertyDefaults sessionPropertyDefaults,
             QueryManagerConfig queryManagerConfig,
             DispatchExecutor dispatchExecutor,
-            ClusterStatusSender clusterStatusSender)
+            ClusterStatusSender clusterStatusSender,
+            SecurityConfig securityConfig)
     {
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
         this.queryPreparer = requireNonNull(queryPreparer, "queryPreparer is null");
@@ -118,6 +124,8 @@ public class DispatchManager
         this.clusterStatusSender = requireNonNull(clusterStatusSender, "clusterStatusSender is null");
 
         this.queryTracker = new QueryTracker<>(queryManagerConfig, dispatchExecutor.getScheduledExecutor());
+
+        this.securityConfig = requireNonNull(securityConfig, "securityConfig is null");
     }
 
     @PostConstruct
@@ -179,6 +187,9 @@ public class DispatchManager
                 throw new PrestoException(QUERY_TEXT_TOO_LARGE, format("Query text length (%s) exceeds the maximum length (%s)", queryLength, maxQueryLength));
             }
 
+            // check permissions
+            checkPermissions(queryId, sessionContext);
+
             // decode session
             session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory);
 
@@ -237,6 +248,36 @@ public class DispatchManager
             DispatchQuery failedDispatchQuery = failedDispatchQueryFactory.createFailedDispatchQuery(session, query, Optional.empty(), throwable);
             queryCreated(failedDispatchQuery);
         }
+    }
+
+    private void checkPermissions(QueryId queryId, SessionContext sessionContext)
+    {
+        Identity identity = sessionContext.getIdentity();
+        // When selectAuthorizedIdentity API is not enabled, only check delegation permission
+        if (!securityConfig.isAuthorizedIdentitySelectionEnabled()) {
+            accessControl.checkCanSetUser(
+                    identity,
+                    new AccessControlContext(
+                            queryId,
+                            Optional.ofNullable(sessionContext.getClientInfo()),
+                            Optional.ofNullable(sessionContext.getSource())),
+                    identity.getPrincipal(),
+                    identity.getUser());
+            return;
+        }
+
+        // When selectAuthorizedIdentity API is enabled,
+        // 1. Check the delegation permission, which is inside the API call
+        // 2. Select the authorized user
+        // 3. TODO: UPDATE the identity of the session according to the authorized identity from the API call
+        accessControl.selectAuthorizedIdentity(
+                identity,
+                new AccessControlContext(
+                        queryId,
+                        Optional.ofNullable(sessionContext.getClientInfo()),
+                        Optional.ofNullable(sessionContext.getSource())),
+                identity.getUser(),
+                sessionContext.getCertificates());
     }
 
     private boolean queryCreated(DispatchQuery dispatchQuery)

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -18,12 +18,15 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,6 +38,11 @@ public interface AccessControl
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanSetUser(Identity identity, AccessControlContext accessControlContext, Optional<Principal> principal, String userName);
+
+    default AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext accessControlContext, String userName, List<X509Certificate> certificates)
+    {
+        return new AuthorizedIdentity(userName, "", true);
+    }
 
     /**
      * Check if the query is unexpectedly modified using the credentials passed in the identity.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -42,7 +43,9 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.security.Principal;
+import java.security.cert.X509Certificate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -162,6 +165,15 @@ public class AccessControlManager
         requireNonNull(userName, "userName is null");
 
         authenticationCheck(() -> systemAccessControl.get().checkCanSetUser(identity, context, principal, userName));
+    }
+
+    @Override
+    public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        requireNonNull(userName, "userName is null");
+        requireNonNull(certificates, "certificates is null");
+
+        return systemAccessControl.get().selectAuthorizedIdentity(identity, context, userName, certificates);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -24,6 +25,8 @@ import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 
 import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -59,6 +62,12 @@ public class AllowAllSystemAccessControl
     @Override
     public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
     {
+    }
+
+    @Override
+    public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        return new AuthorizedIdentity(userName, "", true);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -33,6 +34,7 @@ import io.airlift.units.Duration;
 
 import java.nio.file.Paths;
 import java.security.Principal;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -179,6 +181,12 @@ public class FileBasedSystemAccessControl
         }
 
         denySetUser(principal, userName);
+    }
+
+    @Override
+    public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        return new AuthorizedIdentity(userName, "always return the given user for file based access control", true);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
@@ -19,9 +19,12 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.session.ResourceEstimates;
 import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.transaction.TransactionId;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -29,6 +32,11 @@ import java.util.Set;
 public interface SessionContext
 {
     Identity getIdentity();
+
+    default List<X509Certificate> getCertificates()
+    {
+        return ImmutableList.of();
+    }
 
     @Nullable
     String getCatalog();

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
+    private boolean authorizedIdentitySelectionEnabled;
 
     public enum AuthenticationType
     {
@@ -66,5 +67,18 @@ public class SecurityConfig
                 .map(AuthenticationType::valueOf)
                 .collect(toImmutableList());
         return this;
+    }
+
+    @Config("permissions.authorized-identity-selection-enabled")
+    @ConfigDescription("Authorized identity selection enabled")
+    public SecurityConfig setAuthorizedIdentitySelectionEnabled(boolean authorizedIdentitySelectionEnabled)
+    {
+        this.authorizedIdentitySelectionEnabled = authorizedIdentitySelectionEnabled;
+        return this;
+    }
+
+    public boolean isAuthorizedIdentitySelectionEnabled()
+    {
+        return authorizedIdentitySelectionEnabled;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -122,6 +122,7 @@ import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -397,7 +398,8 @@ public class LocalQueryRunner
                                 new NodeSchedulerConfig(),
                                 new NodeSpillConfig(),
                                 new TracingConfig(),
-                                new CompilerConfig())),
+                                new CompilerConfig(),
+                                new SecurityConfig())),
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new ColumnPropertyManager(),
@@ -489,6 +491,7 @@ public class LocalQueryRunner
                 withInitialTransaction ? Optional.of(transactionManager.beginTransaction(false)) : defaultSession.getTransactionId(),
                 defaultSession.isClientTransactionSupport(),
                 defaultSession.getIdentity(),
+                defaultSession.getCertificates(),
                 defaultSession.getSource(),
                 defaultSession.getCatalog(),
                 defaultSession.getSchema(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -29,6 +29,7 @@ import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.operator.StageExecutionDescriptor;
+import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
@@ -101,8 +102,8 @@ public class TestAdaptivePhasedExecutionPolicy
                 new NodeSchedulerConfig(),
                 new NodeSpillConfig(),
                 new TracingConfig(),
-                new CompilerConfig()))).build();
-
+                new CompilerConfig(),
+                new SecurityConfig()))).build();
         AdaptivePhasedExecutionPolicy policy = new AdaptivePhasedExecutionPolicy();
         Collection<StageExecutionAndScheduler> schedulers = getStageExecutionAndSchedulers(4);
         assertTrue(policy.createExecutionSchedule(session, schedulers) instanceof AllAtOnceExecutionSchedule);

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -169,7 +169,8 @@ public class TestAccessControlManager
                         Optional.of(PRINCIPAL),
                         ImmutableMap.of(),
                         ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery),
-                        ImmutableMap.of()),
+                        ImmutableMap.of(),
+                        Optional.empty()),
                 context,
                 testQuery);
         assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
@@ -184,7 +185,8 @@ public class TestAccessControlManager
                                 Optional.of(PRINCIPAL),
                                 ImmutableMap.of(),
                                 ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery + " modified"),
-                                ImmutableMap.of()),
+                                ImmutableMap.of(),
+                                Optional.empty()),
                         context,
                         testQuery));
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 
 import javax.servlet.AsyncContext;
@@ -46,11 +47,13 @@ public class MockHttpServletRequest
 {
     private final ListMultimap<String, String> headers;
     private final String remoteAddress;
+    private final Map<String, Object> attributes;
 
-    public MockHttpServletRequest(ListMultimap<String, String> headers, String remoteAddress)
+    public MockHttpServletRequest(ListMultimap<String, String> headers, String remoteAddress, Map<String, Object> attributes)
     {
         this.headers = ImmutableListMultimap.copyOf(requireNonNull(headers, "headers is null"));
         this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress is null");
+        this.attributes = ImmutableMap.copyOf(requireNonNull(attributes, "attributes is null"));
     }
 
     @Override
@@ -93,6 +96,12 @@ public class MockHttpServletRequest
     public Enumeration<String> getHeaderNames()
     {
         return enumeration(headers.keySet());
+    }
+
+    @Override
+    public Object getAttribute(String name)
+    {
+        return attributes.get(name);
     }
 
     @Override
@@ -247,12 +256,6 @@ public class MockHttpServletRequest
 
     @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object getAttribute(String name)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
@@ -105,7 +105,8 @@ public class TestHttpRequestSessionContext
                                 urlEncode(SERIALIZED_SQL_FUNCTION_ID_ADD_1_TO_INT_ARRAY),
                                 urlEncode(SERIALIZED_SQL_FUNCTION_ADD_1_to_INT_ARRAY)))
                         .build(),
-                "testRemote");
+                "testRemote",
+                ImmutableMap.of());
 
         HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
         assertEquals(context.getSource(), "testSource");
@@ -145,7 +146,8 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_CLIENT_INFO, "null")
                         .put(PRESTO_PREPARED_STATEMENT, "query1=abcdefg")
                         .build(),
-                "testRemote");
+                "testRemote",
+                ImmutableMap.of());
         new HttpRequestSessionContext(request, new SqlParserOptions());
     }
 
@@ -163,7 +165,8 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_CLIENT_INFO, "null")
                         .put(PRESTO_PREPARED_STATEMENT, "query1=select * from tbl:ns")
                         .build(),
-                "testRemote");
+                "testRemote",
+                ImmutableMap.of());
         SqlParserOptions options = new SqlParserOptions();
         options.allowIdentifierSymbol(EnumSet.allOf(IdentifierSymbol.class));
 
@@ -193,7 +196,8 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_EXTRA_CREDENTIAL, "test.json=" + urlEncode("{\"a\" : \"b\", \"c\" : \"d=\"}") + ", test.token.key3 = abc=cd")
                         .put(PRESTO_EXTRA_CREDENTIAL, "test.token.abc=xyz")
                         .build(),
-                "testRemote");
+                "testRemote",
+                ImmutableMap.of());
 
         HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
         assertEquals(

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -79,7 +79,8 @@ public class TestQuerySessionSupplier
                     .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
                     .put(PRESTO_SESSION_FUNCTION, format("%s=%s", urlEncode(SERIALIZED_SQL_FUNCTION_ID_ADD), urlEncode(SERIALIZED_SQL_FUNCTION_ADD)))
                     .build(),
-            "testRemote");
+            "testRemote",
+            ImmutableMap.of());
 
     @Test
     public void testCreateSession()
@@ -129,7 +130,8 @@ public class TestQuerySessionSupplier
                 ImmutableListMultimap.<String, String>builder()
                         .put(PRESTO_USER, "testUser")
                         .build(),
-                "remoteAddress");
+                "remoteAddress",
+                ImmutableMap.of());
         HttpRequestSessionContext context1 = new HttpRequestSessionContext(request1, new SqlParserOptions());
         assertEquals(context1.getClientTags(), ImmutableSet.of());
 
@@ -138,7 +140,8 @@ public class TestQuerySessionSupplier
                         .put(PRESTO_USER, "testUser")
                         .put(PRESTO_CLIENT_TAGS, "")
                         .build(),
-                "remoteAddress");
+                "remoteAddress",
+                ImmutableMap.of());
         HttpRequestSessionContext context2 = new HttpRequestSessionContext(request2, new SqlParserOptions());
         assertEquals(context2.getClientTags(), ImmutableSet.of());
     }
@@ -151,7 +154,8 @@ public class TestQuerySessionSupplier
                         .put(PRESTO_USER, "testUser")
                         .put(PRESTO_TIME_ZONE, "unknown_timezone")
                         .build(),
-                "testRemote");
+                "testRemote",
+                ImmutableMap.of());
         HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
         QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
                 createTestTransactionManager(),

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -29,7 +29,8 @@ public class TestSecurityConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
-                .setAuthenticationTypes(""));
+                .setAuthenticationTypes("")
+                .setAuthorizedIdentitySelectionEnabled(false));
     }
 
     @Test
@@ -37,10 +38,12 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
+                .put("permissions.authorized-identity-selection-enabled", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
-                .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD));
+                .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
+                .setAuthorizedIdentitySelectionEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -22,6 +22,7 @@ import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.WarningCollector;
@@ -166,7 +167,8 @@ public class TestAnalyzer
                 new NodeSchedulerConfig(),
                 new NodeSpillConfig(),
                 new TracingConfig(),
-                new CompilerConfig()))).build();
+                new CompilerConfig(),
+                new SecurityConfig()))).build();
         assertFails(session, WINDOW_FUNCTION_ORDERBY_LITERAL,
                 "SELECT SUM(x) OVER (PARTITION BY y ORDER BY 1) AS s\n" +
                         "FROM (values (1,10), (2, 10)) AS T(x, y)");
@@ -560,7 +562,8 @@ public class TestAnalyzer
                 new NodeSchedulerConfig(),
                 new NodeSpillConfig(),
                 new TracingConfig(),
-                new CompilerConfig()))).build();
+                new CompilerConfig(),
+                new SecurityConfig()))).build();
         analyze(session, "SELECT a, b, c, d, e, f, g, h, i, j, k, SUM(l)" +
                 "FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))\n" +
                 "t (a, b, c, d, e, f, g, h, i, j, k, l)\n" +

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
@@ -76,7 +76,7 @@ public class TestCredentialPassthrough
         return testSessionBuilder()
                 .setCatalog("mysql")
                 .setSchema(TEST_SCHEMA)
-                .setIdentity(new Identity(mySqlServer.getUser(), Optional.empty(), ImmutableMap.of(), extraCredentials, ImmutableMap.of()))
+                .setIdentity(new Identity(mySqlServer.getUser(), Optional.empty(), ImmutableMap.of(), extraCredentials, ImmutableMap.of(), Optional.empty()))
                 .build();
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
@@ -17,12 +17,15 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.SystemAccessControl;
 
 import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -51,6 +54,12 @@ public abstract class ForwardingSystemAccessControl
     public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
         delegate().checkCanSetUser(identity, context, principal, userName);
+    }
+
+    @Override
+    public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        return delegate().selectAuthorizedIdentity(identity, context, userName, certificates);
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
@@ -69,7 +69,8 @@ public class PrestoSparkSessionContext
                         prestoSparkSession.getPrincipal(),
                         ImmutableMap.of(),  // presto on spark does not support role management
                         extraCredentials.build(),
-                        extraTokenAuthenticators.build()),
+                        extraTokenAuthenticators.build(),
+                        Optional.empty()),
                 prestoSparkSession.getCatalog().orElse(null),
                 prestoSparkSession.getSchema().orElse(null),
                 prestoSparkSession.getSource().orElse(null),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AuthorizedIdentity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AuthorizedIdentity.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class AuthorizedIdentity
+{
+    private final String userName;
+    private final Optional<String> reasonForSelect;
+    private final Optional<Boolean> delegationCheckResult;
+
+    public AuthorizedIdentity(String userName, String reasonForSelect, Boolean delegationCheckResult)
+    {
+        this.userName = requireNonNull(userName, "userName is null");
+        this.reasonForSelect = Optional.ofNullable(reasonForSelect);
+        this.delegationCheckResult = Optional.ofNullable(delegationCheckResult);
+    }
+
+    public String getUserName()
+    {
+        return userName;
+    }
+
+    public Optional<String> getReasonForSelect()
+    {
+        return reasonForSelect;
+    }
+
+    public Optional<Boolean> getDelegationCheckResult()
+    {
+        return delegationCheckResult;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorIdentity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorIdentity.java
@@ -29,10 +29,11 @@ public class ConnectorIdentity
     private final Optional<SelectedRole> role;
     private final Map<String, String> extraCredentials;
     private final Map<String, TokenAuthenticator> extraAuthenticators;
+    private final Optional<String> reasonForSelect;
 
     public ConnectorIdentity(String user, Optional<Principal> principal, Optional<SelectedRole> role)
     {
-        this(user, principal, role, emptyMap(), emptyMap());
+        this(user, principal, role, emptyMap(), emptyMap(), Optional.empty());
     }
 
     public ConnectorIdentity(
@@ -40,13 +41,15 @@ public class ConnectorIdentity
             Optional<Principal> principal,
             Optional<SelectedRole> role,
             Map<String, String> extraCredentials,
-            Map<String, TokenAuthenticator> extraAuthenticators)
+            Map<String, TokenAuthenticator> extraAuthenticators,
+            Optional<String> reasonForSelect)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
         this.role = requireNonNull(role, "role is null");
         this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
         this.extraAuthenticators = unmodifiableMap(new HashMap<>(requireNonNull(extraAuthenticators, "extraAuthenticators is null")));
+        this.reasonForSelect = requireNonNull(reasonForSelect, "reasonForSelect is null");
     }
 
     public String getUser()
@@ -74,6 +77,11 @@ public class ConnectorIdentity
         return extraAuthenticators;
     }
 
+    public Optional<String> getReasonForSelect()
+    {
+        return reasonForSelect;
+    }
+
     @Override
     public String toString()
     {
@@ -83,6 +91,8 @@ public class ConnectorIdentity
         role.ifPresent(role -> sb.append(", role=").append(role));
         sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append(", extraAuthenticators=").append(extraAuthenticators.keySet());
+        reasonForSelect.ifPresent(
+                reason -> sb.append(", reasonForSelect=").append(reason));
         sb.append('}');
         return sb.toString();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
@@ -29,6 +29,7 @@ public class Identity
     private final Optional<Principal> principal;
     private final Map<String, SelectedRole> roles;
     private final Map<String, String> extraCredentials;
+    private final Optional<String> reasonForSelect;
 
     /**
      * extraAuthenticators is used when short-lived access token has to be refreshed periodically.
@@ -40,7 +41,7 @@ public class Identity
 
     public Identity(String user, Optional<Principal> principal)
     {
-        this(user, principal, emptyMap(), emptyMap(), emptyMap());
+        this(user, principal, emptyMap(), emptyMap(), emptyMap(), Optional.empty());
     }
 
     public Identity(
@@ -48,13 +49,15 @@ public class Identity
             Optional<Principal> principal,
             Map<String, SelectedRole> roles,
             Map<String, String> extraCredentials,
-            Map<String, TokenAuthenticator> extraAuthenticators)
+            Map<String, TokenAuthenticator> extraAuthenticators,
+            Optional<String> reasonForSelect)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
         this.roles = unmodifiableMap(requireNonNull(roles, "roles is null"));
         this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
         this.extraAuthenticators = unmodifiableMap(new HashMap<>(requireNonNull(extraAuthenticators, "extraAuthenticators is null")));
+        this.reasonForSelect = requireNonNull(reasonForSelect, "reasonForSelect is null");
     }
 
     public String getUser()
@@ -82,6 +85,11 @@ public class Identity
         return extraAuthenticators;
     }
 
+    public Optional<String> getReasonForSelect()
+    {
+        return reasonForSelect;
+    }
+
     public ConnectorIdentity toConnectorIdentity()
     {
         return new ConnectorIdentity(
@@ -89,7 +97,8 @@ public class Identity
                 principal,
                 Optional.empty(),
                 extraCredentials,
-                extraAuthenticators);
+                extraAuthenticators,
+                reasonForSelect);
     }
 
     public ConnectorIdentity toConnectorIdentity(String catalog)
@@ -100,7 +109,8 @@ public class Identity
                 principal,
                 Optional.ofNullable(roles.get(catalog)),
                 extraCredentials,
-                extraAuthenticators);
+                extraAuthenticators,
+                reasonForSelect);
     }
 
     @Override
@@ -131,6 +141,8 @@ public class Identity
         sb.append(", roles=").append(roles);
         sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append(", extraAuthenticators=").append(extraAuthenticators.keySet());
+        reasonForSelect.ifPresent(
+                reason -> sb.append(", reasonForSelect=").append(reason));
         sb.append('}');
         return sb.toString();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -18,7 +18,9 @@ import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.SchemaTableName;
 
 import java.security.Principal;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -52,6 +54,11 @@ public interface SystemAccessControl
      * @throws AccessDeniedException if not allowed
      */
     void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName);
+
+    default AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        return new AuthorizedIdentity(userName, "", true);
+    }
 
     /**
      * Check if the query is unexpectedly modified using the credentials passed in the identity.

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2914,6 +2914,7 @@ public abstract class AbstractTestQueries
                 Optional.empty(),
                 getSession().isClientTransactionSupport(),
                 getSession().getIdentity(),
+                getSession().getCertificates(),
                 getSession().getSource(),
                 getSession().getCatalog(),
                 getSession().getSchema(),

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
@@ -24,6 +24,8 @@ import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.ImmutableMap;
 
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +47,12 @@ public class TestingSessionContext
     public Identity getIdentity()
     {
         return session.getIdentity();
+    }
+
+    @Override
+    public List<X509Certificate> getCertificates()
+    {
+        return session.getCertificates();
     }
 
     @Override


### PR DESCRIPTION
In this PR we introduce a new security API: selectAuthorizedIdentity. The goal of this new API is to replace the delegation concept in Presto, more specially checkCanSetUser API. checkCanSetUser verifies if the provided username is eligible to execute the query based on the provided principal. This kind of checks bring potential security loopholes, e.g., illegal data reading by providing a fake username from the client. The new API aims to fix these loopholes by selecting an authorized username from identities extracted from certificates or the crypto auth tokens (CATs) from the clients.

This PR introduces the following changes:
1. Create a new security API selectAuthorizedIdentity.
2. Extract certificates from the client, more specifically from the http request attributes, and pass them to the API.
3. The result from the new API call is verified, and an exception could be thrown properly.
4. Invoke the new API in DispatchManager to select the authorized identity. (In the end the returned identity should replace original username; but as an intermediate step, we don't do the replacement in this PR.)

 ```
  == RELEASE NOTES ==

  General Changes
  * Add a new security API ``selectAuthorizedIdentity``
  * Add a configuration property ``permissions.authorized-identity-selection-enable``. When it is true, the new API 
    ``selectAuthorizedIdentity`` is called; otherwise, ``checkCanSetUser`` is called instead as before.
```