### PR TITLE
Upgrade ranger dependency version with shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2060,7 +2060,7 @@
             <dependency>
                 <groupId>com.facebook.presto.ranger</groupId>
                 <artifactId>ranger-apache</artifactId>
-                <version>2.1.0-2</version>
+                <version>2.1.0-3</version>
             </dependency>
 
             <!-- force newer version to be used for dependencies -->


### PR DESCRIPTION
This version is shaded as extra dependencies coming from ranger dependencies.
With ranger-apache:2.1.0-2 (Before) -
![image](https://user-images.githubusercontent.com/7887476/187855053-6afe9aac-7679-48d5-aed0-231f217fa751.png)


With ranger-apache:2.1.0-3 (Current) -
![image](https://user-images.githubusercontent.com/7887476/187854929-ea3ce8b5-74df-475e-b253-d5983abf7979.png)

```
== NO RELEASE NOTE ==
```
