### PR TITLE
Fix some bugs in HBO

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveHistoryBasedStatsTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveHistoryBasedStatsTracking.java
@@ -18,7 +18,10 @@ import com.facebook.presto.execution.SqlQueryManager;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
@@ -27,14 +30,15 @@ import com.google.common.collect.ImmutableList;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.TRACK_HISTORY_BASED_PLAN_STATISTICS;
 import static com.facebook.presto.SystemSessionProperties.USE_HISTORY_BASED_PLAN_STATISTICS;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
-import static io.airlift.tpch.TpchTable.LINE_ITEM;
 import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestHiveHistoryBasedStatsTracking
@@ -44,7 +48,7 @@ public class TestHiveHistoryBasedStatsTracking
     public QueryRunner createQueryRunner()
             throws Exception
     {
-        QueryRunner queryRunner = HiveQueryRunner.createQueryRunner(ImmutableList.of(ORDERS, LINE_ITEM));
+        QueryRunner queryRunner = HiveQueryRunner.createQueryRunner(ImmutableList.of(ORDERS));
 
         queryRunner.installPlugin(new Plugin()
         {
@@ -82,6 +86,44 @@ public class TestHiveHistoryBasedStatsTracking
         }
     }
 
+    @Test
+    public void testBroadcastJoin()
+    {
+        try {
+            getQueryRunner().execute("CREATE TABLE test_orders WITH (partitioned_by = ARRAY['ds', 'ts']) AS " +
+                    "SELECT orderkey, orderpriority, comment, custkey, '2020-09-01' as ds, '00:01' as ts FROM orders where orderkey < 2000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, comment, custkey, '2020-09-02' as ds, '00:02' as ts FROM orders WHERE orderkey >= 1000 AND orderkey < 2000");
+
+            // CBO Statistics
+            Plan plan = plan("SELECT * FROM " +
+                                        "(SELECT * FROM test_orders where ds = '2020-09-01' and substr(CAST(custkey AS VARCHAR), 1, 3) <> '370') t1 JOIN " +
+                                        "(SELECT * FROM test_orders where ds = '2020-09-02' and substr(CAST(custkey AS VARCHAR), 1, 3) = '370') t2 ON t1.orderkey = t2.orderkey", createSession());
+
+            assertTrue(PlanNodeSearcher.searchFrom(plan.getRoot())
+                    .where(node -> node instanceof JoinNode && ((JoinNode) node).getDistributionType().get().equals(JoinNode.DistributionType.PARTITIONED))
+                    .findFirst()
+                    .isPresent());
+
+            // HBO Statistics
+            executeAndTrackHistory("SELECT * FROM " +
+                    "(SELECT * FROM test_orders where ds = '2020-09-01' and substr(CAST(custkey AS VARCHAR), 1, 3) <> '370') t1 JOIN " +
+                    "(SELECT * FROM test_orders where ds = '2020-09-02' and substr(CAST(custkey AS VARCHAR), 1, 3) = '370') t2 ON t1.orderkey = t2.orderkey");
+
+            plan = plan("SELECT * FROM " +
+                    "(SELECT * FROM test_orders where ds = '2020-09-01' and substr(CAST(custkey AS VARCHAR), 1, 3) <> '370') t1 JOIN " +
+                    "(SELECT * FROM test_orders where ds = '2020-09-02' and substr(CAST(custkey AS VARCHAR), 1, 3) = '370') t2 ON t1.orderkey = t2.orderkey", createSession());
+
+            assertTrue(PlanNodeSearcher.searchFrom(plan.getRoot())
+                    .where(node -> node instanceof JoinNode && ((JoinNode) node).getDistributionType().get().equals(JoinNode.DistributionType.REPLICATED))
+                    .findFirst()
+                    .isPresent());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_orders");
+        }
+    }
+
     @Override
     protected void assertPlan(@Language("SQL") String query, PlanMatchPattern pattern)
     {
@@ -103,6 +145,7 @@ public class TestHiveHistoryBasedStatsTracking
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "true")
                 .setSystemProperty(TRACK_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "automatic")
                 .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
                 .build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -171,8 +171,14 @@ public class IterativeOptimizer
                 if (result.getTransformedPlan().isPresent()) {
                     // If we rewrite a plan node, topmost node should remain statistically equivalent.
                     PlanNode transformedNode = result.getTransformedPlan().get();
-                    if (node.getStatsEquivalentPlanNode().isPresent() && !transformedNode.getStatsEquivalentPlanNode().isPresent()) {
-                        transformedNode = transformedNode.assignStatsEquivalentPlanNode(node.getStatsEquivalentPlanNode());
+                    PlanNode resolvedtransformedNode = context.lookup.resolve(result.getTransformedPlan().get());
+                    if (node.getStatsEquivalentPlanNode().isPresent() && !resolvedtransformedNode.getStatsEquivalentPlanNode().isPresent()) {
+                        if (transformedNode instanceof GroupReference) {
+                            context.memo.assignStatsEquivalentPlanNode((GroupReference) transformedNode, node.getStatsEquivalentPlanNode());
+                        }
+                        else {
+                            transformedNode = transformedNode.assignStatsEquivalentPlanNode(node.getStatsEquivalentPlanNode());
+                        }
                     }
                     node = context.memo.replace(group, transformedNode, rule.getClass().getName());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -158,6 +158,11 @@ public class Memo
         return node;
     }
 
+    public void assignStatsEquivalentPlanNode(GroupReference reference, Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        getGroup(reference.getGroupId()).assignStatsEquivalentPlanNode(statsEquivalentPlanNode);
+    }
+
     private void evictStatisticsAndCost(int group)
     {
         getGroup(group).stats = null;
@@ -286,6 +291,11 @@ public class Memo
         {
             this.membership = requireNonNull(member, "member is null");
             this.logicalProperties = logicalProperties;
+        }
+
+        private void assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+        {
+            membership = membership.assignStatsEquivalentPlanNode(statsEquivalentPlanNode);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -787,7 +787,7 @@ public class HashGenerationOptimizer
                 }
             }
 
-            ProjectNode projectNode = new ProjectNode(planWithProperties.node.getSourceLocation(), idAllocator.getNextId(), planWithProperties.getNode(), assignments.build(), LOCAL);
+            ProjectNode projectNode = new ProjectNode(planWithProperties.node.getSourceLocation(), idAllocator.getNextId(), planWithProperties.node.getStatsEquivalentPlanNode(), planWithProperties.getNode(), assignments.build(), LOCAL);
             return new PlanWithProperties(projectNode, outputHashVariables);
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
@@ -14,6 +14,9 @@
 
 package com.facebook.presto.spi.statistics;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -22,6 +25,7 @@ import static java.lang.Double.NaN;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 
+@ThriftStruct
 public final class Estimate
 {
     // todo eventually add some notion of statistic reliability
@@ -54,7 +58,8 @@ public final class Estimate
         return new Estimate(value);
     }
 
-    private Estimate(double value)
+    @ThriftConstructor
+    public Estimate(double value)
     {
         this.value = value;
     }
@@ -65,6 +70,7 @@ public final class Estimate
     }
 
     @JsonProperty
+    @ThriftField(1)
     public double getValue()
     {
         return value;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoricalPlanStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoricalPlanStatistics.java
@@ -13,21 +13,28 @@
  */
 package com.facebook.presto.spi.statistics;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 import static java.lang.String.format;
 
-// TODO: Make this class thrift compatible for efficient serialization.
+@ThriftStruct
 public class HistoricalPlanStatistics
 {
     // TODO: Add more data for historical runs, like avg/min/max over last N days/runs
     private final PlanStatistics lastRunStatistics;
 
-    public HistoricalPlanStatistics(PlanStatistics lastRunStatistics)
+    @ThriftConstructor
+    public HistoricalPlanStatistics(@JsonProperty("lastRunStatistics") PlanStatistics lastRunStatistics)
     {
         this.lastRunStatistics = lastRunStatistics;
     }
 
+    @ThriftField(1)
     public PlanStatistics getLastRunStatistics()
     {
         return lastRunStatistics;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
@@ -13,8 +13,15 @@
  */
 package com.facebook.presto.spi.statistics;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class PlanStatistics
 {
     private static final PlanStatistics EMPTY = new PlanStatistics(Estimate.unknown(), Estimate.unknown(), 0);
@@ -29,24 +36,28 @@ public class PlanStatistics
         return EMPTY;
     }
 
+    @ThriftConstructor
     public PlanStatistics(Estimate rowCount, Estimate outputSize, double confidence)
     {
-        this.rowCount = requireNonNull(rowCount, "rowCount can not be null");
-        this.outputSize = requireNonNull(outputSize, "rowCount can not be null");
+        this.rowCount = requireNonNull(rowCount, "rowCount is null");
+        this.outputSize = requireNonNull(outputSize, "outputSize is null");
         checkArgument(confidence >= 0 && confidence <= 1, "confidence should be between 0 and 1");
         this.confidence = confidence;
     }
 
+    @ThriftField(1)
     public Estimate getRowCount()
     {
         return rowCount;
     }
 
+    @ThriftField(2)
     public Estimate getOutputSize()
     {
         return outputSize;
     }
 
+    @ThriftField(3)
     public double getConfidence()
     {
         return confidence;
@@ -57,5 +68,34 @@ public class PlanStatistics
         if (!condition) {
             throw new IllegalArgumentException(message);
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PlanStatistics that = (PlanStatistics) o;
+        return Double.compare(that.confidence, confidence) == 0 && Objects.equals(rowCount, that.rowCount) && Objects.equals(outputSize, that.outputSize);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(rowCount, outputSize, confidence);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PlanStatistics{" +
+                "rowCount=" + rowCount +
+                ", outputSize=" + outputSize +
+                ", confidence=" + confidence +
+                '}';
     }
 }


### PR DESCRIPTION
Commit 1: Depends on https://github.com/prestodb/presto/pull/18340

Found some bugs in HBO which were leading to some optimizations not happening. Fixed them and dded a test which checks that we are able to optimize a query by changing its distribution type to BROADCAST.

Commit 2: Fix NPE in join canonicalization, where we called `accept(source).get()` without checking if optional is present. This happens when plan canonicalization is not implemented for some node.

Commit 3: 

* Fix bug in Memo/IterativeOptimizer, which assigned statsEquivalentPlanNode to GroupReference, which shouldn't happen. FIxed it by assigning to the group member instead
* Fixed HashGenerationOptimizer which was not propogating stats equivalent information when creating a Project node. 
* Added test described above



```
== NO RELEASE NOTE ==
```
