### PR TITLE
Add a plan optimizer to allow maintain ordering for table writes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -237,6 +237,7 @@ public final class SystemSessionProperties
     public static final String LEAF_NODE_LIMIT_ENABLED = "leaf_node_limit_enabled";
     public static final String PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID = "push_remote_exchange_through_group_id";
     public static final String OPTIMIZE_MULTIPLE_APPROX_PERCENTILE_ON_SAME_FIELD = "optimize_multiple_approx_percentile_on_same_field";
+    public static final String TABLE_WRITE_ORDERING = "table_write_ordering";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1350,6 +1351,11 @@ public final class SystemSessionProperties
                         OPTIMIZE_MULTIPLE_APPROX_PERCENTILE_ON_SAME_FIELD,
                         "Combine individual approx_percentile calls on individual field to evaluation on an array",
                         featuresConfig.isOptimizeMultipleApproxPercentileOnSameFieldEnabled(),
+                        false),
+                booleanProperty(
+                        TABLE_WRITE_ORDERING,
+                        "Maintain the ordering when writing to a table",
+                        featuresConfig.isTableWriteOrdering(),
                         false));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -235,6 +235,8 @@ public class FeaturesConfig
     private boolean pushRemoteExchangeThroughGroupId;
     private boolean isOptimizeMultipleApproxPercentileOnSameFieldEnabled = true;
 
+    private boolean tableWriteOrdering;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2188,6 +2190,19 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeMultipleApproxPercentileOnSameFieldEnabled(boolean isOptimizeMultipleApproxPercentileOnSameFieldEnabled)
     {
         this.isOptimizeMultipleApproxPercentileOnSameFieldEnabled = isOptimizeMultipleApproxPercentileOnSameFieldEnabled;
+        return this;
+    }
+
+    public boolean isTableWriteOrdering()
+    {
+        return tableWriteOrdering;
+    }
+
+    @Config("table-write-ordering")
+    @ConfigDescription("Enable table write ordering")
+    public FeaturesConfig setTableWriteOrdering(boolean tableWriteOrdering)
+    {
+        this.tableWriteOrdering = tableWriteOrdering;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -150,6 +150,7 @@ import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer
 import com.facebook.presto.sql.planner.optimizations.TransformQuantifiedComparisonApplyToLateralJoin;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
 import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
+import com.facebook.presto.sql.planner.optimizations.WriteOrderingOptimizer;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -669,6 +670,8 @@ public class PlanOptimizers
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())));
+
+        builder.add(new WriteOrderingOptimizer());
 
         // DO NOT add optimizers that change the plan shape (computations) after this point
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WriteOrderingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WriteOrderingOptimizer.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.TABLE_WRITE_ORDERING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.mergingExchange;
+import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+
+public final class WriteOrderingOptimizer
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types,
+                             PlanVariableAllocator variableAllocator,
+                             PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (!session.getSystemProperty(TABLE_WRITE_ORDERING, Boolean.class)) {
+            return plan;
+        }
+        return rewriteWith(new Rewriter(idAllocator), plan, null);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        private Rewriter(PlanNodeIdAllocator idAllocator)
+        {
+            this.idAllocator = idAllocator;
+        }
+
+        @Override
+        public PlanNode visitTableWriter(TableWriterNode node, RewriteContext context)
+        {
+            PlanNode current = node;
+            // recursively searching down the tree to skip the exchange nodes.
+            while (true) {
+                List<PlanNode> sources = current.getSources();
+                if (sources.size() == 1 && sources.get(0) instanceof ExchangeNode) {
+                    current = sources.get(0);
+                }
+                else {
+                    break;
+                }
+            }
+            // found the first non-exchange node
+            List<PlanNode> sources = current.getSources();
+            PlanNode newNode = node;
+            // Try to recreate a node if and only if previous node is a sort node
+            if (sources.size() == 1) {
+                PlanNode previous = sources.get(0);
+                if (previous instanceof SortNode) {
+                    SortNode previousSortNode = (SortNode) previous;
+                    if (!previousSortNode.isPartial()) {
+                        // if previous is not partial sort we can directly link to the previous node
+                        current = previous;
+                    }
+                    else {
+                        // if previous is partial sort, we need to add a RemoteStreamingMerge
+                        current = mergingExchange(
+                                idAllocator.getNextId(),
+                                REMOTE_STREAMING,
+                                current,
+                                previousSortNode.getOrderingScheme());
+                    }
+                    // Now that 'current' is the true source of the LocalExchange, we can try connect 'node' to 'current'
+                    newNode = new TableWriterNode(
+                            node.getSourceLocation(),
+                            node.getId(),
+                            current,
+                            node.getTarget(),
+                            node.getRowCountVariable(),
+                            node.getFragmentVariable(),
+                            node.getTableCommitContextVariable(),
+                            node.getColumns(),
+                            node.getColumnNames(),
+                            node.getNotNullColumnVariables(),
+                            node.getTablePartitioningScheme(),
+                            node.getPreferredShufflePartitioningScheme(),
+                            node.getStatisticsAggregation());
+                }
+            }
+            return newNode;
+        }
+    }
+}


### PR DESCRIPTION
This change adds an optimizer to allow maintain ordering for table writes. Currently the table write does seem to honor an order by keyword. Namely, for a query like 
`create table <X> as select ... order by Y`
The ordering does not hold on the actual write. This makes sense in general because generally there is no notion of "order" for tables anyway. But for certain case, such as Google sheet connectors, when the underlying table does have the notion of ordering, this order by operation should be honored.

The reason why the order does not hold currently, seems due to the remote and local exchange of pages can be in arbitrary oder, so the ordered data from a sort operator loses its order. This optimizer removes the changes between sort and the write to maintain the order. The idea is to match the original sort (without write) plan, where a RemoteStreamingMerge is connected to output directly. This diff tries to make RemoteStreamingMerge connect to TableWriter directly as well.

This optimizer is only enabled with a new session property, so this is a safe change by default for all connectors.

Test plan - (Please fill in how you tested your changes)

Tested in internal test env. Unit test to be added. Below shows some query plans from the testing.

Plan without any write, just the sort
```
 - Output[datestr, source, unspecified0] => [datestr:varchar, msg$_$_$source:varchar, count:bigint]
         source := msg$_$_$source (1:25)
         unspecified0 := count (1:37)
     - RemoteStreamingMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
         - LocalMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
             - PartialSort[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                 - RemoteStreamingExchange[REPARTITION] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                     - Project[projectLocality = LOCAL] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                         - Aggregate(FINAL)[msg$_$_$source, datestr][$hashvalue] => [msg$_$_$source:varchar, datestr:varchar, $hashvalue:bigint, count:bigint]
                                 count := "presto.default.count"((count_14)) (1:37)
                             - LocalExchange[HASH][$hashvalue] (msg$_$_$source, datestr) => [msg$_$_$source:varchar, datestr:varchar, count_14:bigint, $hashvalue:
                                 - RemoteStreamingExchange[REPARTITION][$hashvalue_15] => [msg$_$_$source:varchar, datestr:varchar, count_14:bigint, $hashvalue_15
                                     - Aggregate(PARTIAL)[msg$_$_$source, datestr][$hashvalue_16] => [msg$_$_$source:varchar, datestr:varchar, $hashvalue_16:bigin
                                             count_14 := "presto.default.count"(*) (1:37)
                                         - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=rawdata, tableName=kaf
                                                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                                                 $hashvalue_16 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(msg$_$_$source), BIGINT'0')),
                                                 LAYOUT: rawdata.kafka_hp_presto_query_event_nodedup{domains={datestr=[ [["2022-06-01", <max>)] ]}}
                                                 msg$_$_$source := msg$_$_$source:string:-1:SYNTHESIZED:[msg.source]
                                                 datestr := datestr:string:-13:PARTITION_KEY (1:51)
                                                     :: [["2022-06-01", "2022-09-28"]]

```


Write plan without the optimizer:
```
 - Output[rows] => [rows_14:bigint]
         rows := rows_14
     - TableCommit[Optional[gsheets.default.dummy]] => [rows_14:bigint]
         - RemoteStreamingExchange[GATHER] => [rows:bigint, fragments:varbinary, commitcontext:varbinary]
             - TableWriter => [rows:bigint, fragments:varbinary, commitcontext:varbinary]
                     datestr := datestr (1:54)
                     source := msg$_$_$source (1:63)
                     unspecified0 := count (1:75)
                     Statistics collected: 0
                 - LocalExchange[SINGLE] () => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                     - RemoteStreamingExchange[REPARTITION] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                         - RemoteStreamingMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                             - LocalMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                 - PartialSort[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                     - RemoteStreamingExchange[REPARTITION] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                         - Project[projectLocality = LOCAL] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                             - Aggregate(FINAL)[msg$_$_$source, datestr][$hashvalue] => [msg$_$_$source:varchar, datestr:varchar, $hashvalue:bigin
                                                     count := "presto.default.count"((count_15)) (1:75)
                                                 - LocalExchange[HASH][$hashvalue] (msg$_$_$source, datestr) => [msg$_$_$source:varchar, datestr:varchar, count_15
                                                     - RemoteStreamingExchange[REPARTITION][$hashvalue_16] => [msg$_$_$source:varchar, datestr:varchar, count_15:b
                                                         - Aggregate(PARTIAL)[msg$_$_$source, datestr][$hashvalue_17] => [msg$_$_$source:varchar, datestr:varchar,
                                                                 count_15 := "presto.default.count"(*) (1:75)
                                                             - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=ra
                                                                     Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{rows: ? (?), cpu: ?, memory: 0
                                                                     $hashvalue_17 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(msg$_$_$so
                                                                     LAYOUT: rawdata.kafka_hp_presto_query_event_nodedup{domains={datestr=[ [["2022-06-01", <max>)
                                                                     msg$_$_$source := msg$_$_$source:string:-1:SYNTHESIZED:[msg.source]
                                                                     datestr := datestr:string:-13:PARTITION_KEY (1:89)
                                                                         :: [["2022-06-01", "2022-09-28"]]
``` 

Write plan With the optimizer:
```
 - Output[rows] => [rows_14:bigint]
         rows := rows_14
     - TableCommit[Optional[gsheets.default.dummy]] => [rows_14:bigint]
         - RemoteStreamingExchange[GATHER] => [rows:bigint, fragments:varbinary, commitcontext:varbinary]
             - TableWriter => [rows:bigint, fragments:varbinary, commitcontext:varbinary]
                     datestr := datestr (1:54)
                     source := msg$_$_$source (1:63)
                     unspecified0 := count (1:75)
                     Statistics collected: 0
                 - RemoteStreamingMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                     - LocalMerge[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                         - PartialSort[count DESC_NULLS_LAST, msg$_$_$source ASC_NULLS_LAST] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                             - RemoteStreamingExchange[REPARTITION] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                 - Project[projectLocality = LOCAL] => [msg$_$_$source:varchar, datestr:varchar, count:bigint]
                                     - Aggregate(FINAL)[msg$_$_$source, datestr][$hashvalue] => [msg$_$_$source:varchar, datestr:varchar, $hashvalue:bigint, count
                                             count := "presto.default.count"((count_15)) (1:75)
                                         - LocalExchange[HASH][$hashvalue] (msg$_$_$source, datestr) => [msg$_$_$source:varchar, datestr:varchar, count_15:bigint,
                                             - RemoteStreamingExchange[REPARTITION][$hashvalue_16] => [msg$_$_$source:varchar, datestr:varchar, count_15:bigint, $
                                                 - Aggregate(PARTIAL)[msg$_$_$source, datestr][$hashvalue_17] => [msg$_$_$source:varchar, datestr:varchar, $hashva
                                                         count_15 := "presto.default.count"(*) (1:75)
                                                     - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=rawdata, t
                                                             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{rows: ? (?), cpu: ?, memory: 0.00, net
                                                             $hashvalue_17 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(msg$_$_$source), B
                                                             LAYOUT: rawdata.kafka_hp_presto_query_event_nodedup{domains={datestr=[ [["2022-06-01", <max>)] ]}}
                                                             msg$_$_$source := msg$_$_$source:string:-1:SYNTHESIZED:[msg.source]
                                                             datestr := datestr:string:-13:PARTITION_KEY (1:89)
                                                                 :: [["2022-06-01", "2022-09-28"]]
```



```
== RELEASE NOTES ==

General Changes
* add a session property `table_write_ordering` to allow maintain ordering for table writes
