### PR TITLE
[native] Correct test data path for internal test runs

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/tests/PlanFragmentTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/PlanFragmentTest.cpp
@@ -25,9 +25,11 @@ using namespace facebook::presto;
 
 namespace {
 std::string getDataPath(const std::string& fileName) {
+  static const std::string kFbcode = "fbcode";
+
   std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath + "/presto_cpp/presto_protocol/tests/data/" + fileName;
+  if (boost::algorithm::ends_with(currentPath, kFbcode)) {
+    return currentPath.substr(0, currentPath.length() - kFbcode.length()) + "third-party/presto_cpp/presto_protocol/tests/data/" + fileName;
   }
 
   if (boost::algorithm::ends_with(currentPath, "fbsource")) {


### PR DESCRIPTION
Correct test data path for internal test runs as the code was moved to a different location.

Test plan - (Please fill in how you tested your changes)
Tested internally. Here we just have to make sure existing CI runs are green.

```
== NO RELEASE NOTE ==
```
