### PR TITLE
Add more gitignore for presto-native-execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ presto-docs-venv/
 # presto-native-execution
 #==============================================================================#
 _build/
+cmake-build-*/
 *.swp
 *~
 a.out


### PR DESCRIPTION
Exclude cmake build directories created by CLion from git tracking.