### PR TITLE
[Pinot Connector] Upgrade Pinot version to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dep.alluxio.version>2.8.1</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
-        <dep.pinot.version>0.10.0</dep.pinot.version>
+        <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.hudi.version>0.11.0</dep.hudi.version>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -240,6 +240,14 @@
                     <groupId>io.perfmark</groupId>
                     <artifactId>perfmark-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -281,7 +289,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.17.2</version>
+            <version>3.19.2</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -319,6 +327,10 @@
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -641,6 +653,43 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>helix-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>helix-core</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>metadata-store-directory-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>metrics-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>zookeeper-api</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-slf4j-impl</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.slf4j</groupId>
+                                <artifactId>slf4j-jdk14</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.JsonType;
@@ -133,6 +134,8 @@ public class PinotColumnUtils
                 return TimestampType.TIMESTAMP;
             case JSON:
                 return JsonType.JSON;
+            case BIG_DECIMAL:
+                return DecimalType.createDecimalType();
             default:
                 break;
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -25,7 +25,7 @@ import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
+import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.connector.presto.PinotScatterGatherQueryClient;
 import org.apache.pinot.connector.presto.grpc.PinotStreamingQueryClient;
 
@@ -38,8 +38,8 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.apache.pinot.common.utils.grpc.GrpcQueryClient.Config.CONFIG_MAX_INBOUND_MESSAGE_BYTES_SIZE;
-import static org.apache.pinot.common.utils.grpc.GrpcQueryClient.Config.CONFIG_USE_PLAIN_TEXT;
+import static org.apache.pinot.common.config.GrpcConfig.CONFIG_MAX_INBOUND_MESSAGE_BYTES_SIZE;
+import static org.apache.pinot.common.config.GrpcConfig.CONFIG_USE_PLAIN_TEXT;
 
 public class PinotPageSourceProvider
         implements ConnectorPageSourceProvider
@@ -138,7 +138,7 @@ public class PinotPageSourceProvider
     }
 
     @VisibleForTesting
-    static GrpcQueryClient.Config extractGrpcQueryClientConfig(PinotConfig config)
+    static GrpcConfig extractGrpcQueryClientConfig(PinotConfig config)
     {
         Map<String, Object> target = new HashMap<>();
         target.put(CONFIG_USE_PLAIN_TEXT, !config.isUseSecureConnection());
@@ -151,7 +151,7 @@ public class PinotPageSourceProvider
             setOrRemoveProperty(target, "tls.truststore.password", config.getGrpcTlsTrustStorePassword());
             setOrRemoveProperty(target, "tls.truststore.type", config.getGrpcTlsTrustStoreType());
         }
-        return new GrpcQueryClient.Config(target);
+        return new GrpcConfig(target);
     }
     // The method is created because Pinot Config does not like null as value, if value is null, we should
     // remove the key instead.

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotPageSourceProvider.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.pinot;
 
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
+import org.apache.pinot.common.config.GrpcConfig;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.pinot.PinotConfig.DEFAULT_STREAMING_SERVER_GRPC_MAX_INBOUND_MESSAGE_BYTES;
@@ -30,7 +30,7 @@ public class TestPinotPageSourceProvider
     public void testExtractTlsPropertyDefault()
     {
         PinotConfig config = new PinotConfig();
-        GrpcQueryClient.Config extracted = PinotPageSourceProvider.extractGrpcQueryClientConfig(config);
+        GrpcConfig extracted = PinotPageSourceProvider.extractGrpcQueryClientConfig(config);
         assertEquals(extracted.getMaxInboundMessageSizeBytes(), DEFAULT_STREAMING_SERVER_GRPC_MAX_INBOUND_MESSAGE_BYTES);
         assertTrue(extracted.isUsePlainText());
         assertNotNull(extracted.getTlsConfig());
@@ -52,7 +52,7 @@ public class TestPinotPageSourceProvider
                 .setGrpcTlsKeyStoreType("jks-keystore")
                 .setUseSecureConnection(true);
 
-        GrpcQueryClient.Config extracted = PinotPageSourceProvider.extractGrpcQueryClientConfig(config);
+        GrpcConfig extracted = PinotPageSourceProvider.extractGrpcQueryClientConfig(config);
         assertEquals(extracted.getMaxInboundMessageSizeBytes(), DEFAULT_STREAMING_SERVER_GRPC_MAX_INBOUND_MESSAGE_BYTES);
         assertFalse(extracted.isUsePlainText());
         assertNotNull(extracted.getTlsConfig());

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
@@ -33,12 +33,14 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.connector.presto.PinotScatterGatherQueryClient;
 import org.apache.pinot.connector.presto.grpc.Utils;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
+import org.apache.pinot.core.common.datatable.DataTableBuilderV4;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +108,8 @@ public class TestPinotSegmentPageSource
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.TIMESTAMP, true);
             case JSON:
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.JSON, true);
+            case BIG_DECIMAL:
+                return new DimensionFieldSpec(columnName, FieldSpec.DataType.BIG_DECIMAL, true, BigDecimal.ZERO);
             case BOOLEAN_ARRAY:
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.BOOLEAN, false);
             case INT_ARRAY:
@@ -137,13 +141,13 @@ public class TestPinotSegmentPageSource
             }
             DataSchema.ColumnDataType[] columnDataTypes = ALL_TYPES_ARRAY;
             DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
-            DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
+            DataTableBuilder dataTableBuilder = new DataTableBuilderV4(dataSchema);
             for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
                 dataTableBuilder.startRow();
                 for (int colId = 0; colId < numColumns; colId++) {
                     switch (columnDataTypes[colId]) {
                         case BOOLEAN:
-                            dataTableBuilder.setColumn(colId, RANDOM.nextBoolean());
+                            dataTableBuilder.setColumn(colId, String.valueOf(RANDOM.nextBoolean()));
                             break;
                         case INT:
                             dataTableBuilder.setColumn(colId, RANDOM.nextInt());
@@ -227,6 +231,9 @@ public class TestPinotSegmentPageSource
                             catch (DecoderException e) {
                                 throw new RuntimeException(e);
                             }
+                            break;
+                        case BIG_DECIMAL:
+                            dataTableBuilder.setColumn(colId, BigDecimal.ONE);
                             break;
                         default:
                             throw new RuntimeException("Unsupported type - " + columnDataTypes[colId]);
@@ -360,7 +367,7 @@ public class TestPinotSegmentPageSource
         DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
         String[] stringArray = {"stringVal1", "stringVal2"};
         int[] intArray = {10, 34, 67};
-        DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
+        DataTableBuilder dataTableBuilder = new DataTableBuilderV4(dataSchema);
         dataTableBuilder.startRow();
         dataTableBuilder.setColumn(0, intArray);
         dataTableBuilder.setColumn(1, stringArray);

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentStreamingPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentStreamingPageSource.java
@@ -18,9 +18,9 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.testing.assertions.Assert;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.common.utils.DataTable;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
 import org.apache.pinot.common.utils.grpc.GrpcRequestBuilder;
 import org.apache.pinot.connector.presto.grpc.PinotStreamingQueryClient;
 import org.apache.pinot.connector.presto.grpc.Utils;
@@ -42,7 +42,7 @@ public class TestPinotSegmentStreamingPageSource
     {
         private final ImmutableList<DataTable> dataTables;
 
-        MockPinotStreamingQueryClient(GrpcQueryClient.Config pinotConfig, List<DataTable> dataTables)
+        MockPinotStreamingQueryClient(GrpcConfig pinotConfig, List<DataTable> dataTables)
         {
             super(pinotConfig);
             this.dataTables = ImmutableList.copyOf(dataTables);
@@ -88,7 +88,7 @@ public class TestPinotSegmentStreamingPageSource
             PinotSplit mockPinotSplit,
             List<PinotColumnHandle> handlesSurviving)
     {
-        MockPinotStreamingQueryClient mockPinotQueryClient = new MockPinotStreamingQueryClient(new GrpcQueryClient.Config(pinotConfig.getStreamingServerGrpcMaxInboundMessageBytes(), true), dataTables);
+        MockPinotStreamingQueryClient mockPinotQueryClient = new MockPinotStreamingQueryClient(new GrpcConfig(pinotConfig.getStreamingServerGrpcMaxInboundMessageBytes(), true), dataTables);
         return new PinotSegmentStreamingPageSource(session, pinotConfig, mockPinotQueryClient, mockPinotSplit, handlesSurviving);
     }
 

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -91,6 +91,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>3.19.2</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -121,4 +122,75 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-transport</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-buffer</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-transport-classes-epoll</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-transport-classes-kqueue</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-transport-native-unix-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-resolver</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.netty</groupId>
+                                <artifactId>netty-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>helix-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>helix-core</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>metadata-store-directory-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>metrics-common</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.helix</groupId>
+                                <artifactId>zookeeper-api</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-slf4j-impl</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.slf4j</groupId>
+                                <artifactId>slf4j-jdk14</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
```
== RELEASE NOTES ==

Pinot Changes
* Upgrade Pinot release version to 0.11.0
* Support Pinot ``BigDecimal`` type
* Fix Pinot ``BYTES`` type decoding issue
```
