### PR TITLE
[native] Fix the intermediate type of approx_percentile

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -39,6 +39,7 @@ import com.facebook.presto.geospatial.SpatialPartitioningInternalAggregateFuncti
 import com.facebook.presto.geospatial.SphericalGeoFunctions;
 import com.facebook.presto.geospatial.aggregation.ConvexHullAggregation;
 import com.facebook.presto.geospatial.aggregation.GeometryUnionAgg;
+import com.facebook.presto.operator.aggregation.AlternativeApproxPercentile;
 import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregation;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations;
@@ -642,12 +643,6 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(CountAggregation.class)
                 .aggregates(VarianceAggregation.class)
                 .aggregates(CentralMomentsAggregation.class)
-                .aggregates(ApproximateLongPercentileAggregations.class)
-                .aggregates(ApproximateLongPercentileArrayAggregations.class)
-                .aggregates(ApproximateDoublePercentileAggregations.class)
-                .aggregates(ApproximateDoublePercentileArrayAggregations.class)
-                .aggregates(ApproximateRealPercentileAggregations.class)
-                .aggregates(ApproximateRealPercentileArrayAggregations.class)
                 .aggregates(CountIfAggregation.class)
                 .aggregates(BooleanAndAggregation.class)
                 .aggregates(BooleanOrAggregation.class)
@@ -935,6 +930,15 @@ public class BuiltInTypeAndFunctionNamespaceManager
             builder.override(MIN_AGGREGATION, ALTERNATIVE_MIN);
             builder.override(MAX_BY, ALTERNATIVE_MAX_BY);
             builder.override(MIN_BY, ALTERNATIVE_MIN_BY);
+            builder.functions(AlternativeApproxPercentile.getFunctions());
+        }
+        else {
+            builder.aggregates(ApproximateLongPercentileAggregations.class);
+            builder.aggregates(ApproximateLongPercentileArrayAggregations.class);
+            builder.aggregates(ApproximateDoublePercentileAggregations.class);
+            builder.aggregates(ApproximateDoublePercentileArrayAggregations.class);
+            builder.aggregates(ApproximateRealPercentileAggregations.class);
+            builder.aggregates(ApproximateRealPercentileArrayAggregations.class);
         }
 
         return builder.getFunctions();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeApproxPercentile.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeApproxPercentile.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.BuiltInFunction;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public final class AlternativeApproxPercentile
+{
+    private AlternativeApproxPercentile() {}
+
+    public static BuiltInFunction[] getFunctions()
+    {
+        List<BuiltInFunction> functions = new ArrayList<>();
+        boolean[] ft = {false, true};
+        for (Type type : new Type[] {BigintType.BIGINT, RealType.REAL, DoubleType.DOUBLE}) {
+            for (boolean percentileArray : ft) {
+                for (boolean weighted : ft) {
+                    for (boolean accuracy : ft) {
+                        functions.add(new Function(type, percentileArray, weighted, accuracy));
+                    }
+                }
+            }
+        }
+        return functions.toArray(new BuiltInFunction[0]);
+    }
+
+    private static Type createReturnType(Type valueType, boolean percentileArray)
+    {
+        return percentileArray ? new ArrayType(valueType) : valueType;
+    }
+
+    private static List<Type> createArgumentTypes(
+            Type valueType, boolean percentileArray, boolean weighted, boolean accuracy)
+    {
+        List<Type> arguments = new ArrayList<>();
+        arguments.add(valueType);
+        if (weighted) {
+            arguments.add(BigintType.BIGINT);
+        }
+        if (percentileArray) {
+            arguments.add(new ArrayType(DoubleType.DOUBLE));
+        }
+        else {
+            arguments.add(DoubleType.DOUBLE);
+        }
+        if (accuracy) {
+            arguments.add(DoubleType.DOUBLE);
+        }
+        return arguments;
+    }
+
+    private static class Function
+            extends SqlAggregationFunction
+    {
+        private static final String NAME = "approx_percentile";
+        private final Type valueType;
+        private final List<Type> inputTypes;
+        private final Type outputType;
+
+        Function(Type valueType, boolean percentileArray, boolean weighted, boolean accuracy)
+        {
+            super(
+                    NAME,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    createReturnType(valueType, percentileArray).getTypeSignature(),
+                    createArgumentTypes(valueType, percentileArray, weighted, accuracy).stream().map(Type::getTypeSignature).collect(ImmutableList.toImmutableList()));
+            this.valueType = valueType;
+            inputTypes = createArgumentTypes(valueType, percentileArray, weighted, accuracy);
+            outputType = createReturnType(valueType, percentileArray);
+        }
+
+        public String getDescription()
+        {
+            return "";
+        }
+
+        @Override
+        public BuiltInAggregationFunctionImplementation specialize(
+                BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+        {
+            Type intermediateType = RowType.from(
+                    ImmutableList.of(
+                            new RowType.Field(Optional.of("percentiles"), new ArrayType(DoubleType.DOUBLE)),
+                            new RowType.Field(Optional.of("percentileArray"), BooleanType.BOOLEAN),
+                            new RowType.Field(Optional.of("accuracy"), DoubleType.DOUBLE),
+                            new RowType.Field(Optional.of("k"), IntegerType.INTEGER),
+                            new RowType.Field(Optional.of("n"), BigintType.BIGINT),
+                            new RowType.Field(Optional.of("minValue"), valueType),
+                            new RowType.Field(Optional.of("maxValue"), valueType),
+                            new RowType.Field(Optional.of("items"), new ArrayType(valueType)),
+                            new RowType.Field(Optional.of("levels"), new ArrayType(IntegerType.INTEGER))));
+            return new BuiltInAggregationFunctionImplementation(
+                    NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
+                    true, false, null, null, null);
+        }
+    }
+}

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -25,7 +25,7 @@ TEST(VeloxToPrestoExceptionTranslatorTest, exceptionTranslation) {
   for (const bool withContext : {false, true}) {
     SCOPED_TRACE(fmt::format("withContext: {}", withContext));
     // Setup context based on 'withContext' flag.
-    auto contextMessageFunction = [](auto* arg) {
+    auto contextMessageFunction = [](VeloxException::Type type, auto* arg) {
       return std::string(static_cast<char*>(arg));
     };
     std::string contextMessage = "context message";

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -935,12 +935,7 @@ core::PlanNodePtr VeloxQueryPlanConverter::toVeloxQueryPlan(
     };
 
     return std::make_shared<core::LocalPartitionNode>(
-        node->id,
-        type,
-        partitionFunctionFactory,
-        outputType,
-        std::move(sourceNodes),
-        outputType); // TODO Remove this parameter once Velox is updated.
+        node->id, type, partitionFunctionFactory, std::move(sourceNodes));
   }
 
   if (isRoundRobinPartition(node)) {
@@ -950,20 +945,11 @@ core::PlanNodePtr VeloxQueryPlanConverter::toVeloxQueryPlan(
     };
 
     return std::make_shared<core::LocalPartitionNode>(
-        node->id,
-        type,
-        partitionFunctionFactory,
-        outputType,
-        std::move(sourceNodes),
-        outputType); // TODO Remove this parameter once Velox is updated.
+        node->id, type, partitionFunctionFactory, std::move(sourceNodes));
   }
 
   if (type == core::LocalPartitionNode::Type::kGather) {
-    return core::LocalPartitionNode::gather(
-        node->id,
-        outputType,
-        std::move(sourceNodes),
-        outputType); // TODO Remove this parameter once Velox is updated.
+    return core::LocalPartitionNode::gather(node->id, std::move(sourceNodes));
   }
 
   VELOX_UNSUPPORTED(

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveAggregationQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveAggregationQueries.java
@@ -61,11 +61,21 @@ public class TestHiveAggregationQueries
 
         assertQuery("SELECT linenumber = 2 AND quantity > 10, sum(quantity / 7) FROM lineitem GROUP BY 1");
 
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25) FROM orders");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25) FROM orders");
+        assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, 0.25) FROM orders GROUP BY 1");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25, 0.005) FROM orders");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005) FROM orders");
         assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders");
         assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25), approx_percentile(totalprice, orderkey, 0.5) FROM orders");
         assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders GROUP BY 1");
         assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25, 0.005), approx_percentile(totalprice, 0.5, 0.005) FROM orders");
         assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005), approx_percentile(totalprice, orderkey, 0.5, 0.005) FROM orders");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5]) FROM orders");
+        assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders GROUP BY 1");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5], 0.005) FROM orders");
+        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5], 0.005) FROM orders");
 
         // count is not using any channel or mask.
         // sum1 and sum3 are using different channels, but the same mask.


### PR DESCRIPTION
Summary:
Before this change, intermediate aggregation node for `approx_percentile` in worker only sees a type signature of `VARBINARY -> VARBINARY`, thus not be able to figure out the actual value type and cannot perform the merge properly when the value type is not `DOUBLE`.

This fix changes the intermediate result type to `ROW` so that we can get the value type from it and instantiate accumulator with proper type.

Fix https://github.com/facebookincubator/velox/issues/2430

Differential Revision: D39733152

