### PR TITLE
[native] Add support for arrays and maps in VALUES clause

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -695,39 +695,6 @@ void setCellFromVariant(
       setCellFromVariantByKind, data->typeKind(), data, row, value);
 }
 
-void setCellFromConstantVector(
-    const RowVectorPtr& data,
-    vector_size_t row,
-    vector_size_t column,
-    VectorPtr valueVector) {
-  auto columnVector = data->childAt(column);
-  if (valueVector->isNullAt(0)) {
-    // This is a constant vector and will have only one element.
-    columnVector->setNull(row, true);
-    return;
-  }
-  switch (valueVector->typeKind()) {
-    case TypeKind::SHORT_DECIMAL: {
-      auto flatVector =
-          columnVector->as<FlatVector<velox::UnscaledShortDecimal>>();
-      flatVector->set(
-          row,
-          valueVector->as<ConstantVector<velox::UnscaledShortDecimal>>()
-              ->valueAt(0));
-    } break;
-    case TypeKind::LONG_DECIMAL: {
-      auto flatVector =
-          columnVector->as<FlatVector<velox::UnscaledLongDecimal>>();
-      flatVector->set(
-          row,
-          valueVector->as<ConstantVector<velox::UnscaledLongDecimal>>()
-              ->valueAt(0));
-    } break;
-    default:
-      VELOX_UNSUPPORTED();
-  }
-}
-
 velox::core::SortOrder toVeloxSortOrder(const protocol::SortOrder& sortOrder) {
   switch (sortOrder) {
     case protocol::SortOrder::ASC_NULLS_FIRST:
@@ -1288,8 +1255,8 @@ VeloxQueryPlanConverter::toVeloxQueryPlan(
         if (!constantExpr->hasValueVector()) {
           setCellFromVariant(rowVector, row, column, constantExpr->value());
         } else {
-          setCellFromConstantVector(
-              rowVector, row, column, constantExpr->valueVector());
+          auto columnVector = rowVector->childAt(column);
+          columnVector->copy(constantExpr->valueVector().get(), row, 0, 1);
         }
       } else {
         VELOX_FAIL("Expected constant expression");

--- a/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
@@ -43,6 +43,9 @@ public class HiveExternalWorkerQueryRunner
         String workerCount = System.getenv("WORKER_COUNT");
         int cacheMaxSize = 4096; // 4GB size cache
 
+        checkArgument(prestoServerPath != null, "Native worker binary path is missing. Add PRESTO_SERVER environment variable.");
+        checkArgument(baseDataDir != null, "Data directory path is missing.. Add DATA_DIR environment variable.");
+
         return createQueryRunner(
                 Optional.ofNullable(prestoServerPath),
                 Optional.ofNullable(baseDataDir).map(Paths::get),

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestHiveQueries.java
@@ -42,8 +42,8 @@ public class AbstractTestHiveQueries
         String workerCount = System.getProperty("WORKER_COUNT");
         int cacheMaxSize = 0;
 
-        assertNotNull(prestoServerPath);
-        assertNotNull(baseDataDir);
+        assertNotNull(prestoServerPath, "Native worker binary path is missing. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.");
+        assertNotNull(baseDataDir, "Data directory path is missing. Add -DDATA_DIR=<path/to/data> to your JVM arguments.");
 
         return HiveExternalWorkerQueryRunner.createNativeQueryRunner(baseDataDir, prestoServerPath, Optional.ofNullable(workerCount).map(Integer::parseInt), cacheMaxSize, useThrift);
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
@@ -280,6 +280,11 @@ abstract class TestHiveQueries
 
         assertQuery("SELECT array[1, 2, 3], array[0.1, NULL, 0.23, 0.00004], array['x', 'y', 'zetta']");
 
+        assertQuery("SELECT * FROM (VALUES (array[1, 23, 456])) as t(a)");
+        assertQuery("SELECT * FROM (VALUES (array[1, NULL, 23, 456])) as t(a)");
+
+        assertQuery("SELECT * FROM (VALUES (map(array[1, 2, 3], array[10, 20, 30]))) as t(a)");
+
         assertQuery("SELECT BIGINT '12345', INTEGER '1234', SMALLINT '123', TINYINT '12', TRUE, FALSE, DOUBLE '1.234', REAL '1.23', 'ABC', 'Somewhat longish string', NULL, array[1, 2, 3]");
     }
 


### PR DESCRIPTION
Fix queries like

```
SELECT * FROM (VALUES (array[1, 23, 456])) as t(a)
SELECT * FROM (VALUES (array[1, NULL, 23, 456])) as t(a)
```

```
== NO RELEASE NOTE ==
```
