### PR TITLE
[native] Fix a 'range-loop-construct' warning from clang

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -44,7 +44,7 @@ int64_t sumOpSpillBytes(
   int64_t sum = 0;
   const auto& taskStats = taskInfo.stats;
   for (const auto& pipelineStats : taskStats.pipelines) {
-    for (const auto opStats : pipelineStats.operatorSummaries) {
+    for (const auto& opStats : pipelineStats.operatorSummaries) {
       if (opStats.operatorType != opType) {
         continue;
       }


### PR DESCRIPTION
Fix a 'range-loop-construct' warning from clang. gcc does not produce such warning over the same code.
The original warnings:
third-party/presto_cpp/main/tests/TaskManagerTest.cpp:47:21: error: loop variable 'opStats' creates a copy from type 'const facebook::presto::protocol::OperatorStats' [-Werror,-Wrange-loop-construct]
    for (const auto opStats : pipelineStats.operatorSummaries) {
                    ^
third-party/presto_cpp/main/tests/TaskManagerTest.cpp:47:10: note: use reference type 'const facebook::presto::protocol::OperatorStats &' to prevent copying
    for (const auto opStats : pipelineStats.operatorSummaries) {
         ^~~~~~~~~~~~~~~~~~~~
                    &
1 error generated.
Command failed with exit code 1.

Test plan - (Please fill in how you tested your changes)
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```
