### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1153,7 +1153,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <version>8.0.28</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in mysql:mysql-connector-java 5.1.48
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2018-3258](https://www.oscs1024.com/hd/CVE-2018-3258)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.48 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS