### PR TITLE
Fix Hudi queries from S3 table when using hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -88,13 +88,13 @@ public class HiveCachingHdfsConfiguration
         return config;
     }
 
-    private static class CachingJobConf
+    public static class CachingJobConf
             extends WrapperJobConf
             implements FileSystemFactory
     {
         private final BiFunction<Configuration, URI, FileSystem> factory;
 
-        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration config)
+        public CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration config)
         {
             super(config);
             this.factory = requireNonNull(factory, "factory is null");


### PR DESCRIPTION
Fixes https://github.com/apache/hudi/issues/6332 and https://github.com/prestodb/presto/issues/17736

WrapperJobConf object wraps the actual Configuration object and HoodieTableMetaClient
is unaware of this wrapping. As a result, the client is unable to find the `fs.s3.impl`
property and fails the query with "No FileSystem for scheme: s3". The entire stacktrace is as below - 

```
org.apache.hudi.exception.HoodieIOException: Failed to get instance of org.apache.hadoop.fs.FileSystem
	at org.apache.hudi.common.fs.FSUtils.getFs(FSUtils.java:109)
	at org.apache.hudi.common.table.HoodieTableMetaClient.getFs(HoodieTableMetaClient.java:294)
	at org.apache.hudi.common.table.HoodieTableMetaClient.<init>(HoodieTableMetaClient.java:127)
	at org.apache.hudi.common.table.HoodieTableMetaClient.newMetaClient(HoodieTableMetaClient.java:641)
	at org.apache.hudi.common.table.HoodieTableMetaClient.access$000(HoodieTableMetaClient.java:80)
	at org.apache.hudi.common.table.HoodieTableMetaClient$Builder.build(HoodieTableMetaClient.java:710)
	at com.facebook.presto.hive.HudiDirectoryLister.<init>(HudiDirectoryLister.java:61)
	at com.facebook.presto.hive.StoragePartitionLoader.<init>(StoragePartitionLoader.java:145)
	at com.facebook.presto.hive.DelegatingPartitionLoader.<init>(DelegatingPartitionLoader.java:54)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.<init>(BackgroundHiveSplitLoader.java:93)
	at com.facebook.presto.hive.HiveSplitManager.getSplits(HiveSplitManager.java:293)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager.getSplits(ClassLoaderSafeConnectorSplitManager.java:41)
	at com.facebook.presto.split.SplitManager.getSplits(SplitManager.java:89)
	at com.facebook.presto.split.CloseableSplitSourceProvider.getSplits(CloseableSplitSourceProvider.java:52)
	at com.facebook.presto.sql.planner.SplitSourceFactory$Visitor.lambda$visitTableScan$0(SplitSourceFactory.java:156)
	at com.facebook.presto.sql.planner.LazySplitSource.getDelegate(LazySplitSource.java:96)
	at com.facebook.presto.sql.planner.LazySplitSource.getConnectorId(LazySplitSource.java:48)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStageScheduler(SectionExecutionFactory.java:281)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStreamingLinkedStageExecutions(SectionExecutionFactory.java:243)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStreamingLinkedStageExecutions(SectionExecutionFactory.java:221)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createSectionExecutions(SectionExecutionFactory.java:167)
	at com.facebook.presto.execution.scheduler.LegacySqlQueryScheduler.createStageExecutions(LegacySqlQueryScheduler.java:353)
	at com.facebook.presto.execution.scheduler.LegacySqlQueryScheduler.<init>(LegacySqlQueryScheduler.java:242)
	at com.facebook.presto.execution.scheduler.LegacySqlQueryScheduler.createSqlQueryScheduler(LegacySqlQueryScheduler.java:171)
	at com.facebook.presto.execution.SqlQueryExecution.planDistribution(SqlQueryExecution.java:557)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:405)
	at com.facebook.presto.$gen.Presto_null__testversion____20221003_105515_1.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:286)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:197)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: No FileSystem for scheme: s3
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:2660)
	at org.apache.hadoop.fs.PrestoFileSystemCache.createFileSystem(PrestoFileSystemCache.java:144)
	at org.apache.hadoop.fs.PrestoFileSystemCache.getInternal(PrestoFileSystemCache.java:89)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:62)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295)
	at org.apache.hudi.common.fs.FSUtils.getFs(FSUtils.java:107)
	... 31 more
```

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
