### PR TITLE
Add MAP_SUBSET function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -67,6 +67,16 @@ Map Functions
         SELECT map_filter(MAP(ARRAY[10, 20, 30], ARRAY['a', NULL, 'c']), (k, v) -> v IS NOT NULL); -- {10 -> a, 30 -> c}
         SELECT map_filter(MAP(ARRAY['k1', 'k2', 'k3'], ARRAY[20, 3, 15]), (k, v) -> v > 10); -- {k1 -> 20, k3 -> 15}
 
+.. function:: map_subset(map(K,V), array(k)) -> map(K,V)
+
+    Constructs a map from those entries of ``map`` for which the key is in the array given::
+
+        SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[10]); -- {}
+        SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[1]); -- {1->'a'}
+        SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[1,3]); -- {1->'a'}
+        SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[]); -- {}
+        SELECT map_subset(MAP(ARRAY[], ARRAY[]), ARRAY[1,2]); -- {}
+
 .. function:: map_keys(x(K,V)) -> array(K)
 
     Returns all the keys in the map ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -156,6 +156,7 @@ import com.facebook.presto.operator.scalar.MapIndeterminateOperator;
 import com.facebook.presto.operator.scalar.MapKeys;
 import com.facebook.presto.operator.scalar.MapNotEqualOperator;
 import com.facebook.presto.operator.scalar.MapSubscriptOperator;
+import com.facebook.presto.operator.scalar.MapSubsetFunction;
 import com.facebook.presto.operator.scalar.MapValues;
 import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.MathFunctions.LegacyLogFunction;
@@ -784,6 +785,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(ArrayGreaterThanOrEqualOperator.class)
                 .scalar(ArrayElementAtFunction.class)
                 .scalar(ArraySortFunction.class)
+                .scalar(MapSubsetFunction.class)
                 .scalar(ArraySortComparatorFunction.class)
                 .scalar(ArrayShuffleFunction.class)
                 .scalar(ArrayReverseFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubsetFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubsetFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.TypedSet;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+@ScalarFunction("map_subset")
+@Description("returns a map where the keys are a subset of the given array of keys")
+public final class MapSubsetFunction
+{
+    private MapSubsetFunction() {}
+
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlType("MAP(K,V)")
+    public static Block mapSubset(
+            @TypeParameter("K") Type keyType,
+            @TypeParameter("V") Type valueType,
+            @TypeParameter("MAP(K,V)") Type mapType,
+            @SqlType("MAP(K,V)") Block mapBlock, @SqlType("ARRAY(K)") Block keySubset)
+    {
+        if (mapBlock.getPositionCount() == 0 || keySubset.getPositionCount() == 0) {
+            return mapType.createBlockBuilder(null, 0).build();
+        }
+
+        TypedSet typedSet = new TypedSet(keyType, keySubset.getPositionCount(), "map_subset");
+        for (int i = 0; i < keySubset.getPositionCount(); i++) {
+            if (!keySubset.isNull(i)) {
+                typedSet.add(keySubset, i);
+            }
+        }
+
+        int toFind = typedSet.size();
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, toFind);
+        BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
+
+        for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+            if (typedSet.contains(mapBlock, i)) {
+                keyType.appendTo(mapBlock, i, blockBuilder);
+                valueType.appendTo(mapBlock, i + 1, blockBuilder);
+                toFind--;
+                if (toFind == 0) {
+                    break;
+                }
+            }
+        }
+
+        mapBlockBuilder.closeEntry();
+        return (Block) mapType.getObject(mapBlockBuilder, mapBlockBuilder.getPositionCount() - 1);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6212,4 +6212,12 @@ public abstract class AbstractTestQueries
         String multipleJoin = "SELECT o.orderkey, l.partkey, p.name FROM orders o LEFT JOIN lineitem l ON o.orderkey = l.orderkey LEFT JOIN part p ON l.partkey=p.partkey";
         assertQuery(enableRandomize, multipleJoin, getSession(), multipleJoin);
     }
+
+    @Test
+    public void testMapSubset()
+    {
+        assertQuery("select m[1], m[3] from (select map_subset(map(array[1,2,3,4], array['a', 'b', 'c', 'd']), array[1,3,10]) m)", "select 'a', 'c'");
+        assertQuery("select cardinality(map_subset(map(array[1,2,3,4], array['a', 'b', 'c', 'd']), array[10,20]))", "select 0");
+        assertQuery("select cardinality(map_subset(map(), array[10,20]))", "select 0");
+    }
 }


### PR DESCRIPTION
Adding MAP_SUBSET function that takes an array of keys to return a new map that contains only entries from the input that with keys in the given array.

Test plan - Added tests

```
== RELEASE NOTES ==

General Changes
* A new builtin function :func:`map_subset` is added. This function takes a map and an array of keys and returns a map with entries from the input map with keys contained in the array supplied.

```

