### PR TITLE
[native] Change asyncCacheSsdGb config type to uint64_t

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -96,8 +96,8 @@ int32_t SystemConfig::systemMemoryGb() const {
   return opt.hasValue() ? opt.value() : kSystemMemoryGbDefault;
 }
 
-int32_t SystemConfig::asyncCacheSsdGb() const {
-  auto opt = optionalProperty<int32_t>(std::string(kAsyncCacheSsdGb));
+uint64_t SystemConfig::asyncCacheSsdGb() const {
+  auto opt = optionalProperty<uint64_t>(std::string(kAsyncCacheSsdGb));
   return opt.hasValue() ? opt.value() : kAsyncCacheSsdGbDefault;
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -103,7 +103,7 @@ class SystemConfig : public ConfigBase {
   static constexpr int32_t kNumIoThreadsDefault = 30;
   static constexpr int32_t kShutdownOnsetSecDefault = 10;
   static constexpr int32_t kSystemMemoryGbDefault = 40;
-  static constexpr int32_t kAsyncCacheSsdGbDefault = 0;
+  static constexpr uint64_t kAsyncCacheSsdGbDefault = 0;
   static constexpr std::string_view kAsyncCacheSsdPathDefault{
       "/mnt/flash/async_cache."};
   static constexpr bool kEnableSerializedPageChecksumDefault = true;
@@ -132,7 +132,7 @@ class SystemConfig : public ConfigBase {
 
   int32_t systemMemoryGb() const;
 
-  int32_t asyncCacheSsdGb() const;
+  uint64_t asyncCacheSsdGb() const;
 
   std::string asyncCacheSsdPath() const;
 


### PR DESCRIPTION
Current asyncCacheSsdGb type is int32_t. When applying left bit shifting of 30 to get byte count, there is not enough bits to preserve the result. Changing the type to uint64_t to avoid such scenarios.
```
== NO RELEASE NOTE ==
```
