### PR TITLE
Fix resource managers accidentally sending each other heartbeats in disaggregated coordinators setup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -94,6 +94,13 @@ public class ServerConfig
         return this;
     }
 
+    public boolean isWorker()
+    {
+        // At this moment we use the inverted logic to determine a worker, but this is fragile since the presto architecture might add new components in the future.
+        // It would be better to have a flag set from the configuration.
+        return !isCoordinator() && !isCatalogServer() && !isResourceManager();
+    }
+
     @NotNull(message = "presto.version must be provided when it cannot be automatically determined")
     public String getPrestoVersion()
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -407,7 +407,12 @@ public class ServerMainModule
                     public void configure(Binder moduleBinder)
                     {
                         configBinder(moduleBinder).bindConfig(ResourceManagerConfig.class);
-                        moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
+
+                        // In the disaggregated-coordinators setup, we should only send heartbeat from the coordinators and workers.
+                        if (serverConfig.isCoordinator() || serverConfig.isWorker()) {
+                            moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
+                        }
+
                         if (serverConfig.isCoordinator()) {
                             moduleBinder.bind(ClusterMemoryManagerService.class).in(Scopes.SINGLETON);
                             moduleBinder.bind(ResourceGroupService.class).to(ResourceManagerResourceGroupService.class).in(Scopes.SINGLETON);
@@ -548,7 +553,7 @@ public class ServerMainModule
         binder.bind(ConnectorTypeSerdeManager.class).in(Scopes.SINGLETON);
 
         // connector metadata update handle json serde
-        binder.bind(new TypeLiteral<ConnectorTypeSerde<ConnectorMetadataUpdateHandle>>(){})
+        binder.bind(new TypeLiteral<ConnectorTypeSerde<ConnectorMetadataUpdateHandle>>() {})
                 .annotatedWith(ForJsonMetadataUpdateHandle.class)
                 .to(ConnectorMetadataUpdateHandleJsonSerde.class)
                 .in(Scopes.SINGLETON);


### PR DESCRIPTION
…
Test plan 
* Covered by the existing unit tests to make sure the modules load.
* Need to deploy and run the verifier to test out that no connections established.

```
== RELEASE NOTES ==

General Changes
* Fix resource managers accidentally sending each other heartbeats in disaggregated coordinators setup

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
