### PR TITLE
ExternalPlanStatisticsProvider interface and SmarterWarehouse plugin …

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -245,6 +245,7 @@ public final class SystemSessionProperties
     public static final String HASH_BASED_DISTINCT_LIMIT_ENABLED = "hash_based_distinct_limit_enabled";
     public static final String HASH_BASED_DISTINCT_LIMIT_THRESHOLD = "hash_based_distinct_limit_threshold";
     public static final String QUICK_DISTINCT_LIMIT_ENABLED = "quick_distinct_limit_enabled";
+    public static final String USE_EXTERNAL_PLAN_STATISTICS = "use_external_plan_statistics";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1377,6 +1378,11 @@ public final class SystemSessionProperties
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,
                         "Randomize null join key for outer join",
                         featuresConfig.isRandomizeOuterJoinNullKeyEnabled(),
+                        false),
+                booleanProperty(
+                        USE_EXTERNAL_PLAN_STATISTICS,
+                        "Use plan statistics from external service in query optimizer",
+                        featuresConfig.isUseExternalPlanStatistics(),
                         false));
     }
 
@@ -2316,5 +2322,10 @@ public final class SystemSessionProperties
     public static boolean randomizeOuterJoinNullKeyEnabled(Session session)
     {
         return session.getSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, Boolean.class);
+    }
+
+    public static boolean useExternalPlanStatisticsEnabled(Session session)
+    {
+        return session.getSystemProperty(USE_EXTERNAL_PLAN_STATISTICS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -13,15 +13,30 @@
  */
 package com.facebook.presto.cost;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.statistics.EmptyPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.ExternalPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.ExternalPlanStatisticsProviderFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class HistoryBasedPlanStatisticsManager
@@ -32,6 +47,15 @@ public class HistoryBasedPlanStatisticsManager
 
     private HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider = EmptyPlanStatisticsProvider.getInstance();
     private boolean statisticsProviderAdded;
+    private static final Logger log = Logger.get(HistoryBasedPlanStatisticsManager.class);
+    private static final File EXTERNAL_PLAN_STATISTICS_PROVIDER_CONFIG = new File("etc/external-plan-statistics-provider.properties");
+    private static final String EXTERNAL_PLAN_STATISTICS_PROVIDER_PROPERTY_NAME = "external-plan-statistics-provider.factory";
+    private static final String DEFAULT_EXTERNAL_PLAN_STATISTICS_PROVIDER_FACTORY_NAME = "smarter-warehouse";
+    private ExternalPlanStatisticsProvider externalPlanStatisticsProvider;
+    private final Map<String, ExternalPlanStatisticsProviderFactory> externalPlanStatisticsProviderFactories = new ConcurrentHashMap<>();
+
+    private final Metadata metadata;
+    private boolean externalProviderAdded;
 
     @Inject
     public HistoryBasedPlanStatisticsManager(ObjectMapper objectMapper, SessionPropertyManager sessionPropertyManager, Metadata metadata, HistoryBasedOptimizationConfig config)
@@ -40,6 +64,7 @@ public class HistoryBasedPlanStatisticsManager
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(objectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     public void addHistoryBasedPlanStatisticsProviderFactory(HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider)
@@ -51,9 +76,19 @@ public class HistoryBasedPlanStatisticsManager
         statisticsProviderAdded = true;
     }
 
+    public void addExternalPlanStatisticsProviderFactory(ExternalPlanStatisticsProviderFactory factory)
+    {
+        requireNonNull(factory, "ExternalPlanStatisticsProviderFactory is null");
+
+        if (externalPlanStatisticsProviderFactories.putIfAbsent(factory.getName(), factory) != null) {
+            throw new IllegalArgumentException(format("ExternalPlanStatisticsProviderFactory '%s' is already registered", factory.getName()));
+        }
+    }
+
     public HistoryBasedPlanStatisticsCalculator getHistoryBasedPlanStatisticsCalculator(StatsCalculator delegate)
     {
-        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, delegate, planCanonicalInfoProvider, config);
+        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, delegate,
+                planCanonicalInfoProvider, config, () -> externalPlanStatisticsProvider, metadata);
     }
 
     public HistoryBasedPlanStatisticsTracker getHistoryBasedPlanStatisticsTracker()
@@ -64,5 +99,42 @@ public class HistoryBasedPlanStatisticsManager
     public PlanCanonicalInfoProvider getPlanCanonicalInfoProvider()
     {
         return planCanonicalInfoProvider;
+    }
+
+    public void loadExternalPlanStatisticsProvider()
+            throws Exception
+    {
+        if (EXTERNAL_PLAN_STATISTICS_PROVIDER_CONFIG.exists()) {
+            Map<String, String> properties = new HashMap<>(loadProperties(EXTERNAL_PLAN_STATISTICS_PROVIDER_CONFIG));
+            String factoryName = properties.remove(EXTERNAL_PLAN_STATISTICS_PROVIDER_PROPERTY_NAME);
+
+            checkArgument(!isNullOrEmpty(factoryName),
+                    "External Plan Statistics Provider configuration %s does not contain %s", EXTERNAL_PLAN_STATISTICS_PROVIDER_CONFIG.getAbsoluteFile(),
+                    EXTERNAL_PLAN_STATISTICS_PROVIDER_PROPERTY_NAME);
+            load(factoryName, properties);
+        }
+        else {
+            load(DEFAULT_EXTERNAL_PLAN_STATISTICS_PROVIDER_FACTORY_NAME, ImmutableMap.of());
+        }
+    }
+
+    @VisibleForTesting
+    public void load(String factoryName, Map<String, String> properties)
+    {
+        log.info("-- Loading External Plan Statistics Provider factory --");
+
+        ExternalPlanStatisticsProviderFactory factory = externalPlanStatisticsProviderFactories.get(factoryName);
+        checkState(factory != null, "External Plan Statistics Provider factory %s is not registered", factoryName);
+
+        ExternalPlanStatisticsProvider provider = factory.create(properties);
+
+        if (externalProviderAdded) {
+            throw new IllegalStateException("ExternalPlanStatisticsProvider can only be set once");
+        }
+
+        this.externalPlanStatisticsProvider = provider;
+        externalProviderAdded = true;
+
+        log.info("-- Loaded External Plan Statistics Provider %s --", factoryName);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableStatisticsExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableStatisticsExtractor.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class TableStatisticsExtractor
+{
+    private TableStatisticsExtractor() {}
+
+    private static class Visitor
+            extends InternalPlanVisitor<Void, Void>
+    {
+        private final ImmutableMap.Builder<PlanNodeId, TableStatistics> tableStatistics;
+        private final Function<TableScanNode, TableStatistics> tableStatisticsProvider;
+
+        private Visitor(Function<TableScanNode, TableStatistics> tableStatisticsProvider)
+        {
+            this.tableStatisticsProvider = tableStatisticsProvider;
+            this.tableStatistics = ImmutableMap.builder();
+        }
+
+        @Override
+        public Void visitPlan(PlanNode node, Void context)
+        {
+            for (PlanNode child : node.getSources()) {
+                child.accept(this, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitTableScan(TableScanNode node, Void context)
+        {
+            collectTableStatsForNodeId(node, node.getId()); // stats associated with self id
+            return null;
+        }
+
+        @Override
+        public Void visitProject(ProjectNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            if (source instanceof FilterNode) {
+                optionallyCollectStatsForNodeSource(node.getId(), ((FilterNode) source).getSource()); // potentially ScanFilterProject node
+            }
+            else {
+                optionallyCollectStatsForNodeSource(node.getId(), source); // potentially ScanProject node
+            }
+            return super.visitProject(node, context);
+        }
+
+        @Override
+        public Void visitFilter(FilterNode node, Void context)
+        {
+            optionallyCollectStatsForNodeSource(node.getId(), node.getSource());
+            return super.visitFilter(node, context);
+        }
+
+        @Override
+        public Void visitValues(ValuesNode node, Void context)
+        {
+            final int rowCount = node.getRows().size();
+            tableStatistics.put(node.getId(), TableStatistics.builder().setRowCount(Estimate.of(rowCount))
+                    .setTotalSize(Estimate.of(rowCount)).build()); // TODO temporary estimate, need to calculate actual size
+            return null;
+        }
+
+        private void optionallyCollectStatsForNodeSource(PlanNodeId parentId, PlanNode node)
+        {
+            if (node instanceof TableScanNode) {
+                collectTableStatsForNodeId((TableScanNode) node, parentId); // stats associated with parent node id
+            }
+        }
+
+        private void collectTableStatsForNodeId(TableScanNode tableScanNode, PlanNodeId relatedNodeId)
+        {
+            final TableStatistics statistics = tableStatisticsProvider.apply(tableScanNode);
+            tableStatistics.put(relatedNodeId, statistics);
+        }
+
+        public Map<PlanNodeId, TableStatistics> getTableStatistics()
+        {
+            return tableStatistics.build();
+        }
+    }
+
+    /**
+     * @return nodeId to TableStatistics mapping for every TableScanNode in node tree
+     */
+    public static Map<PlanNodeId, TableStatistics> extractTableStatistics(PlanNode node,
+            Function<TableScanNode, TableStatistics> tableStatisticsProvider)
+    {
+        Visitor visitor = new Visitor(tableStatisticsProvider);
+        node.accept(visitor, null);
+        return visitor.getTableStatistics();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerF
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
+import com.facebook.presto.spi.statistics.ExternalPlanStatisticsProviderFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
 import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
@@ -296,6 +297,11 @@ public class PluginManager
         for (HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider : plugin.getHistoryBasedPlanStatisticsProviders()) {
             log.info("Registering plan statistics provider %s", historyBasedPlanStatisticsProvider.getName());
             historyBasedPlanStatisticsManager.addHistoryBasedPlanStatisticsProviderFactory(historyBasedPlanStatisticsProvider);
+        }
+
+        for (ExternalPlanStatisticsProviderFactory factory : plugin.getExternalPlanStatisticsProviderFactories()) {
+            log.info("Registering plan statistics provider factory %s", factory.getName());
+            historyBasedPlanStatisticsManager.addExternalPlanStatisticsProviderFactory(factory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -31,6 +31,7 @@ import com.facebook.airlift.node.NodeModule;
 import com.facebook.airlift.tracetoken.TraceTokenModule;
 import com.facebook.drift.server.DriftServer;
 import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
+import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManagerModule;
 import com.facebook.presto.eventlistener.EventListenerManager;
@@ -174,6 +175,7 @@ public class PrestoServer
             injector.getInstance(QueryPrerequisitesManager.class).loadQueryPrerequisites();
             injector.getInstance(NodeTtlFetcherManager.class).loadNodeTtlFetcher();
             injector.getInstance(ClusterTtlProviderManager.class).loadClusterTtlProvider();
+            injector.getInstance(HistoryBasedPlanStatisticsManager.class).loadExternalPlanStatisticsProvider();
 
             startAssociatedProcesses(injector);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -89,6 +89,7 @@ public class FeaturesConfig
     private int maxReorderedJoins = 9;
     private boolean useHistoryBasedPlanStatistics;
     private boolean trackHistoryBasedPlanStatistics;
+    private boolean useExternalPlanStatistics;
     private boolean redistributeWrites = true;
     private boolean scaleWriters;
     private DataSize writerMinSize = new DataSize(32, MEGABYTE);
@@ -758,6 +759,18 @@ public class FeaturesConfig
     public FeaturesConfig setTrackHistoryBasedPlanStatistics(boolean trackHistoryBasedPlanStatistics)
     {
         this.trackHistoryBasedPlanStatistics = trackHistoryBasedPlanStatistics;
+        return this;
+    }
+
+    public boolean isUseExternalPlanStatistics()
+    {
+        return useExternalPlanStatistics;
+    }
+
+    @Config("optimizer.use-external-plan-statistics")
+    public FeaturesConfig setUseExternalPlanStatistics(boolean useExternalPlanStatistics)
+    {
+        this.useExternalPlanStatistics = useExternalPlanStatistics;
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerF
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
+import com.facebook.presto.spi.statistics.ExternalPlanStatisticsProviderFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
 import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
@@ -112,6 +113,10 @@ public interface Plugin
     }
 
     default Iterable<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProviders()
+    {
+        return emptyList();
+    }
+    default Iterable<ExternalPlanStatisticsProviderFactory> getExternalPlanStatisticsProviderFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ExternalPlanStatisticsProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ExternalPlanStatisticsProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface ExternalPlanStatisticsProvider
+{
+    String getName();
+
+    PlanStatistics getStats(
+            PlanNode plan,
+            QueryId queryId,
+            Function<PlanNode, String> planPrinter,
+            Optional<Function<PlanNode, Map<PlanNodeId, TableStatistics>>> tableStatisticsExtractor);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ExternalPlanStatisticsProviderFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ExternalPlanStatisticsProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import java.util.Map;
+
+public interface ExternalPlanStatisticsProviderFactory
+{
+    String getName();
+
+    ExternalPlanStatisticsProvider create(Map<String, String> config);
+}


### PR DESCRIPTION
…for Cardinality Prediction

- add ExternalPlanStatisticsProvider interface to plug external statistics providers
- add SmarterWarehouse plugin to call CardinalityPrediction service for Join nodes if external statistics provider enabled

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
