### PR TITLE
Add release notes for 0.276.1

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.276.1
     release/release-0.276
     release/release-0.275
     release/release-0.274

--- a/presto-docs/src/main/sphinx/release/release-0.276.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.276.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.276.1
+===============
+
+General Changes
+_______________
+* Fix a lock contention in Hive Connector. (:pr:`18295`)

--- a/presto-docs/src/main/sphinx/release/release-0.276.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.276.rst
@@ -2,6 +2,10 @@
 Release 0.276
 =============
 
+.. warning::
+
+   There is a lock contention in Hive connector which slows the query execution.
+
 **Details**
 ===========
 


### PR DESCRIPTION
Added release notes for 0.276.1

Test plan - 
Built the docs and verified on macbook.

```
== NO RELEASE NOTE ==
```
