### PR TITLE
[native] Add Presto write protocols

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -28,6 +28,7 @@
 #include "presto_cpp/main/connectors/hive/storage_adapters/FileSystems.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
+#include "presto_cpp/presto_protocol/WriteProtocol.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/caching/SsdCache.h"
@@ -146,6 +147,8 @@ void PrestoServer::run() {
   registerOptionalHiveStorageAdapters();
   protocol::registerHiveConnectors();
   protocol::registerTpchConnector();
+  protocol::PrestoNoCommitWriteProtocol::registerProtocol();
+  protocol::PrestoTaskCommitWriteProtocol::registerProtocol();
 
   auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
       systemConfig->numIoThreads(),

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include "velox/common/base/tests/Fs.h"
+#include "velox/common/base/Fs.h"
 
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/TaskManager.h"

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -25,19 +25,7 @@
 #include "presto_cpp/main/types/TypeSignatureTypeConverter.h"
 // clang-format on
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <folly/container/F14Set.h>
-
-#if __has_include("filesystem")
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 using namespace facebook::velox;
 
@@ -110,6 +98,46 @@ std::shared_ptr<connector::ColumnHandle> toColumnHandle(
   }
 
   throw std::invalid_argument("Unknown column handle type: " + column->_type);
+}
+
+connector::hive::LocationHandle::TableType toTableType(
+    protocol::TableType tableType) {
+  switch (tableType) {
+    case protocol::TableType::NEW:
+      return connector::hive::LocationHandle::TableType::kNew;
+    case protocol::TableType::EXISTING:
+      return connector::hive::LocationHandle::TableType::kExisting;
+    case protocol::TableType::TEMPORARY:
+      return connector::hive::LocationHandle::TableType::kTemporary;
+    default:
+      throw std::invalid_argument("Unknown table type");
+  }
+}
+
+connector::hive::LocationHandle::WriteMode toWriteMode(
+    protocol::WriteMode writeMode) {
+  switch (writeMode) {
+    case protocol::WriteMode::STAGE_AND_MOVE_TO_TARGET_DIRECTORY:
+      return connector::hive::LocationHandle::WriteMode::
+          kStageAndMoveToTargetDirectory;
+    case protocol::WriteMode::DIRECT_TO_TARGET_NEW_DIRECTORY:
+      return connector::hive::LocationHandle::WriteMode::
+          kDirectToTargetNewDirectory;
+    case protocol::WriteMode::DIRECT_TO_TARGET_EXISTING_DIRECTORY:
+      return connector::hive::LocationHandle::WriteMode::
+          kDirectToTargetExistingDirectory;
+    default:
+      throw std::invalid_argument("Unknown write mode");
+  }
+}
+
+std::shared_ptr<connector::hive::LocationHandle> toLocationHandle(
+    const protocol::LocationHandle& locationHandle) {
+  return std::make_shared<connector::hive::LocationHandle>(
+      locationHandle.targetPath,
+      locationHandle.writePath,
+      toTableType(locationHandle.tableType),
+      toWriteMode(locationHandle.writeMode));
 }
 
 int64_t toInt64(
@@ -1632,24 +1660,51 @@ VeloxQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::TableWriterNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
-  auto outputTableHandle = std::dynamic_pointer_cast<protocol::CreateHandle>(
-                               tableWriteInfo->writerTarget)
-                               ->handle;
+  std::string connectorId;
+  std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+      inputColumns;
+  std::shared_ptr<connector::ConnectorInsertTableHandle> hiveTableHandle;
+  if (auto createHandle = std::dynamic_pointer_cast<protocol::CreateHandle>(
+          tableWriteInfo->writerTarget)) {
+    connectorId = createHandle->handle.connectorId;
 
-  auto hiveOutputTableHandle =
-      std::dynamic_pointer_cast<protocol::HiveOutputTableHandle>(
-          outputTableHandle.connectorHandle);
+    auto hiveOutputTableHandle =
+        std::dynamic_pointer_cast<protocol::HiveOutputTableHandle>(
+            createHandle->handle.connectorHandle);
 
-  auto uuid = boost::uuids::random_generator()();
-  auto fileName = boost::uuids::to_string(uuid);
+    for (const auto& columnHandle : hiveOutputTableHandle->inputColumns) {
+      inputColumns.emplace_back(
+          std::dynamic_pointer_cast<connector::hive::HiveColumnHandle>(
+              toColumnHandle(&columnHandle)));
+    }
 
-  auto filePath =
-      fs::path(hiveOutputTableHandle->locationHandle.writePath) / fileName;
+    hiveTableHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
+        inputColumns, toLocationHandle(hiveOutputTableHandle->locationHandle));
+  } else if (
+      auto insertHandle = std::dynamic_pointer_cast<protocol::InsertHandle>(
+          tableWriteInfo->writerTarget)) {
+    connectorId = insertHandle->handle.connectorId;
 
-  auto hiveTableHandle =
-      std::make_shared<velox::connector::hive::HiveInsertTableHandle>(filePath);
-  auto insertTableHandle = std::make_shared<core::InsertTableHandle>(
-      outputTableHandle.connectorId, hiveTableHandle);
+    auto hiveInsertTableHandle =
+        std::dynamic_pointer_cast<protocol::HiveInsertTableHandle>(
+            insertHandle->handle.connectorHandle);
+
+    for (const auto& columnHandle : hiveInsertTableHandle->inputColumns) {
+      inputColumns.emplace_back(
+          std::dynamic_pointer_cast<connector::hive::HiveColumnHandle>(
+              toColumnHandle(&columnHandle)));
+    }
+
+    hiveTableHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
+        inputColumns, toLocationHandle(hiveInsertTableHandle->locationHandle));
+  } else {
+    VELOX_UNSUPPORTED(
+        "Unsupported table writer handle: {}",
+        toJsonString(tableWriteInfo->writerTarget));
+  }
+
+  auto insertTableHandle =
+      std::make_shared<core::InsertTableHandle>(connectorId, hiveTableHandle);
 
   auto outputType = toRowType(
       {node->rowCountVariable,

--- a/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
@@ -9,10 +9,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(presto_protocol OBJECT presto_protocol.cpp Base64Util.cpp
-                                   DataSize.cpp Duration.cpp Connectors.cpp)
+add_library(
+  presto_protocol OBJECT presto_protocol.cpp Base64Util.cpp DataSize.cpp
+                         Duration.cpp Connectors.cpp WriteProtocol.cpp)
 
-target_link_libraries(presto_protocol velox_type ${RE2})
+target_link_libraries(presto_protocol velox_type velox_hive_write_protocol ${RE2})
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/presto_protocol/WriteProtocol.h"
+
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/exec/TableWriter.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec;
+
+namespace facebook::presto::protocol {
+
+namespace {
+
+std::string buildPartitionUpdate(
+    const std::shared_ptr<const WriterParameters> writerParameters,
+    vector_size_t numWrittenRows) {
+  const auto hiveWriterParameters =
+      std::dynamic_pointer_cast<const HiveWriterParameters>(writerParameters);
+  VELOX_CHECK(
+      hiveWriterParameters != nullptr,
+      "Presto commit protocol only supports Hive commits at the moment.")
+  // clang-format off
+ auto partitionUpdateJson = folly::toJson(
+   folly::dynamic::object
+     ("name", "")
+     ("updateMode", hiveWriterParameters->encodeUpdateMode())
+     ("writePath", hiveWriterParameters->writeDirectory())
+     ("targetPath", hiveWriterParameters->targetDirectory())
+     ("fileWriteInfos", folly::dynamic::array(
+       folly::dynamic::object
+         ("writeFileName", hiveWriterParameters->writeFileName())
+         ("targetFileName", hiveWriterParameters->targetFileName())
+         ("fileSize", 0)))
+     ("rowCount", numWrittenRows)
+     ("inMemoryDataSizeInBytes", 0)
+     ("onDiskDataSizeInBytes", 0)
+     ("containsNumberedFileNames", true));
+  // clang-format on
+  return partitionUpdateJson;
+}
+
+RowVectorPtr buildTableWriterCommitOutput(
+    const TableWriterWriteInfo& writeInfo,
+    const std::string& commitStrategy,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  std::vector<VectorPtr> columns = {};
+
+  vector_size_t numOutputRows = 1;
+  FlatVectorPtr<int64_t> rowWrittenVector;
+  FlatVectorPtr<StringView> fragmentsVector;
+  ConstantVectorPtr<StringView> commitContextVector;
+  if (writeInfo.outputType()->size() <= 1) {
+    rowWrittenVector = std::dynamic_pointer_cast<FlatVector<int64_t>>(
+        BaseVector::create(BIGINT(), 1, pool));
+    rowWrittenVector->set(0, writeInfo.numWrittenRows());
+    columns.emplace_back(rowWrittenVector);
+  } else {
+    numOutputRows = writeInfo.writeParameters()->size() + 1;
+
+    // Set rows column
+    rowWrittenVector = std::dynamic_pointer_cast<FlatVector<int64_t>>(
+        BaseVector::create(BIGINT(), numOutputRows, pool));
+    rowWrittenVector->set(0, writeInfo.numWrittenRows());
+    for (int idx = 1; idx < numOutputRows; ++idx) {
+      rowWrittenVector->setNull(idx, true);
+    }
+    columns.emplace_back(rowWrittenVector);
+
+    // Set fragments column
+    fragmentsVector = std::dynamic_pointer_cast<velox::FlatVector<StringView>>(
+        BaseVector::create(VARBINARY(), numOutputRows, pool));
+    fragmentsVector->setNull(0, true);
+    for (int i = 1; i < numOutputRows; i++) {
+      fragmentsVector->set(
+          i,
+          StringView(buildPartitionUpdate(
+              writeInfo.writeParameters()->at(i - 1),
+              writeInfo.numWrittenRows())));
+    }
+    columns.emplace_back(fragmentsVector);
+
+    // Set commitcontext column
+    // clang-format off
+   auto commitContextJson = folly::toJson(
+     folly::dynamic::object
+         ("lifespan", "TaskWide")
+         ("taskId", writeInfo.taskId())
+         ("pageSinkCommitStrategy", commitStrategy)
+         ("lastPage", true));
+    // clang-format on
+    commitContextVector = std::make_shared<ConstantVector<StringView>>(
+        pool, numOutputRows, false, VARBINARY(), StringView(commitContextJson));
+    columns.emplace_back(commitContextVector);
+  }
+
+  return std::make_shared<RowVector>(
+      pool, writeInfo.outputType(), BufferPtr(nullptr), numOutputRows, columns);
+}
+
+} // namespace
+
+RowVectorPtr PrestoNoCommitWriteProtocol::commit(
+    const WriteInfo& writeInfo,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  if (const auto* tableWriterWriteInfo =
+          dynamic_cast<const TableWriterWriteInfo*>(&writeInfo)) {
+    return commit(*tableWriterWriteInfo, pool);
+  }
+  VELOX_UNSUPPORTED(
+      "PrestoNoCommitWriteProtocol currently only supports TableWriter commit");
+}
+
+RowVectorPtr PrestoNoCommitWriteProtocol::commit(
+    const TableWriterWriteInfo& writeInfo,
+    memory::MemoryPool* FOLLY_NONNULL pool) {
+  return buildTableWriterCommitOutput(writeInfo, encodeCommitStrategy(), pool);
+}
+
+RowVectorPtr PrestoTaskCommitWriteProtocol::commit(
+    const WriteInfo& writeInfo,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  if (const auto* tableWriterWriteInfo =
+          dynamic_cast<const TableWriterWriteInfo*>(&writeInfo)) {
+    return commit(*tableWriterWriteInfo, pool);
+  }
+  VELOX_UNSUPPORTED(
+      "PrestoNoCommitWriteProtocol currently only supports TableWriter commit");
+}
+
+RowVectorPtr PrestoTaskCommitWriteProtocol::commit(
+    const TableWriterWriteInfo& writeInfo,
+    memory::MemoryPool* FOLLY_NONNULL pool) {
+  return buildTableWriterCommitOutput(writeInfo, encodeCommitStrategy(), pool);
+}
+
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/WriteProtocol.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/HiveWriteProtocol.h"
+
+namespace facebook::velox::exec {
+class TableWriterWriteInfo;
+}
+namespace facebook::presto::protocol {
+
+class PrestoNoCommitWriteProtocol
+    : public velox::connector::hive::HiveNoCommitWriteProtocol {
+ public:
+  ~PrestoNoCommitWriteProtocol() {}
+
+  velox::RowVectorPtr commit(
+      const velox::connector::WriteInfo& writeInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  static void registerProtocol() {
+    registerWriteProtocol(
+        velox::connector::WriteProtocol::CommitStrategy::kNoCommit,
+        []() { return std::make_shared<PrestoNoCommitWriteProtocol>(); });
+  }
+
+ private:
+  velox::RowVectorPtr commit(
+      const velox::exec::TableWriterWriteInfo& tableWriterOperator,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool);
+};
+
+class PrestoTaskCommitWriteProtocol
+    : public velox::connector::hive::HiveTaskCommitWriteProtocol {
+ public:
+  ~PrestoTaskCommitWriteProtocol() {}
+
+  velox::RowVectorPtr commit(
+      const velox::connector::WriteInfo& writeInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  static void registerProtocol() {
+    registerWriteProtocol(
+        velox::connector::WriteProtocol::CommitStrategy::kTaskCommit,
+        []() { return std::make_shared<PrestoTaskCommitWriteProtocol>(); });
+  }
+
+ private:
+  velox::RowVectorPtr commit(
+      const velox::exec::TableWriterWriteInfo& tableWriterOperator,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool);
+};
+
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
@@ -6412,7 +6412,7 @@ void to_json(json& j, const std::shared_ptr<ConnectorInsertTableHandle>& p) {
   }
   String type = p->_type;
 
-  if (type == "hive") {
+  if (getConnectorKey(type) == "hive") {
     j = *std::static_pointer_cast<HiveInsertTableHandle>(p);
     return;
   }
@@ -6430,7 +6430,7 @@ void from_json(const json& j, std::shared_ptr<ConnectorInsertTableHandle>& p) {
         " ConnectorInsertTableHandle  ConnectorInsertTableHandle");
   }
 
-  if (type == "hive") {
+  if (getConnectorKey(type) == "hive") {
     std::shared_ptr<HiveInsertTableHandle> k =
         std::make_shared<HiveInsertTableHandle>();
     j.get_to(*k);

--- a/presto-native-execution/presto_cpp/presto_protocol/special/ConnectorInsertTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/special/ConnectorInsertTableHandle.cpp.inc
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorInsertTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (getConnectorKey(type) == "hive") {
+    j = *std::static_pointer_cast<HiveInsertTableHandle>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorInsertTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorInsertTableHandle  ConnectorInsertTableHandle");
+  }
+
+  if (getConnectorKey(type) == "hive") {
+    std::shared_ptr<HiveInsertTableHandle> k =
+        std::make_shared<HiveInsertTableHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ConnectorInsertTableHandle>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type ConnectorInsertTableHandle ");
+}
+} // namespace facebook::presto::protocol


### PR DESCRIPTION
Add PrestoNoCommitWriteProtocol and PrestoTaskCommitWriteProtocol,
which extends the write protocols of Hive connector and make commit()
return the specific format of outputs expected by Presto from
the table writer. Register the two write protocols during server start.
The right protocol will be picked up by the table writer,
given the CommitStrategy used by the TableWriter.

== NO RELEASE NOTE ==
```
