### PR TITLE
Fix compilation error for order by in aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -57,7 +57,7 @@ public class PlannerUtils
                 orderBy.getSortItems().stream()
                         .map(SortItem::getSortKey)
                         .map(item -> {
-                            checkArgument(item instanceof SymbolReference, "must be symbol reference");
+                            checkArgument(item instanceof SymbolReference, "Sort items in order by must be symbol reference");
                             return variable(getSourceLocation(item), ((SymbolReference) item).getName(), types.get(item));
                         }).collect(toImmutableList()),
                 orderBy.getSortItems().stream()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -585,9 +585,11 @@ public final class ExpressionTreeRewriter<C>
 
             List<Expression> arguments = rewrite(node.getArguments(), context);
 
+            Optional<OrderBy> orderBy = node.getOrderBy().map(x -> rewriteOrderBy(x, context));
+
             if (!sameElements(node.getArguments(), arguments) || !sameElements(rewrittenWindow, node.getWindow())
-                    || !sameElements(filter, node.getFilter())) {
-                return new FunctionCall(node.getName(), rewrittenWindow, filter, node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)), node.isDistinct(), node.isIgnoreNulls(), arguments);
+                    || !sameElements(filter, node.getFilter()) || !sameElements(orderBy, node.getOrderBy())) {
+                return new FunctionCall(node.getName(), rewrittenWindow, filter, orderBy, node.isDistinct(), node.isIgnoreNulls(), arguments);
             }
             return node;
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6190,4 +6190,11 @@ public abstract class AbstractTestQueries
             assertTrue(totalPrice07WeightedAccuracy <= totalPrices.get((int) (0.71 * totalPrices.size())));
         }
     }
+
+    @Test
+    public void testOrderByCompilation()
+    {
+        String sql = "SELECT orderkey, array_agg(abs(1) ORDER BY orderkey) FROM orders GROUP BY orderkey ORDER BY orderkey";
+        assertQuery(sql, "SELECT orderkey, array_agg(1) FROM orders GROUP BY orderkey ORDER BY orderkey");
+    }
 }


### PR DESCRIPTION
### Bug fix
Fix #18373
Aggregation with order by clause will fail compilation when the aggregation input is a function. This PR fix the compilation error. It also edits the error output to be more informative.

### Test plan - (Please fill in how you tested your changes)

Add tests which fails in current code but succeeds with this PR. Also test end to end.

```
== RELEASE NOTES ==

General Changes
* Fix the compilation error when aggregation has order by clause and the input is a function.
```
