### PR TITLE
Throw FileNotFoundException if file does not exist on S3

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -53,6 +53,7 @@ import org.testng.annotations.Test;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -267,7 +268,7 @@ public class TestPrestoS3FileSystem
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = ".*Failing getObject call with " + HTTP_NOT_FOUND + ".*")
+    @Test(expectedExceptions = FileNotFoundException.class, expectedExceptionsMessageRegExp = "File does not exist: s3n://test-bucket/test")
     public void testReadNotFound()
             throws Exception
     {


### PR DESCRIPTION
`PrestoS3FileSystem` throws more specific `FileNotFoundException` exception if a file does not exist on S3.
The PR also fixes performance downgrade for reading newly created delta table stored on S3 https://github.com/delta-io/connectors/issues/437.

Test plan - existing tests

```
== RELEASE NOTES ==

Delta Lake Connector Changes
* Improve performance of reading newly created tables
```
