### PR TITLE
Add PrestoSparkHttpWorkerClient support and RemoteHttpResultFetcher

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -92,6 +92,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskResultFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskResultFetcher.java
@@ -22,15 +22,16 @@ import com.facebook.presto.spi.page.SerializedPage;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.SERIALIZED_PAGE_CHECKSUM_ERROR;
@@ -38,16 +39,29 @@ import static com.facebook.presto.spi.page.PagesSerdeUtil.isChecksumValid;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class HttpNativeExecutionTaskResultFetcher {
-    private static final Duration FETCH_INTERVAL = new Duration(
-            200,
-            TimeUnit.MILLISECONDS);
+/**
+ * This class helps to fetch results for a native task through HTTP communications with a Presto worker. The object of this class will give back a CompletableFuture to the caller
+ * upon start(). This future will be completed when retrievals of results by the fetcher is completed. Results are retrieved and stored in an internal buffer, which is supposed to
+ * be polled by the caller. Note that the completion of the future does not mean all results have been consumed by the caller. The caller is responsible for making sure all results
+ * be consumed after future completion.
+ * There is a capacity cap (MAX_BUFFER_SIZE) for internal buffer managed by HttpNativeExecutionTaskResultFetcher. The fetcher will stop fetching results when buffer limit is hit
+ * and resume fetching after some of the buffer has been consumed and buffer size comes down below the limit.
+ * <p>
+ * The fetcher specifically serves to fetch table write commit metadata results from Presto worker so currently no shuffle result fetching is supported.
+ */
+public class HttpNativeExecutionTaskResultFetcher
+{
+    private static final Duration FETCH_INTERVAL = new Duration(200, TimeUnit.MILLISECONDS);
+    private static final Duration POLL_TIMEOUT = new Duration(100, TimeUnit.MILLISECONDS);
+    private static final DataSize MAX_BUFFER_SIZE = new DataSize(128, DataSize.Unit.MEGABYTE);
 
     private final ScheduledExecutorService scheduler;
     private final PrestoSparkHttpWorkerClient workerClient;
     // Timeout for each fetching request
     private final Duration requestTimeout;
     private final TaskId taskId;
+    private final LinkedBlockingDeque<SerializedPage> pageBuffer = new LinkedBlockingDeque<>();
+    private final AtomicLong bufferMemoryBytes;
 
     private ScheduledFuture<?> schedulerFuture;
     private boolean started;
@@ -56,97 +70,134 @@ public class HttpNativeExecutionTaskResultFetcher {
      * The instance of this class helps to fetch results from remote Presto
      * worker. When start() is called, the fetcher polls the remote result
      * endpoint in a fixed interval until all results fetched or exceptions
-     * occur. A CompletableFuture is returned for optional async handling.
-     * Exceptions will be wrapped inside of the CompletableFuture in case any
-     * occur.
+     * occur. A CompletableFuture is returned for result retrieving completion
+     * signalling. Callers are responsible to call pollPage() constantly to get
+     * retrieved pages. Exceptions will be wrapped inside of the
+     * CompletableFuture in case any occur.
      */
     public HttpNativeExecutionTaskResultFetcher(
             ScheduledExecutorService scheduler,
             PrestoSparkHttpWorkerClient workerClient,
             TaskId taskId,
-            Duration requestTimeout) {
+            Duration requestTimeout)
+    {
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.requestTimeout = requireNonNull(requestTimeout, "requestTimeout is null");
+        this.bufferMemoryBytes = new AtomicLong();
     }
 
-    public CompletableFuture<List<SerializedPage>> start() {
+    public CompletableFuture<Void> start()
+    {
         if (started) {
             throw new PrestoException(
                     GENERIC_INTERNAL_ERROR,
                     "trying to start an already started TaskResultFetcher for '" + taskId + "'");
         }
-        CompletableFuture<List<SerializedPage>> future = new CompletableFuture<>();
+        CompletableFuture<Void> future = new CompletableFuture<>();
         schedulerFuture = scheduler.scheduleAtFixedRate(
                 new HttpNativeExecutionTaskResultFetcherRunner(
                         workerClient,
                         taskId,
                         future,
-                        requestTimeout),
+                        pageBuffer,
+                        requestTimeout,
+                        bufferMemoryBytes),
                 0,
                 (long) FETCH_INTERVAL.getValue(),
                 FETCH_INTERVAL.getUnit());
         started = true;
         return future.handle(
-                (List<SerializedPage> pages, Throwable throwable) -> {
+                (Void result, Throwable throwable) ->
+                {
                     schedulerFuture.cancel(false);
                     if (throwable != null) {
                         throw new CompletionException(throwable.getCause());
                     }
-                    return pages;
+                    return result;
                 });
     }
 
+    /**
+     * Blocking call to poll from result buffer. Blocks until content becomes
+     * available in the buffer, or until timeout is hit.
+     *
+     * @return the first SerializedPage result buffer contains.
+     */
+    public SerializedPage pollPage()
+            throws InterruptedException
+    {
+        SerializedPage page = pageBuffer.poll((long) POLL_TIMEOUT.getValue(), POLL_TIMEOUT.getUnit());
+        if (page != null) {
+            bufferMemoryBytes.addAndGet(-page.getSizeInBytes());
+        }
+        return page;
+    }
+
     private static class HttpNativeExecutionTaskResultFetcherRunner
-            implements Runnable {
-        private static final DataSize MAX_RESPONSE_SIZE = new DataSize(32,
-                DataSize.Unit.MEGABYTE);
+            implements Runnable
+    {
+        private static final DataSize MAX_RESPONSE_SIZE = new DataSize(32, DataSize.Unit.MEGABYTE);
         private static final int MAX_HTTP_TIMEOUT_RETRIES = 3;
 
         private final Duration requestTimeout;
         private final TaskId taskId;
         private final PrestoSparkHttpWorkerClient client;
+        private final LinkedBlockingDeque<SerializedPage> pageBuffer;
+        private final AtomicLong bufferMemoryBytes;
+        private final CompletableFuture<Void> future;
 
         private int timeoutRetries;
         private long token;
-        private CompletableFuture<List<SerializedPage>> future;
-        private List<SerializedPage> serializedPages;
 
         public HttpNativeExecutionTaskResultFetcherRunner(
-                PrestoSparkHttpWorkerClient client, TaskId taskId,
-                CompletableFuture<List<SerializedPage>> future,
-                Duration requestTimeout) {
+                PrestoSparkHttpWorkerClient client,
+                TaskId taskId,
+                CompletableFuture<Void> future,
+                LinkedBlockingDeque<SerializedPage> pageBuffer,
+                Duration requestTimeout,
+                AtomicLong bufferMemoryBytes)
+        {
             this.timeoutRetries = 0;
             this.token = 0;
             this.taskId = requireNonNull(taskId, "taskId is null");
             this.client = requireNonNull(client, "client is null");
             this.future = requireNonNull(future, "future is null");
-            this.serializedPages = new ArrayList<>();
-            this.requestTimeout = requireNonNull(requestTimeout,
+            this.pageBuffer = requireNonNull(pageBuffer, "pageBuffer is null");
+            this.requestTimeout = requireNonNull(
+                    requestTimeout,
                     "requestTimeout is null");
+            this.bufferMemoryBytes = requireNonNull(
+                    bufferMemoryBytes,
+                    "bufferMemoryBytes is null");
         }
 
         @Override
-        public void run() {
+        public void run()
+        {
             try {
+                if (bufferMemoryBytes.longValue() >= MAX_BUFFER_SIZE.toBytes()) {
+                    return;
+                }
                 PageBufferClient.PagesResponse pagesResponse = client.getResults(
                         token,
                         MAX_RESPONSE_SIZE)
-                        .get((long) requestTimeout.getValue(),
-                                requestTimeout.getUnit());
+                        .get((long) requestTimeout.getValue(), requestTimeout.getUnit());
 
                 List<SerializedPage> pages = pagesResponse.getPages();
+                long bytes = 0;
                 for (SerializedPage page : pages) {
                     if (!isChecksumValid(page)) {
                         throw new PrestoException(
                                 SERIALIZED_PAGE_CHECKSUM_ERROR,
                                 format("Received corrupted serialized page from host %s",
-                                        HostAddress.fromUri(
-                                                client.getLocation())));
+                                        HostAddress.fromUri(client.getLocation())));
                     }
+                    bytes += page.getSizeInBytes();
                 }
-                serializedPages.addAll(pages);
+                pageBuffer.addAll(pages);
+                bufferMemoryBytes.addAndGet(bytes);
                 long nextToken = pagesResponse.getNextToken();
                 if (pages.size() > 0) {
                     client.acknowledgeResultsAsync(nextToken);
@@ -154,18 +205,21 @@ public class HttpNativeExecutionTaskResultFetcher {
                 this.token = nextToken;
                 if (pagesResponse.isClientComplete()) {
                     client.abortResults();
-                    future.complete(serializedPages);
+                    future.complete(null);
                 }
-            } catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 if (!future.isDone()) {
                     // This should never happen, but as a sanity check we set exception to future.
                     client.abortResults();
                     future.completeExceptionally(e);
                 }
-            } catch (ExecutionException | PrestoException e) {
+            }
+            catch (ExecutionException | PrestoException e) {
                 client.abortResults();
                 future.completeExceptionally(e);
-            } catch (TimeoutException e) {
+            }
+            catch (TimeoutException e) {
                 if (++timeoutRetries >= MAX_HTTP_TIMEOUT_RETRIES) {
                     client.abortResults();
                     future.completeExceptionally(e);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskResultFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskResultFetcher.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.operator.PageBufferClient;
+import com.facebook.presto.spark.execution.http.PrestoSparkHttpWorkerClient;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.page.SerializedPage;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.SERIALIZED_PAGE_CHECKSUM_ERROR;
+import static com.facebook.presto.spi.page.PagesSerdeUtil.isChecksumValid;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class HttpNativeExecutionTaskResultFetcher {
+    private static final Duration FETCH_INTERVAL = new Duration(
+            200,
+            TimeUnit.MILLISECONDS);
+
+    private final ScheduledExecutorService scheduler;
+    private final PrestoSparkHttpWorkerClient workerClient;
+    // Timeout for each fetching request
+    private final Duration requestTimeout;
+    private final TaskId taskId;
+
+    private ScheduledFuture<?> schedulerFuture;
+    private boolean started;
+
+    /**
+     * The instance of this class helps to fetch results from remote Presto
+     * worker. When start() is called, the fetcher polls the remote result
+     * endpoint in a fixed interval until all results fetched or exceptions
+     * occur. A CompletableFuture is returned for optional async handling.
+     * Exceptions will be wrapped inside of the CompletableFuture in case any
+     * occur.
+     */
+    public HttpNativeExecutionTaskResultFetcher(
+            ScheduledExecutorService scheduler,
+            PrestoSparkHttpWorkerClient workerClient,
+            TaskId taskId,
+            Duration requestTimeout) {
+        this.scheduler = requireNonNull(scheduler, "scheduler is null");
+        this.workerClient = requireNonNull(workerClient, "workerClient is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.requestTimeout = requireNonNull(requestTimeout, "requestTimeout is null");
+    }
+
+    public CompletableFuture<List<SerializedPage>> start() {
+        if (started) {
+            throw new PrestoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "trying to start an already started TaskResultFetcher for '" + taskId + "'");
+        }
+        CompletableFuture<List<SerializedPage>> future = new CompletableFuture<>();
+        schedulerFuture = scheduler.scheduleAtFixedRate(
+                new HttpNativeExecutionTaskResultFetcherRunner(
+                        workerClient,
+                        taskId,
+                        future,
+                        requestTimeout),
+                0,
+                (long) FETCH_INTERVAL.getValue(),
+                FETCH_INTERVAL.getUnit());
+        started = true;
+        return future.handle(
+                (List<SerializedPage> pages, Throwable throwable) -> {
+                    schedulerFuture.cancel(false);
+                    if (throwable != null) {
+                        throw new CompletionException(throwable.getCause());
+                    }
+                    return pages;
+                });
+    }
+
+    private static class HttpNativeExecutionTaskResultFetcherRunner
+            implements Runnable {
+        private static final DataSize MAX_RESPONSE_SIZE = new DataSize(32,
+                DataSize.Unit.MEGABYTE);
+        private static final int MAX_HTTP_TIMEOUT_RETRIES = 3;
+
+        private final Duration requestTimeout;
+        private final TaskId taskId;
+        private final PrestoSparkHttpWorkerClient client;
+
+        private int timeoutRetries;
+        private long token;
+        private CompletableFuture<List<SerializedPage>> future;
+        private List<SerializedPage> serializedPages;
+
+        public HttpNativeExecutionTaskResultFetcherRunner(
+                PrestoSparkHttpWorkerClient client, TaskId taskId,
+                CompletableFuture<List<SerializedPage>> future,
+                Duration requestTimeout) {
+            this.timeoutRetries = 0;
+            this.token = 0;
+            this.taskId = requireNonNull(taskId, "taskId is null");
+            this.client = requireNonNull(client, "client is null");
+            this.future = requireNonNull(future, "future is null");
+            this.serializedPages = new ArrayList<>();
+            this.requestTimeout = requireNonNull(requestTimeout,
+                    "requestTimeout is null");
+        }
+
+        @Override
+        public void run() {
+            try {
+                PageBufferClient.PagesResponse pagesResponse = client.getResults(
+                        token,
+                        MAX_RESPONSE_SIZE)
+                        .get((long) requestTimeout.getValue(),
+                                requestTimeout.getUnit());
+
+                List<SerializedPage> pages = pagesResponse.getPages();
+                for (SerializedPage page : pages) {
+                    if (!isChecksumValid(page)) {
+                        throw new PrestoException(
+                                SERIALIZED_PAGE_CHECKSUM_ERROR,
+                                format("Received corrupted serialized page from host %s",
+                                        HostAddress.fromUri(
+                                                client.getLocation())));
+                    }
+                }
+                serializedPages.addAll(pages);
+                long nextToken = pagesResponse.getNextToken();
+                if (pages.size() > 0) {
+                    client.acknowledgeResultsAsync(nextToken);
+                }
+                this.token = nextToken;
+                if (pagesResponse.isClientComplete()) {
+                    client.abortResults();
+                    future.complete(serializedPages);
+                }
+            } catch (InterruptedException e) {
+                if (!future.isDone()) {
+                    // This should never happen, but as a sanity check we set exception to future.
+                    client.abortResults();
+                    future.completeExceptionally(e);
+                }
+            } catch (ExecutionException | PrestoException e) {
+                client.abortResults();
+                future.completeExceptionally(e);
+            } catch (TimeoutException e) {
+                if (++timeoutRetries >= MAX_HTTP_TIMEOUT_RETRIES) {
+                    client.abortResults();
+                    future.completeExceptionally(e);
+                }
+            }
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpWorkerClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpWorkerClient.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.http;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.operator.HttpRpcShuffleClient;
+import com.facebook.presto.operator.PageBufferClient;
+import com.facebook.presto.operator.RpcShuffleClient;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+
+import static com.facebook.airlift.http.client.HttpStatus.familyForStatusCode;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_SIZE;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class PrestoSparkHttpWorkerClient
+        implements RpcShuffleClient {
+    private static final Logger log = Logger.get(PrestoSparkHttpWorkerClient.class);
+
+    private final HttpClient httpClient;
+    private final URI location;
+    private final TaskId taskId;
+
+    public PrestoSparkHttpWorkerClient(HttpClient httpClient, TaskId taskId, URI location) {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.location = requireNonNull(location, "location is null");
+    }
+
+    @Override
+    public ListenableFuture<PageBufferClient.PagesResponse> getResults(
+            long token,
+            DataSize maxResponseSize) {
+        URI uri = uriBuilderFrom(location)
+                .appendPath(taskId.toString())
+                .appendPath("/results/0")
+                .appendPath(String.valueOf(token))
+                .build();
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setHeader(PRESTO_MAX_SIZE, maxResponseSize.toString())
+                        .setUri(uri)
+                        .build(),
+                new HttpRpcShuffleClient.PageResponseHandler());
+    }
+
+    @Override
+    public void acknowledgeResultsAsync(long nextToken) {
+        URI uri = uriBuilderFrom(location)
+                .appendPath(taskId.toString())
+                .appendPath("/results/0")
+                .appendPath(String.valueOf(nextToken))
+                .appendPath("acknowledge")
+                .build();
+        httpClient.executeAsync(
+                prepareGet().setUri(uri).build(),
+                new ResponseHandler<Void, RuntimeException>() {
+                    @Override
+                    public Void handleException(Request request,
+                                                Exception exception) {
+                        log.debug(exception, "Acknowledge request failed: %s",
+                                uri);
+                        return null;
+                    }
+
+                    @Override
+                    public Void handle(Request request, Response response) {
+                        if (familyForStatusCode(
+                                response.getStatusCode()) != HttpStatus.Family.SUCCESSFUL) {
+                            log.debug(
+                                    "Unexpected acknowledge response code: %s",
+                                    response.getStatusCode());
+                        }
+                        return null;
+                    }
+                });
+    }
+
+    @Override
+    public ListenableFuture<?> abortResults() {
+        URI uri = uriBuilderFrom(location)
+                .appendPath(taskId.toString())
+                .build();
+        return httpClient.executeAsync(
+                prepareDelete().setUri(uri).build(),
+                createStatusResponseHandler());
+    }
+
+    @Override
+    public Throwable rewriteException(Throwable throwable) {
+        return null;
+    }
+
+    public URI getLocation() {
+        return location;
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpWorkerClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpWorkerClient.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.http;
+
+import com.facebook.airlift.http.client.HeaderName;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.RequestStats;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.operator.PageBufferClient;
+import com.facebook.presto.spi.page.PageCodecMarker;
+import com.facebook.presto.spi.page.PagesSerdeUtil;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilder;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.presto.PrestoMediaTypes.PRESTO_PAGES_TYPE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_TASK_INSTANCE_ID;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestPrestoSparkHttpWorkerClient
+{
+    private static final String TASK_ROOT_PATH = "/v1/task";
+    private static final URI BASE_URI = uriBuilder()
+            .scheme("http")
+            .host("localhost")
+            .port(8080)
+            .build();
+
+    @Test
+    public void testResultGet()
+    {
+        TaskId taskId = new TaskId(
+                "testid",
+                0,
+                0,
+                0);
+        URI uri = uriBuilderFrom(BASE_URI).appendPath(TASK_ROOT_PATH).build();
+        PrestoSparkHttpWorkerClient workerClient = new PrestoSparkHttpWorkerClient(new MockHttpClient(), taskId, uri);
+        ListenableFuture<PageBufferClient.PagesResponse> future = workerClient.getResults(0, new DataSize(32, DataSize.Unit.MEGABYTE));
+        try {
+            PageBufferClient.PagesResponse page = future.get();
+            assertEquals(0, page.getToken());
+            assertEquals(true, page.isClientComplete());
+            assertEquals(taskId.toString(), page.getTaskInstanceId());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testResultAcknowledge()
+    {
+        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        URI uri = uriBuilderFrom(BASE_URI).appendPath(TASK_ROOT_PATH).build();
+        PrestoSparkHttpWorkerClient workerClient = new PrestoSparkHttpWorkerClient(
+                new MockHttpClient(),
+                taskId,
+                uri);
+        workerClient.acknowledgeResultsAsync(1);
+    }
+
+    @Test
+    public void testResultAbort()
+    {
+        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        URI uri = uriBuilderFrom(BASE_URI).appendPath(TASK_ROOT_PATH).build();
+        PrestoSparkHttpWorkerClient workerClient = new PrestoSparkHttpWorkerClient(new MockHttpClient(), taskId, uri);
+        ListenableFuture<?> future = workerClient.abortResults();
+        try {
+            future.get();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    public static class MockImmediateHttpResponseFuture<T>
+            implements HttpClient.HttpResponseFuture<T>
+    {
+        private T result;
+        private Throwable e;
+
+        public MockImmediateHttpResponseFuture(T result)
+        {
+            this.result = result;
+        }
+
+        public MockImmediateHttpResponseFuture(Throwable e)
+        {
+            this.e = e;
+        }
+
+        @Override
+        public String getState()
+        {
+            return null;
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor)
+        {}
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isDone()
+        {
+            return true;
+        }
+
+        @Override
+        public T get()
+                throws ExecutionException
+        {
+            if (e == null) {
+                return result;
+            }
+            throw new ExecutionException(e);
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit)
+                throws ExecutionException
+        {
+            return get();
+        }
+    }
+
+    public static class MockHttpClient
+            implements com.facebook.airlift.http.client.HttpClient
+    {
+
+        @Override
+        public <T, E extends Exception> T execute(Request request,
+                ResponseHandler<T, E> responseHandler)
+                throws E
+        {
+            try {
+                return executeAsync(request, responseHandler).get();
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+
+        @Override
+        public <T, E extends Exception> HttpResponseFuture<T> executeAsync(
+                Request request, ResponseHandler<T, E> responseHandler)
+        {
+            URI uri = request.getUri();
+            String method = request.getMethod();
+            ListMultimap<String, String> headers = request.getHeaders();
+            String path = uri.getPath();
+            String taskId = getTaskId(uri);
+            if (method.equalsIgnoreCase("GET")) {
+                if (path.contains("/results")) {
+
+                    // GET /v1/task/{taskId}/results/{bufferId}/{token}/acknowledge
+                    if (path.contains("acknowledge")) {
+                        try {
+                            responseHandler.handle(
+                                    request,
+                                    MockResponse.createDummyResultResponse());
+                            return new MockImmediateHttpResponseFuture<>(
+                                    responseHandler.handle(
+                                            request,
+                                            MockResponse.createDummyResultResponse()));
+                        }
+                        catch (Exception e) {
+                            e.printStackTrace();
+                            return new MockImmediateHttpResponseFuture<>(e);
+                        }
+                    }
+
+                    // GET /v1/task/{taskId}/results/{bufferId}/{token}
+                    else {
+                        try {
+                            return new MockImmediateHttpResponseFuture<>(
+                                    responseHandler.handle(
+                                            request,
+                                            MockResponse.createResultResponse(
+                                                    HttpStatus.OK,
+                                                    taskId,
+                                                    0,
+                                                    1,
+                                                    true)));
+                        }
+                        catch (Exception e) {
+                            e.printStackTrace();
+                            return new MockImmediateHttpResponseFuture<>(e);
+                        }
+                    }
+                }
+            }
+            else if (method.equalsIgnoreCase("DELETE")) {
+
+                // DELETE /v1/task/{taskId}
+                try {
+                    return new MockImmediateHttpResponseFuture<>(
+                            responseHandler.handle(
+                                    request,
+                                    MockResponse.createDummyResultResponse()));
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                    return new MockImmediateHttpResponseFuture<>(e);
+                }
+            }
+            return new MockImmediateHttpResponseFuture<>(
+                    new Exception("Unknown path " + path));
+        }
+
+        @Override
+        public RequestStats getStats()
+        {
+            return null;
+        }
+
+        @Override
+        public long getMaxContentLength()
+        {
+            return 0;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean isClosed()
+        {
+            return false;
+        }
+
+        private String getTaskId(URI uri)
+        {
+            String fromTaskId = uri.getPath().substring(
+                    TASK_ROOT_PATH.length() + 1);
+            int endPos = fromTaskId.indexOf("/");
+            if (endPos < 0) {
+                return fromTaskId;
+            }
+            return fromTaskId.substring(0, endPos);
+        }
+    }
+
+    public static class MockResponse
+            implements Response
+    {
+        private final int statusCode;
+        private final String statusMessage;
+        private ListMultimap<HeaderName, String> headers;
+        private InputStream inputStream;
+
+        private MockResponse()
+        {
+            this.statusCode = HttpStatus.OK.code();
+            this.statusMessage = HttpStatus.OK.toString();
+            this.headers = ArrayListMultimap.create();
+        }
+
+        private MockResponse(int statusCode, String statusMessage,
+                ListMultimap<HeaderName, String> headers,
+                InputStream inputStream)
+        {
+            this.statusCode = statusCode;
+            this.statusMessage = statusMessage;
+            this.headers = headers;
+            this.inputStream = inputStream;
+        }
+
+        public static Response createDummyResultResponse()
+        {
+            return new MockResponse();
+        }
+
+        public static Response createResultResponse(
+                HttpStatus httpStatus,
+                String taskId,
+                long token,
+                long nextToken,
+                boolean bufferComplete)
+        {
+            DynamicSliceOutput slicedOutput = new DynamicSliceOutput(1024);
+            SerializedPage serializedPage = new SerializedPage(
+                    EMPTY_SLICE,
+                    PageCodecMarker.none(),
+                    0,
+                    0,
+                    0);
+            PagesSerdeUtil.writeSerializedPage(slicedOutput, serializedPage);
+            ListMultimap<HeaderName, String> headers = ArrayListMultimap.create();
+            headers.put(HeaderName.of(PRESTO_PAGE_TOKEN),
+                    String.valueOf(token));
+            headers.put(HeaderName.of(PRESTO_PAGE_NEXT_TOKEN),
+                    String.valueOf(nextToken));
+            headers.put(HeaderName.of(PRESTO_BUFFER_COMPLETE),
+                    String.valueOf(bufferComplete));
+            headers.put(HeaderName.of(PRESTO_TASK_INSTANCE_ID), taskId);
+            headers.put(HeaderName.of(CONTENT_TYPE),
+                    PRESTO_PAGES_TYPE.toString());
+            return new MockResponse(
+                    httpStatus.code(),
+                    httpStatus.toString(),
+                    headers,
+                    slicedOutput.slice().getInput());
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return statusCode;
+        }
+
+        @Override
+        public String getStatusMessage()
+        {
+            return statusMessage;
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return headers;
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return 0;
+        }
+
+        @Override
+        public InputStream getInputStream()
+                throws IOException
+        {
+            return inputStream;
+        }
+    }
+}


### PR DESCRIPTION
Add component for the use case of Batch Velox. The added components include:
* Prestissimo worker http client wrapper as a single worker communication endpoint.
* Prestissimo worker task result fetcher.

Tests
* TestPrestoSparkHttpWorkerClient - Added mock classes to test result endpoints

```
== NO RELEASE NOTE ==
```
