### PR TITLE
Rewrite IF(predicate, AGG(x)) to aggregation with mask

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRewriteConditionalAggregationBenchmarks.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRewriteConditionalAggregationBenchmarks.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+
+import java.util.Map;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlRewriteConditionalAggregationBenchmarks
+        extends AbstractSqlBenchmark
+{
+    private static final Logger LOGGER = Logger.get(SqlRewriteConditionalAggregationBenchmarks.class);
+
+    public SqlRewriteConditionalAggregationBenchmarks(LocalQueryRunner localQueryRunner, @Language("SQL") String sql)
+    {
+        super(localQueryRunner, "sql_rewrite_conditional_aggregation", 5, 10, sql);
+    }
+
+    // The improvement from this optimization depends on two aspects: 1) how many aggregation computations we skip by pushing the condition to aggregation
+    // 2) how expensive the aggregation is. In this benchmark, I include three queries which varies the two variants in benchmark.
+    public static void main(String[] args)
+    {
+        Map<String, String> enableOptimization = ImmutableMap.of("optimize_conditional_aggregation_enabled", "true");
+        LOGGER.info("SQL query with more grouping sets");
+        String sqlWithCube = "SELECT IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), APPROX_DISTINCT(tax)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), APPROX_DISTINCT(extendedprice)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), APPROX_DISTINCT(discount))"
+                + " FROM lineitem GROUP BY CUBE(suppkey, orderkey, partkey)";
+        LOGGER.info("Without optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(), sqlWithCube).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        LOGGER.info("With optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(enableOptimization), sqlWithCube).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+
+        LOGGER.info("SQL query with fewer grouping sets");
+        String sqlNoCube = "SELECT IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), APPROX_DISTINCT(tax)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('101', 2), APPROX_DISTINCT(extendedprice)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('110', 2), APPROX_DISTINCT(discount))"
+                + " FROM lineitem GROUP BY GROUPING SETS ((suppkey), (orderkey), (partkey))";
+        LOGGER.info("Without optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(), sqlNoCube).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        LOGGER.info("With optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(enableOptimization), sqlNoCube).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+
+        LOGGER.info("SQL query with cheaper aggregation functions");
+        String sqlWithSum = "SELECT IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), SUM(tax)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), SUM(extendedprice)),"
+                + " IF(GROUPING(suppkey, orderkey, partkey) = FROM_BASE('011', 2), SUM(discount))"
+                + " FROM lineitem GROUP BY CUBE(suppkey, orderkey, partkey)";
+        LOGGER.info("Without optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(), sqlWithSum).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        LOGGER.info("With optimization");
+        new SqlRewriteConditionalAggregationBenchmarks(createLocalQueryRunner(enableOptimization), sqlWithSum).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -245,6 +245,7 @@ public final class SystemSessionProperties
     public static final String HASH_BASED_DISTINCT_LIMIT_ENABLED = "hash_based_distinct_limit_enabled";
     public static final String HASH_BASED_DISTINCT_LIMIT_THRESHOLD = "hash_based_distinct_limit_threshold";
     public static final String QUICK_DISTINCT_LIMIT_ENABLED = "quick_distinct_limit_enabled";
+    public static final String OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED = "optimize_conditional_aggregation_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1377,6 +1378,11 @@ public final class SystemSessionProperties
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,
                         "Randomize null join key for outer join",
                         featuresConfig.isRandomizeOuterJoinNullKeyEnabled(),
+                        false),
+                booleanProperty(
+                        OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED,
+                        "Enable rewrite from IF(predicate, AGG(x)) to AGG(IF(predicate), x)",
+                        featuresConfig.isOptimizeConditionalAggregationEnabled(),
                         false));
     }
 
@@ -2316,5 +2322,10 @@ public final class SystemSessionProperties
     public static boolean randomizeOuterJoinNullKeyEnabled(Session session)
     {
         return session.getSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, Boolean.class);
+    }
+
+    public static boolean isOptimizeConditionalAggregationEnabled(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -237,6 +237,7 @@ public class FeaturesConfig
     private boolean nativeExecutionEnabled;
     private String nativeExecutionExecutablePath = "./presto_server";
     private boolean randomizeOuterJoinNullKey;
+    private boolean isOptimizeConditionalAggregationEnabled;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2230,6 +2231,19 @@ public class FeaturesConfig
     public FeaturesConfig setRandomizeOuterJoinNullKeyEnabled(boolean randomizeOuterJoinNullKey)
     {
         this.randomizeOuterJoinNullKey = randomizeOuterJoinNullKey;
+        return this;
+    }
+
+    public boolean isOptimizeConditionalAggregationEnabled()
+    {
+        return isOptimizeConditionalAggregationEnabled;
+    }
+
+    @Config("optimizer.optimize-conditional-aggregation-enabled")
+    @ConfigDescription("Enable rewriting from IF(predicate, AGG(x)) to AGG(IF(predicate), x)")
+    public FeaturesConfig setOptimizeConditionalAggregationEnabled(boolean isOptimizeConditionalAggregationEnabled)
+    {
+        this.isOptimizeConditionalAggregationEnabled = isOptimizeConditionalAggregationEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.isOptimizeConditionalAggregationEnabled;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
+import static com.facebook.presto.sql.planner.VariablesExtractor.extractAll;
+import static com.facebook.presto.sql.planner.VariablesExtractor.extractUnique;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.function.Function.identity;
+
+/**
+ * Rewrite IF(predicate, AGG(x)) to AGG(x) with Mask.
+ * The plan will change
+ * When the aggregation does not have mask
+ * <p>
+ * From:
+ * <pre>
+ * - Project (val <- IF(condition, agg))
+ *   - Aggregation (agg <- AGG(x))
+ * </pre>
+ * To:
+ * <pre>
+ * - Project (val <- IF(condition, agg))
+ *   - Aggregation (agg <- AGG(x), mask <- Mask)
+ *     - Project (Mask <- condition)
+ * </pre>
+ * <p>
+ * Or
+ * When the aggregation already has mask
+ * <p>
+ * From:
+ * <pre>
+ * - Project (val <- IF(condition, agg))
+ *   - Aggregation (agg <- AGG(x), mask)
+ * </pre>
+ * To:
+ * <pre>
+ * - Project (val <- IF(condition, agg))
+ *   - Aggregation (agg <- AGG(x), mask <- Mask)
+ *     - Project (Mask <- AND(mask, condition))
+ * </pre>
+ * <p>
+ */
+public class RewriteIfOverAggregation
+        implements PlanOptimizer
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public RewriteIfOverAggregation(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan,
+            Session session,
+            TypeProvider types,
+            PlanVariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator,
+            WarningCollector warningCollector)
+    {
+        if (isOptimizeConditionalAggregationEnabled(session)) {
+            return SimplePlanRewriter.rewriteWith(
+                    new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager)), plan, ImmutableMap.of());
+        }
+        return plan;
+    }
+
+    // Map<VariableReferenceExpression, RowExpression> stores the candidate IF expressions for rewrite.
+    private static class Rewriter
+            extends SimplePlanRewriter<Map<VariableReferenceExpression, RowExpression>>
+    {
+        private final PlanVariableAllocator planVariableAllocator;
+        private final PlanNodeIdAllocator planNodeIdAllocator;
+        private final RowExpressionDeterminismEvaluator determinismEvaluator;
+
+        private Rewriter(PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, RowExpressionDeterminismEvaluator determinismEvaluator)
+        {
+            this.planVariableAllocator = variableAllocator;
+            this.planNodeIdAllocator = idAllocator;
+            this.determinismEvaluator = determinismEvaluator;
+        }
+
+        private static VariableReferenceExpression getTrueValueFromIf(RowExpression rowExpression)
+        {
+            checkState(rowExpression instanceof SpecialFormExpression
+                    && ((SpecialFormExpression) rowExpression).getArguments().get(1) instanceof VariableReferenceExpression);
+            return (VariableReferenceExpression) ((SpecialFormExpression) rowExpression).getArguments().get(1);
+        }
+
+        private static RowExpression inlineReferences(RowExpression expression, Assignments assignments)
+        {
+            return RowExpressionVariableInliner.inlineVariables(variable -> assignments.getMap().getOrDefault(variable, variable), expression);
+        }
+
+        @Override
+        public PlanNode visitPlan(PlanNode node, RewriteContext<Map<VariableReferenceExpression, RowExpression>> context)
+        {
+            // This optimizer targets plan generated from IF(predicate, AGG(x)). The plan generated will be Project <- Aggregation, where project includes the IF expression.
+            // Here we pass an empty map in context by default, so as to not pass the candidate IF expressions unless it's a project node.
+            return context.defaultRewrite(node, ImmutableMap.of());
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Map<VariableReferenceExpression, RowExpression>> context)
+        {
+            // The rewrite will change the aggregation output, hence we only do the rewrite if the aggregation output is only used in the IF expression, i.e. variables which
+            // occurs only once in the assignments.
+            Set<VariableReferenceExpression> candidateVariables = node.getAssignments().getExpressions().stream()
+                    .flatMap(expression -> extractAll(expression).stream())
+                    .collect(Collectors.groupingBy(identity(), Collectors.counting())).entrySet().stream()
+                    .filter(entry -> entry.getValue() == 1)
+                    .map(Map.Entry::getKey)
+                    .collect(toImmutableSet());
+
+            ImmutableSet.Builder<RowExpression> candidateIfBuilder = ImmutableSet.builder();
+            IfExpressionExtractor ifExpressionExtractor = new IfExpressionExtractor();
+            // Collect candidate IF expressions in assignments
+            node.getAssignments().getExpressions().forEach(expression -> expression.accept(ifExpressionExtractor, candidateIfBuilder));
+            // The true value should be only used once in the assignments
+            Map<VariableReferenceExpression, RowExpression> candidatesInAssignments = candidateIfBuilder.build().stream()
+                    .filter(x -> candidateVariables.contains(getTrueValueFromIf(x)))
+                    .collect(toImmutableMap(Rewriter::getTrueValueFromIf, identity()));
+
+            // The true value used in the candidate passed from context should only be used once in the assignments, i.e. an identity assignment in this case.
+            // Also inline the if expression so that it can be resolved when we push the condition to aggregation.
+            Map<VariableReferenceExpression, RowExpression> candidatePassedFromContext = context.get().entrySet().stream()
+                    .filter(x -> candidateVariables.contains(x.getKey()))
+                    .collect(toImmutableMap(Map.Entry::getKey, x -> inlineReferences(x.getValue(), node.getAssignments())));
+
+            ImmutableMap.Builder<VariableReferenceExpression, RowExpression> candidates = ImmutableMap.builder();
+            candidates.putAll(candidatesInAssignments);
+            candidates.putAll(candidatePassedFromContext);
+
+            return context.defaultRewrite(node, candidates.build());
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Map<VariableReferenceExpression, RowExpression>> context)
+        {
+            Map<VariableReferenceExpression, RowExpression> candidate = context.get().entrySet().stream()
+                    .filter(x -> node.getAggregations().containsKey(x.getKey()))
+                    .filter(x -> extractUnique(x.getValue()).stream().filter(variable -> !variable.equals(x.getKey())).allMatch(node.getSource().getOutputVariables()::contains)) // only if expression can be resolved by aggregation inputs
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            if (candidate.isEmpty()) {
+                return context.defaultRewrite(node, ImmutableMap.of());
+            }
+
+            Assignments.Builder sourceProjection = Assignments.builder();
+            ImmutableMap.Builder<VariableReferenceExpression, Aggregation> newAggregations = ImmutableMap.builder();
+            candidate.forEach((aggregationOutput, ifExpression) -> {
+                checkState(ifExpression instanceof SpecialFormExpression && ((SpecialFormExpression) ifExpression).getForm().equals(IF));
+                RowExpression condition = ((SpecialFormExpression) ifExpression).getArguments().get(0);
+                Aggregation aggregation = node.getAggregations().get(aggregationOutput);
+                RowExpression maskExpression = aggregation.getMask().isPresent() ? and(aggregation.getMask().get(), condition) : condition;
+                VariableReferenceExpression maskVariable = planVariableAllocator.newVariable(maskExpression);
+                Aggregation newAggregation = new Aggregation(
+                        aggregation.getCall(),
+                        aggregation.getFilter(),
+                        aggregation.getOrderBy(),
+                        aggregation.isDistinct(),
+                        Optional.of(maskVariable));
+                sourceProjection.put(maskVariable, maskExpression);
+                newAggregations.put(aggregationOutput, newAggregation);
+            });
+
+            sourceProjection.putAll(node.getSource().getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
+            newAggregations.putAll(
+                    node.getAggregations().entrySet().stream().filter(x -> !candidate.containsKey(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+            AggregationNode aggregationNode = new AggregationNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    new ProjectNode(planNodeIdAllocator.getNextId(), node.getSource(), sourceProjection.build()),
+                    newAggregations.build(),
+                    node.getGroupingSets(),
+                    node.getPreGroupedVariables(),
+                    node.getStep(),
+                    node.getHashVariable(),
+                    node.getGroupIdVariable());
+
+            return context.defaultRewrite(aggregationNode, ImmutableMap.of());
+        }
+
+        private boolean isCandidateIfExpression(RowExpression rowExpression)
+        {
+            return determinismEvaluator.isDeterministic(rowExpression) &&
+                    rowExpression instanceof SpecialFormExpression && ((SpecialFormExpression) rowExpression).getForm().equals(IF)
+                    && ((SpecialFormExpression) rowExpression).getArguments().get(1) instanceof VariableReferenceExpression
+                    && (
+                    ((SpecialFormExpression) rowExpression).getArguments().size() == 2
+                            || ((SpecialFormExpression) rowExpression).getArguments().get(2) instanceof ConstantExpression
+                            && ((ConstantExpression) ((SpecialFormExpression) rowExpression).getArguments().get(2)).isNull());
+        }
+
+        // Extract candidate IF expression from row expression
+        private class IfExpressionExtractor
+                extends DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<RowExpression>>
+        {
+            @Override
+            public Void visitSpecialForm(SpecialFormExpression specialForm, ImmutableSet.Builder<RowExpression> context)
+            {
+                if (isCandidateIfExpression(specialForm)) {
+                    context.add(specialForm);
+                }
+                return super.visitSpecialForm(specialForm, context);
+            }
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -207,7 +207,8 @@ public class TestFeaturesConfig
                 .setOptimizeMultipleApproxPercentileOnSameFieldEnabled(true)
                 .setNativeExecutionEnabled(false)
                 .setNativeExecutionExecutablePath("./presto_server")
-                .setRandomizeOuterJoinNullKeyEnabled(false));
+                .setRandomizeOuterJoinNullKeyEnabled(false)
+                .setOptimizeConditionalAggregationEnabled(false));
     }
 
     @Test
@@ -366,6 +367,7 @@ public class TestFeaturesConfig
                 .put("native-execution-enabled", "true")
                 .put("native-execution-executable-path", "/bin/echo")
                 .put("optimizer.randomize-outer-join-null-key", "true")
+                .put("optimizer.optimize-conditional-aggregation-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -521,7 +523,8 @@ public class TestFeaturesConfig
                 .setOptimizeMultipleApproxPercentileOnSameFieldEnabled(false)
                 .setNativeExecutionEnabled(true)
                 .setNativeExecutionExecutablePath("/bin/echo")
-                .setRandomizeOuterJoinNullKeyEnabled(true);
+                .setRandomizeOuterJoinNullKeyEnabled(true)
+                .setOptimizeConditionalAggregationEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRewriteIfOverAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRewriteIfOverAggregation.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.groupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+
+public class TestRewriteIfOverAggregation
+        extends BasePlanTest
+{
+    private Session enableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED, "true")
+                .build();
+    }
+
+    @Test
+    public void testConditionOnGrouping()
+    {
+        assertPlan("SELECT orderstatus, shippriority, IF(GROUPING(orderstatus, shippriority) = 0, sum(totalprice)) "
+                        + "FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderstatus, shippriority))",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("pricesum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                project(
+                                        ImmutableMap.of("mask", expression("array[1, 0][groupid+1]=0")),
+                                        groupingSet(
+                                                ImmutableList.of(ImmutableList.of("orderstatus"), ImmutableList.of("orderstatus", "shippriority")),
+                                                ImmutableMap.of("totalprice", "totalprice"),
+                                                "groupid",
+                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderstatus", "orderstatus", "shippriority", "shippriority")))))));
+    }
+
+    // Should not be rewritten
+    @Test
+    public void testConditionOnAggregation()
+    {
+        assertPlan("select orderpriority, if(count(1)>3000, avg(totalprice)) from orders group by orderpriority ",
+                enableOptimization(),
+                anyTree(
+                        project(
+                                ImmutableMap.of("ifexp", expression("if(count > 3000, avg, null)")),
+                                aggregation(
+                                        ImmutableMap.of("avg", functionCall("avg", ImmutableList.of("partial_avg")), "count", functionCall("count", ImmutableList.of("partial_count"))),
+                                        exchange(
+                                                aggregation(
+                                                        ImmutableMap.of("partial_avg", functionCall("avg", ImmutableList.of("totalprice")), "partial_count", functionCall("count", ImmutableList.of())),
+                                                        project(
+                                                                ImmutableMap.of("totalprice", expression("totalprice"), "orderpriority", expression("orderpriority")),
+                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority")))))))));
+    }
+
+    @Test
+    public void testMultipleArgumentsAggregation()
+    {
+        assertPlan("SELECT orderstatus, shippriority, IF(GROUPING(orderstatus, shippriority) = 0, max_by(shippriority, totalprice)) "
+                        + "FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderstatus, shippriority))",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("result", functionCall("max_by", ImmutableList.of("shippriority", "totalprice"))),
+                                project(
+                                        ImmutableMap.of("mask", expression("array[1, 0][groupid+1]=0")),
+                                        groupingSet(
+                                                ImmutableList.of(ImmutableList.of("orderstatus"), ImmutableList.of("orderstatus", "shippriority")),
+                                                ImmutableMap.of("totalprice", "totalprice", "shippriority", "shippriority"),
+                                                "groupid",
+                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderstatus", "orderstatus", "shippriority", "shippriority")))))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
@@ -26,6 +26,7 @@ import org.intellij.lang.annotations.Language;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
@@ -46,6 +47,15 @@ class QueryAssertions
                 .setCatalog("local")
                 .setSchema("default")
                 .build());
+    }
+
+    public QueryAssertions(Map<String, String> systemProperties)
+    {
+        Session.SessionBuilder builder = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("default");
+        systemProperties.forEach(builder::setSystemProperty);
+        runner = new LocalQueryRunner(builder.build());
     }
 
     public QueryAssertions(Session session)

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestConditionalAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestConditionalAggregations.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED;
+
+public class TestConditionalAggregations
+        extends BasePlanTest
+{
+    private static final Map<String, String> sessionProperties = ImmutableMap.of(OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED, "true");
+    private QueryAssertions assertions;
+
+    public TestConditionalAggregations()
+    {
+        super(sessionProperties);
+    }
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions(sessionProperties);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testAggregationSkipped()
+    {
+        String sql = "select y, grouping(y) grouping_y, IF(grouping(y)!=1, sum(x)) from (VALUES (1,1,1), (9223372036854775807,2,1)) AS T(x,y,z)"
+                + " group by grouping sets ((y), (z)) ORDER BY 1, 2";
+        QueryAssertions asserionNoOptimization = new QueryAssertions();
+        asserionNoOptimization.assertFails(sql, "bigint addition overflow:.*");
+        assertions.assertQuery(sql, "VALUES (1, 0, 1), (2, 0, 9223372036854775807), (NULL, 1, NULL)");
+    }
+
+    @Test
+    public void testPredicateOnGroupBy()
+    {
+        assertions.assertQuery(
+                "SELECT y, IF(y>1, sum(x)) FROM (VALUES (1, 2), (5, 2), (1,1), (3, 1)) t(x, y) GROUP BY y ORDER BY y",
+                "VALUES (INTEGER '1', CAST(NULL AS BIGINT)), (INTEGER '2', BIGINT '6')");
+        assertions.assertQuery(
+                "SELECT y, SUM(IF(y>1, x)) FROM (VALUES (1, 2), (5, 2), (1,1), (3, 1)) t(x, y) GROUP BY y ORDER BY y",
+                "VALUES (INTEGER '1', CAST(NULL AS BIGINT)), (INTEGER '2', BIGINT '6')");
+
+        assertions.assertQuery(
+                "SELECT z, IF(z<2, MAX_BY(x, y)) FROM (VALUES (1, 2, 1), (5, 3, 1), (1, 4, 2), (3, 1, 2)) t(x, y, z) GROUP BY z ORDER BY z",
+                "VALUES (INTEGER '1', INTEGER '5'), (INTEGER '2', CAST(NULL AS INTEGER))");
+        assertions.assertQuery(
+                "SELECT z, MAX_BY(IF(z<2, x), y) FROM (VALUES (1, 2, 1), (5, 3, 1), (1, 4, 2), (3, 1, 2)) t(x, y, z) GROUP BY z ORDER BY z",
+                "VALUES (INTEGER '1', INTEGER '5'), (INTEGER '2', CAST(NULL AS INTEGER))");
+
+        assertions.assertQuery(
+                "SELECT z, IF(z<2, MIN_BY(x, y)) FROM (VALUES (1, 2, 1), (5, 3, 1), (1, 4, 2), (3, 1, 2)) t(x, y, z) GROUP BY z ORDER BY z",
+                "VALUES (INTEGER '1', INTEGER '1'), (INTEGER '2', CAST(NULL AS INTEGER))");
+        assertions.assertQuery(
+                "SELECT z, MIN_BY(IF(z<2, x), y) FROM (VALUES (1, 2, 1), (5, 3, 1), (1, 4, 2), (3, 1, 2)) t(x, y, z) GROUP BY z ORDER BY z",
+                "VALUES (INTEGER '1', INTEGER '1'), (INTEGER '2', CAST(NULL AS INTEGER))");
+
+        assertions.assertQuery(
+                "SELECT y, IF(y>1, REDUCE_AGG(x, 0, (a, b) -> a+b, (a, b) -> a+b)) FROM (VALUES (1, 2), (5, 2), (1,1), (3, 1)) t(x, y) GROUP BY y ORDER BY y",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER)), (INTEGER '2', INTEGER '6')");
+        assertions.assertQuery(
+                "SELECT y, REDUCE_AGG(IF(y>1, x), 0, (a, b) -> a+b, (a, b) -> a+b) FROM (VALUES (1, 2), (5, 2), (1,1), (3, 1)) t(x, y) GROUP BY y ORDER BY y",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER)), (INTEGER '2', INTEGER '6')");
+
+        assertions.assertQuery(
+                "SELECT max_by(IF(x > 1, x), y), max_by(x, y) FROM (VALUES (1, 2), (1, 3), (0, 5), (0,6), (3, 0), (3, 1)) t(x, y)",
+                "VALUES (CAST(NULL AS INTEGER), INTEGER '0')");
+    }
+
+    @Test
+    public void testPredicateOnGroupingSet()
+    {
+        assertions.assertQuery(
+                "SELECT y, z, IF(grouping(y)=0, sum(x)), if(grouping(z) = 0, count(x)) FROM (VALUES (1, 2, 8), (5, 2, 0), (1,1, 4), (3, 1, 0)) t(x, y, z) " +
+                        "GROUP BY grouping sets ((y), (z)) ORDER BY y, z",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER), BIGINT '4', CAST(NULL AS BIGINT)), " +
+                        "(INTEGER '2', CAST(NULL AS INTEGER),  BIGINT '6', CAST(NULL AS BIGINT)), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '0', CAST(NULL AS BIGINT), BIGINT '2'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '4', CAST(NULL AS BIGINT), BIGINT '1'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '8', CAST(NULL AS BIGINT), BIGINT '1')");
+
+        assertions.assertQuery(
+                "SELECT z, p, IF(grouping(z)=0, MAX_BY(x, y)), IF(grouping(p)=0, MAX_BY(y, x)) FROM (VALUES (1, 2, 1, 9), (5, 3, 1, 4), (1, 4, 2, 4), (3, 1, 2, 9)) t(x, y, z, p) GROUP BY grouping sets ((z), (p)) ORDER BY z, p",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER), INTEGER '5', CAST(NULL AS INTEGER)), " +
+                        "(INTEGER '2', CAST(NULL AS INTEGER),  INTEGER '1', CAST(NULL AS INTEGER)), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '4', CAST(NULL AS INTEGER), INTEGER '3'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '9', CAST(NULL AS INTEGER), INTEGER '1')");
+
+        assertions.assertQuery(
+                "SELECT z, p, IF(grouping(z)=0, MIN_BY(x, y)), IF(grouping(p)=0, MIN_BY(y, x)) FROM (VALUES (1, 2, 1, 9), (5, 3, 1, 4), (1, 4, 2, 4), (3, 1, 2, 9)) t(x, y, z, p) GROUP BY grouping sets ((z), (p)) ORDER BY z, p",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER), INTEGER '1', CAST(NULL AS INTEGER)), " +
+                        "(INTEGER '2', CAST(NULL AS INTEGER),  INTEGER '3', CAST(NULL AS INTEGER)), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '4', CAST(NULL AS INTEGER), INTEGER '4'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '9', CAST(NULL AS INTEGER), INTEGER '2')");
+
+        assertions.assertQuery(
+                "SELECT y, z, IF(grouping(y)=0, REDUCE_AGG(x, 0, (a, b) -> a+b, (a, b) -> a+b)), if(grouping(z) = 0, REDUCE_AGG(x, 0, (a, b) -> a*b, (a, b) -> a*b)) FROM (VALUES (1, 2, 8), (5, 2, 0), (1,1, 4), (3, 1, 0)) t(x, y, z) " +
+                        "GROUP BY grouping sets ((y), (z)) ORDER BY y, z",
+                "VALUES (INTEGER '1', CAST(NULL AS INTEGER), INTEGER '4', CAST(NULL AS INTEGER)), " +
+                        "(INTEGER '2', CAST(NULL AS INTEGER),  INTEGER '6', CAST(NULL AS INTEGER)), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '0', CAST(NULL AS INTEGER), INTEGER '0'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '4', CAST(NULL AS INTEGER), INTEGER '0'), " +
+                        "(CAST(NULL AS INTEGER), INTEGER '8', CAST(NULL AS INTEGER), INTEGER '0')");
+    }
+}


### PR DESCRIPTION
### What's the change?

IF(predicate, AGG(x)) generates a plan which does aggregation on the whole dataset then project the aggregation results with a IF expression.

However, this is not efficient, as we calculate the the aggregation for the whole dataset, and discard part of it.

To avoid this inefficiency, we added this optimization which include the predicate to the mask of the aggregation.

### Test plan - (Please fill in how you tested your changes)

Add unit test. Also test locally.

```
== RELEASE NOTES ==

General Changes
* Add an optimization which rewrites ``IF(predicate, AGG(x))`` to aggregation with mask in plan level. Controlled by system property `optimize_conditional_aggregation_enabled` and default to false.
```

