### PR TITLE
Fix one more JsonCreator issue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -52,7 +52,7 @@ public class WindowNode
 
     @JsonCreator
     public WindowNode(
-            Optional<SourceLocation> sourceLocation,
+            @JsonProperty("sourceLocation") Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("specification") Specification specification,


### PR DESCRIPTION
As stated in https://github.com/prestodb/presto/pull/18246, “Constructor/factory method
where every argument is annotated with either JsonProperty or JacksonInject, to
indicate name of property to bind to”.  
Add @JsonProperty to class WindowNode to make the code work in buck test.

Test plan - (Please fill in how you tested your changes)
Github action workflows

```
== NO RELEASE NOTE ==
```
