### PR TITLE
Make plan hashing more consistent

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.inject.Inject;
 
 import static java.util.Objects.requireNonNull;
@@ -38,7 +39,8 @@ public class HistoryBasedPlanStatisticsManager
     {
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
-        this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(objectMapper, metadata);
+        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
     }
 


### PR DESCRIPTION
Depends on https://github.com/prestodb/presto/pull/18545

I spent a lot of time debugging why plan hashes are sometimes inconsistent. It was hard to reproduce without pages long queries, and sometimes only pops up in different jvm instances. I found 2 fixes:

1) Use `ORDER_MAP_ENTRIES_BY_KEYS` in json object mapper. Jackson doesn't seem to always respect order of map entries. So we sort map entries by keys during serialization.

2) Use json representation to sort RowExpression instead of RowExpression::toString. toString can contain object addresses, but our json representations don't.

It will be extremely hard to write tests where this fails. But these changes are simple and sound enough that we can use them. 

```
== NO RELEASE NOTE ==
```
