### PR TITLE
Rename kAnti to kNullAwareAnti

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1047,7 +1047,7 @@ VeloxQueryPlanConverter::toVeloxQueryPlan(
       joinType = JoinType::kLeftSemi;
     } else if (auto notCall = isNot(node->predicate)) {
       if (equal(notCall->arguments[0], semiJoin->semiJoinOutput)) {
-        joinType = JoinType::kAnti;
+        joinType = JoinType::kNullAwareAnti;
       }
     }
 


### PR DESCRIPTION
Summary:
This is the first step to add regular anti join.  Rename the join type
name to better reflect the properties of the join.

Differential Revision: D39514817

