### PR TITLE
Add memory limit check for HashBuilderOperator during memory revoke

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -300,7 +300,7 @@ public class MemoryRevokingScheduler
                     long revokedBytes = operatorContext.requestMemoryRevoking();
                     if (revokedBytes > 0) {
                         remainingBytesToRevoke.addAndGet(-revokedBytes);
-                        log.debug("memoryPool=%s: requested revoking %s; remaining %s", memoryPoolId, revokedBytes, remainingBytesToRevoke.get());
+                        log.debug("memoryPool=%s, operatorContext: %s: requested revoking %s; remaining %s", memoryPoolId, operatorContext, revokedBytes, remainingBytesToRevoke.get());
                     }
                 }
                 return null;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -1209,7 +1209,7 @@ public class TestHashJoinOperator
         buildLookupSource(buildSideSetup);
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of.* \\[Spilled:.*")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of.* \\[Estimated Spilled:.*")
     public void testSpillMemoryLimit()
     {
         Session session = testSessionBuilder().setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "1000B").build();


### PR DESCRIPTION
When the HashBuilderOperator trying to spill more data than allowed memory during memory revoke, it fails fast before spillin to avoid unnecessary process and avoid memory pressure during unspilling the data

Test plan - unit test and verifier run

```
== RELEASE NOTES ==

General Changes
* Add memory limit check for HashBuilderOperator during memory revoke
