### PR TITLE
Do not raise NO_NODES_AVAILABLE exception in SimpleTtlNodeSelector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
@@ -162,14 +162,9 @@ public class SimpleTtlNodeSelector
         List<InternalNode> eligibleNodes = filterNodesByTtl(activeNodes, excludedNodes, ttlInfo, estimatedExecutionTimeRemaining);
         List<InternalNode> selectedNodes = selectNodes(limit, new ResettableRandomizedIterator<>(eligibleNodes));
 
-        if (selectedNodes.isEmpty()) {
-            if (fallbackToSimpleNodeSelection) {
-                log.warn("No nodes available with enough TTL (%s), falling back to simple node selection.", estimatedExecutionTimeRemaining);
-                return simpleNodeSelector.selectRandomNodes(limit, excludedNodes);
-            }
-
-            log.warn("No nodes available with enough TTL (%s). Active nodes: %s", estimatedExecutionTimeRemaining, activeNodes);
-            throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
+        if (selectedNodes.isEmpty() && fallbackToSimpleNodeSelection) {
+            log.warn("No nodes available with enough TTL (%s), falling back to simple node selection.", estimatedExecutionTimeRemaining);
+            return simpleNodeSelector.selectRandomNodes(limit, excludedNodes);
         }
 
         return selectedNodes;


### PR DESCRIPTION
This is fixing a bug introduced in https://github.com/prestodb/presto/pull/18292 The `selectRandomNodes` function interface can sometimes return an empty list and that is okay. So we should not raise the NO_NODES_AVAILABLE exception in that scenario.

```
== NO RELEASE NOTE ==
```
