### PR TITLE
[native] Refactor to creating MemoryUsageTracker

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -92,7 +92,11 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
   auto pool = memory::getProcessDefaultMemoryManager().getRoot().addScopedChild(
       "query_root");
   pool->setMemoryUsageTracker(velox::memory::MemoryUsageTracker::create(
-      maxUserMemoryPerNode, maxSystemMemoryPerNode, maxTotalMemoryPerNode));
+      velox::memory::MemoryUsageConfigBuilder()
+          .maxUserMemory(maxUserMemoryPerNode)
+          .maxSystemMemory(maxSystemMemoryPerNode)
+          .maxTotalMemory(maxTotalMemoryPerNode)
+          .build()));
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       executor(),


### PR DESCRIPTION
MemoryUsageTracker::create(int64_t maxUserMemory, int64_t maxSystemMemory,int64_t maxTotalMemory) will be removed by https://github.com/facebookincubator/velox/pull/2643, so we should use MemoryUsageTracker::create(const MemoryUsageConfig& config)


```
== NO RELEASE NOTE ==
```
