### PR TITLE
DiscoveryNodeManager to not return Coordinator/Resource Manager if not allowed by NodeStatusService

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -443,6 +443,18 @@ public final class DiscoveryNodeManager
         return getAllNodes().getShuttingDownNodes().size();
     }
 
+    @Managed
+    public int getActiveResourceManagerCount()
+    {
+        return getAllNodes().getActiveResourceManagers().size();
+    }
+
+    @Managed
+    public int getActiveCoordinatorCount()
+    {
+        return getAllNodes().getActiveCoordinators().size();
+    }
+
     @Override
     public Set<InternalNode> getNodes(NodeState state)
     {
@@ -591,8 +603,6 @@ public final class DiscoveryNodeManager
             return service ->
                     !nodeStatusService.isPresent()
                             || nodeStatusService.get().isAllowed(service.getLocation())
-                            || isCoordinator(service)
-                            || isResourceManager(service)
                             || isCatalogServer(service);
         }
 


### PR DESCRIPTION
In some mysterious conditions, we noticed coordinators are showing up in discovery service, and this lead to a bad state where resource managed start failing getResourceGroupInfo call due to incosistency in the coordinator count. we won't to mitigate it by removing this checks which are no longer needed given NodeStatusService should filter them.

Redoes the old PR https://github.com/prestodb/presto/pull/18086 which got reverted: https://github.com/prestodb/presto/pull/18193 due to an issue of active coordinators were not found during verifier run.

Test plan - Verifier run

```
== NO RELEASE NOTE ==
```
