### PR TITLE
Fix join-distribution-type and optimizer.join-reordering-strategy default values in the documentation

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -23,7 +23,7 @@ General Properties
 
     * **Type:** ``string``
     * **Allowed values:** ``AUTOMATIC``, ``PARTITIONED``, ``BROADCAST``
-    * **Default value:** ``PARTITIONED``
+    * **Default value:** ``AUTOMATIC``
 
     The type of distributed join to use.  When set to ``PARTITIONED``, presto will
     use hash distributed joins.  When set to ``BROADCAST``, it will broadcast the
@@ -715,7 +715,7 @@ Optimizer Properties
 
     * **Type:** ``string``
     * **Allowed values:** ``AUTOMATIC``, ``ELIMINATE_CROSS_JOINS``, ``NONE``
-    * **Default value:** ``ELIMINATE_CROSS_JOINS``
+    * **Default value:** ``AUTOMATIC``
 
     The join reordering strategy to use.  ``NONE`` maintains the order the tables are listed in the
     query.  ``ELIMINATE_CROSS_JOINS`` reorders joins to eliminate cross joins where possible and


### PR DESCRIPTION
The PR fixes default values for `join-distribution-type` and `optimizer.join-reordering-strategy` in the documentation.
Actual default value for both properties is `AUTOMATIC`, which is also mentioned in [CBO doc](https://github.com/prestodb/presto/blob/e3c9af6c4b386c4dd366e3fea4760a2a49592086/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst).

Refs:
https://github.com/prestodb/presto/blob/bcc88c1bf8463675761e2de963676a1de393e9de/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java#L71
https://github.com/prestodb/presto/blob/bcc88c1bf8463675761e2de963676a1de393e9de/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java#L87

Test plan - existing tests

```
== NO RELEASE NOTE ==
```
