### PR TITLE
Add config to fallback to simple node selection when using TTL based scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelectorConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelectorConfig.java
@@ -22,6 +22,7 @@ public class SimpleTtlNodeSelectorConfig
 {
     private boolean useDefaultExecutionTimeEstimateAsFallback;
     private Duration defaultExecutionTimeEstimate = new Duration(30, TimeUnit.MINUTES);
+    private boolean fallbackToSimpleNodeSelection;
 
     public boolean getUseDefaultExecutionTimeEstimateAsFallback()
     {
@@ -44,6 +45,18 @@ public class SimpleTtlNodeSelectorConfig
     public SimpleTtlNodeSelectorConfig setDefaultExecutionTimeEstimate(Duration defaultExecutionTimeEstimate)
     {
         this.defaultExecutionTimeEstimate = defaultExecutionTimeEstimate;
+        return this;
+    }
+
+    public boolean getFallbackToSimpleNodeSelection()
+    {
+        return fallbackToSimpleNodeSelection;
+    }
+
+    @Config("simple-ttl-node-selector.fallback-to-simple-node-selection")
+    public SimpleTtlNodeSelectorConfig setFallbackToSimpleNodeSelection(boolean fallbackToSimpleNodeSelection)
+    {
+        this.fallbackToSimpleNodeSelection = fallbackToSimpleNodeSelection;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/nodeselection/TestSimpleTtlNodeSelectorConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/nodeselection/TestSimpleTtlNodeSelectorConfig.java
@@ -29,7 +29,8 @@ public class TestSimpleTtlNodeSelectorConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SimpleTtlNodeSelectorConfig.class)
                 .setUseDefaultExecutionTimeEstimateAsFallback(false)
-                .setDefaultExecutionTimeEstimate(new Duration(30, TimeUnit.MINUTES)));
+                .setDefaultExecutionTimeEstimate(new Duration(30, TimeUnit.MINUTES))
+                .setFallbackToSimpleNodeSelection(false));
     }
 
     @Test
@@ -38,11 +39,13 @@ public class TestSimpleTtlNodeSelectorConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback", "true")
                 .put("simple-ttl-node-selector.default-execution-time-estimate", "1h")
+                .put("simple-ttl-node-selector.fallback-to-simple-node-selection", "true")
                 .build();
 
         SimpleTtlNodeSelectorConfig expected = new SimpleTtlNodeSelectorConfig()
                 .setUseDefaultExecutionTimeEstimateAsFallback(true)
-                .setDefaultExecutionTimeEstimate(new Duration(1, TimeUnit.HOURS));
+                .setDefaultExecutionTimeEstimate(new Duration(1, TimeUnit.HOURS))
+                .setFallbackToSimpleNodeSelection(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add config to fallback to simple node selection when using TTL based scheduling. If nodes with enough TTL are not available when scheduling a query, the query fails. This config allows us to fallback to simple node selection to avoid failure in such scenarios.

Test plan - Unit tests

```
== NO RELEASE NOTE ==
```
