### PR TITLE
Fix weighted fair scheduling in disagg coordinator

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -24,6 +24,7 @@ import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
 import com.facebook.presto.resourceGroups.reloading.ReloadingResourceGroupConfigurationManager;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
@@ -132,22 +133,28 @@ class H2TestUtil
     public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao)
             throws Exception
     {
-        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1);
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1, false);
     }
 
     public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), coordinatorCount);
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), coordinatorCount, false);
     }
 
     public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, Map<String, String> coordinatorProperties, int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, coordinatorProperties, coordinatorCount);
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, coordinatorProperties, coordinatorCount, false);
     }
 
-    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, String environment, Map<String, String> coordinatorProperties, int coordinatorCount)
+    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, Map<String, String> coordinatorProperties, int coordinatorCount, boolean weightedFairSchedulingEnabled)
+            throws Exception
+    {
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, coordinatorProperties, coordinatorCount, weightedFairSchedulingEnabled);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, String environment, Map<String, String> coordinatorProperties, int coordinatorCount, boolean weightedFairSchedulingEnabled)
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner
@@ -167,7 +174,7 @@ class H2TestUtil
             }
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");
-            setup(queryRunner, dao, environment);
+            setup(queryRunner, dao, environment, weightedFairSchedulingEnabled);
             queryRunner.waitForClusterToGetReady();
             return queryRunner;
         }
@@ -185,8 +192,7 @@ class H2TestUtil
         return createQueryRunner(dbConfigUrl, dao);
     }
 
-    private static void setup(DistributedQueryRunner queryRunner, H2ResourceGroupsDao dao, String environment)
-            throws InterruptedException
+    private static void resourceGroupSetup(H2ResourceGroupsDao dao)
     {
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
@@ -206,6 +212,39 @@ class H2TestUtil
         dao.insertSelector(6, 6, ".*", ".*", null, null, null, null);
         dao.insertSelector(7, 100_000, null, null, EXPLAIN.name(), null, null, null);
         dao.insertSelector(9, 10_000, "user.*", "abc", null, null, null, null);
+    }
+
+    private static void resourceGroupSetupWithWeightedFairPolicy(H2ResourceGroupsDao dao)
+    {
+        dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
+        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, SchedulingPolicy.WEIGHTED_FAIR.toString(), null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, 1000, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, 10, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
+        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(8, "test", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(9, "test-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 8L, TEST_ENVIRONMENT);
+        dao.insertSelector(2, 10_000, "user.*", "test", null, null, null, null);
+        dao.insertSelector(4, 1_000, "user.*", "(?i).*adhoc.*", null, null, null, null);
+        dao.insertSelector(5, 100, "user.*", "(?i).*dashboard.*", null, null, null, null);
+        dao.insertSelector(4, 10, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null);
+        dao.insertSelector(2, 1, "user.*", null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null, null);
+        dao.insertSelector(6, 6, ".*", ".*", null, null, null, null);
+        dao.insertSelector(7, 100_000, null, null, EXPLAIN.name(), null, null, null);
+        dao.insertSelector(9, 10_000, "user.*", "abc", null, null, null, null);
+    }
+
+    private static void setup(DistributedQueryRunner queryRunner, H2ResourceGroupsDao dao, String environment, boolean weightedFairSchedulingEnabled)
+            throws InterruptedException
+    {
+        if (weightedFairSchedulingEnabled) {
+            resourceGroupSetupWithWeightedFairPolicy(dao);
+        }
+        else {
+            resourceGroupSetup(dao);
+        }
 
         int expectedSelectors = 7;
         if (environment.equals(TEST_ENVIRONMENT_2)) {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesSchedulingPolicy.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesSchedulingPolicy.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups.db;
+
+import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.execution.QueryState.QUEUED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.cancelQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.adhocSession;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.createQueryRunner;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.dashboardSession;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDao;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDbConfigUrl;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+// run single threaded to avoid creating multiple query runners at once
+@Test(singleThreaded = true)
+public class TestDistributedQueuesSchedulingPolicy
+{
+    private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        String dbConfigUrl = getDbConfigUrl();
+        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
+        ImmutableMap.Builder<String, String> coordinatorProperties = new ImmutableMap.Builder<>();
+        coordinatorProperties.put("query-manager.experimental.required-coordinators", "2");
+        coordinatorProperties.put("resource-manager.query-heartbeat-interval", "10ms");
+        coordinatorProperties.put("resource-group-runtimeinfo-refresh-interval", "500ms");
+        coordinatorProperties.put("concurrency-threshold-to-enable-resource-group-refresh", "0");
+
+        queryRunner = createQueryRunner(dbConfigUrl, dao, coordinatorProperties.build(), 2, true);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        closeQuietly(queryRunner);
+        queryRunner = null;
+    }
+
+    @Test(timeOut = 60_000)
+    public void test()
+            throws Exception
+    {
+        QueryId firstAdhocQuery = createQuery(queryRunner, 0, adhocSession(), LONG_LASTING_QUERY);
+
+        QueryId secondAdhocQuery = createQuery(queryRunner, 1, adhocSession(), LONG_LASTING_QUERY);
+
+        QueryId firstDashboardQuery = createQuery(queryRunner, 0, dashboardSession(), LONG_LASTING_QUERY);
+
+        QueryId secondDashboardQuery = createQuery(queryRunner, 1, dashboardSession(), LONG_LASTING_QUERY);
+
+        waitForQueryState(queryRunner, 0, firstAdhocQuery, RUNNING);
+        waitForQueryState(queryRunner, 1, secondAdhocQuery, RUNNING);
+        waitForQueryState(queryRunner, 0, firstDashboardQuery, RUNNING);
+        waitForQueryState(queryRunner, 1, secondDashboardQuery, RUNNING);
+
+        Map<ResourceGroupId, ResourceGroupRuntimeInfo> resourceGroupRuntimeInfoSnapshot;
+        int globalRunningQueries = 0;
+        do {
+            MILLISECONDS.sleep(100);
+            globalRunningQueries = 0;
+            for (int coordinator = 0; coordinator < 2; coordinator++) {
+                resourceGroupRuntimeInfoSnapshot = queryRunner.getCoordinator(coordinator).getResourceGroupManager().get().getResourceGroupRuntimeInfosSnapshot();
+                ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfoSnapshot.get(new ResourceGroupId("global"));
+                if (resourceGroupRuntimeInfo != null) {
+                    globalRunningQueries += resourceGroupRuntimeInfo.getDescendantRunningQueries();
+                }
+            }
+        } while (globalRunningQueries != 4);
+
+        QueryId thirdAdhocQuery = createQuery(queryRunner, 1, adhocSession(), LONG_LASTING_QUERY);
+        QueryId thirdDashboardQuery = createQuery(queryRunner, 1, dashboardSession(), LONG_LASTING_QUERY);
+
+        waitForQueryState(queryRunner, 1, thirdAdhocQuery, QUEUED);
+        waitForQueryState(queryRunner, 1, thirdDashboardQuery, QUEUED);
+
+        int globalQueuedQueries = 0;
+        do {
+            MILLISECONDS.sleep(100);
+            globalQueuedQueries = 0;
+            for (int coordinator = 0; coordinator < 2; coordinator++) {
+                resourceGroupRuntimeInfoSnapshot = queryRunner.getCoordinator(coordinator).getResourceGroupManager().get().getResourceGroupRuntimeInfosSnapshot();
+                ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfoSnapshot.get(new ResourceGroupId("global"));
+                if (resourceGroupRuntimeInfo != null) {
+                    globalQueuedQueries += resourceGroupRuntimeInfo.getDescendantQueuedQueries();
+                }
+            }
+        } while (globalQueuedQueries != 2);
+
+        cancelQuery(queryRunner, 0, firstDashboardQuery);
+        waitForQueryState(queryRunner, 1, thirdAdhocQuery, RUNNING);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
@@ -41,7 +41,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1, false)) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
@@ -55,7 +55,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2, ImmutableMap.of(), 1)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2, ImmutableMap.of(), 1, false)) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);


### PR DESCRIPTION
    In disaggregated coordinator, each coordinator is considering it's own running queries to decide which
    resource group should run the next query in weighted fair scheduling. This lead to an issue when
    with n coordinators each allowing single query to run for the resource group which has lower weight
    and lead to n slots been used by the resource group even if it's weight will allow it to run lower than
    n queries.

    With the fix, we consider global running query count for the given resource group, which helps decide the
    correct number of queries we should run for a lower weight resource group and allow more slots be given to
    high priority resource group as per weighted fair scheduling.

Test plan - unit test + shadow run

```
== RELEASE NOTES ==

General Changes
* Fix for weighted fair scheduling in disaggregated coordinator