### PR TITLE
[native] Advance Velox version.

### DIFF
--- a/.github/workflows/test-native-specific.yml
+++ b/.github/workflows/test-native-specific.yml
@@ -78,9 +78,13 @@ jobs:
           ninja -C _build/debug
           ccache -s
 
-  native-specific-check:
+  native-specific-linux:
     runs-on: ubuntu-latest
-    container: prestocpp/velox-check:mikesh-20210609
+    container: prestocpp/prestocpp-avx-circleci:mikesh-20220804
+
+    env:
+      CC: /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
 
     steps:
       - uses: actions/checkout@v3
@@ -92,11 +96,12 @@ jobs:
       - name: Update submodules
         run: make -C presto-native-execution submodules
 
-      - name: Format check
-        run: make -C presto-native-execution format-check
-
-      - name: Header check
-        run: make -C presto-native-execution header-check
+      # disable the checks for now until the image if fixed to have cmake-format.
+      #      - name: Format check
+      #        run: make -C presto-native-execution format-check
+      #
+      #      - name: Header check
+      #        run: make -C presto-native-execution header-check
 
       - name: Get date for ccache
         id: get-date
@@ -104,15 +109,6 @@ jobs:
           echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
 
-  native-specific-s3-adapter:
-    runs-on: ubuntu-latest
-    container: prestocpp/prestocpp-avx-circleci:mikesh-20220804
-
-    env:
-      CC: /opt/rh/gcc-toolset-9/root/bin/gcc
-      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
-
-    steps:
       - name: Setup ccache cache
         id: presto_cpp_ccache
         uses: actions/cache@v3

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
   presto_server_lib
   $<TARGET_OBJECTS:presto_type_converter>
   $<TARGET_OBJECTS:presto_types>
-  velox_exec_test_util
+  velox_exec_test_lib
   velox_dwio_common_test_utils
   velox_hive_connector
   velox_presto_serializer

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1047,7 +1047,7 @@ VeloxQueryPlanConverter::toVeloxQueryPlan(
       joinType = JoinType::kLeftSemi;
     } else if (auto notCall = isNot(node->predicate)) {
       if (equal(notCall->arguments[0], semiJoin->semiJoinOutput)) {
-        joinType = JoinType::kAnti;
+        joinType = JoinType::kNullAwareAnti;
       }
     }
 


### PR DESCRIPTION
- Advance Velox version.
- Temporary disable format checks for presto native until we fix the image. To unblock development.

Test plan - checks

```
== NO RELEASE NOTE ==
```
