### PR TITLE
Add new NativeExecutionNode for Presto-on-Spark native execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
 import com.google.common.collect.ImmutableList;
@@ -84,6 +85,13 @@ public class SchedulingOrderVisitor
 
         @Override
         public Void visitTableScan(TableScanNode node, Consumer<PlanNodeId> schedulingOrder)
+        {
+            schedulingOrder.accept(node.getId());
+            return null;
+        }
+
+        @Override
+        public Void visitNativeExecution(NativeExecutionNode node, Consumer<PlanNodeId> schedulingOrder)
         {
             schedulingOrder.accept(node.getId());
             return null;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Plans.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Plans.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,6 +54,13 @@ public class Plans
         public PlanNode visitGroupReference(GroupReference node, Void context)
         {
             return lookup.resolve(node).accept(this, context);
+        }
+
+        @Override
+        public PlanNode visitNativeExecution(NativeExecutionNode node, Void context)
+        {
+            node.getSubPlan().accept(this, context);
+            return node;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
@@ -181,4 +181,9 @@ public abstract class InternalPlanVisitor<R, C>
     {
         return visitPlan(node, context);
     }
+
+    public R visitNativeExecution(NativeExecutionNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/NativeExecutionNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/NativeExecutionNode.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The NativeExecutionNode is a wrapper node encapsulating the actual logical plan nodes in the subPlan field which will be eventually executed on the native engine.
+ */
+@Immutable
+public class NativeExecutionNode
+        extends InternalPlanNode
+{
+    private final PlanNode subPlan;
+
+    @JsonCreator
+    public NativeExecutionNode(Optional<SourceLocation> sourceLocation, @JsonProperty("id") PlanNodeId id, @JsonProperty("subPlan") PlanNode subPlan)
+    {
+        this(sourceLocation, id, Optional.empty(), subPlan);
+    }
+
+    public NativeExecutionNode(Optional<SourceLocation> sourceLocation, PlanNodeId id, Optional<PlanNode> statsEquivalentPlanNode, PlanNode subPlan)
+    {
+        super(sourceLocation, id, statsEquivalentPlanNode);
+        this.subPlan = requireNonNull(subPlan, "subPlan is null");
+    }
+
+    public NativeExecutionNode(PlanNode subPlan)
+    {
+        this(subPlan.getSourceLocation(), subPlan.getId(), subPlan.getStatsEquivalentPlanNode(), subPlan);
+    }
+
+    /*
+     * Since NativeExecutionNode will hide its subPlan away from outside viewer, the getSources() intended to
+     * return an empty list to avoid any Vistor visiting the subPlan.
+     */
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return subPlan.getOutputVariables();
+    }
+
+    @JsonProperty
+    public PlanNode getSubPlan()
+    {
+        return subPlan;
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        throw new UnsupportedOperationException("replaceChildren is not supported by NativeExecutionNode");
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return new NativeExecutionNode(getSourceLocation(), getId(), statsEquivalentPlanNode, subPlan.assignStatsEquivalentPlanNode(statsEquivalentPlanNode));
+    }
+
+    @Override
+    public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitNativeExecution(this, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.MergeJoinNode;
 import com.facebook.presto.sql.planner.plan.MetadataDeleteNode;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
@@ -1211,6 +1212,15 @@ public class PlanPrinter
         }
 
         @Override
+        public Void visitNativeExecution(NativeExecutionNode node, Void context)
+        {
+            NodeRepresentation nodeOutput = addNode(node, "NativeExecution", ImmutableList.of(node.getSubPlan()));
+            node.getSubPlan().accept(this, context);
+
+            return null;
+        }
+
+        @Override
         public Void visitPlan(PlanNode node, Void context)
         {
             throw new UnsupportedOperationException("not yet implemented: " + node.getClass().getName());
@@ -1288,6 +1298,11 @@ public class PlanPrinter
         public NodeRepresentation addNode(PlanNode node, String name, String identifier, List<PlanNode> children)
         {
             return addNode(node, name, identifier, ImmutableList.of(node.getId()), children, ImmutableList.of());
+        }
+
+        public NodeRepresentation addNode(PlanNode node, String name, List<PlanNode> children)
+        {
+            return addNode(node, name, "", ImmutableList.of(node.getId()), children, ImmutableList.of());
         }
 
         public NodeRepresentation addNode(PlanNode rootNode, String name, String identifier, List<PlanNodeId> allNodes, List<PlanNode> children, List<PlanFragmentId> remoteSources)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -69,6 +69,7 @@ import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.OffsetNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
@@ -954,6 +955,14 @@ public class PlanBuilder
                 replicateVariables,
                 unnestVariables,
                 ordinalityVariable);
+    }
+
+    public NativeExecutionNode nativeExecution(PlanNode subPlan)
+    {
+        return new NativeExecutionNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                subPlan);
     }
 
     public static Expression expression(String sql)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecutionPlanRewrite.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecutionPlanRewrite.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrestoSparkNativeExecutionPlanRewrite
+        extends AbstractTestQueryFramework
+{
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+
+    private void assertPlanMatch(Session session, PlanNode actual, PlanMatchPattern expected)
+    {
+        PlanAssert.assertPlan(
+                session,
+                METADATA,
+                (node, sourceStats, lookup, session2, types) -> PlanNodeStatsEstimate.unknown(),
+                new Plan(actual, TypeProvider.empty(), StatsAndCosts.empty()),
+                expected);
+    }
+
+    private void assertPlanNotMatch(Session session, PlanNode actual, PlanMatchPattern expected)
+    {
+        PlanAssert.assertPlanDoesNotMatch(
+                session,
+                METADATA,
+                (node, sourceStats, lookup, session2, types) -> PlanNodeStatsEstimate.unknown(),
+                new Plan(actual, TypeProvider.empty(), StatsAndCosts.empty()),
+                expected);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner();
+    }
+
+    @Test
+    public void testSingleStagePlanFragment()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .build();
+
+        SubPlan subPlan = subplan(
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment FROM orders_bucketed",
+                session);
+        PlanFragment fragment = subPlan.getFragment();
+        PlanNode root = fragment.getRoot();
+
+        assertEquals(1, fragment.getTableScanSchedulingOrder().size());
+        assertTrue(fragment.getTableScanSchedulingOrder().contains(root.getId()));
+        assertEquals(1, subPlan.getAllFragments().size());
+        assertTrue(root instanceof NativeExecutionNode);
+        assertPlanMatch(session, ((NativeExecutionNode) root).getSubPlan(), anyTree(node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testMultiStagePlanFragmentsWithCoordinatorOnlyFragment()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .setSystemProperty("table_writer_merge_operator_enabled", "false")
+                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
+                .build();
+
+        SubPlan subPlan = subplan("CREATE TABLE test_table_1 as SELECT orderkey, custkey FROM orders ", session);
+        List<PlanFragment> fragmentList = subPlan.getAllFragments();
+
+        assertEquals(2, fragmentList.size());
+
+        PlanFragment fragment1 = fragmentList.get(0);
+        assertTrue(fragment1.getPartitioning().isCoordinatorOnly());
+        assertPlanNotMatch(session, fragment1.getRoot(), anyTree(node(NativeExecutionNode.class)));
+
+        PlanFragment fragment2 = fragmentList.get(1);
+        PlanNode root = fragment2.getRoot();
+        assertFalse(fragment2.getPartitioning().isCoordinatorOnly());
+        assertEquals(1, fragment2.getTableScanSchedulingOrder().size());
+        assertTrue(fragment2.getTableScanSchedulingOrder().contains(root.getId()));
+        assertTrue(root instanceof NativeExecutionNode);
+        assertPlanMatch(session, ((NativeExecutionNode) root).getSubPlan(), anyTree(node(TableScanNode.class)));
+    }
+}


### PR DESCRIPTION
Right now, the new NativeExecutionNode will be added at the stage top level to delegate the entire stage to external native engine

```
== NO RELEASE NOTE ==
```
