### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.2</version>
+            <version>2.12.6.1</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.10.2
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)
- [MPS-2022-12500](https://www.oscs1024.com/hd/MPS-2022-12500)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.10.2 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS