### PR TITLE
Add ARRAY_MIN_BY, ARRAY_MAX_BY functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -81,6 +81,20 @@ Array Functions
 
     Returns the minimum value of input array.
 
+.. function:: array_max_by(array(T), function(T, U)) -> T
+
+    Applies the provided function to each element, and returns the element that gives the maximum value.
+    ``U`` can be any orderable type. ::
+
+        SELECT array_max_by(ARRAY ['a', 'bbb', 'cc'], x -> LENGTH(x)) -- 'bbb'
+
+.. function:: array_min_by(array(T), function(T, U)) -> T
+
+    Applies the provided function to each element, and returns the element that gives the minimum value.
+    ``U`` can be any orderable type. ::
+
+        SELECT array_min_by(ARRAY ['a', 'bbb', 'cc'], x -> LENGTH(x)) -- 'a'
+
 .. function:: array_normalize(x, p) -> array
 
    Normalizes array ``x`` by dividing each element by the p-norm of the array.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar.sql;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
 import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 
@@ -59,7 +60,7 @@ public class ArraySqlFunctions
     @TypeParameter("T")
     @SqlParameter(name = "input", type = "array(T)")
     @SqlType("map(T, int)")
-    public static String arrayFrequencyBigint()
+    public static String arrayFrequency()
     {
         return "RETURN reduce(" +
                 "input," +
@@ -88,5 +89,31 @@ public class ArraySqlFunctions
     public static String arrayHasDuplicatesVarchar()
     {
         return "RETURN cardinality(array_duplicates(input)) > 0";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_max_by", deterministic = true, calledOnNullInput = true)
+    @Description("Get the maximum value of array, by using a specific transformation function")
+    @TypeParameter("T")
+    @TypeParameter("U")
+    @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "f", type = "function(T, U)")})
+    @SqlType("T")
+    public static String arrayMaxBy()
+    {
+        return "RETURN input[" +
+                "array_max(zip_with(transform(input, f), sequence(1, cardinality(input)), (x, y)->IF(x IS NULL, NULL, (x, y))))[2]" +
+                "]";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_min_by", deterministic = true, calledOnNullInput = true)
+    @Description("Get the minimum value of array, by using a specific transformation function")
+    @TypeParameter("T")
+    @TypeParameter("U")
+    @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "f", type = "function(T, U)")})
+    @SqlType("T")
+    public static String arrayMinBy()
+    {
+        return "RETURN input[" +
+                "array_min(zip_with(transform(input, f), sequence(1, cardinality(input)), (x, y)->IF(x IS NULL, NULL, (x, y))))[2]" +
+                "]";
     }
 }


### PR DESCRIPTION
This PR adds 2 functions in order to get the max or min element of an array, while using a transformation function. This is the equivalent of [Scala's maxBy/minBy](https://www.scala-lang.org/api/2.12.6/scala/collection/TraversableOnce.html#maxBy[B](f:A=%3EB):A) functions.

The current way of obtaining an equivalent behaviour would be to either use `ARRAY_SORT` with a custom comparator and selecting the first element, or something similar to the following pattern:
```
ARRAY_MAX_BY(a, f) :=
  REDUCE(
    a,
    (NULL, NULL),
    ((curr_max, curr_max_elt), elt) ->
      IF(curr_max IS NULL OR f(elt) >= curr_max,
         (f(elt), elt),
         (curr_max, curr_max_elt)),
    (curr_max, curr_max_elt) -> curr_max_elt)
```
These current methods are neither elegant nor optimized.


Test plan - (Please fill in how you tested your changes)
`mvn -Dtest="TestArrayMinByFunction,TestArrayMaxByFunction" test`

```
== RELEASE NOTES ==

General Changes
* Add functions :func:`array_min_by`, :func:`array_max_by`, to find the smallest or largest element of an array when applying a custom measuring function
```
