### PR TITLE
Making spilled pages in memory size volatile

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -74,7 +74,7 @@ public class FileSingleStreamSpiller
 
     private boolean writable = true;
     private boolean committed;
-    private long spilledPagesInMemorySize;
+    private volatile long spilledPagesInMemorySize;
     private ListenableFuture<?> spillInProgress = Futures.immediateFuture(null);
 
     public FileSingleStreamSpiller(


### PR DESCRIPTION
Given FileSingleStreamSpiller#spilledPagesInMemorySize calculation is done in seperate thread, making it volatile so threads reading data can see the updated value immediately


```
== NO RELEASE NOTE ==
```
