### PR TITLE
Reduce objects in Presto worker

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -446,16 +446,16 @@ public class DwrfMetadataReader
     private RowGroupIndex toRowGroupIndex(HiveWriterVersion hiveWriterVersion, DwrfProto.RowIndexEntry rowIndexEntry, HiveBloomFilter bloomFilter)
     {
         List<Long> positionsList = rowIndexEntry.getPositionsList();
-        ImmutableList.Builder<Integer> positions = ImmutableList.builderWithExpectedSize(positionsList.size());
+        int[] positions = new int[positionsList.size()];
         for (int index = 0; index < positionsList.size(); index++) {
             long longPosition = positionsList.get(index);
             int intPosition = (int) longPosition;
 
             checkState(intPosition == longPosition, "Expected checkpoint position %s, to be an integer", index);
 
-            positions.add(intPosition);
+            positions[index] = intPosition;
         }
-        return new RowGroupIndex(positions.build(), toColumnStatistics(hiveWriterVersion, rowIndexEntry.getStatistics(), true, bloomFilter));
+        return new RowGroupIndex(positions, toColumnStatistics(hiveWriterVersion, rowIndexEntry.getStatistics(), true, bloomFilter));
     }
 
     private List<ColumnStatistics> toColumnStatistics(HiveWriterVersion hiveWriterVersion, List<DwrfProto.ColumnStatistics> columnStatistics, boolean isRowGroup)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -421,12 +421,11 @@ public class DwrfMetadataWriter
 
     private static RowIndexEntry toRowGroupIndex(RowGroupIndex rowGroupIndex)
     {
-        return RowIndexEntry.newBuilder()
-                .addAllPositions(rowGroupIndex.getPositions().stream()
-                        .map(Integer::longValue)
-                        .collect(toImmutableList()))
-                .setStatistics(toColumnStatistics(rowGroupIndex.getColumnStatistics()))
-                .build();
+        RowIndexEntry.Builder builder = RowIndexEntry.newBuilder();
+        for (int position : rowGroupIndex.getPositions()) {
+            builder.addPositions(position);
+        }
+        return builder.setStatistics(toColumnStatistics(rowGroupIndex.getColumnStatistics())).build();
     }
 
     private static DwrfProto.CompressionKind toCompression(CompressionKind compressionKind)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -253,16 +253,16 @@ public class OrcMetadataReader
     private static RowGroupIndex toRowGroupIndex(HiveWriterVersion hiveWriterVersion, RowIndexEntry rowIndexEntry, HiveBloomFilter bloomFilter)
     {
         List<Long> positionsList = rowIndexEntry.getPositionsList();
-        ImmutableList.Builder<Integer> positions = ImmutableList.builder();
+        int[] positions = new int[positionsList.size()];
         for (int index = 0; index < positionsList.size(); index++) {
             long longPosition = positionsList.get(index);
             int intPosition = (int) longPosition;
 
             checkState(intPosition == longPosition, "Expected checkpoint position %s, to be an integer", index);
 
-            positions.add(intPosition);
+            positions[index] = intPosition;
         }
-        return new RowGroupIndex(positions.build(), toColumnStatistics(hiveWriterVersion, rowIndexEntry.getStatistics(), true, bloomFilter));
+        return new RowGroupIndex(positions, toColumnStatistics(hiveWriterVersion, rowIndexEntry.getStatistics(), true, bloomFilter));
     }
 
     private static ColumnStatistics toColumnStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.ColumnStatistics statistics, boolean isRowGroup, HiveBloomFilter bloomFilter)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -378,12 +378,11 @@ public class OrcMetadataWriter
 
     private static RowIndexEntry toRowGroupIndex(RowGroupIndex rowGroupIndex)
     {
-        return OrcProto.RowIndexEntry.newBuilder()
-                .addAllPositions(rowGroupIndex.getPositions().stream()
-                        .map(Integer::longValue)
-                        .collect(toList()))
-                .setStatistics(toColumnStatistics(rowGroupIndex.getColumnStatistics()))
-                .build();
+        OrcProto.RowIndexEntry.Builder builder = OrcProto.RowIndexEntry.newBuilder();
+        for (int position : rowGroupIndex.getPositions()) {
+            builder.addPositions(position);
+        }
+        return builder.setStatistics(toColumnStatistics(rowGroupIndex.getColumnStatistics())).build();
     }
 
     private static OrcProto.CompressionKind toCompression(CompressionKind compressionKind)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/RowGroupIndex.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/RowGroupIndex.java
@@ -14,28 +14,25 @@
 package com.facebook.presto.orc.metadata;
 
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
-import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
-
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class RowGroupIndex
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowGroupIndex.class).instanceSize();
-    private static final int INTEGER_INSTANCE_SIZE = ClassLayout.parseClass(Integer.class).instanceSize();
 
-    private final List<Integer> positions;
+    private final int[] positions;
     private final ColumnStatistics statistics;
 
-    public RowGroupIndex(List<Integer> positions, ColumnStatistics statistics)
+    public RowGroupIndex(int[] positions, ColumnStatistics statistics)
     {
-        this.positions = ImmutableList.copyOf(requireNonNull(positions, "positions is null"));
+        this.positions = requireNonNull(positions, "positions is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
     }
 
-    public List<Integer> getPositions()
+    public int[] getPositions()
     {
         return positions;
     }
@@ -47,6 +44,6 @@ public class RowGroupIndex
 
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + positions.size() * INTEGER_INSTANCE_SIZE + statistics.getRetainedSizeInBytes();
+        return INSTANCE_SIZE + sizeOf(positions) + statistics.getRetainedSizeInBytes();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
@@ -84,6 +84,6 @@ public class TestStripeReader
 
     private static List<RowGroupIndex> createRowGroupIndex(ColumnStatistics columnStatistics)
     {
-        return ImmutableList.of(new RowGroupIndex(ImmutableList.of(0, 0, 0, 0), columnStatistics));
+        return ImmutableList.of(new RowGroupIndex(new int[]{0, 0, 0, 0}, columnStatistics));
     }
 }


### PR DESCRIPTION
Presto heavily uses RowGroupIndex for pruning. On some internal
meta deployments RowGroupIndexes are cached in CachingStripeMetadataSource.
On these deployments 25% of the objects have root in RowGroupIndex.
Before this change RowGroupIndex, contained ImmutableList of positions
and each position is a boxed integer.
After this change RowGroupIndex contains the primitive integer array.
This eliminates about 15% of the objects on these deployments.

Test plan - 
Existing tests

```
== NO RELEASE NOTE ==
```
