### PR TITLE
Make aggregations order in Planner deterministic

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -95,6 +95,7 @@ import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -346,7 +347,10 @@ public class PlanBuilder
     {
         private final TypeProvider types;
         private PlanNode source;
-        private Map<VariableReferenceExpression, Aggregation> assignments = new HashMap<>();
+        // Preserve order when creating assignments, so it's consistent when printed/iterated. Some
+        // optimizations create variable names by iterating over it, and this will make plan more consistent
+        // in future runs.
+        private Map<VariableReferenceExpression, Aggregation> assignments = new LinkedHashMap<>();
         private AggregationNode.GroupingSetDescriptor groupingSets;
         private List<VariableReferenceExpression> preGroupedVariables = new ArrayList<>();
         private Step step = Step.SINGLE;


### PR DESCRIPTION
Sometimes in planner, order of aggregation variables changes making it difficult to debug. This is because hashCode() of some objects is not defined properly, leading to iteration order dependent on jvm state. Using ImmutableMap.Builder should fix it.

```
== NO RELEASE NOTE ==
```
