### PR TITLE
Precompute all history based statistics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculator.java
@@ -35,4 +35,17 @@ public interface StatsCalculator
             Lookup lookup,
             Session session,
             TypeProvider types);
+
+    /**
+     * Presto Optimizer will call this once for a query that needs StatsCalculator interface. It is called
+     * with the root PlanNode, so StatsCalculator can prepare for future `calculateStats` calls.
+     *
+     * @param root Root of plan tree for query
+     */
+    default void registerPlan(
+            PlanNode root,
+            Session session)
+    {
+        // no-op
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -553,7 +553,7 @@ public class PlanOptimizers
 
         // We do a single pass, and assign `statsEquivalentPlanNode` to each node.
         // After this step, nodes with same `statsEquivalentPlanNode` will share same history based statistics.
-        builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new HistoricalStatisticsEquivalentPlanMarkingOptimizer()));
+        builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new HistoricalStatisticsEquivalentPlanMarkingOptimizer(statsCalculator)));
 
         builder.add(new IterativeOptimizer(
                 // Because ReorderJoins runs only once,
@@ -567,7 +567,7 @@ public class PlanOptimizers
 
         // After ReorderJoins, `statsEquivalentPlanNode` will be unassigned to intermediate join nodes.
         // We run it again to mark this for intermediate join nodes.
-        builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new HistoricalStatisticsEquivalentPlanMarkingOptimizer()));
+        builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new HistoricalStatisticsEquivalentPlanMarkingOptimizer(statsCalculator)));
 
         builder.add(new IterativeOptimizer(
                 ruleStats,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNodeWithHash.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNodeWithHash.java
@@ -51,13 +51,15 @@ public class PlanNodeWithHash
             return false;
         }
         PlanNodeWithHash that = (PlanNodeWithHash) o;
-        return Objects.equals(planNode, that.planNode) && Objects.equals(hash, that.hash);
+        // We compare object equality for Plan nodes. It is necessary because plan nodes can be expensive to compare,
+        // and its also sufficient because we only hash stats equivalent plan nodes, which don't change while planning.
+        return planNode == that.planNode && Objects.equals(hash, that.hash);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(planNode, hash);
+        return Objects.hash(System.identityHashCode(planNode), hash);
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.HistoryBasedPlanStatisticsCalculator;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
@@ -73,6 +74,7 @@ public class TestHistoryBasedStatsTracking
     public void setUp()
     {
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        ((HistoryBasedPlanStatisticsCalculator) queryRunner.getStatsCalculator()).invalidateCache();
         getHistoryProvider().clearCache();
     }
 
@@ -179,11 +181,8 @@ public class TestHistoryBasedStatsTracking
 
     private void executeAndTrackHistory(String sql)
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
-        InMemoryHistoryBasedPlanStatisticsProvider provider = getHistoryProvider();
-
-        queryRunner.execute(sql);
-        provider.waitProcessQueryEvents();
+        getQueryRunner().execute(sql);
+        getHistoryProvider().waitProcessQueryEvents();
     }
 
     private InMemoryHistoryBasedPlanStatisticsProvider getHistoryProvider()


### PR DESCRIPTION
At start of planning, call `registerPlan()`, which can precompute hashes and history based statistics to be used in future. This helps eliminate serial network calls when computing history based statistics


```
== NO RELEASE NOTE ==
```
