### PR TITLE
Fix some small json issues

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -159,13 +159,13 @@ public class TaskStats
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
-            @JsonProperty("userMemoryReservation") long userMemoryReservationInBytes,
+            @JsonProperty("userMemoryReservationInBytes") long userMemoryReservationInBytes,
             @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
             @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
 
             @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
             @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
-            @JsonProperty("peakNodeTotalMemoryInbytes") long peakNodeTotalMemoryInBytes,
+            @JsonProperty("peakNodeTotalMemoryInBytes") long peakNodeTotalMemoryInBytes,
 
             @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
             @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticsWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticsWriterNode.java
@@ -39,7 +39,7 @@ public class StatisticsWriterNode
 
     @JsonCreator
     public StatisticsWriterNode(
-            Optional<SourceLocation> sourceLocation,
+            @JsonProperty("sourceLocation") Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("tableHandle") TableHandle tableHandle,

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadataUpdateHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadataUpdateHandle.java
@@ -28,7 +28,7 @@ public class TestingMetadataUpdateHandle
 
     @ThriftConstructor
     @JsonCreator
-    public TestingMetadataUpdateHandle(int value)
+    public TestingMetadataUpdateHandle(@JsonProperty("value") int value)
     {
         this.value = value;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SourceLocation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SourceLocation.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class SourceLocation
 {
     private final int line;
@@ -46,5 +48,31 @@ public class SourceLocation
     public int getColumn()
     {
         return column;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        SourceLocation that = (SourceLocation) obj;
+
+        return line == that.line && column == that.column;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(line, column);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
@@ -43,7 +43,7 @@ public final class ValuesNode
 
     @JsonCreator
     public ValuesNode(
-            Optional<SourceLocation> sourceLocation,
+            @JsonProperty("location") Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
             @JsonProperty("rows") List<List<RowExpression>> rows,


### PR DESCRIPTION
A few json serialization/deserialization test case failures were found when I try to run the
 tests internally. While I haven't get to the reason why the same test cases run ok on 
github (there are a number of differences) But by reviewing the code, I can see that the 
code was not conformed to the jackson doc. For one “Constructor/factory method 
where every argument is annotated with either JsonProperty or JacksonInject, to 
indicate name of property to bind to” 
from http://fasterxml.github.io/jackson-annotations/javadoc/2.10/
And some of the name in JsonProperty is not consistent with the actual variables 
name, like 'userMemoryReservation' vs 'userMemoryReservationInBytes' and 
'peakNodeTotalMemoryInbytes' vs 'peakNodeTotalMemoryInBytes' (b is in lower case) 
Those will cause deserialization issues in my tests. With those fixes, my tests all turn 
green  and the tests here are also good.

Test plan - (Please fill in how you tested your changes)

Make sure all CI runs are green
I also added a test case when there is a SourceLocation in the json doc.

```
== NO RELEASE NOTE ==
```
