### PR TITLE
Add file info to exception thrown from OrcSelectiveRecordReader.OrcBlockLoader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -779,6 +779,11 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         }
     }
 
+    protected OrcDataSourceId getOrcDataSourceId()
+    {
+        return orcDataSource.getId();
+    }
+
     private static class StripeInfo
     {
         private final StripeInformation stripe;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSourceId.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSourceId.java
@@ -50,4 +50,30 @@ public final class OrcDataSourceId
     {
         return id;
     }
+
+    /**
+     * Add the ORC file path to an exception to provide mode debug context.
+     */
+    public void attachToException(Throwable throwable)
+    {
+        requireNonNull(throwable, "throwable is null");
+        throwable.addSuppressed(new OrcDataSourceIdStackInfoException(this));
+    }
+
+    /**
+     * This exception is supposed to provide extra context by being used as a
+     * suppressed exception attached to a main exception.
+     * <p>
+     * Attaching as a suppressed exception allows to avoid modification
+     * of top level exception just for the sake of providing more debug info.
+     */
+    private static class OrcDataSourceIdStackInfoException
+            extends RuntimeException
+    {
+        public OrcDataSourceIdStackInfoException(OrcDataSourceId orcDataSourceId)
+        {
+            super("Failed to read ORC file: " + orcDataSourceId);
+            this.setStackTrace(new StackTraceElement[0]); // we are not interested in the stack
+        }
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -926,7 +926,7 @@ public class OrcSelectiveRecordReader
         }
 
         @Override
-        public final void load(LazyBlock lazyBlock)
+        public void load(LazyBlock lazyBlock)
         {
             if (loaded) {
                 return;
@@ -936,7 +936,12 @@ public class OrcSelectiveRecordReader
                 reader.read(offset, positions, positionCount);
             }
             catch (IOException e) {
+                OrcSelectiveRecordReader.this.getOrcDataSourceId().attachToException(e);
                 throw new UncheckedIOException(e);
+            }
+            catch (RuntimeException e) {
+                OrcSelectiveRecordReader.this.getOrcDataSourceId().attachToException(e);
+                throw e;
             }
 
             Block block = reader.getBlock(positions, positionCount);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcDataSourceId.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcDataSourceId.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.base.Throwables;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestOrcDataSourceId
+{
+    @Test
+    public void testAttachToException()
+    {
+        OrcDataSourceId orcDataSourceId = new OrcDataSourceId("test id");
+        try {
+            throw new RuntimeException("Top exception");
+        }
+        catch (RuntimeException e) {
+            orcDataSourceId.attachToException(e);
+            e.printStackTrace();
+
+            assertEquals(e.getSuppressed().length, 1);
+            assertEquals(e.getSuppressed()[0].getMessage(), "Failed to read ORC file: test id");
+            assertEquals(e.getSuppressed()[0].getStackTrace().length, 0);
+
+            String stackTrace = Throwables.getStackTraceAsString(e);
+            assertTrue(stackTrace.contains("Top exception"));
+            assertTrue(stackTrace.contains("Failed to read ORC file: test id"));
+        }
+    }
+}


### PR DESCRIPTION
Add the ORC file path (OrcDataSourceId) as a suppressed exception to an exception thrown from OrcSelectiveRecordReader.OrcBlockLoader. This allows to avoid modification of the main exception, thus majority of the error classifiers should stay unchanged, and at the same time the ORC file path will be captured in the stack trace. The main target of this modification are ORC files with corrupted data.

The final stack trace looks like this:
```
java.lang.RuntimeException: Top exception
	at com.facebook.presto.orc.TestOrcDataSourceId.testAttachToException(TestOrcDataSourceId.java:31)
...
	at org.testng.TestRunner.run(TestRunner.java:603)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:429)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:423)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:383)
....
	Suppressed: com.facebook.presto.orc.OrcDataSourceId$OrcDataSourceIdStackInfo: Failed to read ORC file: test id

```

I understand that this is a bit unconventional method, and I'm ok if more experienced Presto developers disagree with this approach.

Here is an example query where the path was not included 20220827_011525_06002_zsx9j, and here is where the path was included 20220829_061912_00892_7bnpv

Test plan:
- added new tests

```
== NO RELEASE NOTE ==
```
