### PR TITLE
Add TypeKind to Type

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
@@ -233,4 +233,10 @@ public class ArrayType
     {
         return ARRAY + "(" + elementType.getDisplayName() + ")";
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.ARRAY;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BigintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BigintType.java
@@ -50,4 +50,10 @@ public final class BigintType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.BIGINT;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
@@ -172,4 +172,10 @@ public final class BooleanType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.BOOLEAN;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DateType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DateType.java
@@ -59,4 +59,10 @@ public final class DateType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.DATE;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -157,4 +157,10 @@ public final class DoubleType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.DOUBLE;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerType.java
@@ -66,4 +66,10 @@ public final class IntegerType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.INTEGER;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/JsonType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/JsonType.java
@@ -96,4 +96,10 @@ public class JsonType
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.JSON;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongDecimalType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongDecimalType.java
@@ -142,4 +142,10 @@ final class LongDecimalType
                 block.getLong(position, 0),
                 block.getLong(position, SIZE_OF_LONG));
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.LONG_DECIMAL;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
@@ -271,6 +271,12 @@ public class MapType
         return "map(" + keyType.getDisplayName() + ", " + valueType.getDisplayName() + ")";
     }
 
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.MAP;
+    }
+
     public Block createBlockFromKeyValue(int positionCount, Optional<boolean[]> mapIsNull, int[] offsets, Block keyBlock, Block valueBlock)
     {
         return MapBlock.fromKeyValueBlock(

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
@@ -94,4 +94,10 @@ public final class RealType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.REAL;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
@@ -291,6 +291,12 @@ public class RowType
         return result;
     }
 
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.ROW;
+    }
+
     private static void checkElementNotNull(boolean isNull)
     {
         if (isNull) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ShortDecimalType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ShortDecimalType.java
@@ -128,4 +128,10 @@ final class ShortDecimalType
     {
         blockBuilder.writeLong(value).closeEntry();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.SHORT_DECIMAL;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
@@ -165,6 +165,12 @@ public final class SmallintType
         return getClass().hashCode();
     }
 
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.SMALLINT;
+    }
+
     public static long hash(short value)
     {
         // xxhash64 mix

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeType.java
@@ -59,4 +59,10 @@ public final class TimeType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.TIME;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -77,6 +77,12 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.TIMESTAMP;
+    }
+
     private static String getType(TimeUnit precision)
     {
         if (precision == MICROSECONDS) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
@@ -164,6 +164,12 @@ public final class TinyintType
         return getClass().hashCode();
     }
 
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.TINYINT;
+    }
+
     public static long hash(byte value)
     {
         // xxhash64 mix

--- a/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
@@ -56,6 +56,15 @@ public interface Type
     Class<?> getJavaType();
 
     /**
+     * Gets the type kind of this type. It's defined for a sub-set of standard types,
+     * for the rest of the types the {@code TypeKind.OTHER} will be returned.
+     */
+    default TypeKind getKind()
+    {
+        return TypeKind.OTHER;
+    }
+
+    /**
      * For parameterized types returns the list of parameters.
      */
     List<Type> getTypeParameters();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeKind.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeKind.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+public enum TypeKind
+{
+    // primitive types
+    BOOLEAN,
+    TINYINT, // byte
+    SMALLINT, // short
+    INTEGER,
+    BIGINT, // long
+    REAL, // float
+    DOUBLE,
+    SHORT_DECIMAL,
+    LONG_DECIMAL,
+
+    VARCHAR, // string
+    VARBINARY,
+
+    TIME,
+    TIMESTAMP,
+    DATE,
+
+    JSON,
+
+    // complex types
+    ARRAY, // list
+    MAP,
+    ROW, // struct
+
+    // catch all for other types
+    OTHER
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarbinaryType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarbinaryType.java
@@ -123,4 +123,10 @@ public final class VarbinaryType
     {
         return getClass().hashCode();
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.VARBINARY;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
@@ -47,4 +47,10 @@ public final class VarcharType
                         StandardTypes.VARCHAR,
                         singletonList(TypeSignatureParameter.of((long) length))));
     }
+
+    @Override
+    public TypeKind getKind()
+    {
+        return TypeKind.VARCHAR;
+    }
 }


### PR DESCRIPTION
Add an enum class TypeKind to represent the type family of the type. 

Having an enum is very handy when processing types. It allows to use a simple `switch-case` instead of comparing the type instance to some constant value (e.g. IntegerType.INTEGER) or checking if the Type's class is an instance of VarcharType or VarbinaryType.

Hive and Velox follow a similar approach.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
