### PR TITLE
Making spilled pages in memory size volatile for Temp Storage Spiller

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
@@ -77,7 +77,7 @@ public class TempStorageSingleStreamSpiller
     private TempStorageHandle tempStorageHandle;
     private int bufferedBytes;
     private List<DataOutput> bufferedPages = new ArrayList<>();
-    private long spilledPagesInMemorySize;
+    private volatile long spilledPagesInMemorySize;
     private ListenableFuture<?> spillInProgress = Futures.immediateFuture(null);
 
     public TempStorageSingleStreamSpiller(


### PR DESCRIPTION
Given TempStorageSingleStreamSpiller#spilledPagesInMemorySize calculation is done in seperate thread, making it volatile so threads reading data can see the updated value immediately


```
== NO RELEASE NOTE ==
```
