### PR TITLE
Do not throw exception for Parquet corrupted statistics

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
@@ -21,6 +21,7 @@ public enum HiveWarningCode
 {
     PARTITION_NOT_READABLE(1),
     HIVE_TABLESCAN_CONVERTED_TO_VALUESNODE(2),
+    HIVE_FILE_STATISTICS_CORRUPTION(3),
     /**/;
     private final WarningCode warningCode;
 

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
@@ -45,9 +45,6 @@ import java.util.Properties;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hudi.HudiParquetPageSources.createParquetPageSource;
-import static com.facebook.presto.hudi.HudiSessionProperties.getParquetMaxReadBlockSize;
-import static com.facebook.presto.hudi.HudiSessionProperties.isParquetBatchReaderVerificationEnabled;
-import static com.facebook.presto.hudi.HudiSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -101,18 +98,14 @@ public class HudiPageSourceProvider
             dataColumnPageSource = createParquetPageSource(
                     typeManager,
                     hdfsEnvironment,
-                    session.getUser(),
+                    session,
                     configuration,
                     path,
                     baseFile.getStart(),
                     baseFile.getLength(),
                     dataColumns,
-                    getParquetMaxReadBlockSize(session),
-                    isParquetBatchReadsEnabled(session),
-                    isParquetBatchReaderVerificationEnabled(session),
                     TupleDomain.all(), // TODO: predicates
-                    fileFormatDataSourceStats,
-                    false);
+                    fileFormatDataSourceStats);
         }
         else if (tableType == HudiTableType.MOR) {
             Properties schema = getHiveSchema(

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingWarningCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingWarningCollector.java
@@ -85,4 +85,10 @@ public class TestingWarningCollector
         // See the SQL Standard ISO_IEC_9075-2E_2016 24.1: SQLState for more information
         return new PrestoWarning(new WarningCode(code, format("015%02d", code % 100)), "Test warning " + code);
     }
+
+    @VisibleForTesting
+    public void clear()
+    {
+        warnings.clear();
+    }
 }

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -79,6 +79,11 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -95,6 +100,12 @@
             <artifactId>slice</artifactId>
         </dependency>
 
+        <!-- For Presto Hive warning codes -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-common</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -105,12 +116,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-apache2</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.parquet.predicate;
 
-import com.facebook.presto.parquet.ParquetCorruptionException;
 import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.spi.WarningCollector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
@@ -27,8 +27,7 @@ public interface Predicate
     Predicate TRUE = new Predicate()
     {
         @Override
-        public boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id)
-                throws ParquetCorruptionException
+        public boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id, Optional<WarningCollector> warningCollector)
         {
             return true;
         }
@@ -53,9 +52,9 @@ public interface Predicate
      * Statistics to determine if a column is only null
      * @param statistics column statistics
      * @param id Parquet file name
+     * @param warningCollector Presto WarningCollector that is used to collect warnings when the statistics is corrupt
      */
-    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id)
-            throws ParquetCorruptionException;
+    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id, Optional<WarningCollector> warningCollector);
 
     /**
      * Should the Parquet Reader process a file section with the specified dictionary based on that

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -20,6 +20,7 @@ import com.facebook.presto.parquet.ParquetCorruptionException;
 import com.facebook.presto.parquet.ParquetDataSource;
 import com.facebook.presto.parquet.ParquetEncoding;
 import com.facebook.presto.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.WarningCollector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -86,11 +87,39 @@ public final class PredicateUtils
         return new TupleDomainParquetPredicate(parquetTupleDomain, columnReferences.build());
     }
 
-    public static boolean predicateMatches(Predicate parquetPredicate, BlockMetaData block, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain, Optional<ColumnIndexStore> columnIndexStore, boolean readColumnIndex)
+    public static boolean predicateMatches(
+            Predicate parquetPredicate,
+            BlockMetaData block,
+            ParquetDataSource dataSource,
+            Map<List<String>, RichColumnDescriptor> descriptorsByPath,
+            TupleDomain<ColumnDescriptor> parquetTupleDomain,
+            Optional<ColumnIndexStore> columnIndexStore,
+            boolean readColumnIndex)
             throws ParquetCorruptionException
     {
+        return predicateMatches(
+                parquetPredicate,
+                block,
+                dataSource,
+                descriptorsByPath,
+                parquetTupleDomain,
+                columnIndexStore,
+                readColumnIndex,
+                Optional.empty());
+    }
+
+    public static boolean predicateMatches(
+            Predicate parquetPredicate,
+            BlockMetaData block,
+            ParquetDataSource dataSource,
+            Map<List<String>, RichColumnDescriptor> descriptorsByPath,
+            TupleDomain<ColumnDescriptor> parquetTupleDomain,
+            Optional<ColumnIndexStore> columnIndexStore,
+            boolean readColumnIndex,
+            Optional<WarningCollector> warningCollector)
+    {
         Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, descriptorsByPath);
-        if (!parquetPredicate.matches(block.getRowCount(), columnStatistics, dataSource.getId())) {
+        if (!parquetPredicate.matches(block.getRowCount(), columnStatistics, dataSource.getId(), warningCollector)) {
             return false;
         }
 

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
@@ -18,8 +18,12 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.parquet.predicate.DictionaryDescriptor;
 import com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.testing.TestingWarningCollector;
+import com.facebook.presto.testing.TestingWarningCollectorConfig;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -36,6 +40,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -54,6 +59,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.hive.HiveWarningCode.HIVE_FILE_STATISTICS_CORRUPTION;
 import static com.facebook.presto.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate.getDomain;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -71,7 +77,6 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -79,19 +84,7 @@ import static org.testng.Assert.assertTrue;
 public class TestTupleDomainParquetPredicate
 {
     private static final ParquetDataSourceId ID = new ParquetDataSourceId("testFile");
-
-    @Test
-    public void testBoolean()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(PrimitiveTypeName.BOOLEAN, "BooleanColumn");
-        assertEquals(getDomain(columnDescriptor, BOOLEAN, 0, null, ID), Domain.all(BOOLEAN));
-
-        assertEquals(getDomain(columnDescriptor, BOOLEAN, 10, booleanColumnStats(true, true), ID), singleValue(BOOLEAN, true));
-        assertEquals(getDomain(columnDescriptor, BOOLEAN, 10, booleanColumnStats(false, false), ID), singleValue(BOOLEAN, false));
-
-        assertEquals(getDomain(columnDescriptor, BOOLEAN, 20, booleanColumnStats(false, true), ID), Domain.all(BOOLEAN));
-    }
+    private TestingWarningCollector collector = new TestingWarningCollector(new WarningCollectorConfig(), new TestingWarningCollectorConfig().setAddWarnings(true));
 
     private static BooleanStatistics booleanColumnStats(boolean minimum, boolean maximum)
     {
@@ -100,266 +93,13 @@ public class TestTupleDomainParquetPredicate
         return statistics;
     }
 
-    @Test
-    public void testBigint()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT64, "BigintColumn");
-        assertEquals(getDomain(columnDescriptor, BIGINT, 0, null, ID), Domain.all(BIGINT));
-
-        assertEquals(getDomain(columnDescriptor, BIGINT, 10, longColumnStats(100L, 100L), ID), singleValue(BIGINT, 100L));
-
-        assertEquals(getDomain(columnDescriptor, BIGINT, 10, longColumnStats(0L, 100L), ID), create(ValueSet.ofRanges(range(BIGINT, 0L, true, 100L, true)), false));
-
-        assertEquals(getDomain(columnDescriptor, BIGINT, 20, longOnlyNullsStats(10), ID), create(ValueSet.all(BIGINT), true));
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, BIGINT, 10, longColumnStats(100L, 10L), ID))
-                .withMessage("Corrupted statistics for column \"[] required int64 BigintColumn\" in Parquet file \"testFile\": [min: 100, max: 10, num_nulls: 0]");
-    }
-
-    @Test
-    public void testInteger()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "IntegerColumn");
-        assertEquals(getDomain(columnDescriptor, INTEGER, 0, null, ID), Domain.all(INTEGER));
-
-        assertEquals(getDomain(columnDescriptor, INTEGER, 10, longColumnStats(100, 100), ID), singleValue(INTEGER, 100L));
-
-        assertEquals(getDomain(columnDescriptor, INTEGER, 10, longColumnStats(0, 100), ID), create(ValueSet.ofRanges(range(INTEGER, 0L, true, 100L, true)), false));
-
-        assertEquals(getDomain(columnDescriptor, INTEGER, 20, longColumnStats(0, 2147483648L), ID), notNull(INTEGER));
-
-        assertEquals(getDomain(columnDescriptor, INTEGER, 20, longOnlyNullsStats(10), ID), create(ValueSet.all(INTEGER), true));
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, INTEGER, 10, longColumnStats(2147483648L, 10), ID))
-                .withMessage("Corrupted statistics for column \"[] required int32 IntegerColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
-    }
-
-    @Test
-    public void testSmallint()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "SmallintColumn");
-        assertEquals(getDomain(columnDescriptor, SMALLINT, 0, null, ID), Domain.all(SMALLINT));
-
-        assertEquals(getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(100, 100), ID), singleValue(SMALLINT, 100L));
-
-        assertEquals(getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(0, 100), ID), create(ValueSet.ofRanges(range(SMALLINT, 0L, true, 100L, true)), false));
-
-        assertEquals(getDomain(columnDescriptor, SMALLINT, 20, longColumnStats(0, 2147483648L), ID), notNull(SMALLINT));
-
-        assertEquals(getDomain(columnDescriptor, SMALLINT, 20, longOnlyNullsStats(10), ID), create(ValueSet.all(SMALLINT), true));
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(2147483648L, 10), ID))
-                .withMessage("Corrupted statistics for column \"[] required int32 SmallintColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
-    }
-
-    @Test
-    public void testTinyint()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "TinyintColumn");
-        assertEquals(getDomain(columnDescriptor, TINYINT, 0, null, ID), Domain.all(TINYINT));
-
-        assertEquals(getDomain(columnDescriptor, TINYINT, 10, longColumnStats(100, 100), ID), singleValue(TINYINT, 100L));
-
-        assertEquals(getDomain(columnDescriptor, TINYINT, 10, longColumnStats(0, 100), ID), create(ValueSet.ofRanges(range(TINYINT, 0L, true, 100L, true)), false));
-
-        assertEquals(getDomain(columnDescriptor, TINYINT, 20, longColumnStats(0, 2147483648L), ID), notNull(TINYINT));
-
-        assertEquals(getDomain(columnDescriptor, TINYINT, 20, longOnlyNullsStats(10), ID), create(ValueSet.all(TINYINT), true));
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, TINYINT, 10, longColumnStats(2147483648L, 10), ID))
-                .withMessage("Corrupted statistics for column \"[] required int32 TinyintColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
-    }
-
-    @Test
-    public void testDouble()
-            throws Exception
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(PrimitiveTypeName.DOUBLE, "DoubleColumn");
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 0, null, ID), Domain.all(DOUBLE));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(42.24, 42.24), ID), singleValue(DOUBLE, 42.24));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, 42.24), ID), create(ValueSet.ofRanges(range(DOUBLE, 3.3, true, 42.24, true)), false));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(NaN, NaN), ID), Domain.notNull(DOUBLE));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(NaN, NaN, true), ID), Domain.all(DOUBLE));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, NaN), ID), Domain.notNull(DOUBLE));
-
-        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, NaN, true), ID), Domain.all(DOUBLE));
-
-        assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(NaN)), Domain.all(DOUBLE));
-
-        assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(3.3, NaN)), Domain.all(DOUBLE));
-
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(42.24, 3.3), ID))
-                .withMessage("Corrupted statistics for column \"[] required double DoubleColumn\" in Parquet file \"testFile\": [min: 42.24, max: 3.3, num_nulls: 0]");
-    }
-
-    @Test
-    public void testString()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(BINARY, "StringColumn");
-        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 0, null, ID), Domain.all(createUnboundedVarcharType()));
-
-        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("taco", "taco"), ID), singleValue(createUnboundedVarcharType(), utf8Slice("taco")));
-
-        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("apple", "taco"), ID), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
-
-        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("中国", "美利坚"), ID), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("中国"), true, utf8Slice("美利坚"), true)), false));
-
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("taco", "apple"), ID))
-                .withMessage("Corrupted statistics for column \"[] required binary StringColumn\" in Parquet file \"testFile\": [min: taco, max: apple, num_nulls: 0]");
-    }
-
     private static Statistics stringColumnStats(String minimum, String maximum)
     {
         Statistics.Builder builder = Statistics.getBuilderForReading(new PrimitiveType(OPTIONAL, BINARY, "testFile", UTF8));
         builder.withMin(minimum.getBytes())
-               .withMax(maximum.getBytes())
-               .withNumNulls(0);
+                .withMax(maximum.getBytes())
+                .withNumNulls(0);
         return builder.build();
-    }
-
-    @Test
-    public void testFloat()
-            throws Exception
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(FLOAT, "FloatColumn");
-        assertEquals(getDomain(columnDescriptor, REAL, 0, null, ID), Domain.all(REAL));
-
-        float minimum = 4.3f;
-        float maximum = 40.3f;
-
-        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, minimum), ID), singleValue(REAL, (long) floatToRawIntBits(minimum)));
-
-        assertEquals(
-                getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, maximum), ID),
-                create(ValueSet.ofRanges(range(REAL, (long) floatToRawIntBits(minimum), true, (long) floatToRawIntBits(maximum), true)), false));
-
-        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(NaN, NaN), ID), Domain.notNull(REAL));
-
-        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(NaN, NaN, true), ID), Domain.all(REAL));
-
-        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, NaN), ID), Domain.notNull(REAL));
-
-        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, NaN, true), ID), Domain.all(REAL));
-
-        assertEquals(getDomain(REAL, floatDictionaryDescriptor(NaN)), Domain.all(REAL));
-
-        assertEquals(getDomain(REAL, floatDictionaryDescriptor(minimum, NaN)), Domain.all(REAL));
-
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, REAL, 10, floatColumnStats(maximum, minimum), ID))
-                .withMessage("Corrupted statistics for column \"[] required float FloatColumn\" in Parquet file \"testFile\": [min: 40.3, max: 4.3, num_nulls: 0]");
-    }
-
-    @Test
-    public void testDate()
-            throws ParquetCorruptionException
-    {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "DateColumn");
-        assertEquals(getDomain(columnDescriptor, DATE, 0, null, ID), Domain.all(DATE));
-        assertEquals(getDomain(columnDescriptor, DATE, 10, intColumnStats(100, 100), ID), singleValue(DATE, 100L));
-        assertEquals(getDomain(columnDescriptor, DATE, 10, intColumnStats(0, 100), ID), create(ValueSet.ofRanges(range(DATE, 0L, true, 100L, true)), false));
-
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(columnDescriptor, DATE, 10, intColumnStats(200, 100), ID))
-                .withMessage("Corrupted statistics for column \"[] required int32 DateColumn\" in Parquet file \"testFile\": [min: 200, max: 100, num_nulls: 0]");
-    }
-
-    @Test
-    public void testVarcharMatchesWithStatistics()
-            throws ParquetCorruptionException
-    {
-        String value = "Test";
-        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"path"}, BINARY, 0, 0);
-        RichColumnDescriptor column = new RichColumnDescriptor(columnDescriptor, new PrimitiveType(OPTIONAL, BINARY, "Test column"));
-        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), utf8Slice(value));
-        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
-        Statistics<?> stats = getStatsBasedOnType(column.getType());
-        stats.setNumNulls(1L);
-        stats.setMinMaxFromBytes(value.getBytes(), value.getBytes());
-        assertTrue(parquetPredicate.matches(2, singletonMap(column, stats), ID));
-    }
-
-    @Test(dataProvider = "typeForParquetInt32")
-    public void testIntegerMatchesWithStatistics(Type typeForParquetInt32)
-            throws ParquetCorruptionException
-    {
-        RichColumnDescriptor column = new RichColumnDescriptor(
-                new ColumnDescriptor(new String[] {"path"}, INT32, 0, 0),
-                new PrimitiveType(OPTIONAL, INT32, "Test column"));
-        TupleDomain<ColumnDescriptor> effectivePredicate = TupleDomain.withColumnDomains(ImmutableMap.of(
-                column,
-                Domain.create(ValueSet.of(typeForParquetInt32, 42L, 43L, 44L, 112L), false)));
-        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
-
-        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(32, 42)), ID));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(30, 40)), ID));
-        assertEquals(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(1024, 0x10000 + 42)), ID), (typeForParquetInt32 != INTEGER)); // stats invalid for smallint/tinyint
-    }
-
-    @DataProvider
-    public Object[][] typeForParquetInt32()
-    {
-        return new Object[][] {
-                {INTEGER},
-                {SMALLINT},
-                {TINYINT},
-        };
-    }
-
-    @Test
-    public void testBigintMatchesWithStatistics()
-            throws ParquetCorruptionException
-    {
-        RichColumnDescriptor column = new RichColumnDescriptor(
-                new ColumnDescriptor(new String[] {"path"}, INT64, 0, 0),
-                new PrimitiveType(OPTIONAL, INT64, "Test column"));
-        TupleDomain<ColumnDescriptor> effectivePredicate = TupleDomain.withColumnDomains(ImmutableMap.of(
-                column,
-                Domain.create(ValueSet.of(BIGINT, 42L, 43L, 44L, 404L), false)));
-        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
-
-        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(32, 42)), ID));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(30, 40)), ID));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(1024, 0x10000 + 42)), ID));
-    }
-
-    @Test
-    public void testVarcharMatchesWithDictionaryDescriptor()
-    {
-        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"path"}, new PrimitiveType(OPTIONAL, BINARY, 0, ""), 0, 0);
-        RichColumnDescriptor column = new RichColumnDescriptor(columnDescriptor, new PrimitiveType(OPTIONAL, BINARY, "Test column"));
-        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), EMPTY_SLICE);
-        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
-        DictionaryPage page = new DictionaryPage(Slices.wrappedBuffer(new byte[] {0, 0, 0, 0}), 1, PLAIN_DICTIONARY);
-        assertTrue(parquetPredicate.matches(new DictionaryDescriptor(column, Optional.of(page))));
-    }
-
-    private TupleDomain<ColumnDescriptor> getEffectivePredicate(RichColumnDescriptor column, VarcharType type, Slice value)
-    {
-        ColumnDescriptor predicateColumn = new ColumnDescriptor(column.getPath(), column.getType(), 0, 0);
-        Domain predicateDomain = singleValue(type, value);
-        Map<ColumnDescriptor, Domain> predicateColumns = singletonMap(predicateColumn, predicateDomain);
-        return withColumnDomains(predicateColumns);
     }
 
     private static DoubleStatistics doubleColumnStats(double minimum, double maximum)
@@ -406,6 +146,259 @@ public class TestTupleDomainParquetPredicate
         return statistics;
     }
 
+    private static LongStatistics longOnlyNullsStats(long numNulls)
+    {
+        LongStatistics statistics = new LongStatistics();
+        statistics.setNumNulls(numNulls);
+        return statistics;
+    }
+
+    @Test
+    public void testBoolean()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(PrimitiveTypeName.BOOLEAN, "BooleanColumn");
+        assertEquals(getDomain(columnDescriptor, BOOLEAN, 0, null, ID, Optional.of(collector)), Domain.all(BOOLEAN));
+
+        assertEquals(getDomain(columnDescriptor, BOOLEAN, 10, booleanColumnStats(true, true), ID, Optional.of(collector)), singleValue(BOOLEAN, true));
+        assertEquals(getDomain(columnDescriptor, BOOLEAN, 10, booleanColumnStats(false, false), ID, Optional.of(collector)), singleValue(BOOLEAN, false));
+
+        assertEquals(getDomain(columnDescriptor, BOOLEAN, 20, booleanColumnStats(false, true), ID, Optional.of(collector)), Domain.all(BOOLEAN));
+    }
+
+    @Test
+    public void testBigint()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT64, "BigintColumn");
+        assertEquals(getDomain(columnDescriptor, BIGINT, 0, null, ID, Optional.of(collector)), Domain.all(BIGINT));
+
+        assertEquals(getDomain(columnDescriptor, BIGINT, 10, longColumnStats(100L, 100L), ID, Optional.of(collector)), singleValue(BIGINT, 100L));
+
+        assertEquals(getDomain(columnDescriptor, BIGINT, 10, longColumnStats(0L, 100L), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(BIGINT, 0L, true, 100L, true)), false));
+
+        assertEquals(getDomain(columnDescriptor, BIGINT, 20, longOnlyNullsStats(10), ID, Optional.of(collector)), create(ValueSet.all(BIGINT), true));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, BIGINT, 10, longColumnStats(100L, 10L), ID, Optional.of(collector)), BIGINT);
+    }
+
+    @Test
+    public void testInteger()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "IntegerColumn");
+        assertEquals(getDomain(columnDescriptor, INTEGER, 0, null, ID, Optional.of(collector)), Domain.all(INTEGER));
+
+        assertEquals(getDomain(columnDescriptor, INTEGER, 10, longColumnStats(100, 100), ID, Optional.of(collector)), singleValue(INTEGER, 100L));
+
+        assertEquals(getDomain(columnDescriptor, INTEGER, 10, longColumnStats(0, 100), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(INTEGER, 0L, true, 100L, true)), false));
+
+        assertEquals(getDomain(columnDescriptor, INTEGER, 20, longColumnStats(0, 2147483648L), ID, Optional.of(collector)), notNull(INTEGER));
+
+        assertEquals(getDomain(columnDescriptor, INTEGER, 20, longOnlyNullsStats(10), ID, Optional.of(collector)), create(ValueSet.all(INTEGER), true));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, INTEGER, 10, longColumnStats(2147483648L, 10), ID, Optional.of(collector)), INTEGER);
+    }
+
+    @Test
+    public void testSmallint()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "SmallintColumn");
+        assertEquals(getDomain(columnDescriptor, SMALLINT, 0, null, ID, Optional.of(collector)), Domain.all(SMALLINT));
+
+        assertEquals(getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(100, 100), ID, Optional.of(collector)), singleValue(SMALLINT, 100L));
+
+        assertEquals(getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(0, 100), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(SMALLINT, 0L, true, 100L, true)), false));
+
+        assertEquals(getDomain(columnDescriptor, SMALLINT, 20, longColumnStats(0, 2147483648L), ID, Optional.of(collector)), notNull(SMALLINT));
+
+        assertEquals(getDomain(columnDescriptor, SMALLINT, 20, longOnlyNullsStats(10), ID, Optional.of(collector)), create(ValueSet.all(SMALLINT), true));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, SMALLINT, 10, longColumnStats(2147483648L, 10), ID, Optional.of(collector)), SMALLINT);
+    }
+
+    @Test
+    public void testTinyint()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "TinyintColumn");
+        assertEquals(getDomain(columnDescriptor, TINYINT, 0, null, ID, Optional.of(collector)), Domain.all(TINYINT));
+
+        assertEquals(getDomain(columnDescriptor, TINYINT, 10, longColumnStats(100, 100), ID, Optional.of(collector)), singleValue(TINYINT, 100L));
+
+        assertEquals(getDomain(columnDescriptor, TINYINT, 10, longColumnStats(0, 100), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(TINYINT, 0L, true, 100L, true)), false));
+
+        assertEquals(getDomain(columnDescriptor, TINYINT, 20, longColumnStats(0, 2147483648L), ID, Optional.of(collector)), notNull(TINYINT));
+
+        assertEquals(getDomain(columnDescriptor, TINYINT, 20, longOnlyNullsStats(10), ID, Optional.of(collector)), create(ValueSet.all(TINYINT), true));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, TINYINT, 10, longColumnStats(2147483648L, 10), ID, Optional.of(collector)), TINYINT);
+    }
+
+    @Test
+    public void testDouble()
+            throws Exception
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(PrimitiveTypeName.DOUBLE, "DoubleColumn");
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 0, null, ID, Optional.of(collector)), Domain.all(DOUBLE));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(42.24, 42.24), ID, Optional.of(collector)), singleValue(DOUBLE, 42.24));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, 42.24), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(DOUBLE, 3.3, true, 42.24, true)), false));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(NaN, NaN), ID, Optional.of(collector)), Domain.notNull(DOUBLE));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(NaN, NaN, true), ID, Optional.of(collector)), Domain.all(DOUBLE));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, NaN), ID, Optional.of(collector)), Domain.notNull(DOUBLE));
+
+        assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, NaN, true), ID, Optional.of(collector)), Domain.all(DOUBLE));
+
+        assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(NaN)), Domain.all(DOUBLE));
+
+        assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(3.3, NaN)), Domain.all(DOUBLE));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(42.24, 3.3), ID, Optional.of(collector)), DOUBLE);
+    }
+
+    @Test
+    public void testString()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(BINARY, "StringColumn");
+        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 0, null, ID, Optional.of(collector)), Domain.all(createUnboundedVarcharType()));
+
+        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("taco", "taco"), ID, Optional.of(collector)), singleValue(createUnboundedVarcharType(), utf8Slice("taco")));
+
+        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("apple", "taco"), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
+
+        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("中国", "美利坚"), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("中国"), true, utf8Slice("美利坚"), true)), false));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, stringColumnStats("taco", "apple"), ID, Optional.of(collector)), createUnboundedVarcharType());
+    }
+
+    @Test
+    public void testFloat()
+            throws Exception
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(FLOAT, "FloatColumn");
+        assertEquals(getDomain(columnDescriptor, REAL, 0, null, ID, Optional.of(collector)), Domain.all(REAL));
+
+        float minimum = 4.3f;
+        float maximum = 40.3f;
+
+        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, minimum), ID, Optional.of(collector)), singleValue(REAL, (long) floatToRawIntBits(minimum)));
+
+        assertEquals(
+                getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, maximum), ID, Optional.of(collector)),
+                create(ValueSet.ofRanges(range(REAL, (long) floatToRawIntBits(minimum), true, (long) floatToRawIntBits(maximum), true)), false));
+
+        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(NaN, NaN), ID, Optional.of(collector)), Domain.notNull(REAL));
+
+        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(NaN, NaN, true), ID, Optional.of(collector)), Domain.all(REAL));
+
+        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, NaN), ID, Optional.of(collector)), Domain.notNull(REAL));
+
+        assertEquals(getDomain(columnDescriptor, REAL, 10, floatColumnStats(minimum, NaN, true), ID, Optional.of(collector)), Domain.all(REAL));
+
+        assertEquals(getDomain(REAL, floatDictionaryDescriptor(NaN)), Domain.all(REAL));
+
+        assertEquals(getDomain(REAL, floatDictionaryDescriptor(minimum, NaN)), Domain.all(REAL));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, REAL, 10, floatColumnStats(maximum, minimum), ID, Optional.of(collector)), REAL);
+    }
+
+    @Test
+    public void testDate()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "DateColumn");
+        assertEquals(getDomain(columnDescriptor, DATE, 0, null, ID, Optional.of(collector)), Domain.all(DATE));
+        assertEquals(getDomain(columnDescriptor, DATE, 10, intColumnStats(100, 100), ID, Optional.of(collector)), singleValue(DATE, 100L));
+        assertEquals(getDomain(columnDescriptor, DATE, 10, intColumnStats(0, 100), ID, Optional.of(collector)), create(ValueSet.ofRanges(range(DATE, 0L, true, 100L, true)), false));
+
+        assertStatsCorruptionWarning(getDomain(columnDescriptor, DATE, 10, intColumnStats(200, 100), ID, Optional.of(collector)), DATE);
+    }
+
+    @Test
+    public void testVarcharMatchesWithStatistics()
+            throws ParquetCorruptionException
+    {
+        String value = "Test";
+        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"path"}, BINARY, 0, 0);
+        RichColumnDescriptor column = new RichColumnDescriptor(columnDescriptor, new PrimitiveType(OPTIONAL, BINARY, "Test column"));
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), utf8Slice(value));
+        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
+        Statistics<?> stats = getStatsBasedOnType(column.getType());
+        stats.setNumNulls(1L);
+        stats.setMinMaxFromBytes(value.getBytes(), value.getBytes());
+        assertTrue(parquetPredicate.matches(2, singletonMap(column, stats), ID, Optional.of(collector)));
+    }
+
+    @Test(dataProvider = "typeForParquetInt32")
+    public void testIntegerMatchesWithStatistics(Type typeForParquetInt32)
+            throws ParquetCorruptionException
+    {
+        RichColumnDescriptor column = new RichColumnDescriptor(
+                new ColumnDescriptor(new String[] {"path"}, INT32, 0, 0),
+                new PrimitiveType(OPTIONAL, INT32, "Test column"));
+        TupleDomain<ColumnDescriptor> effectivePredicate = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column,
+                Domain.create(ValueSet.of(typeForParquetInt32, 42L, 43L, 44L, 112L), false)));
+        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
+
+        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(32, 42)), ID, Optional.of(collector)));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(30, 40)), ID, Optional.of(collector)));
+        assertEquals(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(1024, 0x10000 + 42)), ID, Optional.of(collector)), (typeForParquetInt32 != INTEGER)); // stats invalid for smallint/tinyint
+    }
+
+    @DataProvider
+    public Object[][] typeForParquetInt32()
+    {
+        return new Object[][] {
+                {INTEGER},
+                {SMALLINT},
+                {TINYINT},
+        };
+    }
+
+    @Test
+    public void testBigintMatchesWithStatistics()
+            throws ParquetCorruptionException
+    {
+        RichColumnDescriptor column = new RichColumnDescriptor(
+                new ColumnDescriptor(new String[] {"path"}, INT64, 0, 0),
+                new PrimitiveType(OPTIONAL, INT64, "Test column"));
+        TupleDomain<ColumnDescriptor> effectivePredicate = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column,
+                Domain.create(ValueSet.of(BIGINT, 42L, 43L, 44L, 404L), false)));
+        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
+
+        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(32, 42)), ID, Optional.of(collector)));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(30, 40)), ID, Optional.of(collector)));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(1024, 0x10000 + 42)), ID, Optional.of(collector)));
+    }
+
+    @Test
+    public void testVarcharMatchesWithDictionaryDescriptor()
+    {
+        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"path"}, new PrimitiveType(OPTIONAL, BINARY, 0, ""), 0, 0);
+        RichColumnDescriptor column = new RichColumnDescriptor(columnDescriptor, new PrimitiveType(OPTIONAL, BINARY, "Test column"));
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), EMPTY_SLICE);
+        TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
+        DictionaryPage page = new DictionaryPage(Slices.wrappedBuffer(new byte[] {0, 0, 0, 0}), 1, PLAIN_DICTIONARY);
+        assertTrue(parquetPredicate.matches(new DictionaryDescriptor(column, Optional.of(page))));
+    }
+
+    private TupleDomain<ColumnDescriptor> getEffectivePredicate(RichColumnDescriptor column, VarcharType type, Slice value)
+    {
+        ColumnDescriptor predicateColumn = new ColumnDescriptor(column.getPath(), column.getType(), 0, 0);
+        Domain predicateDomain = singleValue(type, value);
+        Map<ColumnDescriptor, Domain> predicateColumns = singletonMap(predicateColumn, predicateDomain);
+        return withColumnDomains(predicateColumns);
+    }
+
     private DictionaryDescriptor floatDictionaryDescriptor(float... values)
             throws Exception
     {
@@ -434,15 +427,21 @@ public class TestTupleDomainParquetPredicate
                 Optional.of(new DictionaryPage(Slices.wrappedBuffer(buffer.toByteArray()), values.length, PLAIN_DICTIONARY)));
     }
 
-    private static LongStatistics longOnlyNullsStats(long numNulls)
-    {
-        LongStatistics statistics = new LongStatistics();
-        statistics.setNumNulls(numNulls);
-        return statistics;
-    }
-
     private ColumnDescriptor createColumnDescriptor(PrimitiveTypeName typeName, String columnName)
     {
-        return new ColumnDescriptor(new String[]{}, new PrimitiveType(REQUIRED, typeName, columnName), 0, 0);
+        return new ColumnDescriptor(new String[] {}, new PrimitiveType(REQUIRED, typeName, columnName), 0, 0);
+    }
+
+    private boolean assertStatsCorruptionWarning(Domain domain, Type type)
+    {
+        assertEquals(domain, create(ValueSet.all(type), false));
+        assertTrue(collector.hasWarnings());
+
+        List<PrestoWarning> warnings = collector.getWarnings();
+        assertEquals(warnings.size(), 2);
+        assertEquals(warnings.get(0).getWarningCode(), HIVE_FILE_STATISTICS_CORRUPTION.toWarningCode());
+
+        collector.clear();
+        return true;
     }
 }


### PR DESCRIPTION
`TupleDomainParquetPredicate.getDomain()` is used for Parquet RowGroup elimination. It could throw ParquetCorruptionException if the Parquet file column statistics is corrupted and cause the query to fail. This commit changes the exception to a PrestoWarning with HiveWarningCode `HIVE_FILE_STATISTCIS_CORRUPTION` for such case, and returns the full Domain so that the RowGroup won't be eliminated.

Test plan 
Unit tests in `TestTupleDomainParquetPredicate`


```
== RELEASE NOTES ==

Hive Changes
* Fix an issue which causes query failures when the Parquet file statistics is corrupted.

```

