### PR TITLE
Fix CSE compilation error for duplicate expressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -72,10 +72,12 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -201,13 +203,17 @@ public class PageFunctionCompiler
         if (isOptimizeCommonSubExpression) {
             ImmutableList.Builder<Supplier<PageProjectionWithOutputs>> pageProjections = ImmutableList.builder();
             ImmutableMap.Builder<RowExpression, Integer> expressionsWithPositionBuilder = ImmutableMap.builder();
+            Set<RowExpression> expressionCandidates = new HashSet<>();
             for (int i = 0; i < projections.size(); i++) {
                 RowExpression projection = projections.get(i);
-                if (projection instanceof ConstantExpression || projection instanceof InputReferenceExpression) {
+                // Duplicate expressions are not expected here in general due to duplicate assignments pruning in query optimization, hence we skip CSE for them to allow for a
+                // simpler implementation (and duplicate projections in expressionsWithPositionBuilder will throw exception when calling expressionsWithPositionBuilder.build())
+                if (projection instanceof ConstantExpression || projection instanceof InputReferenceExpression || expressionCandidates.contains(projection)) {
                     pageProjections.add(toPageProjectionWithOutputs(compileProjection(sqlFunctionProperties, sessionFunctions, projection, classNameSuffix), new int[] {i}));
                 }
                 else {
                     expressionsWithPositionBuilder.put(projection, i);
+                    expressionCandidates.add(projection);
                 }
             }
             Map<RowExpression, Integer> expressionsWithPosition = expressionsWithPositionBuilder.build();
@@ -932,6 +938,7 @@ public class PageFunctionCompiler
                     callSiteBinder);
             this.variableMap = ImmutableMap.copyOf(variableMap);
         }
+
         @Override
         public BytecodeNode visitCall(CallExpression call, Scope context)
         {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -198,6 +198,14 @@ public class TestPageFunctionCompiler
     }
 
     @Test
+    public void testCommonSubExpressionDuplicatesInProjection()
+    {
+        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
+        List<Supplier<PageProjectionWithOutputs>> pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), ImmutableList.of(ADD_X_Y, ADD_X_Y), true, Optional.empty());
+        assertEquals(pageProjections.size(), 2);
+    }
+
+    @Test
     public void testCommonSubExpressionLongProjectionList()
     {
         PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
@@ -228,7 +236,7 @@ public class TestPageFunctionCompiler
         Page input = createLongBlockPage(2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         SelectedPositions positions = filter(pageFilter.get(), input);
         assertEquals(positions.size(), 3);
-        assertEquals(positions.getPositions(), new int[]{2, 3, 4});
+        assertEquals(positions.getPositions(), new int[] {2, 3, 4});
     }
 
     private void checkBlockEqual(Block a, Block b)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6055,4 +6055,14 @@ public abstract class AbstractTestQueries
         assertTrue(plan.contains("m := max (1:34)"));
         assertTrue(plan.contains("max := max(expr) RANGE UNBOUNDED_PRECEDING CURRENT_ROW (1:34)"));
     }
+
+    @Test
+    public void testCSECompilation()
+    {
+        String sql = "SELECT " +
+                "FILTER( MAP_VALUES(map1), x -> x >= ELEMENT_AT( MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), COALESCE( ELEMENT_AT( other_map, name ), 'low' ) ) ) AS v1, " +
+                "FILTER( MAP_VALUES(map1), x -> x >= ELEMENT_AT( MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), COALESCE( ELEMENT_AT( other_map, name ), 'low' ) ) ) AS v2 " +
+                "FROM (select MAP(ARRAY['low'], ARRAY[100000]) map1, '' name) CROSS JOIN ( SELECT MAP() AS other_map ) risk_map";
+        assertQuery(sql, "VALUES (100000, 100000)");
+    }
 }


### PR DESCRIPTION
## what does it fix?
fix #18098 

The CSE implementation assumes that there is no duplicate expressions in projection. While this generally holds true, in some corner cases (for example issue #18098) it's not. While we have another PR #18159 fixing the duplicate keys part in the planner side, it's also good to break this dependency in the CSE side.

In this PR, I add an additional check to see if we have duplicate expressions, if yes, just skip this one for CSE optimization. 

For projections with no duplicate expressions, this PR will behave the same. For projections with duplicate expressions, we will hit compilation error in current version and forced to disable CSE optimization, while with this PR, we can still do CSE for other expressions.

## test
Add unit test. Also test e2e locally.

Existing CSE tests in `TestPageFunctionCompiler.java` make sure the trigger and correctness of CSE optimization for cases without duplicates stays the same. I also added an additional test `testCommonSubExpressionDuplicatesInProjection` to make sure with this PR we will not fail due to duplicates.
An end to end test with the SQL query in the issue is added in `AbstractTestQueries.java` to make sure the issue is fixed.

**The failing test native / build-and-test (pull_request) is unrelated to this PR, and is not required from offline discussion. This diff is ready for review.**

```
== RELEASE NOTES ==

General Changes
* Fix compilation error for common sub expression optimization when there are duplicate expressions in projection node
```

