### PR TITLE
Fix more file-not-found issue in presto-main test code

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/geospatial/BenchmarkGeometryToBingTiles.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/BenchmarkGeometryToBingTiles.java
@@ -38,6 +38,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.util.ResourceFileUtils.getResourceFile;
+
 @State(Scope.Thread)
 @Fork(2)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -69,7 +71,7 @@ public class BenchmarkGeometryToBingTiles
         public void setup()
                 throws IOException
         {
-            Path filePath = Paths.get(this.getClass().getClassLoader().getResource("large_polygon.txt").getPath());
+            Path filePath = Paths.get(getResourceFile("large_polygon.txt").getAbsolutePath());
             List<String> lines = Files.readAllLines(filePath);
             String line = lines.get(0);
             String[] parts = line.split("\\|");

--- a/presto-main/src/test/java/com/facebook/presto/geospatial/TestBingTileFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/TestBingTileFunctions.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.geospatial.type.BingTileType.BING_TILE;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static com.facebook.presto.operator.scalar.ApplyFunction.APPLY_FUNCTION;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.util.ResourceFileUtils.getResourceFile;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
@@ -602,7 +603,7 @@ public class TestBingTileFunctions
     public void testLargeGeometryToBingTiles()
             throws Exception
     {
-        Path filePath = Paths.get(this.getClass().getClassLoader().getResource("large_polygon.txt").getPath());
+        Path filePath = Paths.get(getResourceFile("large_polygon.txt").getAbsolutePath());
         List<String> lines = Files.readAllLines(filePath);
         for (String line : lines) {
             String[] parts = line.split("\\|");
@@ -715,7 +716,7 @@ public class TestBingTileFunctions
                 112L);
 
         // Complex input polygon
-        String filePath = this.getClass().getClassLoader().getResource("too_large_polygon.txt").getPath();
+        String filePath = getResourceFile("too_large_polygon.txt").getAbsolutePath();
         String largeWkt = Files.lines(Paths.get(filePath)).findFirst().get();
         assertFunction(
                 "cardinality(geometry_to_bing_tiles(ST_GeometryFromText('" + largeWkt + "'), 16))",

--- a/presto-main/src/test/java/com/facebook/presto/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/TestSphericalGeoFunctions.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.geospatial.SphericalGeoFunctions.toSphericalGeography;
 import static com.facebook.presto.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY;
+import static com.facebook.presto.util.ResourceFileUtils.getResourceFile;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -193,12 +194,12 @@ public class TestSphericalGeoFunctions
         //A Polygon with a large hole
         assertArea("POLYGON((90 0, 0 0, 0 90, 90 0), (89 1, 1 1, 1 89, 89 1))", 348.04E10);
 
-        Path geometryPath = Paths.get(TestSphericalGeoFunctions.class.getClassLoader().getResource("us-states.tsv").getPath());
+        Path geometryPath = Paths.get(getResourceFile("us-states.tsv").getAbsolutePath());
         Map<String, String> stateGeometries = Files.lines(geometryPath)
                 .map(line -> line.split("\t"))
                 .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1]));
 
-        Path areaPath = Paths.get(TestSphericalGeoFunctions.class.getClassLoader().getResource("us-state-areas.tsv").getPath());
+        Path areaPath = Paths.get(getResourceFile("us-state-areas.tsv").getAbsolutePath());
         Map<String, Double> stateAreas = Files.lines(areaPath)
                 .map(line -> line.split("\t"))
                 .filter(parts -> parts.length >= 2)

--- a/presto-main/src/test/java/com/facebook/presto/geospatial/aggregation/TestGeometryConvexHullGeoAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/aggregation/TestGeometryConvexHullGeoAggregation.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.facebook.presto.util.ResourceFileUtils.getResourceFile;
+
 public class TestGeometryConvexHullGeoAggregation
         extends AbstractTestGeoAggregationFunctions
 {
@@ -341,7 +343,7 @@ public class TestGeometryConvexHullGeoAggregation
     public Object[][] points1000()
             throws IOException
     {
-        Path filePath = Paths.get(this.getClass().getClassLoader().getResource("1000_points.txt").getPath());
+        Path filePath = Paths.get(getResourceFile("1000_points.txt").getAbsolutePath());
         List<String> points = Files.readAllLines(filePath);
         return new Object[][] {
                 {

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -31,8 +31,6 @@ import javax.security.auth.kerberos.KerberosPrincipal;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.Set;
 
@@ -43,6 +41,7 @@ import static com.facebook.presto.spi.security.Privilege.SELECT;
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.facebook.presto.util.ResourceFileUtils.getResourceFile;
 import static com.google.common.io.Files.copy;
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -532,25 +531,16 @@ public class TestFileBasedSystemAccessControl
 
         return accessControlManager;
     }
-
-    private File getResourceFile(String resourceName) throws IOException
-    {
-        File resourceFile = newTemporaryFile();
-        resourceFile.deleteOnExit();
-        Files.copy(this.getClass().getClassLoader().getResourceAsStream(resourceName), resourceFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-
-        return resourceFile;
-    }
-
     @Test
-    public void parseUnknownRules()
+    public void parseUnknownRules() throws IOException
     {
-        assertThatThrownBy(() -> parse("src/test/resources/security-config-file-with-unknown-rules.json"))
+        assertThatThrownBy(() -> parse("security-config-file-with-unknown-rules.json"))
                 .hasMessageContaining("Invalid JSON");
     }
 
     private SystemAccessControl parse(String path)
+            throws IOException
     {
-        return new FileBasedSystemAccessControl.Factory().create(ImmutableMap.of(SECURITY_CONFIG_FILE, path));
+        return new FileBasedSystemAccessControl.Factory().create(ImmutableMap.of(SECURITY_CONFIG_FILE, getResourceFile(path).getPath()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/util/ResourceFileUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/ResourceFileUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static org.assertj.core.util.Files.newTemporaryFile;
+
+public final class ResourceFileUtils
+{
+    private ResourceFileUtils() {}
+
+    // This utility method will try to load the resource using a class loader
+    // then copy its content to a temporary file for consumptions by test code
+    // This is useful because some test runner (buck test to be specific) run
+    // all tests out of a jar file. In that case, any attempts trying to read
+    // resource file from file system would fail. You need to load file using
+    // a class loader instead. This method bridges the gap for developers to
+    // read resources from jars as a usual file.
+    public static File getResourceFile(String resourceName)
+            throws IOException
+    {
+        File resourceFile = newTemporaryFile();
+        resourceFile.deleteOnExit();
+        Files.copy(ResourceFileUtils.class.getClassLoader().getResourceAsStream(resourceName), resourceFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        return resourceFile;
+    }
+}


### PR DESCRIPTION
After https://github.com/prestodb/presto/pull/18314 was merged, I found more places in presto-main test code that are reading directly from file system. This PR fix them all. Also extract method getResourceFile() for better code reuse.

Test plan - (Please fill in how you tested your changes)

Make sure all CI runs are green



```
== NO RELEASE NOTE ==
```
