### PR TITLE
Disable flaky presto-spark test

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -804,7 +804,7 @@ public class TestPrestoSparkQueryRunner
         assertThat(sampledRows).isLessThan(totalRows);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testTimeouts()
     {
         // Expected run time for this query is ~30s


### PR DESCRIPTION
This has been failing in our nightlies for some time. Started a thread with @pgupta2 to debug, and disabling meanwhile
```
== NO RELEASE NOTE ==
```
