### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1166,7 +1166,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.3.3</version>
+                <version>42.4.1</version>
             </dependency>
 
             <dependency>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.3-1102-jdbc41</version>
+            <version>42.4.1</version>
         </dependency>
 
         <!-- Presto SPI -->


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.postgresql:postgresql 9.3-1102-jdbc41
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)
- [CVE-2018-10936](https://www.oscs1024.com/hd/CVE-2018-10936)
- [CVE-2020-13692](https://www.oscs1024.com/hd/CVE-2020-13692)


### What did I do？
Upgrade org.postgresql:postgresql from 9.3-1102-jdbc41 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS