### PR TITLE
[native] Table writer 2: Add Presto write protocols

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   presto_thrift_extra
   presto_exception
   presto_http
+  presto_write_protocol
   velox_core
   velox_vector
   velox_exec

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -28,6 +28,7 @@
 #include "presto_cpp/main/connectors/hive/storage_adapters/FileSystems.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
+#include "presto_cpp/presto_protocol/WriteProtocol.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/caching/SsdCache.h"
@@ -147,6 +148,8 @@ void PrestoServer::run() {
   registerOptionalHiveStorageAdapters();
   protocol::registerHiveConnectors();
   protocol::registerTpchConnector();
+  protocol::HiveNoCommitWriteProtocol::registerProtocol();
+  protocol::HiveTaskCommitWriteProtocol::registerProtocol();
 
   auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
       systemConfig->numIoThreads(),

--- a/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
@@ -14,6 +14,10 @@ add_library(presto_protocol OBJECT presto_protocol.cpp Base64Util.cpp
 
 target_link_libraries(presto_protocol velox_type ${RE2})
 
+add_library(presto_write_protocol WriteProtocol.cpp)
+
+target_link_libraries(presto_write_protocol velox_hive_connector)
+
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()

--- a/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/presto_protocol/WriteProtocol.h"
+
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveWriteProtocol.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec;
+
+namespace facebook::presto::protocol {
+
+namespace {
+
+std::string makePartitionUpdate(
+    const std::shared_ptr<const WriterParameters> writerParameters,
+    vector_size_t numWrittenRows) {
+  const auto hiveWriterParameters =
+      std::dynamic_pointer_cast<const HiveWriterParameters>(writerParameters);
+  VELOX_CHECK_NOT_NULL(
+      hiveWriterParameters,
+      "Presto commit protocol only supports Hive commits at the moment.")
+  // clang-format off
+  auto partitionUpdateJson = folly::toJson(
+   folly::dynamic::object
+     ("name", "")(
+      "updateMode",
+      HiveWriterParameters::updateModeToString(
+          hiveWriterParameters->updateMode()))("writePath", hiveWriterParameters->writeDirectory())
+     ("targetPath", hiveWriterParameters->targetDirectory())
+     ("fileWriteInfos", folly::dynamic::array(
+       folly::dynamic::object
+         ("writeFileName", hiveWriterParameters->writeFileName())
+         ("targetFileName", hiveWriterParameters->targetFileName())
+         ("fileSize", 0)))
+     ("rowCount", numWrittenRows)
+     // TODO(gaoge): track and send the fields when inMemoryDataSizeInBytes, onDiskDataSizeInBytes
+     // and containsNumberedFileNames are needed at coordinator when file_renaming_enabled are turned on,
+     // https://fburl.com/18vim7k4.
+     ("inMemoryDataSizeInBytes", 0)
+     ("onDiskDataSizeInBytes", 0)
+     ("containsNumberedFileNames", true));
+  // clang-format on
+  return partitionUpdateJson;
+}
+
+RowVectorPtr makeCommitOutput(
+    const CommitInfo& commitInfo,
+    const std::string& commitStrategy,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  std::vector<VectorPtr> columns = {};
+
+  vector_size_t numOutputRows = 1;
+  if (commitInfo.outputType()->size() <= 1) {
+    columns.emplace_back(BaseVector::createConstant(
+        (int64_t)commitInfo.numWrittenRows(), 1, pool));
+  } else {
+    auto hiveCommitInfo =
+        std::dynamic_pointer_cast<const HiveConnectorCommitInfo>(
+            commitInfo.connectorCommitInfo());
+    VELOX_CHECK_NOT_NULL(
+        hiveCommitInfo,
+        "Presto write protocol expects commit info from Hive connector.");
+    numOutputRows = hiveCommitInfo->writerParameters().size() + 1;
+
+    // Set rows column.
+    FlatVectorPtr<int64_t> rowWrittenVector =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numOutputRows, pool);
+    rowWrittenVector->set(0, commitInfo.numWrittenRows());
+    for (int idx = 1; idx < numOutputRows; ++idx) {
+      rowWrittenVector->setNull(idx, true);
+    }
+    columns.emplace_back(rowWrittenVector);
+
+    // Set fragments column.
+    FlatVectorPtr<StringView> fragmentsVector =
+        BaseVector::create<FlatVector<StringView>>(
+            VARBINARY(), numOutputRows, pool);
+    fragmentsVector->setNull(0, true);
+    for (int i = 1; i < numOutputRows; i++) {
+      fragmentsVector->set(
+          i,
+          StringView(makePartitionUpdate(
+              hiveCommitInfo->writerParameters().at(i - 1),
+              commitInfo.numWrittenRows())));
+    }
+    columns.emplace_back(fragmentsVector);
+
+    // Set commitcontext column.
+    // clang-format off
+   auto commitContextJson = folly::toJson(
+     folly::dynamic::object
+         ("lifespan", "TaskWide")
+         ("taskId", commitInfo.taskId())
+         ("pageSinkCommitStrategy", commitStrategy)
+         ("lastPage", true));
+    // clang-format on
+    VectorPtr commitContextVector = BaseVector::createConstant(
+        variant::binary(commitContextJson), numOutputRows, pool);
+    columns.emplace_back(commitContextVector);
+  }
+
+  return std::make_shared<RowVector>(
+      pool, commitInfo.outputType(), nullptr, numOutputRows, columns);
+}
+
+} // namespace
+
+RowVectorPtr HiveNoCommitWriteProtocol::commit(
+    const CommitInfo& commitInfo,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  return makeCommitOutput(
+      commitInfo, commitStrategyToString(commitStrategy()), pool);
+}
+
+RowVectorPtr HiveTaskCommitWriteProtocol::commit(
+    const CommitInfo& commitInfo,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  return makeCommitOutput(
+      commitInfo, commitStrategyToString(commitStrategy()), pool);
+}
+
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/HiveWriteProtocol.h"
+
+namespace facebook::velox::connector {
+class CommitInfo;
+}
+namespace facebook::presto::protocol {
+
+class HiveNoCommitWriteProtocol
+    : public velox::connector::hive::HiveNoCommitWriteProtocol {
+ public:
+  ~HiveNoCommitWriteProtocol() override = default;
+
+  velox::RowVectorPtr commit(
+      const velox::connector::CommitInfo& commitInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  static void registerProtocol() {
+    registerWriteProtocol(
+        CommitStrategy::kNoCommit,
+        std::make_shared<HiveNoCommitWriteProtocol>());
+  }
+};
+
+class HiveTaskCommitWriteProtocol
+    : public velox::connector::hive::HiveTaskCommitWriteProtocol {
+ public:
+  ~HiveTaskCommitWriteProtocol() override = default;
+
+  velox::RowVectorPtr commit(
+      const velox::connector::CommitInfo& commitInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  static void registerProtocol() {
+    registerWriteProtocol(
+        CommitStrategy::kTaskCommit,
+        std::make_shared<HiveTaskCommitWriteProtocol>());
+  }
+};
+
+} // namespace facebook::presto::protocol


### PR DESCRIPTION
Add PrestoNoCommitWriteProtocol and PrestoTaskCommitWriteProtocol,
which extends the write protocols of Hive connector and make commit()
return the specific format of outputs expected by Presto from
the table writer. Register the two write protocols during server start.
The right protocol will be picked up by the table writer,
given the CommitStrategy used by the TableWriter.