### PR TITLE
Handle sentinel partition value for null partition

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSource.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSource.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_CURSOR_ERROR;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -192,7 +193,7 @@ public class HudiPageSource
 
     private static Object deserializePartitionValue(Type type, String valueString, String name, TimeZoneKey timeZoneKey)
     {
-        if (valueString == null) {
+        if (valueString == null || HIVE_DEFAULT_DYNAMIC_PARTITION.equals(valueString)) {
             return null;
         }
 

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.hudi;
 
-import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
@@ -72,7 +71,6 @@ import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMe
 public class HudiSplitManager
         implements ConnectorSplitManager
 {
-    private static final Logger log = Logger.get(HudiSplitManager.class);
     private final HdfsEnvironment hdfsEnvironment;
     private final HudiTransactionManager hudiTransactionManager;
     private final HudiPartitionManager hudiPartitionManager;
@@ -181,7 +179,7 @@ public class HudiSplitManager
                 splitWeightProvider.calculateSplitWeight(sizeInBytes)));
     }
 
-    public static HudiPartition getHudiPartition(ExtendedHiveMetastore metastore, MetastoreContext context, HudiTableLayoutHandle tableLayout, String partitionName)
+    private static HudiPartition getHudiPartition(ExtendedHiveMetastore metastore, MetastoreContext context, HudiTableLayoutHandle tableLayout, String partitionName)
     {
         String databaseName = tableLayout.getTable().getSchemaName();
         String tableName = tableLayout.getTable().getTableName();


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

A Hudi table with null partition value would be written with the sentinel partition value i.e. `__HIVE_DEFAULT_PARTITION__`. This PR handles the sentinel value in Hudi connector while deserializing partition value.
Tested by creating a Hudi table with null partition and querying the same through Presto.

```
== NO RELEASE NOTE ==
```
