### PR TITLE
Add selected authorized user to identity

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -344,6 +344,7 @@ public final class HiveQueryRunner
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .setCatalog(HIVE_CATALOG)
                 .setSchema(schema)
@@ -365,6 +366,7 @@ public final class HiveQueryRunner
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .setCatalog(HIVE_BUCKETED_CATALOG)
                 .setSchema(schema)
@@ -381,6 +383,7 @@ public final class HiveQueryRunner
                                 .orElse(ImmutableMap.of()),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .setSystemProperty(PARTITIONING_PROVIDER_CATALOG, HIVE_CATALOG)
                 .setSystemProperty(EXCHANGE_MATERIALIZATION_STRATEGY, ExchangeMaterializationStrategy.ALL.name())

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -213,6 +213,7 @@ public class TestHiveIntegrationSmokeTest
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
 
@@ -237,6 +238,7 @@ public class TestHiveIntegrationSmokeTest
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -440,6 +440,7 @@ public class TestHiveRecoverableExecution
                         .orElse(ImmutableMap.of()),
                 ImmutableMap.of(),
                 ImmutableMap.of(),
+                Optional.empty(),
                 Optional.empty());
 
         return testSessionBuilder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRoles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRoles.java
@@ -385,6 +385,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ALL, Optional.empty())),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         Session setRoleNone = Session.builder(getQueryRunner().getDefaultSession())
@@ -394,6 +395,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.NONE, Optional.empty())),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         Session setRole1 = Session.builder(getQueryRunner().getDefaultSession())
@@ -403,6 +405,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_1"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         Session setRole2 = Session.builder(getQueryRunner().getDefaultSession())
@@ -412,6 +415,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_2"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         Session setRole3 = Session.builder(getQueryRunner().getDefaultSession())
@@ -421,6 +425,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_3"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         Session setRole4 = Session.builder(getQueryRunner().getDefaultSession())
@@ -430,6 +435,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("set_role_4"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
 
@@ -554,6 +560,7 @@ public class TestHiveRoles
                         ImmutableMap.of("hive", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -47,6 +47,7 @@ public class TestIcebergMetadataListing
                         ImmutableMap.of("hive", new SelectedRole(ROLE, Optional.of("admin"))),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()))
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.sql.tree.Execute;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -42,9 +41,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import java.security.Principal;
-import java.security.cert.X509Certificate;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -73,7 +70,6 @@ public final class Session
     private final Optional<TransactionId> transactionId;
     private final boolean clientTransactionSupport;
     private final Identity identity;
-    private final List<X509Certificate> certificates;
     private final Optional<String> source;
     private final Optional<String> catalog;
     private final Optional<String> schema;
@@ -103,7 +99,6 @@ public final class Session
             Optional<TransactionId> transactionId,
             boolean clientTransactionSupport,
             Identity identity,
-            List<X509Certificate> certificates,
             Optional<String> source,
             Optional<String> catalog,
             Optional<String> schema,
@@ -129,7 +124,6 @@ public final class Session
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
         this.clientTransactionSupport = clientTransactionSupport;
         this.identity = requireNonNull(identity, "identity is null");
-        this.certificates = requireNonNull(certificates, "certificates is null");
         this.source = requireNonNull(source, "source is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -180,11 +174,6 @@ public final class Session
     public Identity getIdentity()
     {
         return identity;
-    }
-
-    public List<X509Certificate> getCertificates()
-    {
-        return certificates;
     }
 
     public Optional<String> getSource()
@@ -404,7 +393,6 @@ public final class Session
                         identity.getExtraAuthenticators(),
                         identity.getSelectedUser(),
                         identity.getReasonForSelect()),
-                certificates,
                 source,
                 catalog,
                 schema,
@@ -460,7 +448,6 @@ public final class Session
                 transactionId,
                 clientTransactionSupport,
                 identity,
-                certificates,
                 source,
                 catalog,
                 schema,
@@ -582,7 +569,6 @@ public final class Session
     public static class SessionBuilder
     {
         private QueryId queryId;
-        private List<X509Certificate> certificates = ImmutableList.of();
         private TransactionId transactionId;
         private boolean clientTransactionSupport;
         private Identity identity;
@@ -621,7 +607,6 @@ public final class Session
             this.transactionId = session.transactionId.orElse(null);
             this.clientTransactionSupport = session.clientTransactionSupport;
             this.identity = session.identity;
-            this.certificates = session.certificates;
             this.source = session.source.orElse(null);
             this.catalog = session.catalog.orElse(null);
             this.schema = session.schema.orElse(null);
@@ -720,12 +705,6 @@ public final class Session
             return this;
         }
 
-        public SessionBuilder setCertificates(List<X509Certificate> certificates)
-        {
-            this.certificates = requireNonNull(certificates, "certificates is null");
-            return this;
-        }
-
         public SessionBuilder setUserAgent(String userAgent)
         {
             this.userAgent = userAgent;
@@ -807,7 +786,6 @@ public final class Session
                     Optional.ofNullable(transactionId),
                     clientTransactionSupport,
                     identity,
-                    certificates,
                     Optional.ofNullable(source),
                     Optional.ofNullable(catalog),
                     Optional.ofNullable(schema),

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -402,6 +402,7 @@ public final class Session
                         roles.build(),
                         identity.getExtraCredentials(),
                         identity.getExtraAuthenticators(),
+                        identity.getSelectedUser(),
                         identity.getReasonForSelect()),
                 certificates,
                 source,

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -31,7 +31,6 @@ import com.facebook.presto.spi.session.ResourceEstimates;
 import com.facebook.presto.transaction.TransactionId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
@@ -317,7 +316,6 @@ public final class SessionRepresentation
                         extraAuthenticators,
                         Optional.empty(),
                         Optional.empty()),
-                ImmutableList.of(),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -315,6 +315,7 @@ public final class SessionRepresentation
                         roles,
                         extraCredentials,
                         extraAuthenticators,
+                        Optional.empty(),
                         Optional.empty()),
                 ImmutableList.of(),
                 source,

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.AbstractFuture;
@@ -187,11 +188,14 @@ public class DispatchManager
                 throw new PrestoException(QUERY_TEXT_TOO_LARGE, format("Query text length (%s) exceeds the maximum length (%s)", queryLength, maxQueryLength));
             }
 
-            // check permissions
+            // check permissions if needed
             checkPermissions(queryId, sessionContext);
 
+            // get authorized identity if possible
+            Optional<AuthorizedIdentity> authorizedIdentity = getAuthorizedIdentity(queryId, sessionContext);
+
             // decode session
-            session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory);
+            session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory, authorizedIdentity);
 
             // prepare query
             preparedQuery = queryPreparer.prepareQuery(session, query, session.getWarningCollector());
@@ -251,10 +255,12 @@ public class DispatchManager
         }
     }
 
+    /**
+     * When selectAuthorizedIdentity API is not enabled, we check the delegation permission
+     */
     private void checkPermissions(QueryId queryId, SessionContext sessionContext)
     {
         Identity identity = sessionContext.getIdentity();
-        // When selectAuthorizedIdentity API is not enabled, only check delegation permission
         if (!securityConfig.isAuthorizedIdentitySelectionEnabled()) {
             accessControl.checkCanSetUser(
                     identity,
@@ -264,21 +270,29 @@ public class DispatchManager
                             Optional.ofNullable(sessionContext.getSource())),
                     identity.getPrincipal(),
                     identity.getUser());
-            return;
         }
+    }
 
-        // When selectAuthorizedIdentity API is enabled,
-        // 1. Check the delegation permission, which is inside the API call
-        // 2. Select the authorized user
-        // 3. TODO: UPDATE the identity of the session according to the authorized identity from the API call
-        accessControl.selectAuthorizedIdentity(
-                identity,
-                new AccessControlContext(
-                        queryId,
-                        Optional.ofNullable(sessionContext.getClientInfo()),
-                        Optional.ofNullable(sessionContext.getSource())),
-                identity.getUser(),
-                sessionContext.getCertificates());
+    /**
+     * When selectAuthorizedIdentity API is enabled,
+     * 1. Check the delegation permission, which is inside the API call
+     * 2. Select and return the authorized identity
+     */
+    private Optional<AuthorizedIdentity> getAuthorizedIdentity(QueryId queryId, SessionContext sessionContext)
+    {
+        if (securityConfig.isAuthorizedIdentitySelectionEnabled()) {
+            Identity identity = sessionContext.getIdentity();
+            AuthorizedIdentity authorizedIdentity = accessControl.selectAuthorizedIdentity(
+                    identity,
+                    new AccessControlContext(
+                            queryId,
+                            Optional.ofNullable(sessionContext.getClientInfo()),
+                            Optional.ofNullable(sessionContext.getSource())),
+                    identity.getUser(),
+                    sessionContext.getCertificates());
+            return Optional.of(authorizedIdentity);
+        }
+        return Optional.empty();
     }
 
     private boolean queryCreated(DispatchQuery dispatchQuery)

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -150,6 +150,7 @@ public final class HttpRequestSessionContext
                 parseRoleHeaders(servletRequest),
                 parseExtraCredentials(servletRequest),
                 ImmutableMap.of(),
+                Optional.empty(),
                 Optional.empty());
 
         X509Certificate[] certs = (X509Certificate[]) servletRequest.getAttribute(X509_ATTRIBUTE);

--- a/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -16,6 +16,9 @@ package com.facebook.presto.server;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
+
+import java.util.Optional;
 
 /**
  * Used on workers.
@@ -24,7 +27,7 @@ public class NoOpSessionSupplier
         implements SessionSupplier
 {
     @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, Optional<AuthorizedIdentity> authorizedIdentity)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -90,7 +90,6 @@ public class QuerySessionSupplier
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
                 .setQueryId(queryId)
                 .setIdentity(identity)
-                .setCertificates(context.getCertificates())
                 .setSource(context.getSource())
                 .setCatalog(context.getCatalog())
                 .setSchema(context.getSchema())

--- a/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
@@ -23,6 +24,7 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.SqlEnvironmentConfig;
 import com.facebook.presto.transaction.TransactionManager;
@@ -44,6 +46,8 @@ import static java.util.Objects.requireNonNull;
 public class QuerySessionSupplier
         implements SessionSupplier
 {
+    private final Logger log = Logger.get(QuerySessionSupplier.class);
+
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final SessionPropertyManager sessionPropertyManager;
@@ -64,9 +68,25 @@ public class QuerySessionSupplier
     }
 
     @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, Optional<AuthorizedIdentity> authorizedIdentity)
     {
         Identity identity = context.getIdentity();
+        if (authorizedIdentity.isPresent()) {
+            identity = new Identity(
+                    identity.getUser(),
+                    identity.getPrincipal(),
+                    identity.getRoles(),
+                    identity.getExtraCredentials(),
+                    identity.getExtraAuthenticators(),
+                    Optional.of(authorizedIdentity.get().getUserName()),
+                    authorizedIdentity.get().getReasonForSelect());
+            log.info(String.format(
+                    "For query %s, given user is %s, authorized user is %s",
+                    queryId.getId(),
+                    identity.getUser(),
+                    authorizedIdentity.get().getUserName()));
+        }
+
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
                 .setQueryId(queryId)
                 .setIdentity(identity)

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -16,8 +16,11 @@ package com.facebook.presto.server;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
+
+import java.util.Optional;
 
 public interface SessionSupplier
 {
-    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
+    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, Optional<AuthorizedIdentity> authorizedIdentity);
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -491,7 +491,6 @@ public class LocalQueryRunner
                 withInitialTransaction ? Optional.of(transactionManager.beginTransaction(false)) : defaultSession.getTransactionId(),
                 defaultSession.isClientTransactionSupport(),
                 defaultSession.getIdentity(),
-                defaultSession.getCertificates(),
                 defaultSession.getSource(),
                 defaultSession.getCatalog(),
                 defaultSession.getSchema(),

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -170,6 +170,7 @@ public class TestAccessControlManager
                         ImmutableMap.of(),
                         ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery),
                         ImmutableMap.of(),
+                        Optional.empty(),
                         Optional.empty()),
                 context,
                 testQuery);
@@ -186,6 +187,7 @@ public class TestAccessControlManager
                                 ImmutableMap.of(),
                                 ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery + " modified"),
                                 ImmutableMap.of(),
+                                Optional.empty(),
                                 Optional.empty()),
                         context,
                         testQuery));

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import javax.servlet.http.HttpServletRequest;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
@@ -99,7 +100,7 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory, Optional.empty());
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -170,6 +171,6 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory, Optional.empty());
     }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
@@ -76,7 +76,14 @@ public class TestCredentialPassthrough
         return testSessionBuilder()
                 .setCatalog("mysql")
                 .setSchema(TEST_SCHEMA)
-                .setIdentity(new Identity(mySqlServer.getUser(), Optional.empty(), ImmutableMap.of(), extraCredentials, ImmutableMap.of(), Optional.empty()))
+                .setIdentity(new Identity(
+                        mySqlServer.getUser(),
+                        Optional.empty(),
+                        ImmutableMap.of(),
+                        extraCredentials,
+                        ImmutableMap.of(),
+                        Optional.empty(),
+                        Optional.empty()))
                 .build();
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -389,7 +389,7 @@ public class PrestoSparkQueryExecutionFactory
         // To keep the same behavior as before, we check the permissions separately here
         checkPermissions(queryId, sessionContext);
 
-        Session session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory);
+        Session session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory, Optional.empty());
 
         session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.empty());
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
@@ -70,6 +70,7 @@ public class PrestoSparkSessionContext
                         ImmutableMap.of(),  // presto on spark does not support role management
                         extraCredentials.build(),
                         extraTokenAuthenticators.build(),
+                        Optional.empty(),
                         Optional.empty()),
                 prestoSparkSession.getCatalog().orElse(null),
                 prestoSparkSession.getSchema().orElse(null),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorIdentity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorIdentity.java
@@ -29,11 +29,12 @@ public class ConnectorIdentity
     private final Optional<SelectedRole> role;
     private final Map<String, String> extraCredentials;
     private final Map<String, TokenAuthenticator> extraAuthenticators;
+    private final Optional<String> selectedUser;
     private final Optional<String> reasonForSelect;
 
     public ConnectorIdentity(String user, Optional<Principal> principal, Optional<SelectedRole> role)
     {
-        this(user, principal, role, emptyMap(), emptyMap(), Optional.empty());
+        this(user, principal, role, emptyMap(), emptyMap(), Optional.empty(), Optional.empty());
     }
 
     public ConnectorIdentity(
@@ -42,6 +43,7 @@ public class ConnectorIdentity
             Optional<SelectedRole> role,
             Map<String, String> extraCredentials,
             Map<String, TokenAuthenticator> extraAuthenticators,
+            Optional<String> selectedUser,
             Optional<String> reasonForSelect)
     {
         this.user = requireNonNull(user, "user is null");
@@ -49,6 +51,7 @@ public class ConnectorIdentity
         this.role = requireNonNull(role, "role is null");
         this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
         this.extraAuthenticators = unmodifiableMap(new HashMap<>(requireNonNull(extraAuthenticators, "extraAuthenticators is null")));
+        this.selectedUser = requireNonNull(selectedUser, "selectedUser is null");
         this.reasonForSelect = requireNonNull(reasonForSelect, "reasonForSelect is null");
     }
 
@@ -77,6 +80,11 @@ public class ConnectorIdentity
         return extraAuthenticators;
     }
 
+    public Optional<String> getSelectedUser()
+    {
+        return selectedUser;
+    }
+
     public Optional<String> getReasonForSelect()
     {
         return reasonForSelect;
@@ -91,6 +99,7 @@ public class ConnectorIdentity
         role.ifPresent(role -> sb.append(", role=").append(role));
         sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append(", extraAuthenticators=").append(extraAuthenticators.keySet());
+        selectedUser.ifPresent(user -> sb.append(", selectedUser=").append(user));
         reasonForSelect.ifPresent(
                 reason -> sb.append(", reasonForSelect=").append(reason));
         sb.append('}');

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
@@ -29,6 +29,7 @@ public class Identity
     private final Optional<Principal> principal;
     private final Map<String, SelectedRole> roles;
     private final Map<String, String> extraCredentials;
+    private final Optional<String> selectedUser;
     private final Optional<String> reasonForSelect;
 
     /**
@@ -39,9 +40,20 @@ public class Identity
      */
     private final Map<String, TokenAuthenticator> extraAuthenticators;
 
+    public Identity(Identity other)
+    {
+        this.user = other.user;
+        this.principal = other.principal;
+        this.roles = other.roles;
+        this.extraCredentials = other.extraCredentials;
+        this.extraAuthenticators = other.extraAuthenticators;
+        this.selectedUser = other.selectedUser;
+        this.reasonForSelect = other.reasonForSelect;
+    }
+
     public Identity(String user, Optional<Principal> principal)
     {
-        this(user, principal, emptyMap(), emptyMap(), emptyMap(), Optional.empty());
+        this(user, principal, emptyMap(), emptyMap(), emptyMap(), Optional.empty(), Optional.empty());
     }
 
     public Identity(
@@ -50,6 +62,7 @@ public class Identity
             Map<String, SelectedRole> roles,
             Map<String, String> extraCredentials,
             Map<String, TokenAuthenticator> extraAuthenticators,
+            Optional<String> selectedUser,
             Optional<String> reasonForSelect)
     {
         this.user = requireNonNull(user, "user is null");
@@ -57,6 +70,7 @@ public class Identity
         this.roles = unmodifiableMap(requireNonNull(roles, "roles is null"));
         this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
         this.extraAuthenticators = unmodifiableMap(new HashMap<>(requireNonNull(extraAuthenticators, "extraAuthenticators is null")));
+        this.selectedUser = requireNonNull(selectedUser, "selectedUser is null");
         this.reasonForSelect = requireNonNull(reasonForSelect, "reasonForSelect is null");
     }
 
@@ -85,6 +99,11 @@ public class Identity
         return extraAuthenticators;
     }
 
+    public Optional<String> getSelectedUser()
+    {
+        return selectedUser;
+    }
+
     public Optional<String> getReasonForSelect()
     {
         return reasonForSelect;
@@ -98,6 +117,7 @@ public class Identity
                 Optional.empty(),
                 extraCredentials,
                 extraAuthenticators,
+                selectedUser,
                 reasonForSelect);
     }
 
@@ -110,6 +130,7 @@ public class Identity
                 Optional.ofNullable(roles.get(catalog)),
                 extraCredentials,
                 extraAuthenticators,
+                selectedUser,
                 reasonForSelect);
     }
 
@@ -141,6 +162,7 @@ public class Identity
         sb.append(", roles=").append(roles);
         sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append(", extraAuthenticators=").append(extraAuthenticators.keySet());
+        selectedUser.ifPresent(user -> sb.append(", selectedUser=").append(user));
         reasonForSelect.ifPresent(
                 reason -> sb.append(", reasonForSelect=").append(reason));
         sb.append('}');

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2914,7 +2914,6 @@ public abstract class AbstractTestQueries
                 Optional.empty(),
                 getSession().isClientTransactionSupport(),
                 getSession().getIdentity(),
-                getSession().getCertificates(),
                 getSession().getSource(),
                 getSession().getCatalog(),
                 getSession().getSchema(),

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
@@ -24,8 +24,6 @@ import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.ImmutableMap;
 
-import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -47,12 +45,6 @@ public class TestingSessionContext
     public Identity getIdentity()
     {
         return session.getIdentity();
-    }
-
-    @Override
-    public List<X509Certificate> getCertificates()
-    {
-        return session.getCertificates();
     }
 
     @Override


### PR DESCRIPTION
PR (#18223) creates a security api ``selectAuthorizedIdentity`` api to select an authorized identity from certificates or crypto auth tokens, and invokes the api without using the returned identity. To complete the loop, this PR aims to pass the returned identity from the api to all the subsequent permission checks. To do that, we add the returned username into the query session identity.

```
== RELEASE NOTES ==

General Changes
* Add ``selectedUser`` into Identity object.
```
