### PR TITLE
Add test dependency on presto-common to presto-benchto-benchmarks

### DIFF
--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -49,6 +49,13 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tpch</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION

(Re) Enable the execution of TestTpchCostBasedPlan & TestTpcdsCostBasedPlan. 
Dependent classes were moved from presto-main to presto-common. So introduce a test dependency between these modules

```
== NO RELEASE NOTE ==
```
