### PR TITLE
Minor MAP_FROM_ENTRIES perf improvement

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlMapFromEntriesBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlMapFromEntriesBenchmark.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import org.intellij.lang.annotations.Language;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlMapFromEntriesBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlMapFromEntriesBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 10, 20, query);
+    }
+
+    public static void main(String[] args)
+    {
+        @Language("SQL") String query = "SELECT MAP_FROM_ENTRIES(ZIP(SEQUENCE(1, 1000), shuffle(SEQUENCE(1, 1000)))) AS x FROM (SELECT 1) CROSS JOIN UNNEST(SEQUENCE(1, 10000)) T(x)";
+        new SqlMapFromEntriesBenchmark(createLocalQueryRunner(), query, "sql_map_entries_1k").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFromEntriesFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFromEntriesFunction.java
@@ -59,21 +59,17 @@ public final class MapFromEntriesFunction
 
         for (int i = 0; i < entryCount; i++) {
             if (block.isNull(i)) {
-                mapBlockBuilder.closeEntry();
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map entry cannot be null");
             }
             Block rowBlock = rowType.getObject(block, i);
 
             if (rowBlock.isNull(0)) {
-                mapBlockBuilder.closeEntry();
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
             }
 
-            if (uniqueKeys.contains(rowBlock, 0)) {
-                mapBlockBuilder.closeEntry();
+            if (!uniqueKeys.add(rowBlock, 0)) {
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Duplicate keys (%s) are not allowed", keyType.getObjectValue(properties, rowBlock, 0)));
             }
-            uniqueKeys.add(rowBlock, 0);
 
             keyType.appendTo(rowBlock, 0, resultBuilder);
             valueType.appendTo(rowBlock, 1, resultBuilder);


### PR DESCRIPTION
Minor performance improvement to use the `TypedSet.add` function that returns false if the key already exists. This should help some because duplicates almost never happen.

Test plan - benchmark added

```
== NO RELEASE NOTE ==
```
