### PR TITLE
Notify upstream task if downstream task finishes early

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -259,6 +259,8 @@ void PrestoExchangeSource::abortResults() {
               "Abort results failed: {}, path {}", statusCode, self->basePath_);
           LOG(ERROR) << errMsg;
           onFinalFailure(errMsg, queue);
+        } else {
+          self->abortResultsSucceeded_.store(true);
         }
       })
       .thenError(
@@ -272,6 +274,13 @@ void PrestoExchangeSource::abortResults() {
             // due to other errors.
             onFinalFailure(errMsg, queue);
           });
+}
+
+void PrestoExchangeSource::close() {
+  closed_.store(true);
+  if (!abortResultsSucceeded_.load()) {
+    abortResults();
+  }
 }
 
 std::shared_ptr<PrestoExchangeSource> PrestoExchangeSource::getSelfPtr() {

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -33,12 +33,10 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       int destination,
       std::shared_ptr<velox::exec::ExchangeQueue> queue);
 
+  void close() override;
+
  private:
   void request() override;
-
-  void close() override {
-    closed_.store(true);
-  }
 
   void doRequest();
 
@@ -59,5 +57,8 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   std::unique_ptr<http::HttpClient> httpClient_;
   int failedAttempts_;
   std::atomic_bool closed_{false};
+  // A boolean indicating whether abortResults() call was issued and was
+  // successfully processed by the remote server.
+  std::atomic_bool abortResultsSucceeded_{false};
 };
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -30,7 +30,7 @@ class HttpResponse {
 
   ~HttpResponse();
 
-  proxygen::HTTPMessage* headers() {
+  proxygen::HTTPMessage* FOLLY_NONNULL headers() {
     return headers_.get();
   }
 
@@ -69,7 +69,7 @@ class HttpResponse {
 class HttpClient {
  public:
   HttpClient(
-      folly::EventBase* eventBase,
+      folly::EventBase* FOLLY_NONNULL eventBase,
       const folly::SocketAddress& address,
       std::chrono::milliseconds timeout);
 
@@ -81,7 +81,7 @@ class HttpClient {
       const std::string& body = "");
 
  private:
-  folly::EventBase* eventBase_;
+  folly::EventBase* FOLLY_NONNULL eventBase_;
   const folly::SocketAddress address_;
   const folly::HHWheelTimer::UniquePtr timer_;
   std::unique_ptr<proxygen::SessionPool> sessionPool_;
@@ -116,7 +116,7 @@ class RequestBuilder {
   }
 
   folly::SemiFuture<std::unique_ptr<HttpResponse>> send(
-      HttpClient* client,
+      HttpClient* FOLLY_NONNULL client,
       const std::string& body = "") {
     header(proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));
     headers_.ensureHostHeader();


### PR DESCRIPTION
This is a second part of a fix for a hanging query. The first part was fixed in Velox: https://github.com/facebookincubator/velox/pull/2384

When downstream task finishes early, for example, due to receiving an empty hash table for the inner join, the upstream task needs to be notified that data is no longer needed. This is done by sending abort-results message from PrestoExchangeSource::close().

```
== NO RELEASE NOTE ==
```
