### PR TITLE
[native] Add EXTRA_CMAKE_FLAGS option in Makefile

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -63,8 +63,7 @@ jobs:
           export CCACHE_DIR=$(realpath ~/.ccache)
           ccache -s
           cd ${GITHUB_WORKSPACE}/presto-native-execution
-          make velox-submodule
-          cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make debug EXTRA_CMAKE_FLAGS=" -DPRESTO_ENABLE_PARQUET=ON "
           ninja -C _build/debug -j 2
           ccache -s
 

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -20,13 +20,10 @@ NUM_THREADS ?= $(shell getconf _NPROCESSORS_CONF 2>/dev/null || echo 1)
 CPU_TARGET ?= "avx"
 CMAKE_PREFIX_PATH ?= "/usr/local"
 
-PRESTO_ENABLE_PARQUET ?= "OFF"
-
 CMAKE_FLAGS := -DTREAT_WARNINGS_AS_ERRORS=${TREAT_WARNINGS_AS_ERRORS}
 CMAKE_FLAGS += -DENABLE_ALL_WARNINGS=${ENABLE_WALL}
 CMAKE_FLAGS += -DCMAKE_PREFIX_PATH=$(CMAKE_PREFIX_PATH)
 CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
-CMAKE_FLAGS += -DPRESTO_ENABLE_PARQUET=$(PRESTO_ENABLE_PARQUET)
 
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1
@@ -54,7 +51,11 @@ velox-submodule:		#: Check out code for velox submodule
 submodules: velox-submodule
 
 cmake: submodules		#: Use CMake to create a Makefile build system
-	cmake -B "$(BUILD_BASE_DIR)/$(BUILD_DIR)" $(FORCE_COLOR) $(CMAKE_FLAGS)
+	cmake -B \
+		"$(BUILD_BASE_DIR)/$(BUILD_DIR)" \
+		$(FORCE_COLOR) \
+		$(CMAKE_FLAGS) \
+		${EXTRA_CMAKE_FLAGS}
 
 build:					#: Build the software based in BUILD_DIR and BUILD_TYPE variables
 	cmake --build $(BUILD_BASE_DIR)/$(BUILD_DIR) -j $(NUM_THREADS)


### PR DESCRIPTION
This allows specifying other options in the CMakeList.txt via Makefile.

Test plan

Modified test native CI workflow to use Makefile and always build Parquet

```
== NO RELEASE NOTE ==
```
