### PR TITLE
Update Iceberg from 0.14.1 to 1.0.0

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.14.1</dep.iceberg.version>
+        <dep.iceberg.version>1.0.0</dep.iceberg.version>
         <dep.nessie.version>0.43.0</dep.nessie.version>
     </properties>
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ManifestsTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ManifestsTable.java
@@ -111,7 +111,7 @@ public class ManifestsTable
 
         Map<Integer, PartitionSpec> partitionSpecsById = icebergTable.specs();
 
-        snapshot.allManifests().forEach(file -> {
+        snapshot.allManifests(icebergTable.io()).forEach(file -> {
             pagesBuilder.beginRow();
             pagesBuilder.appendVarchar(file.path());
             pagesBuilder.appendBigint(file.length());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
@@ -91,6 +91,6 @@ public class RollbackToSnapshotProcedure
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) metadata).getMetastore();
             icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
         }
-        icebergTable.rollback().toSnapshotId(snapshotId).commit();
+        icebergTable.manageSnapshots().rollbackTo(snapshotId).commit();
     }
 }


### PR DESCRIPTION
This updates the `presto-iceberg` connector to the latest Iceberg version 1.0.0. This release is based on the 0.14.1 release and includes changes to remove deprecated APIs with some bug fixes. Release notes can be found [here](https://iceberg.apache.org/releases/#100-release).

```
== RELEASE NOTES ==


Iceberg Changes
* Update Iceberg from 0.14.1 to 1.0.0
