### PR TITLE
Upgrade Delta Standalone to 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2052,12 +2052,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.delta</groupId>
-                <artifactId>delta-standalone_2.12</artifactId>
-                <version>0.3.0</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-delta</artifactId>
                 <version>${project.version}</version>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -20,8 +20,12 @@
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone_2.12</artifactId>
-            <version>0.3.0</version>
+            <version>0.5.0</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.module</groupId>
                     <artifactId>jackson-module-scala_2.12</artifactId>


### PR DESCRIPTION
This PR upgrades Delta Standalone dependency to 0.5.0 for Delta Lake Connector.

Test plan - Existing tests

```
== RELEASE NOTES ==

Delta Lake Connector Changes
* Upgrade Delta Standalone to 0.5.0
```
