### PR TITLE
Remove redundant distinct over group by

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRemoveRedundantDistinctAggregationBenchmarks.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRemoveRedundantDistinctAggregationBenchmarks.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+
+import java.util.Map;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlRemoveRedundantDistinctAggregationBenchmarks
+        extends AbstractSqlBenchmark
+{
+    private static final Logger LOGGER = Logger.get(SqlRewriteConditionalAggregationBenchmarks.class);
+
+    public SqlRemoveRedundantDistinctAggregationBenchmarks(LocalQueryRunner localQueryRunner, @Language("SQL") String sql)
+    {
+        super(localQueryRunner, "remove_redundant_distinct_aggregation", 10, 20, sql);
+    }
+
+    public static void main(String[] args)
+    {
+        Map<String, String> disableOptimization = ImmutableMap.of("remove_redundant_distinct_aggregation_enabled", "false");
+        String sql = "select distinct orderkey, partkey, suppkey, avg(extendedprice) from lineitem group by orderkey, partkey, suppkey";
+        LOGGER.info("Without optimization");
+        new SqlRemoveRedundantDistinctAggregationBenchmarks(createLocalQueryRunner(disableOptimization), sql).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        LOGGER.info("With optimization");
+        new SqlRemoveRedundantDistinctAggregationBenchmarks(createLocalQueryRunner(), sql).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -248,6 +248,7 @@ public final class SystemSessionProperties
     public static final String QUICK_DISTINCT_LIMIT_ENABLED = "quick_distinct_limit_enabled";
     public static final String OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED = "optimize_conditional_aggregation_enabled";
     public static final String ANALYZER_TYPE = "analyzer_type";
+    public static final String REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED = "remove_redundant_distinct_aggregation_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1409,6 +1410,11 @@ public final class SystemSessionProperties
                         OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED,
                         "Enable rewriting IF(condition, AGG(x)) to AGG(x) with condition included in mask",
                         featuresConfig.isOptimizeConditionalAggregationEnabled(),
+                        false),
+                booleanProperty(
+                        REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED,
+                        "Enable removing distinct aggregation node if input is already distinct",
+                        featuresConfig.isRemoveRedundantDistinctAggregationEnabled(),
                         false));
     }
 
@@ -2358,5 +2364,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizeConditionalAggregationEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isRemoveRedundantDistinctAggregationEnabled(Session session)
+    {
+        return session.getSystemProperty(REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -239,6 +239,7 @@ public class FeaturesConfig
     private String nativeExecutionExecutablePath = "./presto_server";
     private boolean randomizeOuterJoinNullKey;
     private boolean isOptimizeConditionalAggregationEnabled;
+    private boolean isRemoveRedundantDistinctAggregationEnabled = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2264,6 +2265,19 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeConditionalAggregationEnabled(boolean isOptimizeConditionalAggregationEnabled)
     {
         this.isOptimizeConditionalAggregationEnabled = isOptimizeConditionalAggregationEnabled;
+        return this;
+    }
+
+    public boolean isRemoveRedundantDistinctAggregationEnabled()
+    {
+        return isRemoveRedundantDistinctAggregationEnabled;
+    }
+
+    @Config("optimizer.remove-redundant-distinct-aggregation-enabled")
+    @ConfigDescription("Enable removing distinct aggregation node if input is already distinct")
+    public FeaturesConfig setRemoveRedundantDistinctAggregationEnabled(boolean isRemoveRedundantDistinctAggregationEnabled)
+    {
+        this.isRemoveRedundantDistinctAggregationEnabled = isRemoveRedundantDistinctAggregationEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -145,6 +145,7 @@ import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
+import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
@@ -601,6 +602,8 @@ public class PlanOptimizers
                         .addAll(new ExtractSpatialJoins(metadata, splitManager, pageSourceManager).rules())
                         .add(new InlineProjections(metadata.getFunctionAndTypeManager()))
                         .build()));
+
+        builder.add(new RemoveRedundantDistinctAggregation());
 
         if (!forceSingleNode) {
             builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isRemoveRedundantDistinctAggregationEnabled;
+import static com.facebook.presto.spi.plan.AggregationNode.isDistinct;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Remove the redundant distinct if output is already distinct.
+ * For example, for query select distinct k, sum(x) from table group by k
+ * The plan will change
+ * <p>
+ * From:
+ * <pre>
+ * - Aggregation group by k, sum
+ *   - Aggregation (sum <- AGG(x)) group by k
+ * </pre>
+ * To:
+ * <pre>
+ * - Aggregation (sum <- AGG(x)) group by k
+ * </pre>
+ * <p>
+ */
+public class RemoveRedundantDistinctAggregation
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isRemoveRedundantDistinctAggregationEnabled(session)) {
+            PlanWithProperties result = new RemoveRedundantDistinctAggregation.Rewriter().accept(plan);
+            return result.getNode();
+        }
+        return plan;
+    }
+
+    private static class PlanWithProperties
+    {
+        private final PlanNode node;
+        // Variables in each set combines to be distinct in the output of the plan node.
+        private final List<Set<VariableReferenceExpression>> distinctVariableSet;
+
+        public PlanWithProperties(PlanNode node, List<Set<VariableReferenceExpression>> distinctVariableSet)
+        {
+            this.node = requireNonNull(node, "node is null");
+            this.distinctVariableSet = requireNonNull(distinctVariableSet, "StreamProperties is null");
+        }
+
+        public PlanNode getNode()
+        {
+            return node;
+        }
+
+        public List<Set<VariableReferenceExpression>> getProperties()
+        {
+            return distinctVariableSet;
+        }
+    }
+
+    private static class Rewriter
+            extends InternalPlanVisitor<PlanWithProperties, Void>
+    {
+        @Override
+        public PlanWithProperties visitPlan(PlanNode node, Void context)
+        {
+            // For nodes such as join, unnest etc. the distinct properties may be violated, hence pass empty list for these cases.
+            return planAndRecplace(node, false);
+        }
+
+        @Override
+        public PlanWithProperties visitAggregation(AggregationNode node, Void context)
+        {
+            PlanWithProperties child = accept(node.getSource());
+            if (isDistinct(node) && child.getProperties().stream().anyMatch(node.getGroupingKeys()::containsAll)) {
+                return child;
+            }
+            ImmutableList.Builder<Set<VariableReferenceExpression>> properties = ImmutableList.builder();
+            // Only do it for aggregations with one single grouping set
+            if (node.getGroupingSetCount() == 1 && !node.getGroupingKeys().isEmpty()) {
+                properties.add(node.getGroupingKeys().stream().collect(toImmutableSet()));
+            }
+            PlanNode newAggregation = node.replaceChildren(ImmutableList.of(child.getNode()));
+            return new PlanWithProperties(newAggregation, properties.build());
+        }
+
+        @Override
+        public PlanWithProperties visitProject(ProjectNode node, Void context)
+        {
+            return planAndRecplace(node, true);
+        }
+
+        private PlanWithProperties accept(PlanNode node)
+        {
+            PlanWithProperties result = node.accept(this, null);
+            return new PlanWithProperties(
+                    result.getNode().assignStatsEquivalentPlanNode(node.getStatsEquivalentPlanNode()),
+                    result.getProperties());
+        }
+
+        private PlanWithProperties planAndRecplace(PlanNode node, boolean passProperties)
+        {
+            List<PlanWithProperties> children = node.getSources().stream().map(this::accept).collect(toImmutableList());
+            PlanNode result = replaceChildren(node, children.stream().map(PlanWithProperties::getNode).collect(toImmutableList()));
+            if (!passProperties) {
+                return new PlanWithProperties(result, ImmutableList.of());
+            }
+            ImmutableList.Builder<Set<VariableReferenceExpression>> properties = ImmutableList.builder();
+            children.stream().map(PlanWithProperties::getProperties).forEach(properties::addAll);
+            return new PlanWithProperties(result, properties.build());
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -211,7 +211,8 @@ public class TestFeaturesConfig
                 .setNativeExecutionEnabled(false)
                 .setNativeExecutionExecutablePath("./presto_server")
                 .setRandomizeOuterJoinNullKeyEnabled(false)
-                .setOptimizeConditionalAggregationEnabled(false));
+                .setOptimizeConditionalAggregationEnabled(false)
+                .setRemoveRedundantDistinctAggregationEnabled(true));
     }
 
     @Test
@@ -372,6 +373,7 @@ public class TestFeaturesConfig
                 .put("native-execution-executable-path", "/bin/echo")
                 .put("optimizer.randomize-outer-join-null-key", "true")
                 .put("optimizer.optimize-conditional-aggregation-enabled", "true")
+                .put("optimizer.remove-redundant-distinct-aggregation-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -529,7 +531,8 @@ public class TestFeaturesConfig
                 .setNativeExecutionEnabled(true)
                 .setNativeExecutionExecutablePath("/bin/echo")
                 .setRandomizeOuterJoinNullKeyEnabled(true)
-                .setOptimizeConditionalAggregationEnabled(true);
+                .setOptimizeConditionalAggregationEnabled(true)
+                .setRemoveRedundantDistinctAggregationEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveRedundantDistinctAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveRedundantDistinctAggregation.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.groupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestRemoveRedundantDistinctAggregation
+        extends BasePlanTest
+{
+    @Test
+    public void testDistinctOverSingleGroupBy()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, SUM(totalprice) FROM orders GROUP BY orderpriority",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                        FINAL,
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                        PARTIAL,
+                                                        project(
+                                                                ImmutableMap.of(),
+                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority")))))))));
+    }
+
+    @Test
+    public void testDistinctOverSingleGroupingSet()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, SUM(totalprice) FROM orders GROUP BY GROUPING SETS ((orderpriority))",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                        FINAL,
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                        PARTIAL,
+                                                        project(
+                                                                ImmutableMap.of(),
+                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority")))))))));
+    }
+
+    // Should not trigger
+    @Test
+    public void testDistinctOverMultipleGroupingSet()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, orderstatus, SUM(totalprice) FROM orders GROUP BY GROUPING SETS ((orderpriority), (orderstatus))",
+                output(
+                        anyTree(
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(
+                                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                                        PARTIAL,
+                                                                        project(
+                                                                                ImmutableMap.of(),
+                                                                                groupingSet(
+                                                                                        ImmutableList.of(ImmutableList.of("orderpriority"), ImmutableList.of("orderstatus")),
+                                                                                        ImmutableMap.of("totalprice", "totalprice"),
+                                                                                        "groupid",
+                                                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority", "orderstatus", "orderstatus"))))))))))));
+    }
+
+    @Test
+    public void testDistinctWithRandom()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, random(), SUM(totalprice) FROM orders GROUP BY orderpriority",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                        FINAL,
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                        PARTIAL,
+                                                        project(
+                                                                ImmutableMap.of(),
+                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority")))))))));
+    }
+
+    @Test
+    public void testDistinctWithRandomFromGroupBy()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, random(), sum from (select orderpriority, SUM(totalprice) as sum FROM orders GROUP BY orderpriority)",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                        FINAL,
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                        PARTIAL,
+                                                        project(
+                                                                ImmutableMap.of(),
+                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority")))))))));
+    }
+
+    // Does not trigger optimization
+    @Test
+    public void testDistinctOverSubsetOfGroupBy()
+    {
+        assertPlan("SELECT DISTINCT orderpriority, sum FROM (SELECT orderpriority, orderstatus, SUM(totalprice) AS sum FROM orders GROUP BY orderpriority, orderstatus)",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        project(
+                                                aggregation(
+                                                        ImmutableMap.of("finalsum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(
+                                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                                        PARTIAL,
+                                                                        project(
+                                                                                ImmutableMap.of(),
+                                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority", "orderstatus", "orderstatus")))))))))));
+    }
+
+    // Does not trigger
+    @Test
+    public void testDistinctExpressionWithGroupBy()
+    {
+        assertPlan("SELECT DISTINCT orderkey+1 AS orderkey, sum FROM (SELECT orderkey, SUM(totalprice) AS sum FROM orders GROUP BY orderkey)",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        FINAL,
+                                        anyTree(
+                                                aggregation(
+                                                        ImmutableMap.of(),
+                                                        PARTIAL,
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("expr", expression("orderkey+1")),
+                                                                        aggregation(
+                                                                                ImmutableMap.of("sum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                                                SINGLE,
+                                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderkey", "orderkey")))))))))));
+    }
+
+    // Does not trigger
+    @Test
+    public void testJoinWithGroupByKey()
+    {
+        assertPlan("select distinct orderkey, avg, tax from (select orderkey, sum(totalprice) avg from orders group by orderkey) as t1 join lineitem using(orderkey)",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        anyTree(
+                                                join(
+                                                        INNER,
+                                                        ImmutableList.of(equiJoinClause("l_orderkey", "orderkey")),
+                                                        project(
+                                                                ImmutableMap.of(),
+                                                                tableScan("lineitem", ImmutableMap.of("l_orderkey", "orderkey", "tax", "tax"))),
+                                                        project(
+                                                                aggregation(
+                                                                        ImmutableMap.of("finallsum", functionCall("sum", ImmutableList.of("partialsum"))),
+                                                                        FINAL,
+                                                                        anyTree(
+                                                                                aggregation(
+                                                                                        ImmutableMap.of("partialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                                                        PARTIAL,
+                                                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderkey", "orderkey"))))))))))));
+    }
+
+    // Does not trigger
+    @Test
+    public void testJoinWithGroupByOnDifferentKey()
+    {
+        assertPlan("select distinct orderstatus, orderkey from (select orderstatus, max_by(orderkey, totalprice) orderkey from orders group by orderstatus) as t1 join lineitem using(orderkey)",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        anyTree(
+                                                join(
+                                                        INNER,
+                                                        ImmutableList.of(equiJoinClause("max_by", "orderkey_10")),
+                                                        project(
+                                                                aggregation(
+                                                                        ImmutableMap.of("max_by", functionCall("max_by", ImmutableList.of("max_by_24"))),
+                                                                        FINAL,
+                                                                        anyTree(
+                                                                                aggregation(
+                                                                                        ImmutableMap.of("max_by_24", functionCall("max_by", ImmutableList.of("orderkey", "totalprice"))),
+                                                                                        PARTIAL,
+                                                                                        project(
+                                                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderkey", "orderkey"))))))),
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of(),
+                                                                        tableScan("lineitem", ImmutableMap.of("orderkey_10", "orderkey"))))))))));
+    }
+
+    @Test
+    public void testAggregationOverDistinct()
+    {
+        assertPlan("select orderstatus, max_by(orderpriority, sum) from (select distinct orderstatus, orderpriority, sum(totalprice) as sum from orders group by orderstatus, orderpriority) group by orderstatus",
+                output(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of("max_by", functionCall("max_by", ImmutableList.of("orderpriority", "sum"))),
+                                        project(
+                                                aggregation(
+                                                        ImmutableMap.of("sum", functionCall("sum", ImmutableList.of("paritialsum"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(
+                                                                        ImmutableMap.of("paritialsum", functionCall("sum", ImmutableList.of("totalprice"))),
+                                                                        PARTIAL,
+                                                                        project(
+                                                                                ImmutableMap.of(),
+                                                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "orderpriority", "orderpriority", "orderstatus", "orderstatus")))))))))));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -1364,6 +1364,17 @@ public abstract class AbstractTestAggregations
                 "SELECT 15000, 15000");
     }
 
+    @Test
+    public void testRemoveRedundantDistinctOverGroupBy()
+    {
+        String trigger = "SELECT DISTINCT suppkey, COUNT(*) FROM lineitem GROUP BY suppkey";
+        assertQuery(trigger, trigger);
+
+        String doNotTrigger = "SELECT DISTINCT suppkey, cnt FROM (SELECT suppkey, COUNT(*) AS cnt FROM lineitem GROUP BY suppkey " +
+                "UNION ALL SELECT suppkey, COUNT(*) AS cnt FROM lineitem GROUP BY suppkey) order by 1, 2";
+        assertQuery(doNotTrigger, doNotTrigger);
+    }
+
     @DataProvider(name = "getType")
     protected Object[][] getDigests()
     {


### PR DESCRIPTION
### What's the change?

Add an optimization which remove distinct if the corresponding output is already distinct after a group by operation.

An example is query "SELECT DISTINCT orderpriority, SUM(totalprice) FROM orders GROUP BY orderpriority", where the distinct operation is redundant.

### Test plan - (Please fill in how you tested your changes)

Add unit test.

### Benchmark results
Sql query: `select distinct orderkey, partkey, suppkey, avg(extendedprice) from lineitem group by orderkey, partkey, suppkey`.
Control: 100.324 cpu ms
Test: 71.382 cpu ms

```
INFO: Without optimization
peak_memory:14040686,elapsed_millis:107,input_rows_per_second:563343,output_rows_per_second:563222,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:106817513,cpu_nanos:106122000,user_nanos:105276000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:121,input_rows_per_second:496354,output_rows_per_second:496247,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:121233823,cpu_nanos:116225000,user_nanos:112490000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:104,input_rows_per_second:577529,output_rows_per_second:577405,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:104193760,cpu_nanos:103269000,user_nanos:102787000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:99,input_rows_per_second:608323,output_rows_per_second:608191,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:98919466,cpu_nanos:98592000,user_nanos:98192000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:103,input_rows_per_second:586097,output_rows_per_second:585970,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:102670618,cpu_nanos:98834000,user_nanos:98230000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:226,input_rows_per_second:265874,output_rows_per_second:265816,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:226328984,cpu_nanos:101054000,user_nanos:100322000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:99,input_rows_per_second:608878,output_rows_per_second:608746,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:98829296,cpu_nanos:97290000,user_nanos:96909000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:97,input_rows_per_second:618267,output_rows_per_second:618134,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:97328389,cpu_nanos:97041000,user_nanos:96738000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:94,input_rows_per_second:639660,output_rows_per_second:639522,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:94073333,cpu_nanos:94008000,user_nanos:93760000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:14040686,elapsed_millis:91,input_rows_per_second:660615,output_rows_per_second:660472,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:91089298,cpu_nanos:90805000,user_nanos:90014000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
remove_redundant_distinct_aggregation ::  100.324 cpu ms :: 13.4MB peak memory :: in 60.2K,      0B,    600K/s,      0B/s :: out 60.2K,  2.07MB,    600K/s,  20.6MB/s

INFO: With optimization
peak_memory:7632508,elapsed_millis:74,input_rows_per_second:812957,output_rows_per_second:812781,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:74019902,cpu_nanos:69991000,user_nanos:69738000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:70,input_rows_per_second:853687,output_rows_per_second:853503,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:70488303,cpu_nanos:69767000,user_nanos:69512000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:70,input_rows_per_second:856021,output_rows_per_second:855836,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:70296139,cpu_nanos:69947000,user_nanos:69751000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:72,input_rows_per_second:839667,output_rows_per_second:839485,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:71665290,cpu_nanos:71003000,user_nanos:70721000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:69,input_rows_per_second:877072,output_rows_per_second:876882,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:68608956,cpu_nanos:68328000,user_nanos:67990000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:67,input_rows_per_second:894244,output_rows_per_second:894050,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:67291472,cpu_nanos:67286000,user_nanos:67140000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:68,input_rows_per_second:887679,output_rows_per_second:887487,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:67789139,cpu_nanos:67608000,user_nanos:67258000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:77,input_rows_per_second:783050,output_rows_per_second:782881,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:76846899,cpu_nanos:76142000,user_nanos:74259000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:85,input_rows_per_second:710566,output_rows_per_second:710412,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:84686002,cpu_nanos:80436000,user_nanos:76732000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
peak_memory:7632508,elapsed_millis:74,input_rows_per_second:815461,output_rows_per_second:815285,input_megabytes:0,input_megabytes_per_second:0,wall_nanos:73792574,cpu_nanos:73309000,user_nanos:72923000,input_rows:60175,input_bytes:0,output_rows:60162,output_bytes:2165832
remove_redundant_distinct_aggregation ::   71.382 cpu ms :: 7.28MB peak memory :: in 60.2K,      0B,    843K/s,      0B/s :: out 60.2K,  2.07MB,    843K/s,  28.9MB/s
```

```
== RELEASE NOTES ==

General Changes
* Add an optimization which removes redundant distinct if the output is already distinct after a group by operation.
   The optimization is controlled by session property `remove_redundant_distinct_aggregation` which is default to false.
```

