### PR TITLE
Add to support configure spill executor plus task level test

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -330,6 +330,9 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
       opOut.peakTotalMemoryReservation = protocol::DataSize(
           op.memoryStats.peakTotalMemoryReservation, protocol::DataUnit::BYTE);
 
+      opOut.spilledDataSize =
+          protocol::DataSize(op.spilledBytes, protocol::DataUnit::BYTE);
+
       for (const auto& stat : op.runtimeStats) {
         auto statName =
             fmt::format("{}.{}.{}", op.operatorType, op.planNodeId, stat.first);

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -81,6 +81,11 @@ int32_t SystemConfig::numIoThreads() const {
   return opt.hasValue() ? opt.value() : kNumIoThreadsDefault;
 }
 
+int32_t SystemConfig::numSpillThreads() const {
+  auto opt = optionalProperty<int32_t>(std::string(kNumSpillThreads));
+  return opt.hasValue() ? opt.value() : std::thread::hardware_concurrency();
+}
+
 int32_t SystemConfig::shutdownOnsetSec() const {
   auto opt = optionalProperty<int32_t>(std::string(kShutdownOnsetSec));
   return opt.hasValue() ? opt.value() : kShutdownOnsetSecDefault;

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -83,6 +83,7 @@ class SystemConfig : public ConfigBase {
       "task.concurrent-lifespans-per-task"};
   static constexpr std::string_view kHttpExecThreads{"http_exec_threads"};
   static constexpr std::string_view kNumIoThreads{"num-io-threads"};
+  static constexpr std::string_view kNumSpillThreads{"num-spill-threads"};
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
   static constexpr std::string_view kSystemMemoryGb{"system-memory-gb"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
@@ -122,6 +123,8 @@ class SystemConfig : public ConfigBase {
   int32_t httpExecThreads() const;
 
   int32_t numIoThreads() const;
+
+  int32_t numSpillThreads() const;
 
   int32_t shutdownOnsetSec() const;
 


### PR DESCRIPTION
Support to configure spill executor in velox from task manager
Add to collect spill runtime stats (converted from op stats)
Add test method to allow configure velox query config from presto task
Add aggregation spill task at presto task level


```
== NO RELEASE NOTE ==
```
