### PR TITLE
[native] Fix RuntimeMetric (Velox -> Presto) conversion.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -74,18 +74,6 @@ void setTiming(
   cpu = protocol::Duration(timing.cpuNanos, protocol::TimeUnit::NANOSECONDS);
 }
 
-protocol::RuntimeMetric toRuntimeMetric(
-    const std::string& name,
-    const RuntimeMetric& metric) {
-  return protocol::RuntimeMetric{
-      name,
-      toPrestoRuntimeUnit(metric.unit),
-      metric.sum,
-      metric.count,
-      metric.min,
-      metric.max};
-}
-
 } // namespace
 
 PrestoTask::PrestoTask(const std::string& taskId) : id(taskId) {
@@ -405,6 +393,18 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
     }
   }
   return str;
+}
+
+protocol::RuntimeMetric toRuntimeMetric(
+    const std::string& name,
+    const RuntimeMetric& metric) {
+  return protocol::RuntimeMetric{
+      name,
+      toPrestoRuntimeUnit(metric.unit),
+      metric.sum,
+      metric.count,
+      metric.max,
+      metric.min};
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -18,6 +18,10 @@
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/exec/Task.h"
 
+namespace facebook::velox {
+struct RuntimeMetric;
+}
+
 namespace facebook::presto {
 
 template <typename T>
@@ -114,5 +118,9 @@ struct PrestoTask {
 
 using TaskMap =
     std::unordered_map<protocol::TaskId, std::shared_ptr<PrestoTask>>;
+
+protocol::RuntimeMetric toRuntimeMetric(
+    const std::string& name,
+    const facebook::velox::RuntimeMetric& metric);
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 add_executable(
   presto_server_test
   PrestoExchangeSourceTest.cpp TaskManagerTest.cpp HttpServerWrapper.cpp
-  PrestoTaskIdTest.cpp AnnouncerTest.cpp QueryContextCacheTest.cpp)
+  PrestoTaskTest.cpp AnnouncerTest.cpp QueryContextCacheTest.cpp)
 
 add_test(presto_server_test presto_server_test)
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -11,12 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "presto_cpp/main/types/PrestoTaskId.h"
+#include "presto_cpp/main/PrestoTask.h"
 #include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::presto;
 
 using facebook::presto::PrestoTaskId;
 
-TEST(PrestoTaskIdTest, basic) {
+class PrestoTaskTest : public testing::Test {};
+
+TEST_F(PrestoTaskTest, basicTaskId) {
   PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3");
 
   EXPECT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
@@ -25,9 +30,27 @@ TEST(PrestoTaskIdTest, basic) {
   EXPECT_EQ(id.id(), 3);
 }
 
-TEST(PrestoTaskIdTest, malformed) {
+TEST_F(PrestoTaskTest, malformedTaskId) {
   ASSERT_THROW(PrestoTaskId(""), std::invalid_argument);
   ASSERT_THROW(
       PrestoTaskId("20201107_130540_00011_wrpkw."), std::invalid_argument);
   ASSERT_THROW(PrestoTaskId("q.1.2"), std::invalid_argument);
+}
+
+TEST_F(PrestoTaskTest, runtimeMetricConversion) {
+  RuntimeMetric veloxMetric;
+  veloxMetric.unit = RuntimeCounter::Unit::kBytes;
+  veloxMetric.sum = 101;
+  veloxMetric.count = 17;
+  veloxMetric.min = 62;
+  veloxMetric.max = 79;
+
+  const std::string metricName{"my_name"};
+  const auto prestoMetric = toRuntimeMetric(metricName, veloxMetric);
+  EXPECT_EQ(metricName, prestoMetric.name);
+  EXPECT_EQ(protocol::RuntimeUnit::BYTE, prestoMetric.unit);
+  EXPECT_EQ(veloxMetric.sum, prestoMetric.sum);
+  EXPECT_EQ(veloxMetric.count, prestoMetric.count);
+  EXPECT_EQ(veloxMetric.max, prestoMetric.max);
+  EXPECT_EQ(veloxMetric.min, prestoMetric.min);
 }


### PR DESCRIPTION
Fix RuntimeMetric (Velox -> Presto) conversion (min and max were swapped).

Test plan - New test.

```
== NO RELEASE NOTE ==
```
