### PR TITLE
Canonicalize domain predicate in TableScanNode

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomain.java
@@ -485,11 +485,11 @@ public final class TupleDomain<T>
         return TupleDomain.withColumnDomains(unmodifiableMap(compactedDomains));
     }
 
-    public TupleDomain<T> canonicalize(boolean removeConstants)
+    public TupleDomain<T> canonicalize(Function<T, Boolean> removeConstants)
     {
         return new TupleDomain<>(domains.map(d -> unmodifiableMap(d.entrySet().stream()
                 .sorted(comparing(domain -> domain.getKey().toString()))
-                .collect(toLinkedMap(Entry::getKey, entry -> entry.getValue().canonicalize(removeConstants))))));
+                .collect(toLinkedMap(Entry::getKey, entry -> entry.getValue().canonicalize(removeConstants.apply(entry.getKey())))))));
     }
 
     public static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableLayoutHandle.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableLayoutHandle.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
+import static com.facebook.presto.common.predicate.Domain.singleValue;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveTableLayoutHandle.canonicalizeDomainPredicate;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveTableLayoutHandle
+{
+    @Test
+    public void testCanonicalizeDomain()
+    {
+        Map<String, HiveColumnHandle> predicateColumns = ImmutableMap.of(
+                "ds", getColumnHandle("ds", true),
+                "col", getColumnHandle("col", false));
+        TupleDomain<Subfield> domain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                new Subfield("ds"), singleValue(VARCHAR, utf8Slice("2022-01-01")),
+                new Subfield("col"), singleValue(VARCHAR, utf8Slice("id"))));
+        TupleDomain<Subfield> newDomain = canonicalizeDomainPredicate(domain, predicateColumns, CONNECTOR);
+        assertTrue(newDomain.getDomains().isPresent());
+        assertEquals(newDomain.getDomains().get().size(), 1);
+        assertEquals(newDomain.getDomains().get().get(new Subfield("col")), singleValue(VARCHAR, utf8Slice("id")));
+    }
+
+    private HiveColumnHandle getColumnHandle(String name, boolean partitioned)
+    {
+        return new HiveColumnHandle(
+                name,
+                HIVE_STRING,
+                HIVE_STRING.getTypeSignature(),
+                1,
+                partitioned ? PARTITION_KEY : REGULAR,
+                Optional.empty(),
+                Optional.empty());
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableLayoutHandle.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableLayoutHandle.java
@@ -60,7 +60,7 @@ public class TpchTableLayoutHandle
     {
         return ImmutableMap.builder()
                 .put("table", table)
-                .put("predicate", predicate.canonicalize(false))
+                .put("predicate", predicate.canonicalize(ignored -> false))
                 .build();
     }
 }


### PR DESCRIPTION
Focusing on 2 parameters hive table layout:

domainPredicate 
currentConstraint

Usually, partition column constraints are found in currentConstraint, and other filters are found in domainPredicate. However, in some complex queries in prod, I found that domainPredicate also contains the partition predicates. 

So when canonicalizing partition predicates, we can just rely on currentConstraint. In domainPredicate, we can skip the partition columns.

```
== NO RELEASE NOTE ==
```
