### PR TITLE
Improve call performance for `sync_partition_metadata` utility

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HdfsContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HdfsContext.java
@@ -32,6 +32,7 @@ public class HdfsContext
     private final Optional<String> tablePath;
     // true if the table already exist in the metastore, false if the table is about to be created in the current transaction
     private final Optional<Boolean> isNewTable;
+    private final Optional<Boolean> isPathValidationNeeded;
     private final Optional<String> clientInfo;
     private final Optional<Set<String>> clientTags;
     private final Optional<ConnectorSession> session;
@@ -53,6 +54,7 @@ public class HdfsContext
         this.tablePath = Optional.empty();
         this.isNewTable = Optional.empty();
         this.session = Optional.empty();
+        this.isPathValidationNeeded = Optional.empty();
     }
 
     /**
@@ -97,6 +99,22 @@ public class HdfsContext
             String schemaName,
             String tableName,
             String tablePath,
+            boolean isNewTable,
+            boolean isPathValidationNeeded)
+    {
+        this(
+                session,
+                Optional.of(requireNonNull(schemaName, "schemaName is null")),
+                Optional.of(requireNonNull(tableName, "tableName is null")),
+                Optional.of(requireNonNull(tablePath, "tablePath is null")),
+                Optional.of(isNewTable),
+                Optional.of(isPathValidationNeeded));
+    }
+    public HdfsContext(
+            ConnectorSession session,
+            String schemaName,
+            String tableName,
+            String tablePath,
             boolean isNewTable)
     {
         this(
@@ -104,7 +122,8 @@ public class HdfsContext
                 Optional.of(requireNonNull(schemaName, "schemaName is null")),
                 Optional.of(requireNonNull(tableName, "tableName is null")),
                 Optional.of(requireNonNull(tablePath, "tablePath is null")),
-                Optional.of(isNewTable));
+                Optional.of(isNewTable),
+                Optional.empty());
     }
 
     private HdfsContext(
@@ -113,6 +132,22 @@ public class HdfsContext
             Optional<String> tableName,
             Optional<String> tablePath,
             Optional<Boolean> isNewTable)
+    {
+        this(
+                session,
+                schemaName,
+                tableName,
+                tablePath,
+                isNewTable,
+                Optional.empty());
+    }
+    private HdfsContext(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            Optional<String> tableName,
+            Optional<String> tablePath,
+            Optional<Boolean> isNewTable,
+            Optional<Boolean> isPathValidationNeeded)
     {
         this.session = Optional.of(requireNonNull(session, "session is null"));
         this.identity = requireNonNull(session.getIdentity(), "session.getIdentity() is null");
@@ -124,6 +159,7 @@ public class HdfsContext
         this.clientTags = Optional.of(session.getClientTags());
         this.tablePath = requireNonNull(tablePath, "tablePath is null");
         this.isNewTable = requireNonNull(isNewTable, "isNewTable is null");
+        this.isPathValidationNeeded = requireNonNull(isPathValidationNeeded, "isPathValidationNeeded is null");
     }
 
     public ConnectorIdentity getIdentity()
@@ -174,6 +210,11 @@ public class HdfsContext
     public Optional<ConnectorSession> getSession()
     {
         return session;
+    }
+
+    public Optional<Boolean> getIsPathValidationNeeded()
+    {
+        return isPathValidationNeeded;
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -145,4 +145,11 @@ public interface ExtendedHiveMetastore
     {
         return ImmutableList.of();
     }
+
+    // Different metastore systems could implement this commit batch size differently based on different underlying database capacity.
+    // Default batch partition commit size is set to 10.
+    default int getPartitionCommitBatchSize()
+    {
+        return 10;
+    }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -824,11 +824,38 @@ public class SemiTransactionalHiveMetastore
             Path currentLocation,
             PartitionStatistics statistics)
     {
+        addPartition(session, databaseName, tableName, tablePath, isNewTable, partition, currentLocation, statistics, false);
+    }
+
+    /**
+     * Add a new partition metadata in metastore
+     *
+     * @param session Connector level session
+     * @param databaseName Name of the schema
+     * @param tableName Name of the table
+     * @param tablePath Storage location of the table
+     * @param isNewTable The new partition is from an existing table or a new table
+     * @param partition The new partition object to be added
+     * @param currentLocation The path for which the partition is added in the table
+     * @param statistics The basic statistics and column statistics for the added partition
+     * @param noNeedToValidatePath check metastore file path. True for no check which is enabled by the sync partition code path only
+     */
+    public synchronized void addPartition(
+            ConnectorSession session,
+            String databaseName,
+            String tableName,
+            String tablePath,
+            boolean isNewTable,
+            Partition partition,
+            Path currentLocation,
+            PartitionStatistics statistics,
+            boolean isPathValidationNeeded)
+    {
         setShared();
         checkArgument(getPrestoQueryId(partition).isPresent());
         Map<List<String>, Action<PartitionAndMore>> partitionActionsOfTable = partitionActions.computeIfAbsent(new SchemaTableName(databaseName, tableName), k -> new HashMap<>());
         Action<PartitionAndMore> oldPartitionAction = partitionActionsOfTable.get(partition.getValues());
-        HdfsContext context = new HdfsContext(session, databaseName, tableName, tablePath, isNewTable);
+        HdfsContext context = new HdfsContext(session, databaseName, tableName, tablePath, isNewTable, isPathValidationNeeded);
         if (oldPartitionAction == null) {
             partitionActionsOfTable.put(
                     partition.getValues(),
@@ -1488,19 +1515,23 @@ public class SemiTransactionalHiveMetastore
                     partition.getSchemaTableName(),
                     ignored -> new PartitionAdder(metastoreContext, partition.getDatabaseName(), partition.getTableName(), delegate, PARTITION_COMMIT_BATCH_SIZE));
 
-            if (pathExists(context, hdfsEnvironment, currentPath)) {
-                if (!targetPath.equals(currentPath)) {
-                    renameDirectory(
-                            context,
-                            hdfsEnvironment,
-                            currentPath,
-                            targetPath,
-                            () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
+            // we can bypass the file storage path checking logic for sync partition code path
+            // because the file paths have been verified during early phase of the sync logic already
+            if (!context.getIsPathValidationNeeded().orElse(false)) {
+                if (pathExists(context, hdfsEnvironment, currentPath)) {
+                    if (!targetPath.equals(currentPath)) {
+                        renameDirectory(
+                                context,
+                                hdfsEnvironment,
+                                currentPath,
+                                targetPath,
+                                () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
+                    }
                 }
-            }
-            else {
-                cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true));
-                createDirectory(context, hdfsEnvironment, targetPath);
+                else {
+                    cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true));
+                    createDirectory(context, hdfsEnvironment, targetPath);
+                }
             }
             String partitionName = getPartitionName(metastoreContext, partition.getDatabaseName(), partition.getTableName(), partition.getValues());
             partitionAdder.addPartition(new PartitionWithStatistics(partition, partitionName, partitionAndMore.getStatisticsUpdate()));

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -115,7 +115,6 @@ import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 public class SemiTransactionalHiveMetastore
 {
     private static final Logger log = Logger.get(SemiTransactionalHiveMetastore.class);
-    private static final int PARTITION_COMMIT_BATCH_SIZE = 8;
     private static final int MAX_LAST_DATA_COMMIT_TIME_ENTRY_PER_TABLE = 100;
     private static final int MAX_LAST_DATA_COMMIT_TIME_ENTRY_PER_TRANSACTION = 10_000;
 
@@ -1513,7 +1512,7 @@ public class SemiTransactionalHiveMetastore
 
             PartitionAdder partitionAdder = partitionAdders.computeIfAbsent(
                     partition.getSchemaTableName(),
-                    ignored -> new PartitionAdder(metastoreContext, partition.getDatabaseName(), partition.getTableName(), delegate, PARTITION_COMMIT_BATCH_SIZE));
+                    ignored -> new PartitionAdder(metastoreContext, partition.getDatabaseName(), partition.getTableName(), delegate));
 
             // we can bypass the file storage path checking logic for sync partition code path
             // because the file paths have been verified during early phase of the sync logic already
@@ -2961,13 +2960,13 @@ public class SemiTransactionalHiveMetastore
         private List<List<String>> createdPartitionValues = new ArrayList<>();
         private List<MetastoreOperationResult> operationResults;
 
-        public PartitionAdder(MetastoreContext metastoreContext, String schemaName, String tableName, ExtendedHiveMetastore metastore, int batchSize)
+        public PartitionAdder(MetastoreContext metastoreContext, String schemaName, String tableName, ExtendedHiveMetastore metastore)
         {
             this.metastoreContext = requireNonNull(metastoreContext, "metastoreContext is null");
             this.schemaName = schemaName;
             this.tableName = tableName;
             this.metastore = metastore;
-            this.batchSize = batchSize;
+            this.batchSize = metastore.getPartitionCommitBatchSize();
             this.partitions = new ArrayList<>(batchSize);
             this.operationResults = new ArrayList<>();
         }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -150,7 +150,24 @@ public class GlueHiveMetastore
     private static final String PUBLIC_ROLE_NAME = "public";
     private static final String DEFAULT_METASTORE_USER = "presto";
     private static final String WILDCARD_EXPRESSION = "";
+
+    // This is the total number of partitions allowed to process in a big batch chunk which splits multiple smaller batch of partitions allowed by BATCH_CREATE_PARTITION_MAX_PAGE_SIZE
+    // Here's an example diagram on how async batches are handled for Create Partition:
+    // |--------BATCH_CREATE_PARTITION_MAX_PAGE_SIZE------------| ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // | p0, p1, p2 .....................................   p99 |
+    // |--------------------------------------------------------|
+    // | p0, p1, p2 .....................................   p99 |
+    // |--------------------------------------------------------|
+    // BATCH_PARTITION_COMMIT_TOTAL_SIZE / BATCH_CREATE_PARTITION_MAX_PAGE_SIZE ..... (10k/100=100 batches)
+    // |--------------------------------------------------------|++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // | p0, p1, p2 .....................................   p99 |
+    // |--------------------------------------------------------|
+    // | p0, p1, p2 .....................................   p99 |
+    // |--------------------------------------------------------|.......... (100 batches)
+    // |--------------------------------------------------------|++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    private static final int BATCH_PARTITION_COMMIT_TOTAL_SIZE = 10000;
     private static final int BATCH_GET_PARTITION_MAX_PAGE_SIZE = 1000;
+    // this is the total number of partitions allowed per batch that glue metastore can process to create partitions
     private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
     private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 1000;
     private static final Comparator<Partition> PARTITION_COMPARATOR = comparing(Partition::getValues, lexicographical(String.CASE_INSENSITIVE_ORDER));
@@ -224,6 +241,14 @@ public class GlueHiveMetastore
     public GlueMetastoreStats getStats()
     {
         return stats;
+    }
+
+    // For Glue metastore there's an upper bound limit on 100 partitions per batch.
+    // Here's the reference: https://docs.aws.amazon.com/glue/latest/webapi/API_BatchCreatePartition.html
+    @Override
+    public int getPartitionCommitBatchSize()
+    {
+        return BATCH_PARTITION_COMMIT_TOTAL_SIZE;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SyncPartitionMetadataProcedure.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SyncPartitionMetadataProcedure.java
@@ -233,7 +233,8 @@ public class SyncPartitionMetadataProcedure
                     false,
                     buildPartitionObject(session, table, name),
                     new Path(table.getStorage().getLocation(), name),
-                    PartitionStatistics.empty());
+                    PartitionStatistics.empty(),
+                    true);
         }
     }
 


### PR DESCRIPTION
**This PR fixes following issues:**

> Case 1: Current implementation for getting partition names takes partition values directly without taking into account of the actual path. e.g. The use of escaped character maybe encoded in HMS(Hive MetaStore) as partition name that could result incorrectness with current naming convention to fetch partition names.

- Solution: Retrieve partition storage location correctly from metastore using correct API calls

> Case 2: Sync partition utility lists file status of each partition twice. In case of handling a large of number of partitions for an external table, redundant check file status is a performance bottleneck.
- Solution: Avoid file status check after knowing the path name from storage already by the sync partition procedure code path.

> Case 3: For create partition call, batch size for number of trunks of partitions to be added to the metastore database is bounded by a fixed number. This limits the performance to update the metastore when the consumer of the underlying database is capable to handle a large number of batch and a large size of update batch. 
- Solution: Different metastore systems could implement this commit batch size differently based on different underlying database capacity.

<br>

== RELEASE NOTES ==

```
General Changes
* improve performance for procedure sync_partition_metadata 

Hive Changes
* Increase default partition batch size per commit for Hive Metastore up to 10. 
* Set default partition batch size per commit for Glue Metastore up to 10,000
```

Detail troubleshoot and solution design can be found in this reference page [here](https://docs.google.com/document/d/1BL9Qtrma6YJcPT3sZc3ofMgYDUWRz0kTKFYEJL0aMwo/edit?usp=sharing)


| # of partitions | Before (min) | after(min) | delta|
| :---: | :---: | :---: | :---: |
| 2,526 | 5 |  1 |  5 |
| 12,000 | 54 | 6 | 9 |
| 39,493 | 92 | 12 | 7 |