### PR TITLE
Fix hbo overhead with LIMIT clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;
@@ -56,7 +57,7 @@ public class StatsEquivalentPlanNodeWithLimit
     @Override
     public List<PlanNode> getSources()
     {
-        return plan.getSources();
+        return ImmutableList.of(plan);
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -76,6 +76,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         @Override
         public PlanNode visitPlan(PlanNode node, RewriteContext<Context> context)
         {
+            node = context.defaultRewrite(node, context.get());
             if (!node.getStatsEquivalentPlanNode().isPresent()) {
                 PlanNode nodeWithLimit = node;
                 // A LIMIT node can affect statistics of several children nodes, so let's put the limit node in the stats equivalent plan node.
@@ -90,7 +91,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
                 }
                 node = node.assignStatsEquivalentPlanNode(Optional.of(nodeWithLimit));
             }
-            return context.defaultRewrite(node, context.get());
+            return node;
         }
 
         @Override
@@ -98,7 +99,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         {
             context.get().getLimits().addLast(node);
             PlanNode result = visitPlan(node, context);
-            context.get().getLimits().pop();
+            context.get().getLimits().removeLast();
             return result;
         }
     }


### PR DESCRIPTION
Example: `SELECT * FROM T1 WHERE <...> LIMIT 10`

When canonicalizing the FilterNode, we canonicalize it as StatsEquivalentPlanNodeWithLimit(FilterNode, LimitNode). This is done because a limit node can effect stats of subplans by breaking early. By including the limit node in plan hash, we reduce historical coverage, but ensure that stats are correct.

When precomputing all hashes of a plan, this didn't work correctly with limit nodes. We didn't precompute hashes of all subplans as StatsEquivalentPlanNodeWithLimit, leading to rehashing, and also multiple rpc calls. We now correct it so `HistoricalStatisticsEquivalentPlanMarkingOptimizer`, can precompute and cache all plan hashes correctly, and then it will also fetch all histories at once, and no future rpc calls will take place



```
== NO RELEASE NOTE ==
```
