### PR TITLE
Support STRPOS pushdown to Pinot; Fix missing configuration property pinot.query-options error

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -654,7 +654,6 @@ public class PinotConfig
         return controllerUrls.get(ThreadLocalRandom.current().nextInt(controllerUrls.size()));
     }
 
-    @NotNull
     public String getQueryOptions()
     {
         return queryOptions;

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
@@ -135,6 +135,9 @@ public class TestPinotExpressionConverters
         testFilter("CONCAT(city, ', CA', city) IN ('San Jose', 'Campbell')",
                 "(concat(concat(\"city\", ', CA', ''), \"city\", '') IN ('San Jose', 'Campbell'))", sessionHolder);
 
+        // strpos
+        testFilter("STRPOS(\"city\", 'Seattle') = 1", "(strpos(\"city\",'Seattle') + 1 = 1)", sessionHolder);
+
         // case, coalesce, if
         testFilter("CASE WHEN city = 'Campbell' THEN regionid ELSE 0 END",
                 "CASE true WHEN (\"city\" = 'Campbell') THEN \"regionId\" ELSE 0 END", sessionHolder);


### PR DESCRIPTION
- Fix the following error when pinot.query-options is missing:
   `Invalid configuration property pinot.query-options: may not be null (for class com.facebook.presto.pinot.PinotConfig.queryOptions)`
- Support STRPOS filter predicates pushdown to Pinot

Test plan 
- Added unit test
- Tested against Pinot DEV env


```
== RELEASE NOTES ==

Pinot Changes
* Add pushdown support for ``STRPOS`` function.
```
