### PR TITLE
Support resource group selection based on clientInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -194,7 +194,8 @@ public class DispatchManager
                     Optional.ofNullable(sessionContext.getSource()),
                     sessionContext.getClientTags(),
                     sessionContext.getResourceEstimates(),
-                    queryType.map(Enum::name)));
+                    queryType.map(Enum::name),
+                    Optional.ofNullable(sessionContext.getClientInfo())));
 
             // apply system default session properties (does not override user set properties)
             session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType.map(Enum::name), Optional.of(selectionContext.getResourceGroupId()));

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/AbstractResourceConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/AbstractResourceConfigurationManager.java
@@ -99,6 +99,7 @@ public abstract class AbstractResourceConfigurationManager
                     spec.getClientTags(),
                     spec.getResourceEstimate(),
                     spec.getQueryType(),
+                    spec.getClientInfoRegex(),
                     spec.getGroup()));
         }
         return selectors.build();

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/SelectorSpec.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/SelectorSpec.java
@@ -31,6 +31,7 @@ public class SelectorSpec
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
     private final Optional<SelectorResourceEstimate> selectorResourceEstimate;
+    private final Optional<Pattern> clientInfoRegex;
     private final ResourceGroupIdTemplate group;
 
     @JsonCreator
@@ -40,6 +41,7 @@ public class SelectorSpec
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("clientTags") Optional<List<String>> clientTags,
             @JsonProperty("selectorResourceEstimate") Optional<SelectorResourceEstimate> selectorResourceEstimate,
+            @JsonProperty("clientInfo") Optional<Pattern> clientInfoRegex,
             @JsonProperty("group") ResourceGroupIdTemplate group)
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
@@ -48,6 +50,7 @@ public class SelectorSpec
         this.clientTags = requireNonNull(clientTags, "clientTags is null");
         this.selectorResourceEstimate = requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
         this.group = requireNonNull(group, "group is null");
+        this.clientInfoRegex = requireNonNull(clientInfoRegex, "clientInfoRegex is null");
     }
 
     public Optional<Pattern> getUserRegex()
@@ -80,6 +83,11 @@ public class SelectorSpec
         return group;
     }
 
+    public Optional<Pattern> getClientInfoRegex()
+    {
+        return clientInfoRegex;
+    }
+
     @Override
     public boolean equals(Object other)
     {
@@ -96,7 +104,9 @@ public class SelectorSpec
                 sourceRegex.map(Pattern::pattern).equals(that.sourceRegex.map(Pattern::pattern))) &&
                 sourceRegex.map(Pattern::flags).equals(that.sourceRegex.map(Pattern::flags)) &&
                 queryType.equals(that.queryType) &&
-                clientTags.equals(that.clientTags);
+                clientTags.equals(that.clientTags) &&
+                clientInfoRegex.map(Pattern::pattern).equals(that.clientInfoRegex.map(Pattern::pattern)) &&
+                clientInfoRegex.map(Pattern::flags).equals(that.clientInfoRegex.map(Pattern::flags));
     }
 
     @Override
@@ -123,6 +133,7 @@ public class SelectorSpec
                 .add("sourceFlags", sourceRegex.map(Pattern::flags))
                 .add("queryType", queryType)
                 .add("clientTags", clientTags)
+                .add("clientInfoRegex", clientInfoRegex)
                 .toString();
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbManagerSpecProvider.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbManagerSpecProvider.java
@@ -108,6 +108,7 @@ public class DbManagerSpecProvider
                                 selectorRecord.getQueryType(),
                                 selectorRecord.getClientTags(),
                                 selectorRecord.getSelectorResourceEstimate(),
+                                selectorRecord.getClientInfoRegex(),
                                 resourceGroupIdTemplateMap.get(selectorRecord.getResourceGroupId()))
                 ).collect(toList());
         ManagerSpec managerSpec = new ManagerSpec(rootGroups, selectors, getCpuQuotaPeriodFromDb());

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -63,7 +63,7 @@ public interface ResourceGroupsDao
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
-    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.query_type, S.client_tags, S.selector_resource_estimate\n" +
+    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.client_info_regex\n" +
             "FROM selectors S\n" +
             "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
             "WHERE R.environment = :environment\n" +
@@ -79,6 +79,7 @@ public interface ResourceGroupsDao
             "  query_type VARCHAR(512),\n" +
             "  client_tags VARCHAR(512),\n" +
             "  selector_resource_estimate VARCHAR(1024),\n" +
+            "  client_info_regex VARCHAR(1024),\n" +
             "  id BIGINT NOT NULL AUTO_INCREMENT,\n" +
             "  PRIMARY KEY (id),\n" +
             "  FOREIGN KEY (resource_group_id) REFERENCES resource_groups (resource_group_id)\n" +

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/SelectorRecord.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/SelectorRecord.java
@@ -38,6 +38,7 @@ public class SelectorRecord
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
     private final Optional<SelectorResourceEstimate> selectorResourceEstimate;
+    private final Optional<Pattern> clientInfoRegex;
 
     public SelectorRecord(
             long resourceGroupId,
@@ -46,7 +47,8 @@ public class SelectorRecord
             Optional<Pattern> sourceRegex,
             Optional<String> queryType,
             Optional<List<String>> clientTags,
-            Optional<SelectorResourceEstimate> selectorResourceEstimate)
+            Optional<SelectorResourceEstimate> selectorResourceEstimate,
+            Optional<Pattern> clientInfoRegex)
     {
         this.resourceGroupId = resourceGroupId;
         this.priority = priority;
@@ -55,6 +57,7 @@ public class SelectorRecord
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.clientTags = requireNonNull(clientTags, "clientTags is null").map(ImmutableList::copyOf);
         this.selectorResourceEstimate = requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
+        this.clientInfoRegex = requireNonNull(clientInfoRegex, "clientInfoRegex is null");
     }
 
     public long getResourceGroupId()
@@ -92,6 +95,11 @@ public class SelectorRecord
         return selectorResourceEstimate;
     }
 
+    public Optional<Pattern> getClientInfoRegex()
+    {
+        return clientInfoRegex;
+    }
+
     public static class Mapper
             implements RowMapper<SelectorRecord>
     {
@@ -109,7 +117,8 @@ public class SelectorRecord
                     Optional.ofNullable(resultSet.getString("source_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("query_type")),
                     Optional.ofNullable(resultSet.getString("client_tags")).map(LIST_STRING_CODEC::fromJson),
-                    Optional.ofNullable(resultSet.getString("selector_resource_estimate")).map(SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC::fromJson));
+                    Optional.ofNullable(resultSet.getString("selector_resource_estimate")).map(SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC::fromJson),
+                    Optional.ofNullable(resultSet.getString("client_info_regex")).map(Pattern::compile));
         }
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
@@ -60,13 +60,14 @@ public class TestFileResourceGroupConfigurationManager
     {
         FileResourceGroupConfigurationManager manager = parse("resource_groups_config_query_type.json");
         List<ResourceGroupSelector> selectors = manager.getSelectors();
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("select")), "global.select");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("explain")), "global.explain");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("insert")), "global.insert");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("delete")), "global.delete");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("describe")), "global.describe");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("data_definition")), "global.data_definition");
-        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("sth_else")), "global.other");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("select"), Optional.empty()), "global.select");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("explain"), Optional.empty()), "global.explain");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("insert"), Optional.empty()), "global.insert");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("delete"), Optional.empty()), "global.delete");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("describe"), Optional.empty()), "global.describe");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("data_definition"), Optional.empty()), "global.data_definition");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("sth_else"), Optional.empty()), "global.other");
+        assertMatch(selectors, new SelectionCriteria(true, "test_user", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("sth_else"), Optional.of("client2_34")), "global.other-2");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Selector specifies an invalid query type: invalid_query_type")

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
@@ -58,8 +58,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "job_testpipeline_user:user"), "user");
 
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty());
 
         assertEquals(selector.match(context).map(SelectionContext::getResourceGroupId), Optional.of(expected));
     }
@@ -71,8 +71,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "testpipeline"), "_s");
 
         Pattern userPattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty());
 
         assertEquals(selector.match(context).map(SelectionContext::getResourceGroupId), Optional.of(expected));
     }
@@ -82,8 +82,8 @@ public class TestResourceGroupIdTemplate
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty());
 
         assertFalse(selector.match(context).isPresent());
     }
@@ -93,8 +93,8 @@ public class TestResourceGroupIdTemplate
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${user}");
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty());
         selector.match(context);
     }
 
@@ -103,8 +103,8 @@ public class TestResourceGroupIdTemplate
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
         Pattern sourcePattern = Pattern.compile("scheduler.important.(testpipeline\\[|(?<pipeline>[^\\[]*)).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty());
         selector.match(context);
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
@@ -44,6 +44,7 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
         assertEquals(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
         assertEquals(selector.match(newSelectionCriteria("userB", "source", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
@@ -57,6 +58,7 @@ public class TestStaticSelector
         StaticSelector selector = new StaticSelector(
                 Optional.empty(),
                 Optional.of(Pattern.compile(".*source.*")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -75,6 +77,7 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
@@ -101,6 +104,7 @@ public class TestStaticSelector
                         Optional.of(new Range<>(
                                 Optional.empty(),
                                 Optional.of(DataSize.valueOf("500MB")))))),
+                Optional.empty(),
                 Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
 
@@ -157,6 +161,7 @@ public class TestStaticSelector
                                 Optional.of(DataSize.valueOf("5TB")),
                                 Optional.empty())))),
                 Optional.empty(),
+                Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
 
         assertEquals(
@@ -202,8 +207,30 @@ public class TestStaticSelector
                 Optional.of(resourceGroupId));
     }
 
+    @Test
+    public void testClientInfoRegex()
+    {
+        ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
+        StaticSelector selector = new StaticSelector(
+                Optional.of(Pattern.compile("user.*")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("client1.*")),
+                new ResourceGroupIdTemplate("global.foo"));
+        assertEquals(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES, Optional.of("client123"))).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
+        assertEquals(selector.match(newSelectionCriteria("userB", "source", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of("client1"))).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
+        assertEquals(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES, Optional.of("A.client123"))), Optional.empty());
+    }
+
     private SelectionCriteria newSelectionCriteria(String user, String source, Set<String> tags, ResourceEstimates resourceEstimates)
     {
-        return new SelectionCriteria(true, user, Optional.ofNullable(source), tags, resourceEstimates, Optional.empty());
+        return new SelectionCriteria(true, user, Optional.ofNullable(source), tags, resourceEstimates, Optional.empty(), Optional.empty());
+    }
+
+    private SelectionCriteria newSelectionCriteria(String user, String source, Set<String> tags, ResourceEstimates resourceEstimates, Optional<String> clientInfo)
+    {
+        return new SelectionCriteria(true, user, Optional.ofNullable(source), tags, resourceEstimates, Optional.empty(), clientInfo);
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
@@ -89,8 +89,8 @@ public interface H2ResourceGroupsDao
     void deleteResourceGroup(@Bind("resource_group_id") long resourceGroupId);
 
     @SqlUpdate("INSERT INTO selectors\n" +
-            "(resource_group_id, priority, user_regex, source_regex, query_type, client_tags, selector_resource_estimate)\n" +
-            "VALUES (:resource_group_id, :priority, :user_regex, :source_regex, :query_type, :client_tags, :selector_resource_estimate)")
+            "(resource_group_id, priority, user_regex, source_regex, query_type, client_tags, selector_resource_estimate, client_info_regex)\n" +
+            "VALUES (:resource_group_id, :priority, :user_regex, :source_regex, :query_type, :client_tags, :selector_resource_estimate, :client_info_regex)")
     void insertSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("priority") long priority,
@@ -98,7 +98,8 @@ public interface H2ResourceGroupsDao
             @Bind("source_regex") String sourceRegex,
             @Bind("query_type") String queryType,
             @Bind("client_tags") String clientTags,
-            @Bind("selector_resource_estimate") String selectorResourceEstimate);
+            @Bind("selector_resource_estimate") String selectorResourceEstimate,
+            @Bind("client_info_regex") String clientInfoRegex);
 
     @SqlUpdate("UPDATE selectors SET\n" +
             " resource_group_id = :resource_group_id\n" +
@@ -108,6 +109,7 @@ public interface H2ResourceGroupsDao
             "WHERE resource_group_id = :resource_group_id\n" +
             " AND ((user_regex IS NULL AND :old_user_regex IS NULL) OR user_regex = :old_user_regex)\n" +
             " AND ((source_regex IS NULL AND :old_source_regex IS NULL) OR source_regex = :old_source_regex)\n" +
+            " AND ((client_info_regex IS NULL AND :old_source_regex IS NULL) OR source_regex = :old_source_regex)\n" +
             " AND ((client_tags IS NULL AND :old_client_tags IS NULL) OR client_tags = :old_client_tags)")
     void updateSelector(
             @Bind("resource_group_id") long resourceGroupId,

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
@@ -55,8 +55,8 @@ public class TestDbManagerSpecProvider
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
         dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, prodEnvironment);
         dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, devEnvironment);
-        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null);
-        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null);
+        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null);
+        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null);
 
         // check the prod configuration
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), prodEnvironment, new ReloadingResourceGroupConfig());
@@ -97,7 +97,7 @@ public class TestDbManagerSpecProvider
         for (int i = 0; i < numberOfUsers; i++) {
             int priority = randomPriorities[i];
             String user = String.valueOf(priority);
-            dao.insertSelector(1, priority, user, ".*", null, null, null);
+            dao.insertSelector(1, priority, user, ".*", null, null, null, null);
             expectedUsers.add(user);
         }
 
@@ -133,7 +133,7 @@ public class TestDbManagerSpecProvider
             assertTrue(ex.getCause() instanceof JdbcSQLIntegrityConstraintViolationException);
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
-        dao.insertSelector(1, 1, null, null, null, null, null);
+        dao.insertSelector(1, 1, null, null, null, null, null, null);
         daoProvider = setup("test_dup_subs");
         dao = daoProvider.get();
         dao.createResourceGroupsGlobalPropertiesTable();
@@ -150,7 +150,7 @@ public class TestDbManagerSpecProvider
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
 
-        dao.insertSelector(2, 2, null, null, null, null, null);
+        dao.insertSelector(2, 2, null, null, null, null, null, null);
     }
 
     @Test

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
@@ -56,22 +56,22 @@ public class TestDbSourceExactMatchSelector
         DbSourceExactMatchSelector selector = new DbSourceExactMatchSelector("test", dao);
 
         assertEquals(
-                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty())),
+                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), Optional.empty())),
                 Optional.empty());
 
         assertEquals(
-                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))).map(SelectionContext::getResourceGroupId),
+                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()), Optional.empty())).map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId1));
         assertEquals(
-                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()))).map(SelectionContext::getResourceGroupId),
+                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()), Optional.empty())).map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId2));
 
         assertEquals(
-                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name()))),
+                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name()), Optional.empty())),
                 Optional.empty());
 
         assertEquals(
-                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))),
+                selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()), Optional.empty())),
                 Optional.empty());
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -127,6 +127,7 @@ public class TestResourceGroupsDao
                         Optional.of(Pattern.compile(".*")),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.empty()));
         map.put(3L,
                 new SelectorRecord(
@@ -136,6 +137,7 @@ public class TestResourceGroupsDao
                         Optional.of(Pattern.compile(".*")),
                         Optional.of(EXPLAIN.name()),
                         Optional.of(ImmutableList.of("tag1", "tag2")),
+                        Optional.empty(),
                         Optional.empty()));
         map.put(4L,
                 new SelectorRecord(
@@ -145,16 +147,17 @@ public class TestResourceGroupsDao
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.of(SELECTOR_RESOURCE_ESTIMATE)));
+                        Optional.of(SELECTOR_RESOURCE_ESTIMATE),
+                        Optional.empty()));
 
         dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
 
-        dao.insertSelector(2, 1, "ping_user", ".*", null, null, null);
-        dao.insertSelector(3, 2, "admin_user", ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(4, 0, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE));
+        dao.insertSelector(2, 1, "ping_user", ".*", null, null, null, null);
+        dao.insertSelector(3, 2, "admin_user", ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, ".*");
+        dao.insertSelector(4, 0, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE), null);
         List<SelectorRecord> records = dao.getSelectors(ENVIRONMENT);
         compareSelectors(map, records);
     }
@@ -169,6 +172,7 @@ public class TestResourceGroupsDao
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1")),
+                Optional.empty(),
                 Optional.empty());
         map.put(2L, updated);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
@@ -176,7 +180,7 @@ public class TestResourceGroupsDao
 
     private static void testSelectorUpdateNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         map.put(2L, updated);
         dao.updateSelector(2, null, null, null, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
@@ -187,6 +191,7 @@ public class TestResourceGroupsDao
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.of(EXPLAIN.name()),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
+                Optional.empty(),
                 Optional.empty());
         map.put(2L, updated);
         dao.updateSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null, null);
@@ -203,7 +208,7 @@ public class TestResourceGroupsDao
     private static void testSelectorDeleteNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
         dao.updateSelector(3, null, null, null, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         map.put(3L, nullRegexes);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelector(3, null, null, null);
@@ -217,12 +222,13 @@ public class TestResourceGroupsDao
             return;
         }
 
-        dao.insertSelector(3, 3L, "user1", "pipeline", null, null, null);
+        dao.insertSelector(3, 3L, "user1", "pipeline", null, null, null, "client_info.*");
         map.put(3L, new SelectorRecord(
                 3L,
                 3L,
                 Optional.of(Pattern.compile("user1")),
                 Optional.of(Pattern.compile("pipeline")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty()));

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
@@ -71,7 +71,7 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
         AtomicBoolean exported = new AtomicBoolean();
@@ -95,7 +95,7 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertSelector(2, 1, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
         InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false);
@@ -113,7 +113,7 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
@@ -152,7 +152,7 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createExactMatchSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         ReloadingResourceGroupConfig config = new ReloadingResourceGroupConfig();
         config.setExactMatchSelectorEnabled(true);

--- a/presto-resource-group-managers/src/test/resources/resource_groups_config_query_type.json
+++ b/presto-resource-group-managers/src/test/resources/resource_groups_config_query_type.json
@@ -49,6 +49,12 @@
           "softMemoryLimit": "2MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 4
+        },
+        {
+          "name": "other-2",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
         }
       ]
     }
@@ -83,6 +89,11 @@
       "user" : "test_user",
       "queryType" : "data_definition",
       "group": "global.data_definition"
+    },
+    {
+      "user": "test_user",
+      "clientInfo" : "client2_.*",
+      "group": "global.other-2"
     },
     {
       "user": "test_user",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SelectionCriteria.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SelectionCriteria.java
@@ -29,6 +29,7 @@ public final class SelectionCriteria
     private final Set<String> clientTags;
     private final ResourceEstimates resourceEstimates;
     private final Optional<String> queryType;
+    private final Optional<String> clientInfo;
 
     public SelectionCriteria(
             boolean authenticated,
@@ -36,7 +37,8 @@ public final class SelectionCriteria
             Optional<String> source,
             Set<String> clientTags,
             ResourceEstimates resourceEstimates,
-            Optional<String> queryType)
+            Optional<String> queryType,
+            Optional<String> clientInfo)
     {
         this.authenticated = authenticated;
         this.user = requireNonNull(user, "user is null");
@@ -44,6 +46,7 @@ public final class SelectionCriteria
         this.clientTags = unmodifiableSet(requireNonNull(clientTags, "tags is null"));
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
+        this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
     }
 
     public boolean isAuthenticated()
@@ -74,5 +77,10 @@ public final class SelectionCriteria
     public Optional<String> getQueryType()
     {
         return queryType;
+    }
+
+    public Optional<String> getClientInfo()
+    {
+        return clientInfo;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -198,14 +198,14 @@ class H2TestUtil
         dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertResourceGroup(8, "test", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dao.insertResourceGroup(9, "test-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 8L, TEST_ENVIRONMENT);
-        dao.insertSelector(2, 10_000, "user.*", "test", null, null, null);
-        dao.insertSelector(4, 1_000, "user.*", "(?i).*adhoc.*", null, null, null);
-        dao.insertSelector(5, 100, "user.*", "(?i).*dashboard.*", null, null, null);
-        dao.insertSelector(4, 10, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(2, 1, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null);
-        dao.insertSelector(6, 6, ".*", ".*", null, null, null);
-        dao.insertSelector(7, 100_000, null, null, EXPLAIN.name(), null, null);
-        dao.insertSelector(9, 10_000, "user.*", "abc", null, null, null);
+        dao.insertSelector(2, 10_000, "user.*", "test", null, null, null, null);
+        dao.insertSelector(4, 1_000, "user.*", "(?i).*adhoc.*", null, null, null, null);
+        dao.insertSelector(5, 100, "user.*", "(?i).*dashboard.*", null, null, null, null);
+        dao.insertSelector(4, 10, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null);
+        dao.insertSelector(2, 1, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null, null);
+        dao.insertSelector(6, 6, ".*", ".*", null, null, null, null);
+        dao.insertSelector(7, 100_000, null, null, EXPLAIN.name(), null, null, null);
+        dao.insertSelector(9, 10_000, "user.*", "abc", null, null, null, null);
 
         int expectedSelectors = 7;
         if (environment.equals(TEST_ENVIRONMENT_2)) {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -208,7 +208,7 @@ public class TestQueuesDb
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         assertEquals(dispatchManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
         int selectorCount = getSelectors(queryRunner).size();
-        dao.insertSelector(4, 100_000, "user.*", "(?i).*reject.*", null, null, null);
+        dao.insertSelector(4, 100_000, "user.*", "(?i).*reject.*", null, null, null, null);
         reloadingConfigurationManager.load();
         assertEquals(getSelectors(queryRunner).size(), selectorCount + 1);
         // Verify the query can be submitted
@@ -250,7 +250,7 @@ public class TestQueuesDb
         dao.insertResourceGroup(10, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
-        dao.insertSelector(10, 200, "user.*", "(?i).*dashboard.*", null, null, null);
+        dao.insertSelector(10, 200, "user.*", "(?i).*dashboard.*", null, null, null, null);
 
         // reload the configuration
         reloadingConfigurationManager.load();
@@ -346,7 +346,7 @@ public class TestQueuesDb
         ReloadingResourceGroupConfigurationManager reloadingConfigurationManager = (ReloadingResourceGroupConfigurationManager) manager.getConfigurationManager();
         int originalSize = getSelectors(queryRunner).size();
         // Add a selector for a non leaf group
-        dao.insertSelector(3, 100, "user.*", "(?i).*non-leaf.*", null, null, null);
+        dao.insertSelector(3, 100, "user.*", "(?i).*non-leaf.*", null, null, null, null);
         reloadingConfigurationManager.load();
         while (getSelectors(queryRunner).size() != originalSize + 1) {
             MILLISECONDS.sleep(500);


### PR DESCRIPTION
We have certain workloads identifiable only through client info. So we want to introduce an option to select resource group based on client info.

Test plan -  unit test

```
== NO RELEASE NOTE ==
```
