### PR TITLE
[native] Add support for TPC-H connector

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -175,6 +175,10 @@ public final class HiveQueryRunner
             queryRunner.installPlugin(new TestingHiveEventListenerPlugin());
             queryRunner.createCatalog("tpch", "tpch");
             queryRunner.createCatalog("tpcds", "tpcds");
+            Map<String, String> tpchProperties = ImmutableMap.<String, String>builder()
+                    .put("tpch.column-naming", "standard")
+                    .build();
+            queryRunner.createCatalog("tpchstandard", "tpch", tpchProperties);
 
             ExtendedHiveMetastore metastore;
             metastore = externalMetastore.orElse(getFileHiveMetastore(queryRunner));

--- a/presto-native-execution/etc/catalog/tpchstandard.properties
+++ b/presto-native-execution/etc/catalog/tpchstandard.properties
@@ -1,0 +1,1 @@
+connector.name=tpch

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_aggregates
   velox_hive_connector
+  velox_tpch_connector
   velox_presto_serializer
   velox_dwio_dwrf_reader)
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -144,6 +144,7 @@ void PrestoServer::run() {
   velox::filesystems::registerLocalFileSystem();
   registerOptionalHiveStorageAdapters();
   protocol::registerHiveConnectors();
+  protocol::registerTpchConnector();
 
   auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
       systemConfig->numIoThreads(),

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_test_utils
   velox_hive_connector
+  velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
   velox_aggregates

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -22,7 +22,7 @@ add_dependencies(presto_types presto_type_converter velox_type
                  velox_dwio_dwrf_proto)
 
 target_link_libraries(presto_types presto_type_converter
-                      velox_hive_partition_function)
+                      velox_hive_partition_function velox_tpch_gen)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
@@ -14,6 +14,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxSplit.h"
 #include <optional>
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/tpch/TpchConnectorSplit.h"
 #include "velox/exec/Exchange.h"
 
 using namespace facebook::velox;
@@ -71,6 +72,15 @@ velox::exec::Split toVeloxSplit(
     return velox::exec::Split(
         std::make_shared<exec::RemoteConnectorSplit>(
             remoteSplit->location.location),
+        splitGroupId);
+  }
+  if (auto tpchSplit = std::dynamic_pointer_cast<const protocol::TpchSplit>(
+          connectorSplit)) {
+    return velox::exec::Split(
+        std::make_shared<connector::tpch::TpchConnectorSplit>(
+            scheduledSplit.split.connectorId,
+            tpchSplit->totalParts,
+            tpchSplit->partNumber),
         splitGroupId);
   }
   if (std::dynamic_pointer_cast<const protocol::EmptySplit>(connectorSplit)) {

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   gtest_main
   presto_protocol
   velox_hive_connector
+  velox_tpch_connector
   velox_exec
   velox_dwio_common_exception
   presto_type_converter
@@ -59,6 +60,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_lib
   velox_hive_connector
+  velox_tpch_connector
   velox_hive_partition_function
   velox_presto_serializer
   velox_serialization

--- a/presto-native-execution/presto_cpp/presto_protocol/Connectors.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Connectors.cpp
@@ -44,6 +44,10 @@ void registerHiveConnectors() {
   registerConnector("hive-hadoop2", "hive");
 }
 
+void registerTpchConnector() {
+  registerConnector("tpch", "tpch");
+}
+
 const std::string& getConnectorKey(const std::string& connectorName) {
   auto it = connectors().find(connectorName);
   VELOX_CHECK(

--- a/presto-native-execution/presto_cpp/presto_protocol/Connectors.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/Connectors.h
@@ -34,8 +34,11 @@ namespace facebook::presto::protocol {
 // connectorKey) entries. Each connectorName uses the corresponding connectorKey
 // to determine the protocol structures.
 
-// Register known Hive connectors
+// Register known Hive connectors.
 void registerHiveConnectors();
+
+// Register the Tpch connector.
+void registerTpchConnector();
 
 bool registerConnector(
     const std::string& connectorName,

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
@@ -2432,6 +2432,75 @@ void to_json(json& j, const HiveSplit& p);
 void from_json(const json& j, HiveSplit& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct TpchPartitioningHandle : public ConnectorPartitioningHandle {
+  String table = {};
+  int64_t totalRows;
+  TpchPartitioningHandle() noexcept;
+};
+void to_json(json& j, const TpchPartitioningHandle& p);
+void from_json(const json& j, TpchPartitioningHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchTransactionHandle : public ConnectorTransactionHandle {
+  String instance = {};
+
+  TpchTransactionHandle() noexcept;
+};
+void to_json(json& j, const TpchTransactionHandle& p);
+void from_json(const json& j, TpchTransactionHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchColumnHandle : public ColumnHandle {
+  String columnName = {};
+  Type   type = {};
+  TpchColumnHandle() noexcept;
+};
+void to_json(json& j, const TpchColumnHandle& p);
+void from_json(const json& j, TpchColumnHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchTableHandle : public ConnectorTableHandle {
+  String tableName = {};
+  double scaleFactor = 0;
+
+  TpchTableHandle() noexcept;
+};
+void to_json(json& j, const TpchTableHandle& p);
+void from_json(const json& j, TpchTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchPredicate {
+  List<TupleDomain<std::shared_ptr<ColumnHandle>>> columnDomains;
+
+  TpchPredicate() noexcept;
+};
+void to_json(json& j, const TpchPredicate& p);
+void from_json(const json& j, TpchPredicate& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchTableLayoutHandle : public ConnectorTableLayoutHandle {
+  TpchTableHandle table;
+  TpchPredicate predicate;
+
+  TpchTableLayoutHandle() noexcept;
+};
+void to_json(json& j, const TpchTableLayoutHandle& p);
+void from_json(const json& j, TpchTableLayoutHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TpchSplit : public ConnectorSplit {
+  TpchTableHandle tableHandle = {};
+  int partNumber;
+  int totalParts;
+  List<HostAddress> addresses = {};
+  TpchPredicate predicate;
+
+  TpchSplit() noexcept;
+};
+void to_json(json& j, const TpchSplit& p);
+void from_json(const json& j, TpchSplit& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct OutputNode : public PlanNode {
   std::shared_ptr<PlanNode> source = {};
   List<String> columnNames = {};

--- a/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
@@ -183,6 +183,10 @@ public class HiveExternalWorkerQueryRunner
                                         "cache.enabled=true%n" +
                                         "cache.max-cache-size=32").getBytes());
 
+                        // Add a tpch catalog.
+                        Files.write(catalogDirectoryPath.resolve("tpchstandard.properties"),
+                                format("connector.name=tpch%n").getBytes());
+
                         // Disable stack trace capturing as some queries (using TRY) generate a lot of exceptions.
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")
                                 .directory(tempDirectoryPath.toFile())

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestTpchQueries.java
@@ -34,4 +34,36 @@ public class TestTpchQueries
         // No tpch catalog exists in the native worker.
         assertQueryFails(session, "SELECT * FROM nation", "No nodes available to run query");
     }
+
+    @Test
+    public void testTpchTinyTables()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalog("tpchstandard")
+                .setSchema("tiny")
+                .build();
+
+        assertQuery(session, "SELECT count(*) FROM customer");
+        assertQuery(session, "SELECT count(*) FROM lineitem");
+        assertQuery(session, "SELECT count(*) FROM orders");
+        assertQuery(session, "SELECT count(*) FROM nation");
+        assertQuery(session, "SELECT count(*) FROM part");
+        assertQuery(session, "SELECT count(*) FROM partsupp");
+        assertQuery(session, "SELECT count(*) FROM region");
+        assertQuery(session, "SELECT count(*) FROM supplier");
+        assertQuery(session, "SELECT c_custkey, c_name, c_nationkey FROM customer");
+        assertQuery(session, "SELECT n_nationkey, n_name, n_regionkey FROM nation");
+        assertQuery(session, "SELECT r_regionkey, r_name FROM region");
+        assertQuery(session, "SELECT SUM(l_discount) FROM lineitem WHERE l_discount != 0.04");
+        assertQuery(session, "SELECT count(*), l_shipdate FROM lineitem WHERE l_linenumber = 3 GROUP BY l_shipdate");
+        assertQuery(session, "SELECT ps_partkey, ps_availqty, ps_supplycost FROM partsupp WHERE ps_availqty < 5");
+        assertQuery(session, "SELECT p_partkey, p_mfgr, p_brand FROM part WHERE p_size = 4 and p_partkey < 1000");
+        assertQuery(session, "SELECT s_suppkey, s_phone FROM supplier WHERE s_acctbal < 100");
+        assertQuery(session, "SELECT c_custkey, c_phone FROM customer WHERE c_acctbal > 9900");
+        assertQuery(session, "SELECT o_orderkey, o_orderdate, o_totalprice FROM orders WHERE o_shippriority = 4");
+
+        // No row passes the filter.
+        assertQuery(session,
+                "SELECT l_linenumber, l_orderkey, l_discount FROM lineitem WHERE l_discount > 0.2");
+    }
 }


### PR DESCRIPTION
presto-native-execution has been extended to support the TPC-H connector.

Test plan 
TPC-H queries are added to TestTpchQueries.java

```
== RELEASE NOTES ==
TPC-H Connector Changes
* Add support for the TPC-H connector in Presto Native Execution.
  Velox only supports standard column naming. 
  The tpch connector property ``tpch.column-naming=standard`` must be set on the Java side.
```
