### PR TITLE
Push RemoteExchange down through GroupId

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -235,6 +235,7 @@ public final class SystemSessionProperties
     public static final String TRACK_HISTORY_BASED_PLAN_STATISTICS = "track_history_based_plan_statistics";
     public static final String MAX_LEAF_NODES_IN_PLAN = "max_leaf_nodes_in_plan";
     public static final String LEAF_NODE_LIMIT_ENABLED = "leaf_node_limit_enabled";
+    public static final String PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID = "push_remote_exchange_through_group_id";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1338,6 +1339,11 @@ public final class SystemSessionProperties
                         LEAF_NODE_LIMIT_ENABLED,
                         "Throw exception if the number of leaf nodes in logical plan exceeds threshold set in max_leaf_nodes_in_plan",
                         compilerConfig.getLeafNodeLimitEnabled(),
+                        false),
+                booleanProperty(
+                        PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID,
+                        "Enable optimization rule to push remote exchange through GroupId",
+                        featuresConfig.isPushRemoteExchangeThroughGroupId(),
                         false));
     }
 
@@ -2252,5 +2258,10 @@ public final class SystemSessionProperties
     public static boolean trackHistoryBasedPlanStatisticsEnabled(Session session)
     {
         return session.getSystemProperty(TRACK_HISTORY_BASED_PLAN_STATISTICS, Boolean.class);
+    }
+
+    public static boolean shouldPushRemoteExchangeThroughGroupId(Session session)
+    {
+        return session.getSystemProperty(PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -232,6 +232,8 @@ public class FeaturesConfig
 
     private double hyperloglogStandardErrorWarningThreshold = 0.004;
 
+    private boolean pushRemoteExchangeThroughGroupId;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2160,6 +2162,18 @@ public class FeaturesConfig
     public FeaturesConfig setQuickDistinctLimitEnabled(boolean quickDistinctLimitEnabled)
     {
         this.quickDistinctLimitEnabled = quickDistinctLimitEnabled;
+        return this;
+    }
+
+    public boolean isPushRemoteExchangeThroughGroupId()
+    {
+        return pushRemoteExchangeThroughGroupId;
+    }
+
+    @Config("optimizer.push-remote-exchange-through-group-id")
+    public FeaturesConfig setPushRemoteExchangeThroughGroupId(boolean value)
+    {
+        this.pushRemoteExchangeThroughGroupId = value;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -88,6 +88,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushPartialAggregationThro
 import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughExchange;
 import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushRemoteExchangeThroughAssignUniqueId;
+import com.facebook.presto.sql.planner.iterative.rule.PushRemoteExchangeThroughGroupId;
 import com.facebook.presto.sql.planner.iterative.rule.PushTableWriteThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
@@ -623,6 +624,7 @@ public class PlanOptimizers
                 ImmutableSet.<Rule<?>>builder()
                         .add(new RemoveRedundantIdentityProjections())
                         .add(new PushRemoteExchangeThroughAssignUniqueId())
+                        .add(new PushRemoteExchangeThroughGroupId(metadata))
                         .add(new InlineProjections(metadata.getFunctionAndTypeManager()))
                         .build()));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughGroupId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughGroupId.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.connector.system.GlobalSystemConnector;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
+import static com.facebook.presto.SystemSessionProperties.getPartitioningProviderCatalog;
+import static com.facebook.presto.SystemSessionProperties.shouldPushRemoteExchangeThroughGroupId;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+import static com.facebook.presto.sql.planner.plan.Patterns.groupId;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Pushes RemoteExchange node down through GroupId node when GroupId node contains non-empty
+ * set of common grouping columns.
+ *
+ * As an example this rule will change following plan
+ * Aggregation [final]
+ *   - RemoteExchange [repartition]
+ *     - Aggregation [partial]
+ *       - GroupId
+ *         - TableScan
+ * To
+ * Aggregation
+ *   - GroupId
+ *     - RemoteExchange [repartition]
+ *       - TableScan
+ *
+ * We can leverage this optimization rule to rewrite plan to be more efficient
+ * if following conditions are true:
+ *
+ * 1. There are large number of grouping sets in query.
+ * 2. Partial aggregation reduction ratio is not great.
+ * 3. There is least one common grouping key among grouping sets.
+ *
+ * Note: This rule is disabled by default. Session property
+ * PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID can be used to enable it.
+ */
+public final class PushRemoteExchangeThroughGroupId
+        implements Rule<ExchangeNode>
+{
+    private final Metadata metadata;
+    private static final Capture<GroupIdNode> GROUP_ID = newCapture();
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .matching(exchange -> exchange.getScope().isRemote())
+            .matching(exchange -> exchange.getType() == REPARTITION)
+            .with(source().matching(
+                    groupId()
+                            .capturedAs(GROUP_ID)
+                            .matching(groupId -> !groupId.getCommonGroupingColumns().isEmpty())));
+
+    public PushRemoteExchangeThroughGroupId(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return shouldPushRemoteExchangeThroughGroupId(session);
+    }
+
+    @Override
+    public Result apply(ExchangeNode node, Captures captures, Context context)
+    {
+        GroupIdNode groupIdNode = captures.get(GROUP_ID);
+
+        List<VariableReferenceExpression> inputs = getOnlyElement(node.getInputs());
+        inputs = removeVariable(inputs, groupIdNode.getGroupIdVariable());
+        inputs = replaceAlias(inputs, groupIdNode.getGroupingColumns());
+
+        PartitioningScheme partitioningScheme = node.getPartitioningScheme();
+        List<VariableReferenceExpression> outputLayout = partitioningScheme.getOutputLayout();
+        outputLayout = removeVariable(outputLayout, groupIdNode.getGroupIdVariable());
+        outputLayout = replaceAlias(outputLayout, groupIdNode.getGroupingColumns());
+
+        Set<VariableReferenceExpression> commonGroupingColumns = groupIdNode.getCommonGroupingColumns();
+        List<VariableReferenceExpression> partitionColumns = replaceAlias(commonGroupingColumns, groupIdNode.getGroupingColumns());
+
+        // Check that new |partitionColumns| must be subset of original partition columns.
+        Map<VariableReferenceExpression, VariableReferenceExpression> groupingColumns = groupIdNode.getGroupingColumns();
+        List<VariableReferenceExpression> originalPartitionColumns =
+                partitioningScheme.getPartitioning().getVariableReferences()
+                        .stream()
+                        .map(expr -> groupingColumns.getOrDefault(expr, expr))
+                        .collect(toImmutableList());
+        if (!originalPartitionColumns.containsAll(partitionColumns)) {
+            return Result.empty();
+        }
+
+        // Create new PartitioningHandle.
+        PartitioningHandle partitioningHandle;
+        if (GlobalSystemConnector.NAME.equals(getPartitioningProviderCatalog(context.getSession()))) {
+            partitioningHandle = partitioningScheme.getPartitioning().getHandle();
+        }
+        else {
+            partitioningHandle = createPartitioningHandle(context.getSession(), partitionColumns);
+        }
+
+        return Result.ofPlanNode(new GroupIdNode(
+                node.getSourceLocation(),
+                groupIdNode.getId(),
+                new ExchangeNode(
+                        node.getSourceLocation(),
+                        node.getId(),
+                        node.getType(),
+                        node.getScope(),
+                        new PartitioningScheme(
+                                Partitioning.create(partitioningHandle, partitionColumns),
+                                outputLayout,
+                                partitioningScheme.getHashColumn(),
+                                partitioningScheme.isReplicateNullsAndAny(),
+                                partitioningScheme.getBucketToPartition()),
+                        ImmutableList.of(groupIdNode.getSource()),
+                        ImmutableList.of(inputs),
+                        node.isEnsureSourceOrdering(),
+                        node.getOrderingScheme()),
+                groupIdNode.getGroupingSets(),
+                groupIdNode.getGroupingColumns(),
+                groupIdNode.getAggregationArguments(),
+                groupIdNode.getGroupIdVariable()));
+    }
+
+    private static List<VariableReferenceExpression> removeVariable(List<VariableReferenceExpression> variables, VariableReferenceExpression variableToRemove)
+    {
+        return variables.stream()
+                .filter(variable -> !variableToRemove.equals(variable))
+                .collect(toImmutableList());
+    }
+
+    private static List<VariableReferenceExpression> replaceAlias(Collection<VariableReferenceExpression> variables, Map<VariableReferenceExpression, VariableReferenceExpression> mapping)
+    {
+        return variables.stream()
+                .map(variable -> mapping.containsKey(variable) ? mapping.get(variable) : variable)
+                .collect(toImmutableList());
+    }
+
+    private PartitioningHandle createPartitioningHandle(Session session, Collection<VariableReferenceExpression> partitioningColumns)
+    {
+        List<Type> partitioningTypes = partitioningColumns.stream()
+                .map(VariableReferenceExpression::getType)
+                .collect(toImmutableList());
+        return metadata.getPartitioningHandleForExchange(
+                session,
+                getPartitioningProviderCatalog(session),
+                getHashPartitionCount(session),
+                partitioningTypes);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -50,6 +50,11 @@ public class Patterns
         return typeOf(AggregationNode.class);
     }
 
+    public static Pattern<GroupIdNode> groupId()
+    {
+        return typeOf(GroupIdNode.class);
+    }
+
     public static Pattern<ApplyNode> applyNode()
     {
         return typeOf(ApplyNode.class);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -202,7 +202,8 @@ public class TestFeaturesConfig
                 .setPreferMergeJoin(false)
                 .setSegmentedAggregationEnabled(false)
                 .setQueryAnalyzerTimeout(new Duration(3, MINUTES))
-                .setQuickDistinctLimitEnabled(false));
+                .setQuickDistinctLimitEnabled(false)
+                .setPushRemoteExchangeThroughGroupId(false));
     }
 
     @Test
@@ -356,6 +357,7 @@ public class TestFeaturesConfig
                 .put("optimizer.segmented-aggregation-enabled", "true")
                 .put("planner.query-analyzer-timeout", "10s")
                 .put("optimizer.quick-distinct-limit-enabled", "true")
+                .put("optimizer.push-remote-exchange-through-group-id", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -506,7 +508,8 @@ public class TestFeaturesConfig
                 .setPreferMergeJoin(true)
                 .setSegmentedAggregationEnabled(true)
                 .setQueryAnalyzerTimeout(new Duration(10, SECONDS))
-                .setQuickDistinctLimitEnabled(true);
+                .setQuickDistinctLimitEnabled(true)
+                .setPushRemoteExchangeThroughGroupId(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.plan.GroupIdNode;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
@@ -55,7 +56,13 @@ public class GroupIdMatcher
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 
         GroupIdNode groupIdNode = (GroupIdNode) node;
-        List<List<VariableReferenceExpression>> actualGroups = groupIdNode.getGroupingSets();
+        Map<VariableReferenceExpression, VariableReferenceExpression> groupingColumns = groupIdNode.getGroupingColumns();
+        List<List<VariableReferenceExpression>> actualGroups = groupIdNode.getGroupingSets()
+                .stream()
+                .map(group -> group.stream()
+                        .map(column -> groupingColumns.get(column))
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
         List<VariableReferenceExpression> actualAggregationArguments = groupIdNode.getAggregationArguments();
 
         if (actualGroups.size() != groups.size()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -60,7 +60,6 @@ import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
@@ -502,9 +501,9 @@ public final class PlanMatchPattern
                 .with(new CorrelationMatcher(correlationSymbolAliases));
     }
 
-    public static PlanMatchPattern groupingSet(List<List<String>> groups, String groupIdAlias, PlanMatchPattern source)
+    public static PlanMatchPattern groupingSet(List<List<String>> groups, Map<String, String> identityMappings, String groupIdAlias, PlanMatchPattern source)
     {
-        return node(GroupIdNode.class, source).with(new GroupIdMatcher(groups, ImmutableMap.of(), groupIdAlias));
+        return node(GroupIdNode.class, source).with(new GroupIdMatcher(groups, identityMappings, groupIdAlias));
     }
 
     private static PlanMatchPattern values(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
@@ -86,7 +86,7 @@ public class TestOptimizeMixedDistinctAggregations
                 aggregation(singleGroupingSet(groupByKeysSecond), aggregationsSecond, ImmutableMap.of(), Optional.empty(), SINGLE,
                         project(
                                 aggregation(singleGroupingSet(groupByKeysFirst), aggregationsFirst, ImmutableMap.of(), Optional.empty(), SINGLE,
-                                        groupingSet(groups.build(), group,
+                                        groupingSet(groups.build(), ImmutableMap.of(), group,
                                                 anyTree(tableScan))))));
 
         assertUnitPlan(sql, expectedPlanPattern);


### PR DESCRIPTION
Grouping sets usually results in following plan
- Aggregation [final]
  - RemoteExchange [repartition]
    - Aggregation [partial]
      - GroupId
        - TableScan

In above plan GroupId expands input rows by N times where N is
number of grouping sets in query. If partial aggregation is not
very effective in reduction, above query will result in large amount of data being shuffled.

We can push RemoteExchange down through GroupId rewrite above plan
as following:
- Aggregation
  - GroupId
    - RemoteExchange [repartition]
      - TableScan

In the rewritten plan we shuffle input data on common grouping keys. We
can enable this optimization if there are no commmon grouping keys among
grouping sets.

We can leverage this optimization rule to rewrite plan to be
more efficient if following conditions are true:
1. There are large number of grouping sets in query.
2. Partial aggregation reduction ratio is not great.
3. There is least one common grouping key among grouping sets.

This rule is disabled by default. Session property
PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID can be used to enable it.

Test plan -
Added unit tests in TestLogicalPlanner.java

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
