### PR TITLE
Fix error logging

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
@@ -86,7 +86,7 @@ public class TestDataWritableWriter
             }
             catch (RuntimeException e) {
                 String errorMessage = "Parquet record is malformed: " + e.getMessage();
-                log.error(errorMessage, e);
+                log.error(e, errorMessage);
                 throw new RuntimeException(errorMessage, e);
             }
             recordConsumer.endMessage();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageBufferClient.java
@@ -408,7 +408,7 @@ public final class PageBufferClient
             {
                 checkNotHoldsLock(this);
 
-                log.error("Request to delete %s failed %s", location, t);
+                log.error(t, "Request to delete %s failed", location);
                 if (!(t instanceof PrestoException) && backoff.failure()) {
                     String message = format("Error closing remote buffer (%s - %s failures, failure duration %s, total failed request time %s)",
                             location,


### PR DESCRIPTION
The log.error() api takes the throwable as the first argument.
This commit tries to fix code which was not using the api correctly.

Test plan - Unit tests

```
== NO RELEASE NOTE ==
```
