### PR TITLE
Fix wrapper job conf

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
@@ -99,10 +99,13 @@ public class WrapperJobConf
     public String get(String name)
     {
         if (config == null) {
-            return super.get(name);
+            // This is weird code, config is ensured to be non-null in constructor. But this method is called
+            // from super class JobConf constructor. config member variable can be only initialized after super
+            // constructor runs. So this is asking for a property, before it is set. Default to null
+            // as Presto does not use the Hadoop specific properties.
+            return null;
         }
-        String result = config.get(name);
-        return result != null ? result : super.get(name);
+        return config.get(name);
     }
 
     @Override


### PR DESCRIPTION
After releasing 0.276, there was an execution time runtime for most
queries. Profiler shows lock contention in the JobConf.get with the 
following call stack. 

![276 query regression](https://user-images.githubusercontent.com/6520371/188783170-9b2198b3-7407-4aa4-9884-5fb6f09d6e5f.png)

This was a regression from https://github.com/prestodb/presto/pull/18115 

The regression was from the following path

1. WrapperJobConf constructor calls JobConf's no args constructor.
2. JobConf's Constructor calls Configuration's no args constructor.
3. Configuration sets the properties field to null.
4. JobConf calls checkAndWarnDeprecation that calls get method.
5. get method is forwarded from WrapperJobConf to JobConf to
Configuration.
6. Configuration get when called with properties field is set to null
will try to load resources and tries to acquire a lock. This is the 
cause for the contention and the slow query execution.

This PR fixes it at step 5 and returning null directly from 
WrapperJobConf for get call. Presto does not use Hadoop
JobConf and this is a safe change.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
