### PR TITLE
[native] Export in-memory cache counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -22,7 +22,6 @@ void registerPrestoCppCounters() {
       kCounterDriverCPUExecutorQueueSize, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterDriverCPUExecutorLatencyMs, facebook::velox::StatType::AVG);
-
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterHTTPExecutorLatencyMs, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
@@ -31,10 +30,8 @@ void registerPrestoCppCounters() {
       kCounterNumHTTPRequestError, facebook::velox::StatType::COUNT);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterHTTPRequestLatencyMs, facebook::velox::StatType::AVG);
-
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumQueryContexts, facebook::velox::StatType::AVG);
-
   REPORT_ADD_STAT_EXPORT_TYPE(kCounterNumTasks, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumTasksRunning, facebook::velox::StatType::AVG);
@@ -67,6 +64,58 @@ void registerPrestoCppCounters() {
       facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMappedMemoryRawAllocBytesLarge, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEmptyEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumSharedEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumExclusiveEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumPrefetchedEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalTinyBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalLargeBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalTinyPaddingBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalLargePaddingBytes,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalPrefetchBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheTotalTinyPaddingBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheSumEvictScore, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeHit, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumHit, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeNew, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumNew, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeEvict, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEvict, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeEvictChecks,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEvictChecks, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeWaitExclusive,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumWaitExclusive, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumCumulativeAllocClocks,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumAllocClocks, facebook::velox::StatType::AVG);
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -59,6 +59,13 @@ constexpr folly::StringPiece kCounterNumRunningDrivers{
 constexpr folly::StringPiece kCounterNumBlockedDrivers{
     "presto_cpp.num_blocked_drivers"};
 
+// Number of total PartitionedOutputBuffer managed by all
+// PartitionedOutputBufferManager
+constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{
+    "presto_cpp.num_partitioned_output_buffer"};
+
+// ================== Memory Counters =================
+
 // Number of bytes of memory MappedMemory currently maps (RSS). It also includes
 // memory that was freed and currently not in use.
 constexpr folly::StringPiece kCounterMappedMemoryBytes{
@@ -66,12 +73,6 @@ constexpr folly::StringPiece kCounterMappedMemoryBytes{
 // Number of bytes of memory MappedMemory currently allocates. Memories in use
 constexpr folly::StringPiece kCounterAllocatedMemoryBytes{
     "presto_cpp.allocated_memory_bytes"};
-
-// Number of total PartitionedOutputBuffer managed by all
-// PartitionedOutputBufferManager
-constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{
-    "presto_cpp.num_partitioned_output_buffer"};
-
 // Number of bytes currently allocated from MappedMemory directly from raw
 // allocateBytes() interface, and internally allocated by malloc. Only small
 // chunks of memory are delegated to malloc
@@ -90,4 +91,87 @@ constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesSizeClass{
 // largest SizeClass cannot accommodate, are counted towards this counter.
 constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesLarge{
     "presto_cpp.mapped_memory_raw_alloc_bytes_large"};
+
+// ================== Cache Counters ==================
+
+// Total number of cache entries.
+constexpr folly::StringPiece kCounterMemoryCacheNumEntries{
+    "presto_cpp.memory_cache_num_entries"};
+// Total number of cache entries that do not cache anything.
+constexpr folly::StringPiece kCounterMemoryCacheNumEmptyEntries{
+    "presto_cpp.memory_cache_num_empty_entries"};
+// Total number of cache entries that are pinned for shared access.
+constexpr folly::StringPiece kCounterMemoryCacheNumSharedEntries{
+    "presto_cpp.memory_cache_num_shared_entries"};
+// Total number of cache entries that are pinned for exclusive access.
+constexpr folly::StringPiece kCounterMemoryCacheNumExclusiveEntries{
+    "presto_cpp.memory_cache_num_exclusive_entries"};
+// Total number of cache entries that are being or have been prefetched but have
+// not been hit.
+constexpr folly::StringPiece kCounterMemoryCacheNumPrefetchedEntries{
+    "presto_cpp.memory_cache_num_prefetched_entries"};
+// Total number of bytes of the cached data that is much smaller than a
+// 'MappedMemory' page (AsyncDataCacheEntry::kTinyDataSize).
+constexpr folly::StringPiece kCounterMemoryCacheTotalTinyBytes{
+    "presto_cpp.memory_cache_total_tiny_bytes"};
+// Total number of bytes of the cached data excluding
+// 'kCounterMemoryCacheTotalTinyBytes'.
+constexpr folly::StringPiece kCounterMemoryCacheTotalLargeBytes{
+    "presto_cpp.memory_cache_total_large_bytes"};
+// Total unused capacity bytes in 'kCounterMemoryCacheTotalTinyBytes'.
+constexpr folly::StringPiece kCounterMemoryCacheTotalTinyPaddingBytes{
+    "presto_cpp.memory_cache_total_tiny_padding_bytes"};
+// Total unused capacity bytes in 'kCounterMemoryCacheTotalLargeBytes'.
+constexpr folly::StringPiece kCounterMemoryCacheTotalLargePaddingBytes{
+    "presto_cpp.memory_cache_total_large_padding_bytes"};
+// Total bytes of cache entries in prefetch state.
+constexpr folly::StringPiece kCounterMemoryCacheTotalPrefetchBytes{
+    "presto_cpp.memory_cache_total_prefetched_bytes"};
+// Sum of scores of evicted entries. This serves to infer an average lifetime
+// for entries in cache.
+constexpr folly::StringPiece kCounterMemoryCacheSumEvictScore{
+    "presto_cpp.memory_cache_sum_evict_score"};
+// Cumulated number of hits (saved IO). The first hit to a prefetched entry does
+// not count.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeHit{
+    "presto_cpp.memory_cache_num_cumulative_hit"};
+// Number of hits (saved IO) since last counter retrieval. The first hit to a
+// prefetched entry does not count.
+constexpr folly::StringPiece kCounterMemoryCacheNumHit{
+    "presto_cpp.memory_cache_num_hit"};
+// Cumulated number of new entries created.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeNew{
+    "presto_cpp.memory_cache_num_cumulative_new"};
+// Number of new entries created since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumNew{
+    "presto_cpp.memory_cache_num_new"};
+// Cumulated number of times a valid entry was removed in order to make space.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvict{
+    "presto_cpp.memory_cache_num_cumulative_evict"};
+// Number of times a valid entry was removed in order to make space, since last
+// counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumEvict{
+    "presto_cpp.memory_cache_num_evict"};
+// Cumulated number of entries considered for evicting.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvictChecks{
+    "presto_cpp.memory_cache_num_cumulative_evict_checks"};
+// Number of entries considered for evicting, since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumEvictChecks{
+    "presto_cpp.memory_cache_num_evict_checks"};
+// Cumulated number of times a user waited for an entry to transit from
+// exclusive to shared mode.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeWaitExclusive{
+    "presto_cpp.memory_cache_num_cumulative_wait_exclusive"};
+// Number of times a user waited for an entry to transit from exclusive to
+// shared mode, since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumWaitExclusive{
+    "presto_cpp.memory_cache_num_wait_exclusive"};
+// Cumulative clocks spent in allocating or freeing memory for backing cache
+// entries.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAllocClocks{
+    "presto_cpp.memory_cache_num_cumulative_alloc_clocks"};
+// Clocks spent in allocating or freeing memory for backing cache
+// entries, since last counter retrieval
+constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
+    "presto_cpp.memory_cache_num_alloc_clocks"};
 } // namespace facebook::presto


### PR DESCRIPTION
Export only in memory related cache counters to help us understand better on cache status
```
== NO RELEASE NOTE ==
```
