### PR TITLE
Fix NPE in FileMergeCacheManager

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
@@ -219,6 +219,9 @@ public class FileMergeCacheManager
         long bytes = 0;
         for (Path path : paths) {
             CacheRange cacheRange = persistedRanges.get(path);
+            if (cacheRange == null) {
+                continue;
+            }
             Lock readLock = cacheRange.getLock().readLock();
             readLock.lock();
             try {


### PR DESCRIPTION
Found this NPE while looking at test failures
```
java.lang.NullPointerException
at com.facebook.presto.cache.filemerge.FileMergeCacheManager.getCacheScopeSizeInBytes(FileMergeCacheManager.java:222)
at com.facebook.presto.cache.filemerge.FileMergeCacheManager.lambda$null$3(FileMergeCacheManager.java:158)
```

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
