### PR TITLE
[native] Add additional configs for MmapArena related properties

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -342,6 +342,9 @@ void PrestoServer::initializeAsyncCache() {
 
   memory::MmapAllocatorOptions options;
   options.capacity = memoryBytes;
+  options.useMmapArena = systemConfig->useMmapArena();
+  options.mmapArenaCapacityRatio = systemConfig->mmapArenaCapacityRatio();
+  
   auto allocator = std::make_shared<memory::MmapAllocator>(options);
   mappedMemory_ = std::make_shared<cache::AsyncDataCache>(
       allocator, memoryBytes, std::move(ssd));

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -125,6 +125,16 @@ bool SystemConfig::enableVeloxExprSetLogging() const {
                                : kEnableVeloxExprSetLoggingDefault;
 }
 
+bool SystemConfig::useMmapArena() const {
+  auto opt = optionalProperty<bool>(std::string(kUseMmapArena));
+  return opt.hasValue() ? opt.value() : kUseMmapArenaDefault;
+}
+
+int32_t SystemConfig::mmapArenaCapacityRatio() const {
+  auto opt = optionalProperty<int32_t>(std::string(kMmapArenaCapacityRatio));
+  return opt.hasValue() ? opt.value() : kMmapArenaCapacityRatioDefault;
+}
+
 NodeConfig* NodeConfig::instance() {
   static std::unique_ptr<NodeConfig> instance = std::make_unique<NodeConfig>();
   return instance.get();

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -90,6 +90,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAsyncCacheSsdPath{"async-cache-ssd-path"};
   static constexpr std::string_view kEnableSerializedPageChecksum{
       "enable-serialized-page-checksum"};
+  static constexpr std::string_view kUseMmapArena{"use-mmap-arena"};
+  static constexpr std::string_view kMmapArenaCapacityRatio{
+      "mmap-arena-capacity-ratio"};
   static constexpr std::string_view kEnableVeloxTaskLogging{
       "enable_velox_task_logging"};
   static constexpr std::string_view kEnableVeloxExprSetLogging{
@@ -103,12 +106,14 @@ class SystemConfig : public ConfigBase {
   static constexpr int32_t kNumIoThreadsDefault = 30;
   static constexpr int32_t kShutdownOnsetSecDefault = 10;
   static constexpr int32_t kSystemMemoryGbDefault = 40;
+  static constexpr int32_t kMmapArenaCapacityRatioDefault = 10;
   static constexpr uint64_t kAsyncCacheSsdGbDefault = 0;
   static constexpr std::string_view kAsyncCacheSsdPathDefault{
       "/mnt/flash/async_cache."};
   static constexpr bool kEnableSerializedPageChecksumDefault = true;
   static constexpr bool kEnableVeloxTaskLoggingDefault = false;
   static constexpr bool kEnableVeloxExprSetLoggingDefault = false;
+  static constexpr bool kUseMmapArenaDefault = false;
 
   static SystemConfig* instance();
 
@@ -141,6 +146,10 @@ class SystemConfig : public ConfigBase {
   bool enableVeloxTaskLogging() const;
 
   bool enableVeloxExprSetLogging() const;
+
+  bool useMmapArena() const;
+
+  int32_t mmapArenaCapacityRatio() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
Added 2 properties:
* use_mmap_arena -> tells the underlying MmapAllocator to use MmapArena if set to true
* mmap_arena_capacity_ratio -> the ratio used to determine a single MmapArena capacity to be initialized based on system memory capacity
```
== NO RELEASE NOTE ==
```
