### PR TITLE
Fix bug in ORC flat map reader causing 'Read past RLE' and 'Positions must monotonically increase' errors

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -774,23 +774,6 @@ public class OrcSelectiveRecordReader
         return columnsWithFilterScores.containsKey(columnIndex) || filterFunctionInputMapping.containsKey(columnIndex);
     }
 
-    private void initializePositions(int batchSize)
-    {
-        if (positions == null || positions.length < batchSize) {
-            positions = new int[batchSize];
-            for (int i = 0; i < batchSize; i++) {
-                positions[i] = i;
-            }
-        }
-
-        if (errors == null || errors.length < batchSize) {
-            errors = new RuntimeException[batchSize];
-        }
-        else {
-            Arrays.fill(errors, null);
-        }
-    }
-
     private int applyFilterFunctionWithNoInputs(int positionCount)
     {
         initializeOutputPositions(positionCount);
@@ -873,6 +856,24 @@ public class OrcSelectiveRecordReader
         }
         else {
             Arrays.fill(tmpErrors, null);
+        }
+    }
+
+    private void initializePositions(int batchSize)
+    {
+        if (positions == null || positions.length < batchSize) {
+            positions = new int[batchSize];
+        }
+
+        for (int i = 0; i < batchSize; i++) {
+            positions[i] = i;
+        }
+
+        if (errors == null || errors.length < batchSize) {
+            errors = new RuntimeException[batchSize];
+        }
+        else {
+            Arrays.fill(errors, null);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -233,7 +233,7 @@ public class MapFlatSelectiveStreamReader
         outputPositions = initializeOutputPositions(outputPositions, positions, positionCount);
 
         if (keyCount == 0 && presentStream == null) {
-            readAllEmpty(positions, positionCount);
+            readAllEmpty(positionCount);
         }
         else {
             readNotAllNulls(offset, positions, positionCount);
@@ -244,9 +244,8 @@ public class MapFlatSelectiveStreamReader
         return outputPositionCount;
     }
 
-    private void readAllEmpty(int[] positions, int positionCount)
+    private void readAllEmpty(int positionCount)
     {
-        outputPositions = positions;
         outputPositionsReadOnly = true;
 
         if (!nonNullsAllowed) {


### PR DESCRIPTION
OrcSelectiveRecordReader maintains a `positions` array with the read positions, which is supposed to be immutable. However, when all flat map column values are empty, the MapFlatSelectiveStreamReader would use this array as an array containing output positions, thus bringing it into the modification cycle in the OrcSelectiveRecordReader.getNextPage.

This PR contains two changes to fix this issue:
1) MapFlatSelectiveStreamReader won't attempt to use the input `positions` array for the output positions.
2) OrcSelectiveRecordReader would reset positions in the `positions` array for every `getNextPage` call to make sure it always has valid values.

Test plan:
- tested on a verifier cluster using queries that used to fail
- it's surprisingly hard to produce a unit test for this issue because it must have a series of steps involving FilterFunction, may be a tuple domain filter, etc. I'll work on the unit test for this issue and will post it after the main fix is landed.

```
== NO RELEASE NOTE ==
```
