### PR TITLE
Fix incorrectly set wall time

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -326,7 +326,7 @@ public class QueryMonitor
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
                 ofMillis(queryStats.getRetriedCpuTime().toMillis()),
-                ofMillis(queryStats.getTotalScheduledTime().toMillis()),
+                ofMillis(queryStats.getElapsedTime().toMillis()),
                 ofMillis(queryStats.getWaitingForPrerequisitesTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
                 ofMillis(queryStats.getResourceWaitingTime().toMillis()),


### PR DESCRIPTION
Wall time should be set to elapsed time, not total scheduled time

Cherry pick of https://github.com/trinodb/trino/commit/7cc7b51a86d0935afddf199073cd942728671b30
Co-Authored-By: William Shen <willshen@users.noreply.github.com>

```
== NO RELEASE NOTE ==
```
