### PR TITLE
Propagate various ORC dictionary settings as session properties

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -69,6 +69,9 @@ public final class HiveSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_SIZE = "orc_optimized_writer_max_stripe_size";
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_ROWS = "orc_optimized_writer_max_stripe_rows";
     private static final String ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY = "orc_optimized_writer_max_dictionary_memory";
+    private static final String ORC_OPTIMIZED_WRITER_INTEGER_DICTIONARY_ENCODING_ENABLED = "orc_optimized_writer_integer_dictionary_encoding_enabled";
+    private static final String ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_ENCODING_ENABLED = "orc_optimized_writer_string_dictionary_encoding_enabled";
+    private static final String ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED = "orc_optimized_writer_string_dictionary_sorting_enabled";
     private static final String ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL = "orc_optimized_writer_compression_level";
     private static final String PAGEFILE_WRITER_MAX_STRIPE_SIZE = "pagefile_writer_max_stripe_size";
     public static final String HIVE_STORAGE_FORMAT = "hive_storage_format";
@@ -271,6 +274,21 @@ public final class HiveSessionProperties
                         ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY,
                         "Experimental: ORC: Max dictionary memory",
                         orcFileWriterConfig.getDictionaryMaxMemory(),
+                        false),
+                booleanProperty(
+                        ORC_OPTIMIZED_WRITER_INTEGER_DICTIONARY_ENCODING_ENABLED,
+                        "ORC: Enable integer dictionary encoding",
+                        orcFileWriterConfig.isIntegerDictionaryEncodingEnabled(),
+                        false),
+                booleanProperty(
+                        ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_ENCODING_ENABLED,
+                        "ORC: Enable string dictionary encoding",
+                        orcFileWriterConfig.isStringDictionaryEncodingEnabled(),
+                        false),
+                booleanProperty(
+                        ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED,
+                        "ORC: Enable string dictionary sorting",
+                        orcFileWriterConfig.isStringDictionarySortingEnabled(),
                         false),
                 integerProperty(
                         ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL,
@@ -799,6 +817,21 @@ public final class HiveSessionProperties
     public static DataSize getOrcOptimizedWriterMaxDictionaryMemory(ConnectorSession session)
     {
         return session.getProperty(ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY, DataSize.class);
+    }
+
+    public static boolean isIntegerDictionaryEncodingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_OPTIMIZED_WRITER_INTEGER_DICTIONARY_ENCODING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isStringDictionaryEncodingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_ENCODING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isStringDictionarySortingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED, Boolean.class);
     }
 
     public static OptionalInt getCompressionLevel(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -49,6 +49,9 @@ public class OrcFileWriterConfig
     private DataSize dwrfStripeCacheMaxSize = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
     private DwrfStripeCacheMode dwrfStripeCacheMode = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MODE;
     private int compressionLevel = DEFAULT_COMPRESSION_LEVEL;
+    private boolean isIntegerDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED;
+    private boolean isStringDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
+    private boolean isStringDictionarySortingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
@@ -137,6 +140,42 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
         this.dictionaryMaxMemory = dictionaryMaxMemory;
+        return this;
+    }
+
+    public boolean isIntegerDictionaryEncodingEnabled()
+    {
+        return isIntegerDictionaryEncodingEnabled;
+    }
+
+    @Config("hive.orc.writer.integer-dictionary-encoding-enabled")
+    public OrcFileWriterConfig setIntegerDictionaryEncodingEnabled(boolean isIntegerDictionaryEncodingEnabled)
+    {
+        this.isIntegerDictionaryEncodingEnabled = isIntegerDictionaryEncodingEnabled;
+        return this;
+    }
+
+    public boolean isStringDictionaryEncodingEnabled()
+    {
+        return isStringDictionaryEncodingEnabled;
+    }
+
+    @Config("hive.orc.writer.string-dictionary-encoding-enabled")
+    public OrcFileWriterConfig setStringDictionaryEncodingEnabled(boolean isStringDictionaryEncodingEnabled)
+    {
+        this.isStringDictionaryEncodingEnabled = isStringDictionaryEncodingEnabled;
+        return this;
+    }
+
+    public boolean isStringDictionarySortingEnabled()
+    {
+        return isStringDictionarySortingEnabled;
+    }
+
+    @Config("hive.orc.writer.string-dictionary-sorting-enabled")
+    public OrcFileWriterConfig setStringDictionarySortingEnabled(boolean isStringDictionarySortingEnabled)
+    {
+        this.isStringDictionarySortingEnabled = isStringDictionarySortingEnabled;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -72,6 +72,9 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferS
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStringStatisticsLimit;
 import static com.facebook.presto.hive.HiveSessionProperties.isDwrfWriterStripeCacheEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isExecutionBasedMemoryAccountingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isIntegerDictionaryEncodingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isStringDictionaryEncodingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isStringDictionarySortingEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
@@ -231,6 +234,9 @@ public class OrcFileWriterFactory
                                     .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
                                     .build())
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
+                            .withIntegerDictionaryEncodingEnabled(isIntegerDictionaryEncodingEnabled(session))
+                            .withStringDictionaryEncodingEnabled(isStringDictionaryEncodingEnabled(session))
+                            .withStringDictionarySortingEnabled(isStringDictionarySortingEnabled(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
                             .withDwrfStripeCacheEnabled(isDwrfWriterStripeCacheEnabled(session))

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -60,7 +60,10 @@ public class TestOrcFileWriterConfig
                 .setDwrfStripeCacheEnabled(false)
                 .setDwrfStripeCacheMaxSize(new DataSize(8, MEGABYTE))
                 .setDwrfStripeCacheMode(INDEX_AND_FOOTER)
-                .setCompressionLevel(Integer.MIN_VALUE));
+                .setCompressionLevel(Integer.MIN_VALUE)
+                .setIntegerDictionaryEncodingEnabled(false)
+                .setStringDictionaryEncodingEnabled(true)
+                .setStringDictionarySortingEnabled(true));
     }
 
     @Test
@@ -79,6 +82,9 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.dwrf-stripe-cache-max-size", "10MB")
                 .put("hive.orc.writer.dwrf-stripe-cache-mode", "FOOTER")
                 .put("hive.orc.writer.compression-level", "5")
+                .put("hive.orc.writer.integer-dictionary-encoding-enabled", "true")
+                .put("hive.orc.writer.string-dictionary-encoding-enabled", "false")
+                .put("hive.orc.writer.string-dictionary-sorting-enabled", "false")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -93,7 +99,10 @@ public class TestOrcFileWriterConfig
                 .setDwrfStripeCacheEnabled(true)
                 .setDwrfStripeCacheMaxSize(new DataSize(10, MEGABYTE))
                 .setDwrfStripeCacheMode(FOOTER)
-                .setCompressionLevel(5);
+                .setCompressionLevel(5)
+                .setIntegerDictionaryEncodingEnabled(true)
+                .setStringDictionaryEncodingEnabled(false)
+                .setStringDictionarySortingEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -44,6 +44,9 @@ public class OrcWriterOptions
     public static final DwrfStripeCacheMode DEFAULT_DWRF_STRIPE_CACHE_MODE = INDEX_AND_FOOTER;
     public static final int DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT = 0;
     public static final int DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT = 20000;
+    public static final boolean DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED = false;
+    public static final boolean DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED = true;
+    public static final boolean DEFAULT_STRING_DICTIONARY_SORTING_ENABLED = true;
 
     private final OrcWriterFlushPolicy flushPolicy;
     private final int rowGroupMaxRowCount;
@@ -271,9 +274,9 @@ public class OrcWriterOptions
         private DataSize maxCompressionBufferSize = DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
         private OptionalInt compressionLevel = OptionalInt.empty();
         private StreamLayoutFactory streamLayoutFactory = new ColumnSizeLayoutFactory();
-        private boolean integerDictionaryEncodingEnabled;
-        private boolean stringDictionarySortingEnabled = true;
-        private boolean stringDictionaryEncodingEnabled = true;
+        private boolean integerDictionaryEncodingEnabled = DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED;
+        private boolean stringDictionarySortingEnabled = DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
+        private boolean stringDictionaryEncodingEnabled = DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
         private boolean dwrfStripeCacheEnabled;
         private DwrfStripeCacheMode dwrfStripeCacheMode = DEFAULT_DWRF_STRIPE_CACHE_MODE;
         private DataSize dwrfStripeCacheMaxSize = DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;


### PR DESCRIPTION
Propagate the following ORC writer settings as session properties:
- integer dictionary encoding enabled
- string dictionary encoding enabled
- string dictionary sorting enabled

Current writer default settings remain unchanged.

Test plan:
- unit tests
- modified OrcWriter to show the settings:
```
Default:
integerDictionaryEncodingEnabled=false, stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true

And then:
set session prism.orc_optimized_writer_integer_dictionary_encoding_enabled = true;
integerDictionaryEncodingEnabled=true, stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true

And then:
set session prism.orc_optimized_writer_string_dictionary_encoding_enabled = false;
integerDictionaryEncodingEnabled=true, stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=false,

And then:
set session prism.orc_optimized_writer_string_dictionary_sorting_enabled = false;
integerDictionaryEncodingEnabled=true, stringDictionarySortingEnabled=false, stringDictionaryEncodingEnabled=false,
```

```
== NO RELEASE NOTE ==
```
