### PR TITLE
Add Total spilled bytes read stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -185,6 +185,7 @@ public class FileSingleStreamSpiller
             InputStream input = closer.register(targetFile.newInputStream());
             Iterator<Page> deserializedPages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
             Iterator<Page> compactPages = transform(deserializedPages, Page::compact);
+            spillerStats.addToTotalSpilledBytesRead(getSpilledPagesInMemorySize());
             return closeWhenExhausted(compactPages, input);
         }
         catch (IOException e) {

--- a/presto-main/src/main/java/com/facebook/presto/spiller/SpillerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/SpillerStats.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SpillerStats
 {
     protected final AtomicLong totalSpilledBytes = new AtomicLong();
+    protected final AtomicLong totalSpilledBytesRead = new AtomicLong();
 
     @Managed
     public long getTotalSpilledBytes()
@@ -27,8 +28,19 @@ public class SpillerStats
         return totalSpilledBytes.get();
     }
 
+    @Managed
+    public long getTotalSpilledBytesRead()
+    {
+        return totalSpilledBytesRead.get();
+    }
+
     public void addToTotalSpilledBytes(long delta)
     {
         totalSpilledBytes.addAndGet(delta);
+    }
+
+    public void addToTotalSpilledBytesRead(long delta)
+    {
+        totalSpilledBytesRead.addAndGet(delta);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
@@ -135,6 +135,7 @@ public class TestBinaryFileSpiller
             throws ExecutionException, InterruptedException
     {
         long spilledBytesBefore = spillerStats.getTotalSpilledBytes();
+        long spilledBytesReadBefore = spillerStats.getTotalSpilledBytesRead();
         long spilledBytes = 0;
 
         assertEquals(memoryContext.getBytes(), 0);
@@ -152,15 +153,19 @@ public class TestBinaryFileSpiller
         List<Iterator<Page>> actualSpills = spiller.getSpills();
         assertEquals(actualSpills.size(), spills.length);
 
+        long readSpilledBytes = 0;
         for (int i = 0; i < actualSpills.size(); i++) {
             List<Page> actualSpill = ImmutableList.copyOf(actualSpills.get(i));
             List<Page> expectedSpill = spills[i];
 
             assertEquals(actualSpill.size(), expectedSpill.size());
             for (int j = 0; j < actualSpill.size(); j++) {
-                assertPageEquals(types, actualSpill.get(j), expectedSpill.get(j));
+                Page actualSpillPage = actualSpill.get(j);
+                assertPageEquals(types, actualSpillPage, expectedSpill.get(j));
+                readSpilledBytes += actualSpillPage.getSizeInBytes();
             }
         }
+        assertEquals(spillerStats.getTotalSpilledBytesRead() - spilledBytesReadBefore, readSpilledBytes);
         spiller.close();
         assertEquals(memoryContext.getBytes(), 0);
     }


### PR DESCRIPTION
Adding metric to track spill bytes read back by the query. Helps with debugging memory issues to understand how much spill bytes are read back during unspil

Test plan - unit test

```
== NO RELEASE NOTE ==
```
