### PR TITLE
Add folly install to setup-macos.sh

### DIFF
--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -17,12 +17,20 @@ set -eufx -o pipefail
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
 MACOS_DEPS="${MACOS_DEPS} bison gperf libsodium"
+export FB_OS_VERSION=v2022.07.11.00
 
 function install_six {
   pip3 install six
 }
 
 export PATH=$(brew --prefix bison)/bin:$PATH
+
+function install_folly {
+  github_checkout facebook/folly "${FB_OS_VERSION}"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF
+}
+
 
 function install_fizz {
   github_checkout facebookincubator/fizz "${FB_OS_VERSION}"
@@ -56,6 +64,7 @@ function install_antlr {
 
 function install_presto_deps {
   install_velox_deps
+  run_and_time install_folly
   run_and_time install_antlr
   run_and_time install_six
   run_and_time install_fizz

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -18,7 +18,7 @@ set -eufx -o pipefail
 
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-ubuntu.sh"
-
+export FB_OS_VERSION=v2022.07.11.00
 sudo apt install -y gperf uuid-dev libsodium-dev
 
 function install_six {


### PR DESCRIPTION
Added FB_OS_VERSION and folly installation to setup-macos scripts.

Test plan:
Tested on local machine. 

```
== NO RELEASE NOTE ==
```
