### PR TITLE
Fix storage descriptor test cases

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -89,7 +89,7 @@ public final class GlueToPrestoConverter
             // the table is an Iceberg/Delta table and decide whether to redirect or fail.
             tableBuilder.setDataColumns(ImmutableList.of(new Column("dummy", HIVE_INT, Optional.empty(), Optional.empty())));
             tableBuilder.getStorageBuilder().setStorageFormat(StorageFormat.fromHiveStorageFormat(HiveStorageFormat.PARQUET));
-            tableBuilder.getStorageBuilder().setLocation(sd.getLocation());
+            tableBuilder.getStorageBuilder().setLocation(sd == null ? "" : sd.getLocation());
         }
         else {
             if (sd == null) {


### PR DESCRIPTION
Storage descriptor related test cases were breaking because location is not always present in case of delta and iceberg tables. However the tableBuilder used in GlueToPrestoConverter was expecting location to be present internally.

The breaking changes were introduced in this PR - https://github.com/prestodb/presto/pull/17655.

Test plan - (Please fill in how you tested your changes)

The PR fixes the below test cases - 
1. `TestHiveClientGlueMetastore.testTableWithoutStorageDescriptor`

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
