### PR TITLE
Add optimization to randomize null key in outer join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -238,6 +238,7 @@ public final class SystemSessionProperties
     public static final String LEAF_NODE_LIMIT_ENABLED = "leaf_node_limit_enabled";
     public static final String PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID = "push_remote_exchange_through_group_id";
     public static final String OPTIMIZE_MULTIPLE_APPROX_PERCENTILE_ON_SAME_FIELD = "optimize_multiple_approx_percentile_on_same_field";
+    public static final String RANDOMIZE_OUTER_JOIN_NULL_KEY = "randomize_outer_join_null_key";
     public static final String KEY_BASED_SAMPLING_ENABLED = "key_based_sampling_enabled";
     public static final String KEY_BASED_SAMPLING_PERCENTAGE = "key_based_sampling_percentage";
     public static final String KEY_BASED_SAMPLING_FUNCTION = "key_based_sampling_function";
@@ -1371,6 +1372,11 @@ public final class SystemSessionProperties
                         NATIVE_EXECUTION_EXECUTABLE_PATH,
                         "The native engine executable file path for native engine execution",
                         featuresConfig.getNativeExecutionExecutablePath(),
+                        false),
+                booleanProperty(
+                        RANDOMIZE_OUTER_JOIN_NULL_KEY,
+                        "Randomize null join key for outer join",
+                        featuresConfig.isRandomizeOuterJoinNullKeyEnabled(),
                         false));
     }
 
@@ -2305,5 +2311,10 @@ public final class SystemSessionProperties
     public static String getNativeExecutionExecutablePath(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_EXECUTABLE_PATH, String.class);
+    }
+
+    public static boolean randomizeOuterJoinNullKeyEnabled(Session session)
+    {
+        return session.getSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -236,6 +236,7 @@ public class FeaturesConfig
     private boolean isOptimizeMultipleApproxPercentileOnSameFieldEnabled = true;
     private boolean nativeExecutionEnabled;
     private String nativeExecutionExecutablePath = "./presto_server";
+    private boolean randomizeOuterJoinNullKey;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2217,5 +2218,18 @@ public class FeaturesConfig
     public String getNativeExecutionExecutablePath()
     {
         return this.nativeExecutionExecutablePath;
+    }
+
+    public boolean isRandomizeOuterJoinNullKeyEnabled()
+    {
+        return randomizeOuterJoinNullKey;
+    }
+
+    @Config("optimizer.randomize-outer-join-null-key")
+    @ConfigDescription("Randomize null join key for outer join")
+    public FeaturesConfig setRandomizeOuterJoinNullKeyEnabled(boolean randomizeOuterJoinNullKey)
+    {
+        this.randomizeOuterJoinNullKey = randomizeOuterJoinNullKey;
+        return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -144,6 +144,7 @@ import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
+import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
@@ -598,6 +599,16 @@ public class PlanOptimizers
                             // Must run before AddExchanges and after ReplicateSemiJoinInDelete
                             // to avoid temporarily having an invalid plan
                             new DetermineSemiJoinDistributionType(costComparator, taskCountEstimator))));
+            builder.add(new RandomizeNullKeyInOuterJoin(metadata.getFunctionAndTypeManager()),
+                    new PruneUnreferencedOutputs(),
+                    new IterativeOptimizer(
+                            ruleStats,
+                            statsCalculator,
+                            estimatedExchangesCostCalculator,
+                            ImmutableSet.of(
+                                    new PruneRedundantProjectionAssignments(),
+                                    new InlineProjections(metadata.getFunctionAndTypeManager()),
+                                    new RemoveRedundantIdentityProjections())));
             builder.add(
                     new IterativeOptimizer(
                             ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slices;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
+import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
+import static com.facebook.presto.SystemSessionProperties.randomizeOuterJoinNullKeyEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class RandomizeNullKeyInOuterJoin
+        implements PlanOptimizer
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public RandomizeNullKeyInOuterJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (getJoinDistributionType(session).canPartition() && randomizeOuterJoinNullKeyEnabled(session)) {
+            return SimplePlanRewriter.rewriteWith(new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator), plan);
+        }
+
+        return plan;
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private static final String LEFT_PREFIX = "l";
+        private static final String RIGHT_PREFIX = "r";
+        private final Session session;
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final PlanNodeIdAllocator planNodeIdAllocator;
+        private final PlanVariableAllocator planVariableAllocator;
+        private final Map<String, Map<VariableReferenceExpression, VariableReferenceExpression>> keyToRandomKeyMap;
+
+        private Rewriter(Session session,
+                FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator planNodeIdAllocator, PlanVariableAllocator planVariableAllocator)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.planNodeIdAllocator = requireNonNull(planNodeIdAllocator, "planNodeIdAllocator is null");
+            this.planVariableAllocator = requireNonNull(planVariableAllocator, "planVariableAllocator is null");
+            this.keyToRandomKeyMap = new HashMap<>();
+        }
+
+        private static boolean isSupportedType(VariableReferenceExpression variable)
+        {
+            return Stream.of(BIGINT, DATE).anyMatch(x -> x.equals(variable.getType())) || (variable.getType() instanceof VarcharType);
+        }
+
+        private static boolean isPartitionedJoin(JoinNode joinNode)
+        {
+            return joinNode.getDistributionType().isPresent() && joinNode.getDistributionType().get() == PARTITIONED;
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode joinNode, RewriteContext<Void> context)
+        {
+            // In this optimization, we add the randomized key to output so it can be reused in case the same key is used in outer join in later stage.
+            // However this can change the input for a cross join (if the input of the cross join gets optimized). For cross join, it does not allow mismatch
+            // of input and output. Need to reassign output in case input of the cross join changes.
+            if (joinNode.isCrossJoin()) {
+                PlanNode rewrittenLeft = context.rewrite(joinNode.getLeft(), context.get());
+                PlanNode rewrittenRight = context.rewrite(joinNode.getRight(), context.get());
+                Set<VariableReferenceExpression> inputVariables = ImmutableSet.<VariableReferenceExpression>builder()
+                        .addAll(rewrittenLeft.getOutputVariables())
+                        .addAll(rewrittenRight.getOutputVariables())
+                        .build();
+                checkState(inputVariables.containsAll(joinNode.getOutputVariables()));
+                return new JoinNode(
+                        joinNode.getSourceLocation(),
+                        joinNode.getId(),
+                        joinNode.getStatsEquivalentPlanNode(),
+                        joinNode.getType(),
+                        rewrittenLeft,
+                        rewrittenRight,
+                        joinNode.getCriteria(),
+                        inputVariables.stream().collect(toImmutableList()),
+                        joinNode.getFilter(),
+                        joinNode.getLeftHashVariable(),
+                        joinNode.getRightHashVariable(),
+                        joinNode.getDistributionType(),
+                        joinNode.getDynamicFilters());
+            }
+
+            // Only do optimization for outer join and partitioned join
+            if (Stream.of(LEFT, RIGHT, FULL).noneMatch(joinType -> joinType.equals(joinNode.getType())) || !isPartitionedJoin(joinNode)) {
+                PlanNode result = context.defaultRewrite(joinNode, context.get());
+                return result;
+            }
+
+            List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
+                    .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
+                    .collect(toImmutableList());
+            if (candidateEquiJoinClauses.isEmpty()) {
+                PlanNode result = context.defaultRewrite(joinNode, context.get());
+                return result;
+            }
+
+            PlanNode rewrittenLeft = context.rewrite(joinNode.getLeft(), context.get());
+            PlanNode rewrittenRight = context.rewrite(joinNode.getRight(), context.get());
+
+            List<VariableReferenceExpression> leftJoinKeys = candidateEquiJoinClauses.stream()
+                    .map(x -> x.getLeft())
+                    .filter(x -> !isAlreadyRandomized(rewrittenLeft, x, LEFT_PREFIX))
+                    .collect(toImmutableList());
+            Map<VariableReferenceExpression, RowExpression> leftKeyRandomVariableMap = generateRandomKeyMap(leftJoinKeys, LEFT_PREFIX);
+
+            List<VariableReferenceExpression> rightJoinKeys = candidateEquiJoinClauses.stream()
+                    .map(x -> x.getRight())
+                    .filter(x -> !isAlreadyRandomized(rewrittenRight, x, RIGHT_PREFIX))
+                    .collect(toImmutableList());
+            Map<VariableReferenceExpression, RowExpression> rightKeyRandomVariableMap = generateRandomKeyMap(rightJoinKeys, RIGHT_PREFIX);
+
+            ImmutableList.Builder<JoinNode.EquiJoinClause> joinClauseBuilder = ImmutableList.builder();
+            // Rewrite supported join clauses
+            List<JoinNode.EquiJoinClause> rewrittenJoinClauses = candidateEquiJoinClauses.stream()
+                    .map(x -> new JoinNode.EquiJoinClause(keyToRandomKeyMap.get(LEFT_PREFIX).get(x.getLeft()), keyToRandomKeyMap.get(RIGHT_PREFIX).get(x.getRight())))
+                    .collect(toImmutableList());
+            joinClauseBuilder.addAll(rewrittenJoinClauses);
+            // Add the join clauses which are not supported back
+            List<JoinNode.EquiJoinClause> unchangedJoinClauses = joinNode.getCriteria().stream()
+                    .filter(x -> !candidateEquiJoinClauses.contains(x))
+                    .collect(toImmutableList());
+            joinClauseBuilder.addAll(unchangedJoinClauses);
+
+            Assignments.Builder leftAssignments = Assignments.builder();
+            leftAssignments.putAll(leftKeyRandomVariableMap);
+            leftAssignments.putAll(rewrittenLeft.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
+
+            Assignments.Builder rightAssignments = Assignments.builder();
+            rightAssignments.putAll(rightKeyRandomVariableMap);
+            rightAssignments.putAll(rewrittenRight.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
+
+            ImmutableList.Builder<VariableReferenceExpression> joinOutputBuilder = ImmutableList.builder();
+            joinOutputBuilder.addAll(leftKeyRandomVariableMap.keySet());
+            joinOutputBuilder.addAll(rightKeyRandomVariableMap.keySet());
+            joinOutputBuilder.addAll(joinNode.getOutputVariables());
+
+            return new JoinNode(
+                    joinNode.getSourceLocation(),
+                    joinNode.getId(),
+                    joinNode.getStatsEquivalentPlanNode(),
+                    joinNode.getType(),
+                    new ProjectNode(rewrittenLeft.getSourceLocation(), planNodeIdAllocator.getNextId(), rewrittenLeft, leftAssignments.build(), LOCAL),
+                    new ProjectNode(rewrittenRight.getSourceLocation(), planNodeIdAllocator.getNextId(), rewrittenRight, rightAssignments.build(), LOCAL),
+                    joinClauseBuilder.build(),
+                    joinOutputBuilder.build(),
+                    joinNode.getFilter(),
+                    joinNode.getLeftHashVariable(),
+                    joinNode.getRightHashVariable(),
+                    joinNode.getDistributionType(),
+                    joinNode.getDynamicFilters());
+        }
+
+        private RowExpression randomizeJoinKey(RowExpression keyExpression, String prefix)
+        {
+            int partitionCount = getHashPartitionCount(session);
+            RowExpression randomNumber = call(
+                    functionAndTypeManager,
+                    "random",
+                    BIGINT,
+                    constant((long) partitionCount, BIGINT));
+            RowExpression randomNumberVarchar = call("CAST", functionAndTypeManager.lookupCast(CAST, randomNumber.getType(), VARCHAR), VARCHAR, randomNumber);
+            RowExpression concatExpression = call(functionAndTypeManager,
+                    "concat",
+                    VARCHAR,
+                    ImmutableList.of(constant(Slices.utf8Slice(prefix), VARCHAR), randomNumberVarchar));
+
+            RowExpression castToVarchar = keyExpression;
+            // Only do cast if keyExpression is not VARCHAR type.
+            if (!(keyExpression.getType() instanceof VarcharType)) {
+                castToVarchar = call("CAST", functionAndTypeManager.lookupCast(CAST, keyExpression.getType(), VARCHAR), VARCHAR, keyExpression);
+            }
+            return new SpecialFormExpression(COALESCE, VARCHAR, ImmutableList.of(castToVarchar, concatExpression));
+        }
+
+        // Do not need to generate randomized variable if the joinKey 1) has already been randomized with the same prefix 2) included in the output of the source node
+        private boolean isAlreadyRandomized(PlanNode source, VariableReferenceExpression joinKey, String prefix)
+        {
+            return keyToRandomKeyMap.containsKey(prefix) && keyToRandomKeyMap.get(prefix).containsKey(joinKey) && source.getOutputVariables().contains(keyToRandomKeyMap.get(prefix).get(joinKey));
+        }
+
+        private Map<VariableReferenceExpression, RowExpression> generateRandomKeyMap(List<VariableReferenceExpression> joinKeys, String prefix)
+        {
+            List<RowExpression> randomExpressions = joinKeys.stream().map(x -> randomizeJoinKey(x, prefix)).collect(toImmutableList());
+            List<VariableReferenceExpression> randomVariable = randomExpressions.stream()
+                    .map(x -> planVariableAllocator.newVariable(x, RandomizeNullKeyInOuterJoin.class.getSimpleName()))
+                    .collect(toImmutableList());
+
+            checkState(joinKeys.size() == randomVariable.size());
+            Map<VariableReferenceExpression, VariableReferenceExpression> newKeyToRandomMap = IntStream.range(0, joinKeys.size()).boxed()
+                    .collect(toImmutableMap(joinKeys::get, randomVariable::get));
+            if (!keyToRandomKeyMap.containsKey(prefix)) {
+                keyToRandomKeyMap.put(prefix, new HashMap<>());
+            }
+            keyToRandomKeyMap.get(prefix).putAll(newKeyToRandomMap);
+
+            Map<VariableReferenceExpression, RowExpression> result = IntStream.range(0, randomVariable.size()).boxed()
+                    .collect(toImmutableMap(randomVariable::get, randomExpressions::get));
+
+            return result;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -206,7 +206,8 @@ public class TestFeaturesConfig
                 .setPushRemoteExchangeThroughGroupId(false)
                 .setOptimizeMultipleApproxPercentileOnSameFieldEnabled(true)
                 .setNativeExecutionEnabled(false)
-                .setNativeExecutionExecutablePath("./presto_server"));
+                .setNativeExecutionExecutablePath("./presto_server")
+                .setRandomizeOuterJoinNullKeyEnabled(false));
     }
 
     @Test
@@ -364,6 +365,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-multiple-approx-percentile-on-same-field", "false")
                 .put("native-execution-enabled", "true")
                 .put("native-execution-executable-path", "/bin/echo")
+                .put("optimizer.randomize-outer-join-null-key", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -518,7 +520,8 @@ public class TestFeaturesConfig
                 .setPushRemoteExchangeThroughGroupId(true)
                 .setOptimizeMultipleApproxPercentileOnSameFieldEnabled(false)
                 .setNativeExecutionEnabled(true)
-                .setNativeExecutionExecutablePath("/bin/echo");
+                .setNativeExecutionExecutablePath("/bin/echo")
+                .setRandomizeOuterJoinNullKeyEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -154,6 +154,11 @@ public class BasePlanTest
         assertPlan(sql, session, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, pattern, queryRunner.getPlanOptimizers(true));
     }
 
+    protected void assertPlan(String sql, Session session, PlanMatchPattern pattern, boolean forceSingleNode)
+    {
+        assertPlan(sql, session, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, pattern, queryRunner.getPlanOptimizers(forceSingleNode));
+    }
+
     protected void assertPlan(String sql, LogicalPlanner.Stage stage, PlanMatchPattern pattern)
     {
         List<PlanOptimizer> optimizers = queryRunner.getPlanOptimizers(true);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestRandomizeNullKeyInOuterJoin
+        extends BasePlanTest
+{
+    private Session enableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, "true")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .build();
+    }
+
+    @Test
+    public void testLeftJoin()
+    {
+        assertPlan("SELECT * FROM orders LEFT JOIN lineitem ON orders.orderkey = lineitem.orderkey",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom")),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(cast(leftCol as varchar), 'l' || cast(random(100) as varchar))")),
+                                                tableScan("orders", ImmutableMap.of("leftCol", "orderkey")))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("rightCol", expression("rightCol"), "rightRandom", expression("coalesce(cast(rightCol as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey")))))),
+                false);
+    }
+
+    @Test
+    public void testRightJoin()
+    {
+        assertPlan("SELECT * FROM orders RIGHT JOIN lineitem ON orders.orderkey = lineitem.orderkey ",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                RIGHT,
+                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom")),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(cast(leftCol as varchar), 'l' || cast(random(100) as varchar))")),
+                                                tableScan("orders", ImmutableMap.of("leftCol", "orderkey")))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("rightCol", expression("rightCol"), "rightRandom", expression("coalesce(cast(rightCol as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey")))))),
+                false);
+    }
+
+    @Test
+    public void testLeftJoinOnSameKey()
+    {
+        assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey_random")),
+                                join(
+                                        LEFT,
+                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                        tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey")))))),
+                false);
+    }
+
+    @Test
+    public void testLeftJoinOnDifferentKey()
+    {
+        assertPlan("select * from part p left join lineitem l on p.partkey = l.partkey left join orders o on l.orderkey = o.orderkey",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                anyTree(
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                join(
+                                                        LEFT,
+                                                        ImmutableList.of(equiJoinClause("p_partkey_random", "l_partkey_random")),
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey"))))))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                false);
+    }
+
+    @Test
+    public void testLeftJoinOnMixedKey()
+    {
+        assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey left join orders o on l.orderkey = o.orderkey",
+                enableOptimization(),
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                anyTree(
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                join(
+                                                        LEFT,
+                                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey_random")),
+                                                        join(
+                                                                LEFT,
+                                                                ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                                                anyTree(
+                                                                        project(
+                                                                                ImmutableMap.of("ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                                                tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
+                                                                anyTree(
+                                                                        project(
+                                                                                ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                                                tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey"))))))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                false);
+    }
+
+    @Test
+    public void testCrossJoin()
+    {
+        assertPlan("SELECT * FROM orders CROSS JOIN lineitem",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                tableScan("orders", ImmutableMap.of("leftCol", "orderkey")),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey"))))),
+                false);
+    }
+
+    @Test
+    public void testCrossJoinOverLeftJoin()
+    {
+        assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey CROSS JOIN lineitem l",
+                enableOptimization(),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                join(
+                                        LEFT,
+                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("ps_partkey", expression("ps_partkey"), "ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                        tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("p_partkey", expression("p_partkey"), "p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey"))))),
+                false);
+    }
+}


### PR DESCRIPTION
### What's added?

This PR adds an optimization for outer join which has many NULL in join keys. 

For each join key equal pair, `leftCol = rightCol`, it adds a `coalesce(cast(leftCol as varchar), 'l' || cast(random(hashpartitions) as varchar)) = coalesce(cast(rightCol as varchar), 'r' || cast(random(hashpartitions) as varchar))`, so as to avoid skew in NULL values.

### Test plan - (Please fill in how you tested your changes)
Add unit tests

**The failure in native test is not related to this PR**

```
== RELEASE NOTES ==

General Changes
* Add optimization for outer join.
  Add randomized value for NULL join keys to avoid skew in NULL. Default to false.

```

