### PR TITLE
Fix scheduling on the coordinator in TestingPrestoServer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -168,6 +168,7 @@ public class TestingPrestoServer
     private final boolean resourceManager;
     private final boolean catalogServer;
     private final boolean coordinator;
+    private final boolean nodeSchedulerIncludeCoordinator;
     private final ServerInfoResource serverInfoResource;
     private final ResourceManagerClusterStateProvider clusterStateProvider;
 
@@ -268,6 +269,7 @@ public class TestingPrestoServer
         this.preserveData = dataDirectory.isPresent();
 
         properties = new HashMap<>(properties);
+        this.nodeSchedulerIncludeCoordinator = (properties.getOrDefault("node-scheduler.include-coordinator", "true")).equals("true");
         String coordinatorPort = properties.remove("http-server.http.port");
         if (coordinatorPort == null) {
             coordinatorPort = "0";
@@ -508,6 +510,9 @@ public class TestingPrestoServer
     public ConnectorId createCatalog(String catalogName, String connectorName, Map<String, String> properties)
     {
         ConnectorId connectorId = connectorManager.createConnection(catalogName, connectorName, properties);
+        if (coordinator && !nodeSchedulerIncludeCoordinator) {
+            return connectorId;
+        }
         updateConnectorIdAnnouncement(announcer, connectorId, nodeManager);
         return connectorId;
     }
@@ -645,6 +650,11 @@ public class TestingPrestoServer
     public boolean isCoordinator()
     {
         return coordinator;
+    }
+
+    public boolean nodeSchedulerIncludeCoordinator()
+    {
+        return nodeSchedulerIncludeCoordinator;
     }
 
     public boolean isResourceManager()

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestTpchQueries.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.Session;
+import org.testng.annotations.Test;
+
+public class TestTpchQueries
+        extends AbstractTestHiveQueries
+{
+    public TestTpchQueries()
+    {
+        super(true);
+    }
+
+    @Test
+    public void testMissingTpchConnector()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+        // No tpch catalog exists in the native worker.
+        assertQueryFails(session, "SELECT * FROM nation", "No nodes available to run query");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -388,7 +388,7 @@ public class DistributedQueryRunner
                 .put("distributed-index-joins-enabled", "true")
                 .put("exchange.checksum-enabled", "true");
         if (coordinator) {
-            propertiesBuilder.put("node-scheduler.include-coordinator", "true");
+            propertiesBuilder.put("node-scheduler.include-coordinator", extraProperties.getOrDefault("node-scheduler.include-coordinator", "true"));
             propertiesBuilder.put("join-distribution-type", "PARTITIONED");
         }
         HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
@@ -651,7 +651,7 @@ public class DistributedQueryRunner
         for (TestingPrestoServer server : servers) {
             server.refreshNodes();
             Set<InternalNode> activeNodesWithConnector = server.getActiveNodesWithConnector(connectorId);
-            if ((server.isCoordinator() || server.isResourceManager()) && activeNodesWithConnector.size() != servers.size()) {
+            if (((server.isCoordinator() && server.nodeSchedulerIncludeCoordinator()) || server.isResourceManager()) && activeNodesWithConnector.size() != servers.size()) {
                 return false;
             }
         }


### PR DESCRIPTION
When `node-scheduler.include-coordinator` is set to `false`, the scheduling must not happen
on the coordinator. TestingPrestoServer has been fixed to follow this semantic.
The fix is not to announce the connectorIds. This is in line with what PrestoServer does today.

Test plan
A new test TestTpchQueries.java has been added to the presto-native-execution.
Since the native worker does not have the tpch catalog, it is easier to add a test there.
This test fails without the fixes in this PR. That is, the query used in the test runs successfully
on the coordinator without the fixes in this PR.

```
== NO RELEASE NOTE ==
```
