### PR TITLE
[native] Temporarily disable macos job for native workers

### DIFF
--- a/.github/workflows/test-native-specific.yml
+++ b/.github/workflows/test-native-specific.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   native-specific-macos:
+    if: ${{ false }}  # disable the macos run for now
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Temporarily disable macos job for native workers as it keeps failing. We should re-enabled it after we can fix the issue.
Here is the issue https://github.com/prestodb/presto/issues/18264

Test plan - (Please fill in how you tested your changes)
See if the macos job is actually disabled


```
== NO RELEASE NOTE ==
```
