### PR TITLE
integrate and implement open telemetry tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
         <module>presto-hudi</module>
         <module>presto-native-execution</module>
         <module>presto-router</module>
+        <module>presto-open-telemetry</module>
     </modules>
 
     <dependencyManagement>
@@ -847,6 +848,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testng-services</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-open-telemetry</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -2093,6 +2100,60 @@
                 <groupId>com.clearspring.analytics</groupId>
                 <artifactId>stream</artifactId>
                 <version>2.9.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-context</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-otlp</artifactId>
+                <version>1.19.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-extension-trace-propagators</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-common</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-trace</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>1.19.0-alpha</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.facebook.presto.spi.session.ResourceEstimates;
 import com.facebook.presto.spi.tracing.Tracer;
+import com.facebook.presto.spi.tracing.TracerHandle;
 import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.ParsingOptions;
@@ -211,19 +212,39 @@ public final class HttpRequestSessionContext
 
         this.sessionFunctions = parseSessionFunctionHeader(servletRequest);
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
-        String tunnelTraceId = trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN));
+
+        Map<String, String> requestHeaders = getRequestHeaders(servletRequest);
+        TracerHandle tracerHandle = tracerProvider.getHandleGenerator().apply(requestHeaders);
+
         if (isTracingEnabled()) {
-            this.tracer = Optional.of(requireNonNull(tracerProvider.getNewTracer(), "tracer is null"));
+            this.tracer = Optional.of(requireNonNull(tracerProvider.getNewTracer(tracerHandle), "tracer is null"));
+            traceToken = Optional.ofNullable(this.tracer.get().getTracerId());
+        }
+        else {
+            this.tracer = Optional.of(NoopTracerProvider.NOOP_TRACER);
 
             // If tunnel trace token is null, we expose the Presto tracing id.
             // Otherwise we preserve the ability of trace token tunneling but
             // still trace Presto internally for aggregation purposes.
-            traceToken = Optional.ofNullable(tunnelTraceId == null ? this.tracer.get().getTracerId() : tunnelTraceId);
+            String tunnelTraceId = trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN));
+            if (tunnelTraceId != null) {
+                traceToken = Optional.of(tunnelTraceId);
+            }
+            else {
+                traceToken = Optional.ofNullable(tracerHandle.getTraceToken());
+            }
         }
-        else {
-            this.tracer = Optional.of(NoopTracerProvider.NOOP_TRACER);
-            traceToken = Optional.ofNullable(tunnelTraceId);
+    }
+
+    private static Map<String, String> getRequestHeaders(HttpServletRequest servletRequest)
+    {
+        ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
+        Enumeration<String> headerNames = servletRequest.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String header = headerNames.nextElement();
+            headers.put(header, servletRequest.getHeader(header));
         }
+        return headers.build();
     }
 
     public static List<String> splitSessionHeader(Enumeration<String> headers)
@@ -502,7 +523,7 @@ public final class HttpRequestSessionContext
      */
     private boolean isTracingEnabled()
     {
-        String clientValue = systemProperties.getOrDefault(DISTRIBUTED_TRACING_MODE, TracingConfig.DistributedTracingMode.NO_TRACE.name());
+        String clientValue = systemProperties.getOrDefault(DISTRIBUTED_TRACING_MODE, "");
 
         // Client session setting overrides everything.
         if (clientValue.equalsIgnoreCase(TracingConfig.DistributedTracingMode.ALWAYS_TRACE.name())) {
@@ -511,13 +532,13 @@ public final class HttpRequestSessionContext
         if (clientValue.equalsIgnoreCase(TracingConfig.DistributedTracingMode.NO_TRACE.name())) {
             return false;
         }
+        if (clientValue.equalsIgnoreCase(TracingConfig.DistributedTracingMode.SAMPLE_BASED.name())) {
+            return true;
+        }
 
-        // Client not set, we then take system default value, and only init
-        // tracing if it's SAMPLE_BASED (TracingConfig prohibits you to
-        // configure system default to be ALWAYS_TRACE). If property manager
-        // not provided then false.
+        // Client not set, we then take system default value if ALWAYS_TRACE (SAMPLE_BASED disabled). If property manager not provided then false.
         return sessionPropertyManager
-                .map(manager -> manager.decodeSystemPropertyValue(DISTRIBUTED_TRACING_MODE, null, TracingConfig.DistributedTracingMode.class) == TracingConfig.DistributedTracingMode.SAMPLE_BASED)
+                .map(manager -> manager.decodeSystemPropertyValue(DISTRIBUTED_TRACING_MODE, null, String.class).equalsIgnoreCase(TracingConfig.DistributedTracingMode.ALWAYS_TRACE.name()))
                 .orElse(false);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -39,9 +39,11 @@ import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
+import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.storage.TempStorageManager;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
 import com.google.common.collect.ImmutableList;
@@ -117,6 +119,7 @@ public class PluginManager
     private final AtomicBoolean pluginsLoaded = new AtomicBoolean();
     private final ImmutableSet<String> disabledConnectors;
     private final HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager;
+    private final TracerProviderManager tracerProviderManager;
 
     @Inject
     public PluginManager(
@@ -134,7 +137,8 @@ public class PluginManager
             SessionPropertyDefaults sessionPropertyDefaults,
             NodeTtlFetcherManager nodeTtlFetcherManager,
             ClusterTtlProviderManager clusterTtlProviderManager,
-            HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager)
+            HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
+            TracerProviderManager tracerProviderManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -162,6 +166,7 @@ public class PluginManager
         this.clusterTtlProviderManager = requireNonNull(clusterTtlProviderManager, "clusterTtlProviderManager is null");
         this.disabledConnectors = requireNonNull(config.getDisabledConnectors(), "disabledConnectors is null");
         this.historyBasedPlanStatisticsManager = requireNonNull(historyBasedPlanStatisticsManager, "historyBasedPlanStatisticsManager is null");
+        this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
     }
 
     public void loadPlugins()
@@ -296,6 +301,11 @@ public class PluginManager
         for (HistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider : plugin.getHistoryBasedPlanStatisticsProviders()) {
             log.info("Registering plan statistics provider %s", historyBasedPlanStatisticsProvider.getName());
             historyBasedPlanStatisticsManager.addHistoryBasedPlanStatisticsProviderFactory(historyBasedPlanStatisticsProvider);
+        }
+
+        for (TracerProvider tracerProvider : plugin.getTracerProviders()) {
+            log.info("Registering tracer provider %s", tracerProvider.getName());
+            tracerProviderManager.addTracerProviderFactory(tracerProvider);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.storage.TempStorageModule;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManagerModule;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
@@ -174,6 +175,7 @@ public class PrestoServer
             injector.getInstance(QueryPrerequisitesManager.class).loadQueryPrerequisites();
             injector.getInstance(NodeTtlFetcherManager.class).loadNodeTtlFetcher();
             injector.getInstance(ClusterTtlProviderManager.class).loadClusterTtlProvider();
+            injector.getInstance(TracerProviderManager.class).loadTracerProvider();
 
             startAssociatedProcesses(injector);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -149,7 +149,6 @@ import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.PredicateCompiler;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.spiller.FileSingleStreamSpillerFactory;
 import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
 import com.facebook.presto.spiller.GenericSpillerFactory;
@@ -195,8 +194,7 @@ import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.statusservice.NodeStatusService;
-import com.facebook.presto.tracing.NoopTracerProvider;
-import com.facebook.presto.tracing.SimpleTracerProvider;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.tracing.TracingConfig;
 import com.facebook.presto.transaction.TransactionManagerConfig;
 import com.facebook.presto.type.TypeDeserializer;
@@ -245,8 +243,6 @@ import static com.facebook.drift.codec.guice.ThriftCodecBinder.thriftCodecBinder
 import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.FLAT;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
-import static com.facebook.presto.tracing.TracingConfig.TracerType.NOOP;
-import static com.facebook.presto.tracing.TracingConfig.TracerType.SIMPLE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
@@ -741,15 +737,7 @@ public class ServerMainModule
 
         // Distributed tracing
         configBinder(binder).bindConfig(TracingConfig.class);
-        install(installModuleIf(
-                TracingConfig.class,
-                config -> !config.getEnableDistributedTracing() || NOOP.equalsIgnoreCase(config.getTracerType()),
-                moduleBinder -> moduleBinder.bind(TracerProvider.class).to(NoopTracerProvider.class).in(Scopes.SINGLETON)));
-
-        install(installModuleIf(
-                TracingConfig.class,
-                config -> config.getEnableDistributedTracing() && SIMPLE.equalsIgnoreCase(config.getTracerType()),
-                moduleBinder -> moduleBinder.bind(TracerProvider.class).to(SimpleTracerProvider.class).in(Scopes.SINGLETON)));
+        binder.bind(TracerProviderManager.class).in(Scopes.SINGLETON);
 
         //Optional Status Detector
         newOptionalBinder(binder, NodeStatusService.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -30,8 +30,8 @@ import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.server.SessionContext;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
@@ -125,7 +125,7 @@ public class QueuedStatementResource
     private final boolean compressionEnabled;
 
     private final SqlParserOptions sqlParserOptions;
-    private final TracerProvider tracerProvider;
+    private final TracerProviderManager tracerProviderManager;
     private final SessionPropertyManager sessionPropertyManager;     // We may need some system default session property values at early query stage even before session is created.
 
     private final QueryBlockingRateLimiter queryRateLimiter;
@@ -138,7 +138,7 @@ public class QueuedStatementResource
             LocalQueryProvider queryResultsProvider,
             SqlParserOptions sqlParserOptions,
             ServerConfig serverConfig,
-            TracerProvider tracerProvider,
+            TracerProviderManager tracerProviderManager,
             SessionPropertyManager sessionPropertyManager,
             QueryBlockingRateLimiter queryRateLimiter)
     {
@@ -149,7 +149,7 @@ public class QueuedStatementResource
 
         this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
         this.timeoutExecutor = requireNonNull(executor, "timeoutExecutor is null").getScheduledExecutor();
-        this.tracerProvider = requireNonNull(tracerProvider, "tracerProvider is null");
+        this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
         this.sessionPropertyManager = sessionPropertyManager;
 
         this.queryRateLimiter = requireNonNull(queryRateLimiter, "queryRateLimiter is null");
@@ -215,7 +215,7 @@ public class QueuedStatementResource
         SessionContext sessionContext = new HttpRequestSessionContext(
                 servletRequest,
                 sqlParserOptions,
-                tracerProvider,
+                tracerProviderManager.getTracerProvider(),
                 Optional.of(sessionPropertyManager));
         Query query = new Query(statement, sessionContext, dispatchManager, queryResultsProvider, 0);
         queries.put(query.getQueryId(), query);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -201,6 +201,7 @@ import com.facebook.presto.sql.tree.StartTransaction;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.TruncateTable;
 import com.facebook.presto.testing.PageConsumerOperator.PageConsumerOutputFactory;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.tracing.TracingConfig;
 import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
@@ -480,7 +481,8 @@ public class LocalQueryRunner
                 new SessionPropertyDefaults(nodeInfo),
                 new ThrowingNodeTtlFetcherManager(),
                 new ThrowingClusterTtlProviderManager(),
-                historyBasedPlanStatisticsManager);
+                historyBasedPlanStatisticsManager,
+                new TracerProviderManager(new TracingConfig()));
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerHandle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tracing;
+
+import com.facebook.presto.spi.tracing.TracerHandle;
+
+public class NoopTracerHandle
+        implements TracerHandle
+{
+    private final String traceToken;
+
+    public NoopTracerHandle()
+    {
+        this.traceToken = "noop_dummy_id";
+    }
+
+    @Override
+    public String getTraceToken()
+    {
+        return traceToken;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerProvider.java
@@ -15,19 +15,44 @@ package com.facebook.presto.tracing;
 
 import com.facebook.presto.spi.tracing.NoopTracer;
 import com.facebook.presto.spi.tracing.Tracer;
+import com.facebook.presto.spi.tracing.TracerHandle;
 import com.facebook.presto.spi.tracing.TracerProvider;
 import com.google.inject.Inject;
+
+import java.util.Map;
+import java.util.function.Function;
 
 public class NoopTracerProvider
         implements TracerProvider
 {
     public static final NoopTracerProvider NOOP_TRACER_PROVIDER = new NoopTracerProvider();
     public static final NoopTracer NOOP_TRACER = new NoopTracer();
+    public static final TracerHandle NOOP_TRACER_HANDLE = new NoopTracerHandle();
+    public static final Function<Map<String, String>, TracerHandle> NOOP_HANDLE_GENERATOR = headers -> NOOP_TRACER_HANDLE;
+
     @Inject
     public NoopTracerProvider() {}
 
     @Override
-    public Tracer getNewTracer()
+    public String getName()
+    {
+        return "NOOP tracer provider";
+    }
+
+    @Override
+    public String getTracerType()
+    {
+        return TracingConfig.TracerType.NOOP;
+    }
+
+    @Override
+    public Function<Map<String, String>, TracerHandle> getHandleGenerator()
+    {
+        return NOOP_HANDLE_GENERATOR;
+    }
+
+    @Override
+    public Tracer getNewTracer(TracerHandle handle)
     {
         return NOOP_TRACER;
     }

--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracer.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracer.java
@@ -31,9 +31,11 @@ public class SimpleTracer
     public final Map<String, SimpleTracerBlock> blockMap = new ConcurrentHashMap<>();
     public final Map<String, SimpleTracerBlock> recorderBlockMap = new LinkedHashMap<>();
     public final List<SimpleTracerPoint> pointList = new CopyOnWriteArrayList<>();
+    public final String traceToken;
 
-    public SimpleTracer()
+    public SimpleTracer(String traceToken)
     {
+        this.traceToken = traceToken;
         addPoint("Start tracing");
     }
 
@@ -86,7 +88,10 @@ public class SimpleTracer
     @Override
     public String getTracerId()
     {
-        return "simple_dummy_id";
+        if (traceToken != null) {
+            return traceToken;
+        }
+        return tracerName;
     }
 
     public String toString()

--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerHandle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tracing;
+
+import com.facebook.presto.spi.tracing.TracerHandle;
+
+public class SimpleTracerHandle
+        implements TracerHandle
+{
+    private final String traceToken;
+
+    public SimpleTracerHandle(String traceToken)
+    {
+        this.traceToken = traceToken;
+    }
+
+    @Override
+    public String getTraceToken()
+    {
+        return traceToken;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerProvider.java
@@ -14,8 +14,14 @@
 package com.facebook.presto.tracing;
 
 import com.facebook.presto.spi.tracing.Tracer;
+import com.facebook.presto.spi.tracing.TracerHandle;
 import com.facebook.presto.spi.tracing.TracerProvider;
 import com.google.inject.Inject;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_TRACE_TOKEN;
 
 public class SimpleTracerProvider
         implements TracerProvider
@@ -26,8 +32,27 @@ public class SimpleTracerProvider
     }
 
     @Override
-    public Tracer getNewTracer()
+    public String getName()
     {
-        return new SimpleTracer();
+        return "Simple tracer provider";
+    }
+
+    @Override
+    public String getTracerType()
+    {
+        return TracingConfig.TracerType.SIMPLE;
+    }
+
+    @Override
+    public Function<Map<String, String>, TracerHandle> getHandleGenerator()
+    {
+        return headers -> new SimpleTracerHandle(headers.get(PRESTO_TRACE_TOKEN));
+    }
+
+    @Override
+    public Tracer getNewTracer(TracerHandle handle)
+    {
+        SimpleTracerHandle tracerHandle = (SimpleTracerHandle) handle;
+        return new SimpleTracer(tracerHandle.getTraceToken());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/tracing/TracerProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/TracerProviderManager.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tracing;
+
+import com.facebook.presto.spi.tracing.TracerProvider;
+import com.google.inject.Inject;
+
+import javax.annotation.Nullable;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class TracerProviderManager
+{
+    private final String tracerType;
+    private final boolean systemTracingEnabled;
+    @Nullable
+    private TracerProvider tracerProvider;
+
+    @Inject
+    public TracerProviderManager(TracingConfig config)
+    {
+        requireNonNull(config, "config is null");
+
+        this.tracerType = config.getTracerType();
+        boolean enableDistributedTracing = config.getEnableDistributedTracing();
+        TracingConfig.DistributedTracingMode distributedTracingMode = config.getDistributedTracingMode();
+        this.systemTracingEnabled = enableDistributedTracing && distributedTracingMode.name().equalsIgnoreCase(TracingConfig.DistributedTracingMode.ALWAYS_TRACE.name());
+    }
+
+    public void addTracerProviderFactory(TracerProvider provider)
+    {
+        if (!tracerType.equals(provider.getTracerType())) {
+            throw new IllegalArgumentException(
+                    format(
+                            "Plugin-configured tracer provider ('%s') does not match system-configured provider ('%s').",
+                            provider.getName(),
+                            tracerType));
+        }
+        if (systemTracingEnabled) {
+            if (tracerProvider != null) {
+                throw new IllegalArgumentException(format("Only a single plugin should set the tracer provider ('%s').", tracerProvider.getTracerType()));
+            }
+            tracerProvider = provider;
+        }
+    }
+
+    public void loadTracerProvider()
+    {
+        if (tracerProvider != null) {
+            return;
+        }
+        // open-telemetry plugin not used / tracer provider not specified or not matching system config / tracing disabled
+        // Check if SimpleTracer is configured and tracing is enabled
+        // Otherwise, use Noop implementation
+        if (tracerType.equals(TracingConfig.TracerType.SIMPLE) && systemTracingEnabled) {
+            tracerProvider = new SimpleTracerProvider();
+        }
+        else {
+            tracerProvider = new NoopTracerProvider();
+        }
+    }
+
+    public TracerProvider getTracerProvider()
+    {
+        if (tracerProvider != null) {
+            return tracerProvider;
+        }
+        return new NoopTracerProvider();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/tracing/TracingConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/TracingConfig.java
@@ -24,6 +24,7 @@ public class TracingConfig
     {
         public static final String NOOP = "noop";
         public static final String SIMPLE = "simple";
+        public static final String OTEL = "otel";
     }
 
     public enum DistributedTracingMode

--- a/presto-main/src/test/java/com/facebook/presto/tracing/testing/TestSimpleTracer.java
+++ b/presto-main/src/test/java/com/facebook/presto/tracing/testing/TestSimpleTracer.java
@@ -14,12 +14,15 @@
 package com.facebook.presto.tracing.testing;
 
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.tracing.TracerHandle;
 import com.facebook.presto.tracing.SimpleTracer;
 import com.facebook.presto.tracing.SimpleTracerProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -44,7 +47,9 @@ public class TestSimpleTracer
     @Test
     public void testAddPoint()
     {
-        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer();
+        Map<String, String> testHeaders = new HashMap<>();
+        TracerHandle testTracerHandle = tracerProvider.getHandleGenerator().apply(testHeaders);
+        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer(testTracerHandle);
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (int i = 0; i < numThreads; i++) {
             CompletableFuture<?> future = new CompletableFuture<>();
@@ -72,7 +77,9 @@ public class TestSimpleTracer
     @Test
     public void testAddBlock()
     {
-        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer();
+        Map<String, String> testHeaders = new HashMap<>();
+        TracerHandle testTracerHandle = tracerProvider.getHandleGenerator().apply(testHeaders);
+        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer(testTracerHandle);
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (int i = 0; i < numThreads; i++) {
             CompletableFuture<?> future = new CompletableFuture<>();
@@ -103,7 +110,9 @@ public class TestSimpleTracer
     @Test
     public void testBlockErrors()
     {
-        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer();
+        Map<String, String> testHeaders = new HashMap<>();
+        TracerHandle testTracerHandle = tracerProvider.getHandleGenerator().apply(testHeaders);
+        SimpleTracer tracer = (SimpleTracer) tracerProvider.getNewTracer(testTracerHandle);
 
         // Duplicate block
         PrestoException exception = expectThrows(PrestoException.class, () -> {

--- a/presto-open-telemetry/pom.xml
+++ b/presto-open-telemetry/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.279-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-open-telemetry</artifactId>
+    <description>Presto - Open Telemetry Tracing</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-extension-trace-propagators</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryBuilder.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+public final class OpenTelemetryBuilder
+{
+    private OpenTelemetryBuilder()
+    {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated.");
+    }
+
+    /**
+     * Get instance of propagator.
+     * Currently, only B3_SINGLE_HEADER can be passed in.
+     */
+    private static TextMapPropagator getPropagatorInstance(String contextPropagator)
+    {
+        TextMapPropagator propagator;
+        if (contextPropagator.equals(OpenTelemetryContextPropagator.W3C)) {
+            propagator = W3CTraceContextPropagator.getInstance();
+        }
+        else if (contextPropagator.equals(OpenTelemetryContextPropagator.B3_SINGLE_HEADER)) {
+            propagator = B3Propagator.injectingSingleHeader();
+        }
+        else {
+            propagator = B3Propagator.injectingMultiHeaders();
+        }
+        return propagator;
+    }
+
+    public static OpenTelemetry build(String contextPropagator)
+    {
+        Resource resource = Resource.getDefault()
+                .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "presto")));
+
+        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().setEndpoint(System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")).build()).build())
+                .setResource(resource)
+                .build();
+
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                .setPropagators(ContextPropagators.create(OpenTelemetryBuilder.getPropagatorInstance(contextPropagator)))
+                .buildAndRegisterGlobal();
+    }
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryContextPropagator.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryContextPropagator.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+public final class OpenTelemetryContextPropagator
+{
+    private OpenTelemetryContextPropagator() {};
+
+    public static final String W3C = "w3c";
+    public static final String B3_SINGLE_HEADER = "b3_single_header";
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryErrorCode.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryErrorCode.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.common.ErrorType;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+
+import static com.facebook.presto.common.ErrorType.EXTERNAL;
+
+public enum OpenTelemetryErrorCode
+        implements ErrorCodeSupplier
+{
+    OPEN_TELEMETRY_CONTEXT_PROPAGATOR_ERROR(0, EXTERNAL);
+
+    private final ErrorCode errorCode;
+
+    OpenTelemetryErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0507_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryHeaders.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryHeaders.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+public class OpenTelemetryHeaders
+{
+    public static final String PRESTO_W3C_PROPAGATION = "traceparent";
+    public static final String PRESTO_B3_SINGLE_HEADER_PROPAGATION = "b3";
+    public static final String PRESTO_TRACE_TOKEN = "X-Presto-Trace-Token";
+    public static final String PRESTO_BAGGAGE_HEADER = "baggage";
+
+    private OpenTelemetryHeaders() {}
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryPlugin.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.tracing.TracerProvider;
+import com.google.common.collect.ImmutableList;
+
+public class OpenTelemetryPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<TracerProvider> getTracerProviders()
+    {
+        return ImmutableList.of(new OpenTelemetryTracerProvider());
+    }
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracer.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracer.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.tracing.Tracer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.spi.StandardErrorCode.DISTRIBUTED_TRACING_ERROR;
+
+public class OpenTelemetryTracer
+        implements Tracer
+{
+    private static String currentContextPropagator = OpenTelemetryContextPropagator.B3_SINGLE_HEADER;
+    private static OpenTelemetry openTelemetry = OpenTelemetryBuilder.build(currentContextPropagator);
+    private final io.opentelemetry.api.trace.Tracer openTelemetryTracer;
+    private final String traceToken;
+    private final Span parentSpan;
+    private final Context parentContext;
+
+    public final Map<String, Span> spanMap = new ConcurrentHashMap<>();
+    public final Map<String, Span> recorderSpanMap = new LinkedHashMap<>();
+
+    public OpenTelemetryTracer(String traceToken, String contextPropagator, String propagatedContext, String baggage)
+    {
+        // Trivial getter method to return carrier
+        // Carrier will be equal to the data to be fetched
+        TextMapGetter<String> trivialGetter = new TextMapGetter<String>()
+        {
+            @Override
+            public String get(String carrier, String key)
+            {
+                return carrier;
+            }
+
+            @Override
+            public Iterable<String> keys(String carrier)
+            {
+                return Arrays.asList(get(carrier, null));
+            }
+        };
+
+        // Rebuild OPEN_TELEMETRY instance if necessary (to use different context propagator)
+        // Will only occur once at max, if contextPropagator is different from B3_SINGLE_HEADER
+        if (contextPropagator != null && !contextPropagator.equals(currentContextPropagator)) {
+            this.openTelemetry = OpenTelemetryBuilder.build(contextPropagator);
+            this.currentContextPropagator = contextPropagator;
+        }
+
+        this.openTelemetryTracer = openTelemetry.getTracer(tracerName);
+        this.traceToken = traceToken;
+
+        if (propagatedContext != null) {
+            // Only process baggage headers if context propagation is successful
+            Context extractedContext = openTelemetry.getPropagators().getTextMapPropagator()
+                    .extract(Context.current(), propagatedContext, trivialGetter);
+            Context contextWithBaggage = W3CBaggagePropagator.getInstance().extract(
+                    extractedContext, baggage, trivialGetter);
+            try (Scope ignored = contextWithBaggage.makeCurrent()) {
+                this.parentSpan = createParentSpan();
+            }
+            this.parentContext = contextWithBaggage;
+        }
+        else {
+            this.parentSpan = createParentSpan();
+            this.parentContext = Context.current();
+        }
+        addBaggageToSpanAttributes(this.parentSpan);
+
+        synchronized (recorderSpanMap) {
+            recorderSpanMap.put("Trace start", this.parentSpan);
+        }
+    }
+
+    /**
+     * Take parent context baggage and set as span attributes.
+     * Call during each span and nested span creation to properly propagate tags.
+     */
+    private void addBaggageToSpanAttributes(Span span)
+    {
+        Baggage baggage = Baggage.fromContext(parentContext);
+        baggage.forEach((s, baggageEntry) -> span.setAttribute(s, baggageEntry.getValue()));
+    }
+
+    private Span createParentSpan()
+    {
+        Span parentSpan = openTelemetryTracer.spanBuilder("Trace start").startSpan();
+        parentSpan.setAttribute("trace_id", traceToken);
+        return parentSpan;
+    }
+
+    private void endUnendedBlocks()
+    {
+        List<String> blocks = new ArrayList<>(spanMap.keySet());
+        for (String currBlock : blocks) {
+            endBlock(currBlock, "");
+        }
+    }
+
+    /**
+     * Add annotation as event to parent span
+     * @param annotation event to add
+     */
+    @Override
+    public void addPoint(String annotation)
+    {
+        parentSpan.addEvent(annotation);
+    }
+
+    /**
+     * Create new span with Open Telemetry tracer
+     * @param blockName name of span
+     * @param annotation event to add to span
+     */
+
+    @Override
+    public void startBlock(String blockName, String annotation)
+    {
+        if (spanMap.containsKey(blockName)) {
+            throw new PrestoException(DISTRIBUTED_TRACING_ERROR, "Duplicated block inserted: " + blockName);
+        }
+        Span span = openTelemetryTracer.spanBuilder(blockName)
+                .setParent(Context.current().with(parentSpan))
+                .startSpan();
+        span.addEvent(annotation);
+        addBaggageToSpanAttributes(span);
+
+        spanMap.put(blockName, span);
+        synchronized (recorderSpanMap) {
+            recorderSpanMap.put(blockName, span);
+        }
+    }
+
+    @Override
+    public void addPointToBlock(String blockName, String annotation)
+    {
+        if (!spanMap.containsKey(blockName)) {
+            throw new PrestoException(DISTRIBUTED_TRACING_ERROR, "Adding point to non-existing block: " + blockName);
+        }
+        spanMap.get(blockName).addEvent(annotation);
+    }
+
+    /**
+     * End Open Telemetry span
+     * @param blockName name of span
+     * @param annotation event to add to span
+     */
+    @Override
+    public void endBlock(String blockName, String annotation)
+    {
+        if (!spanMap.containsKey(blockName)) {
+            throw new PrestoException(DISTRIBUTED_TRACING_ERROR, "Trying to end a non-existing block: " + blockName);
+        }
+        spanMap.remove(blockName);
+        synchronized (recorderSpanMap) {
+            Span span = recorderSpanMap.get(blockName);
+            span.addEvent(annotation);
+            span.end();
+        }
+    }
+
+    @Override
+    public void endTrace(String annotation)
+    {
+        parentSpan.addEvent(annotation);
+        endUnendedBlocks();
+        parentSpan.end();
+    }
+
+    @Override
+    public String getTracerId()
+    {
+        if (traceToken != null) {
+            return traceToken;
+        }
+        return tracerName;
+    }
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracerHandle.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracerHandle.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import com.facebook.presto.spi.tracing.TracerHandle;
+
+public class OpenTelemetryTracerHandle
+        implements TracerHandle
+{
+    private final String traceToken;
+    private final String contextPropagator;
+    private final String propagatedContext;
+    private final String baggage;
+
+    public OpenTelemetryTracerHandle(String traceToken, String contextPropagator, String propagatedContext, String baggage)
+    {
+        this.traceToken = traceToken;
+        this.contextPropagator = contextPropagator;
+        this.propagatedContext = propagatedContext;
+        this.baggage = baggage;
+    }
+
+    @Override
+    public String getTraceToken()
+    {
+        return traceToken;
+    }
+
+    public String getContextPropagator()
+    {
+        return contextPropagator;
+    }
+
+    public String getPropagatedContext()
+    {
+        return propagatedContext;
+    }
+
+    public String getBaggage()
+    {
+        return baggage;
+    }
+}

--- a/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/presto-open-telemetry/src/main/java/com/facebook/presto/opentelemetry/OpenTelemetryTracerProvider.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.opentelemetry;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.tracing.Tracer;
+import com.facebook.presto.spi.tracing.TracerHandle;
+import com.facebook.presto.spi.tracing.TracerProvider;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.facebook.presto.opentelemetry.OpenTelemetryErrorCode.OPEN_TELEMETRY_CONTEXT_PROPAGATOR_ERROR;
+import static com.facebook.presto.opentelemetry.OpenTelemetryHeaders.PRESTO_B3_SINGLE_HEADER_PROPAGATION;
+import static com.facebook.presto.opentelemetry.OpenTelemetryHeaders.PRESTO_BAGGAGE_HEADER;
+import static com.facebook.presto.opentelemetry.OpenTelemetryHeaders.PRESTO_TRACE_TOKEN;
+import static com.facebook.presto.opentelemetry.OpenTelemetryHeaders.PRESTO_W3C_PROPAGATION;
+
+public class OpenTelemetryTracerProvider
+        implements TracerProvider
+{
+    @Inject
+    public OpenTelemetryTracerProvider() {}
+
+    @Override
+    public String getName()
+    {
+        return "Open telemetry tracer provider";
+    }
+
+    @Override
+    public String getTracerType()
+    {
+        return "otel";
+    }
+
+    @Override
+    public Function<Map<String, String>, TracerHandle> getHandleGenerator()
+    {
+        return headers -> {
+            String contextPropagator = determineContextPropagationMode(headers);
+            return new OpenTelemetryTracerHandle(
+                    headers.get(PRESTO_TRACE_TOKEN),
+                    contextPropagator,
+                    getPropagatedContextFromHeader(contextPropagator, headers),
+                    headers.get(PRESTO_BAGGAGE_HEADER));
+        };
+    }
+
+    @Override
+    public Tracer getNewTracer(TracerHandle handle)
+    {
+        OpenTelemetryTracerHandle tracerHandle = (OpenTelemetryTracerHandle) handle;
+        return new OpenTelemetryTracer(
+                tracerHandle.getTraceToken(),
+                tracerHandle.getContextPropagator(),
+                tracerHandle.getPropagatedContext(),
+                tracerHandle.getBaggage());
+    }
+
+    /**
+     * Take header values and determine which context propagation mode is used
+     * Currently only supports b3 single header
+     * @param headers HTTP request headers
+     * @return context propagation mode
+     */
+    private String determineContextPropagationMode(Map<String, String> headers)
+    {
+        if (headers.containsKey(PRESTO_B3_SINGLE_HEADER_PROPAGATION)) {
+            return OpenTelemetryContextPropagator.B3_SINGLE_HEADER;
+        }
+        if (headers.containsKey(PRESTO_W3C_PROPAGATION)) {
+            throw new PrestoException(
+                    OPEN_TELEMETRY_CONTEXT_PROPAGATOR_ERROR,
+                    "Only b3 single header context propagation mode is currently supported.");
+        }
+        return null;
+    }
+
+    /**
+     * Currently only supports b3 single header and w3c propagation
+     * @param contextPropagator context propagator to use
+     * @param headers http request headers
+     * @return header value extracted from http request based on context propagator
+     */
+    private static String getPropagatedContextFromHeader(String contextPropagator, Map<String, String> headers)
+    {
+        if (contextPropagator != null) {
+            if (contextPropagator.equals(OpenTelemetryContextPropagator.B3_SINGLE_HEADER)) {
+                return headers.get(PRESTO_B3_SINGLE_HEADER_PROPAGATION);
+            }
+            if (contextPropagator.equals(OpenTelemetryContextPropagator.W3C)) {
+                return headers.get(PRESTO_W3C_PROPAGATION);
+            }
+        }
+        return null;
+    }
+}

--- a/presto-open-telemetry/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/presto-open-telemetry/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,1 @@
+com.facebook.presto.opentelemetry.OpenTelemetryPlugin

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -171,6 +171,7 @@ import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
+import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.tracing.TracingConfig;
 import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
@@ -310,6 +311,9 @@ public class PrestoSparkModule
         binder.bind(ColumnPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);
+
+        // tracer provider managers
+        binder.bind(TracerProviderManager.class).in(Scopes.SINGLETON);
 
         // block encodings
         binder.bind(BlockEncodingManager.class).in(Scopes.SINGLETON);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
+import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 
@@ -112,6 +113,14 @@ public interface Plugin
     }
 
     default Iterable<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProviders()
+    {
+        return emptyList();
+    }
+
+    /**
+     * Return list of tracer providers specified by tracer plugin
+     */
+    default Iterable<TracerProvider> getTracerProviders()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/tracing/Tracer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/tracing/Tracer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.tracing;
 
 public interface Tracer
 {
+    String tracerName = "com.facebook.presto";
     /**
      * Add a single trace point with current time to the main block
      * @param annotation message associated with the trace point

--- a/presto-spi/src/main/java/com/facebook/presto/spi/tracing/TracerHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/tracing/TracerHandle.java
@@ -13,26 +13,7 @@
  */
 package com.facebook.presto.spi.tracing;
 
-import java.util.Map;
-import java.util.function.Function;
-
-public interface TracerProvider
+public interface TracerHandle
 {
-    String getName();
-
-    /**
-     * Return tracer type provided by TracerProvider
-     */
-    String getTracerType();
-
-    /**
-     * The method returns a function to take a set of HTTP headers and generate the tracer handle
-     */
-    Function<Map<String, String>, TracerHandle> getHandleGenerator();
-
-    /**
-     *
-     * @return A @Tracer that should be kept throughout the whole duration of tracing.
-     */
-    Tracer getNewTracer(TracerHandle handle);
+    String getTraceToken();
 }


### PR DESCRIPTION
Test plan -
- Set Open Telemetry tracer and ensured query state changes are tracked as well as query completes execution successfully.
- Ensured spans of same query are grouped under same parent span / traceId and any prior context, if provided, is properly propagated
- Ensured baggage propagation is supported as well as set as tags of new spans
- Tested trace exporting (export to Datadog agent)
- Configured without open telemetry as well as with SimpleTracer / NoopTracer to ensure backwards compatibility
- Tested edge cases with system config not matching plugin config

```
== RELEASE NOTES ==

General Changes
* Introduced a new plugin type for tracing. The legacy tracer module can be replaced by the new plugin for loading customized tracing infrastructure.

Open Telemetry Changes
* Introduced a new Open Telemetry tracer implementation. Users are able to enable the tracer by installing the ``presto-open-telemetry`` plugin and updating the application configuration (``config.properties``). Open Telemetry tracer can take in propagated context (only B3 specification currently supported) and baggage (W3C specification) headers, if provided, and inject into new traces / spans. Traces can be exported to any specified backend with the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
```

