### PR TITLE
[native] Fix connector creation when cache is enabled

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -454,7 +454,7 @@ std::shared_ptr<velox::connector::Connector> PrestoServer::connectorWithCache(
   LOG(INFO) << "STARTUP: Using AsyncDataCache";
   return facebook::velox::connector::getConnectorFactory(connectorName)
       ->newConnector(
-          connectorName, std::move(properties), connectorIoExecutor_.get());
+          catalogName, std::move(properties), connectorIoExecutor_.get());
 }
 
 void PrestoServer::populateMemAndCPUInfo() {

--- a/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
@@ -170,13 +170,18 @@ public class HiveExternalWorkerQueryRunner
                         if (cacheMaxSize > 0) {
                             Files.write(catalogDirectoryPath.resolve("hive.properties"),
                                     format("connector.name=hive%n" +
-                                            "cache.enabled=true%n" +
-                                            "cache.max-cache-size=%s", cacheMaxSize).getBytes());
+                                           "cache.enabled=true%n" +
+                                           "cache.max-cache-size=%s", cacheMaxSize).getBytes());
                         }
                         else {
                             Files.write(catalogDirectoryPath.resolve("hive.properties"),
                                     format("connector.name=hive").getBytes());
                         }
+                        // Add a hive catalog with caching always enabled.
+                        Files.write(catalogDirectoryPath.resolve("hivecached.properties"),
+                                format("connector.name=hive%n" +
+                                        "cache.enabled=true%n" +
+                                        "cache.max-cache-size=32").getBytes());
 
                         // Disable stack trace capturing as some queries (using TRY) generate a lot of exceptions.
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")


### PR DESCRIPTION
The connector creation when the cache is enabled now correctly uses the
 catalog name instead of the connector name.

Test plan - (Please fill in how you tested your changes)
Added a testCatalog in TestHiveQueries.
This test uses a catalog `hivecached` with cache enabled.
Without this fix, this test fails.
```
== NO RELEASE NOTE ==
```
