### PR TITLE
Support Pinot query options push down

### DIFF
--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -83,6 +83,7 @@ Property Name                                               Description
 ``pinot.broker-authentication-type``                        Pinot authentication method for broker requests. Allowed values are ``NONE`` and ``PASSWORD`` - defaults to ``NONE`` which is no authentication.
 ``pinot.broker-authentication-user``                        Broker username for basic authentication method.
 ``pinot.broker-authentication-password``                    Broker password for basic authentication method.
+``pinot.query-options``                                     Pinot query-related case-sensitive options. E.g. skipUpsert:true,enableNullHandling:true
 ==========================================================  =============================================================================================================
 
 If ``pinot.controller-authentication-type`` is set to ``PASSWORD`` then both ``pinot.controller-authentication-user`` and
@@ -114,6 +115,7 @@ Property Name                                             Description
 ``pinot.controller_authentication_password``              Controller password for basic authentication method.
 ``pinot.broker_authentication_user``                      Broker username for basic authentication method.
 ``pinot.broker_authentication_password``                  Broker password for basic authentication method.
+``pinot.query_options``                                   Pinot query-related case-sensitive options. E.g. skipUpsert:true,enableNullHandling:true
 ========================================================  ==================================================================
 
 Map Pinot Schema to Presto Schema

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
@@ -122,7 +122,7 @@ public class PinotBrokerPageSource
         if (blockBuilder == null) {
             return;
         }
-        if (value == null) {
+        if (value == null || value.isNull()) {
             blockBuilder.appendNull();
             return;
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
@@ -52,12 +52,17 @@ public class PinotColumnUtils
 
     public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType)
     {
+        return getPinotColumnsForPinotSchema(pinotTableSchema, inferDateType, inferTimestampType, false);
+    }
+
+    public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType, boolean nullHandlingEnabled)
+    {
         return pinotTableSchema.getColumnNames().stream()
                 .filter(columnName -> !columnName.startsWith("$")) // Hidden columns starts with "$", ignore them as we can't use them in SQL
                 .map(columnName -> new PinotColumn(
                         columnName,
                         getPrestoTypeFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), inferDateType, inferTimestampType),
-                        isNullableColumnFromPinotType(pinotTableSchema.getFieldSpecFor(columnName)),
+                        isNullableColumnFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), nullHandlingEnabled),
                         getCommentFromPinotType(pinotTableSchema.getFieldSpecFor(columnName))))
                 .collect(toImmutableList());
     }
@@ -67,9 +72,9 @@ public class PinotColumnUtils
         return field.getFieldType().name();
     }
 
-    private static boolean isNullableColumnFromPinotType(FieldSpec field)
+    private static boolean isNullableColumnFromPinotType(FieldSpec field, boolean nullHandlingEnabled)
     {
-        return false;
+        return nullHandlingEnabled;
     }
 
     public static Type getPrestoTypeFromPinotType(FieldSpec field, boolean inferDateType, boolean inferTimestampType)

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -114,6 +114,8 @@ public class PinotConfig
     private String brokerAuthenticationUser;
     private String brokerAuthenticationPassword;
 
+    private String queryOptions;
+
     @NotNull
     public Map<String, String> getExtraHttpHeaders()
     {
@@ -650,5 +652,18 @@ public class PinotConfig
             throw new PinotException(PINOT_INVALID_CONFIGURATION, Optional.empty(), "No pinot controllers specified");
         }
         return controllerUrls.get(ThreadLocalRandom.current().nextInt(controllerUrls.size()));
+    }
+
+    @NotNull
+    public String getQueryOptions()
+    {
+        return queryOptions;
+    }
+
+    @Config("pinot.query-options")
+    public PinotConfig setQueryOptions(String options)
+    {
+        queryOptions = options;
+        return this;
     }
 }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
@@ -54,6 +54,7 @@ public class PinotConnection
                 .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS)
                 .build(asyncReloading(CacheLoader.from(pinotClusterInfoFetcher::getAllTables), executor));
 
+        boolean nullHandlingEnabled = PinotQueryOptionsUtils.isNullHandlingEnabled(pinotConfig.getQueryOptions());
         this.pinotTableColumnCache =
                 CacheBuilder.newBuilder()
                         .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS)
@@ -64,7 +65,7 @@ public class PinotConnection
                                     throws Exception
                             {
                                 Schema tablePinotSchema = pinotClusterInfoFetcher.getTableSchema(tableName);
-                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
+                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema(), nullHandlingEnabled);
                             }
                         }, executor));
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotQueryOptionKey.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotQueryOptionKey.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot;
+
+public class PinotQueryOptionKey
+{
+    private PinotQueryOptionKey()
+    {
+    }
+
+    public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
+}

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotQueryOptionsUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotQueryOptionsUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class PinotQueryOptionsUtils
+{
+    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator(":");
+
+    private PinotQueryOptionsUtils()
+    {
+    }
+
+    public static boolean isNullHandlingEnabled(String queryOptions)
+    {
+        if (isNullOrEmpty(queryOptions)) {
+            return false;
+        }
+        Map<String, String> queryOptionsMap = ImmutableMap.copyOf(MAP_SPLITTER.split(queryOptions));
+        return Boolean.parseBoolean(queryOptionsMap.get(PinotQueryOptionKey.ENABLE_NULL_HANDLING));
+    }
+
+    public static String getQueryOptionsAsString(String queryOptions)
+    {
+        if (isNullOrEmpty(queryOptions)) {
+            return "";
+        }
+
+        Map<String, String> queryOptionsMap = ImmutableMap.copyOf(MAP_SPLITTER.split(queryOptions));
+        if (queryOptionsMap.isEmpty()) {
+            return "";
+        }
+        return queryOptionsMap.entrySet().stream()
+                .filter(kv -> !Strings.isNullOrEmpty(kv.getKey()) && !Strings.isNullOrEmpty(kv.getValue()))
+                .map(kv -> CharMatcher.anyOf("\"`'").trimFrom(kv.getKey()) + "=" + kv.getValue())
+                .collect(Collectors.joining(",", " option(", ") "));
+    }
+}

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
@@ -47,6 +47,7 @@ public class PinotSessionProperties
     public static final String CONTROLLER_AUTHENTICATION_PASSWORD = "controller_authentication_password";
     public static final String BROKER_AUTHENTICATION_USER = "broker_authentication_user";
     public static final String BROKER_AUTHENTICATION_PASSWORD = "broker_authentication_password";
+    public static final String QUERY_OPTIONS = "query_options";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -136,6 +137,11 @@ public class PinotSessionProperties
         return session.getProperty(BROKER_AUTHENTICATION_PASSWORD, String.class);
     }
 
+    public static String getQueryOptions(ConnectorSession session)
+    {
+        return session.getProperty(QUERY_OPTIONS, String.class);
+    }
+
     @Inject
     public PinotSessionProperties(PinotConfig pinotConfig)
     {
@@ -204,6 +210,11 @@ public class PinotSessionProperties
                         BROKER_AUTHENTICATION_PASSWORD,
                         "Broker authentication password",
                         pinotConfig.getBrokerAuthenticationPassword(),
+                        false),
+                stringProperty(
+                        QUERY_OPTIONS,
+                        "Query Options, in the format of k1:v1,k2:v2",
+                        pinotConfig.getQueryOptions(),
                         false),
                 booleanProperty(
                         USE_DATE_TRUNC,

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.pinot.PinotColumnHandle;
 import com.facebook.presto.pinot.PinotConfig;
 import com.facebook.presto.pinot.PinotException;
+import com.facebook.presto.pinot.PinotQueryOptionsUtils;
 import com.facebook.presto.pinot.PinotSessionProperties;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -303,7 +304,7 @@ public class PinotQueryGeneratorContext
     // Generate Pinot query:
     // - takes arguments of expressions/table name/limit clause;
     // - handles the common logic to generate where/groupBy/orderBy clauses.
-    private String generatePinotQueryHelper(boolean forBroker, String expressions, String tableName, String limitClause)
+    private String generatePinotQueryHelper(boolean forBroker, String expressions, String tableName, String limitClause, String queryOptions)
     {
         String query = "SELECT " + expressions + " FROM " + tableName + (forBroker ? "" : TABLE_NAME_SUFFIX_TEMPLATE);
         if (filter.isPresent()) {
@@ -326,6 +327,7 @@ public class PinotQueryGeneratorContext
             query = query + " ORDER BY " + orderByExpressions;
         }
         query = query + limitClause;
+        query = query + queryOptions;
         return query;
     }
 
@@ -383,7 +385,9 @@ public class PinotQueryGeneratorContext
         if (queryLimit > 0) {
             limitClause = " LIMIT " + queryLimit;
         }
-        String query = generatePinotQueryHelper(forBroker, expressions, tableName, limitClause);
+        String queryOptionsProperty = PinotSessionProperties.getQueryOptions(session);
+        String queryOptions = PinotQueryOptionsUtils.getQueryOptionsAsString(queryOptionsProperty);
+        String query = generatePinotQueryHelper(forBroker, expressions, tableName, limitClause, queryOptions);
         LinkedHashMap<VariableReferenceExpression, PinotColumnHandle> assignments = getAssignments();
         List<Integer> indices = getIndicesMappingFromPinotSchemaToPrestoSchema(query, assignments);
         return new PinotQueryGenerator.GeneratedPinotQuery(tableName, query, indices, filter.isPresent(), forBroker);

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
@@ -72,7 +72,8 @@ public class TestPinotConfig
                         .setControllerAuthenticationPassword(null)
                         .setBrokerAuthenticationType("NONE")
                         .setBrokerAuthenticationUser(null)
-                        .setBrokerAuthenticationPassword(null));
+                        .setBrokerAuthenticationPassword(null)
+                        .setQueryOptions(null));
     }
 
     @Test
@@ -121,6 +122,7 @@ public class TestPinotConfig
                 .put("pinot.broker-authentication-type", "PASSWORD")
                 .put("pinot.broker-authentication-user", "admin")
                 .put("pinot.broker-authentication-password", "verysecret")
+                .put("pinot.query-options", "enableNullHandling:true,skipUpsert:true")
                 .build();
 
         PinotConfig expected = new PinotConfig()
@@ -166,7 +168,8 @@ public class TestPinotConfig
                 .setBrokerAuthenticationType("PASSWORD")
                 .setBrokerAuthenticationUser("admin")
                 .setBrokerAuthenticationPassword("verysecret")
-                .setUseSecureConnection(true);
+                .setUseSecureConnection(true)
+                .setQueryOptions("enableNullHandling:true,skipUpsert:true");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSessionProperties.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSessionProperties.java
@@ -36,4 +36,30 @@ public class TestPinotSessionProperties
         ConnectorSession session = new TestingConnectorSession(pinotSessionProperties.getSessionProperties());
         assertEquals(PinotSessionProperties.getOverrideDistinctCountFunction(session), "distinctCountBitmap");
     }
+
+    @Test
+    public void testQueryOptionsParsedProperly()
+    {
+        PinotConfig pinotConfig = new PinotConfig().setQueryOptions(",,enableNullHandling:true,skipUpsert:true,");
+        PinotSessionProperties pinotSessionProperties = new PinotSessionProperties(pinotConfig);
+        ConnectorSession session = new TestingConnectorSession(pinotSessionProperties.getSessionProperties());
+        String queryOptionsProperty = PinotSessionProperties.getQueryOptions(session);
+        assertEquals(queryOptionsProperty, ",,enableNullHandling:true,skipUpsert:true,");
+        assertEquals(
+                PinotQueryOptionsUtils.getQueryOptionsAsString(queryOptionsProperty),
+                " option(enableNullHandling=true,skipUpsert=true) ");
+    }
+
+    @Test
+    public void testQuotedQueryOptionsParsedProperly()
+    {
+        PinotConfig pinotConfig = new PinotConfig().setQueryOptions(",,`enableNullHandling`:true,\"skipUpsert\":true,");
+        PinotSessionProperties pinotSessionProperties = new PinotSessionProperties(pinotConfig);
+        ConnectorSession session = new TestingConnectorSession(pinotSessionProperties.getSessionProperties());
+        String queryOptionsProperty = PinotSessionProperties.getQueryOptions(session);
+        assertEquals(queryOptionsProperty, ",,`enableNullHandling`:true,\"skipUpsert\":true,");
+        assertEquals(
+                PinotQueryOptionsUtils.getQueryOptionsAsString(queryOptionsProperty),
+                " option(enableNullHandling=true,skipUpsert=true) ");
+    }
 }


### PR DESCRIPTION
- Support Pinot's enableNullHandling query option in Presto
- Added unit tests
- Tested against Pinot cluster

```
== RELEASE NOTES ==

Pinot Changes
* Add new config `pinot.query-options` and session property `pinot.query_options` to set [Pinot Query Options](https://docs.pinot.apache.org/users/user-guide-query/query-options) for generated Pinot query.
```
