### PR TITLE
Add exception in the test for Europe/Kyiv timezone.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -74,6 +74,15 @@ public class TestTimeZoneUtils
                 continue;
             }
 
+            if (zoneId.equals("Europe/Kyiv")) {
+                // TODO: remove Once this recently renamed Timezone is supported.
+                // Europe/Kiev was renamed to Europe/Kyiv.
+                // https://www.oracle.com/java/technologies/tzdata-versions.html
+                // Likely need to wait for Joda to supported this renamed timezone.
+                // https://www.joda.org/joda-time/timezones.html
+                continue;
+            }
+
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));
 


### PR DESCRIPTION
Europe/Kiev was recently renamed to Europe/Kyiv and not supported by Joda yet.
Add exception in the test for Europe/Kyiv timezone.

Test plan - Existing tests.

```
== NO RELEASE NOTE ==
```
