### PR TITLE
[native] Allow overriding file system registration.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -143,7 +143,7 @@ void PrestoServer::run() {
   }
 
   registerPrestoCppCounters();
-  velox::filesystems::registerLocalFileSystem();
+  registerFileSystems();
   registerOptionalHiveStorageAdapters();
   protocol::registerHiveConnectors();
   protocol::registerTpchConnector();
@@ -463,6 +463,10 @@ std::vector<std::string> PrestoServer::registerConnectors(
     }
   }
   return catalogNames;
+}
+
+void PrestoServer::registerFileSystems() {
+  velox::filesystems::registerLocalFileSystem();
 }
 
 std::shared_ptr<velox::connector::Connector> PrestoServer::connectorWithCache(

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -82,10 +82,12 @@ class PrestoServer {
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
 
-  void initializeAsyncCache();
-
   virtual std::vector<std::string> registerConnectors(
       const fs::path& configDirectoryPath);
+
+  virtual void registerFileSystems();
+
+  void initializeAsyncCache();
 
  protected:
   virtual std::shared_ptr<velox::connector::Connector> connectorWithCache(


### PR DESCRIPTION
Allowing overriding filesystem so that we can pass file system specific parameters when required.