### PR TITLE
[native] Fix test-native workflow

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -92,5 +92,6 @@ jobs:
           ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm'
 
       - name: Run e2e tests
-        rm -rf /tmp/hive_data/tpch/
-        run: ./mvnw test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas
+        run: |
+          rm -rf /tmp/hive_data/tpch/
+          ./mvnw test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas


### PR DESCRIPTION
Fix a bug introduced in https://github.com/prestodb/presto/pull/18376
that  causes the workflow to fail.

Test plan - (Please fill in how you tested your changes)
Ensure CI runs the test-native leg successfully.

```
== NO RELEASE NOTE ==
```
