### PR TITLE
Enable format/header check for native execution

### DIFF
--- a/.github/workflows/test-native-specific.yml
+++ b/.github/workflows/test-native-specific.yml
@@ -78,6 +78,26 @@ jobs:
           ninja -C _build/debug
           ccache -s
 
+  native-specific-check:
+    runs-on: ubuntu-latest
+    container: prestocpp/velox-check:mikesh-20210609
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: true
+          fetch-depth: 0
+
+      - name: Update submodules
+        run: make -C presto-native-execution submodules
+
+      - name: Format check
+        run: make -C presto-native-execution format-check
+
+      - name: Header check
+        run: make -C presto-native-execution header-check
+
   native-specific-linux:
     runs-on: ubuntu-latest
     container: prestocpp/prestocpp-avx-circleci:mikesh-20220804
@@ -95,13 +115,6 @@ jobs:
 
       - name: Update submodules
         run: make -C presto-native-execution submodules
-
-      # disable the checks for now until the image if fixed to have cmake-format.
-      #      - name: Format check
-      #        run: make -C presto-native-execution format-check
-      #
-      #      - name: Header check
-      #        run: make -C presto-native-execution header-check
 
       - name: Get date for ccache
         id: get-date

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -28,6 +28,8 @@ CMAKE_FLAGS += -DCMAKE_PREFIX_PATH=$(CMAKE_PREFIX_PATH)
 CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 CMAKE_FLAGS += -DPRESTO_ENABLE_PARQUET=$(PRESTO_ENABLE_PARQUET)
 
+SHELL := /bin/bash
+
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1
 ifeq ($(USE_NINJA), 1)


### PR DESCRIPTION
It turns out I have to set SHELL to bash in Makefile to use those popd/pushd commands. As bash is almost everywhere, it's probably not a big issue for a quick fix. I've tested it on MacOS and it works fine for me.
We can see if we can so something better later.

Test plan - (Please fill in how you tested your changes)
Existing CI Runs

```
== NO RELEASE NOTE ==
```
