### PR TITLE
Fetcher timeout should be at http level

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTaskFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTaskFactory.java
@@ -19,6 +19,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.server.TaskUpdateRequest;
@@ -47,6 +48,7 @@ public class NativeExecutionTaskFactory
     private final JsonCodec<TaskInfo> taskInfoCodec;
     private final JsonCodec<PlanFragment> planFragmentCodec;
     private final JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec;
+    private final TaskManagerConfig taskManagerConfig;
 
     @Inject
     public NativeExecutionTaskFactory(
@@ -55,7 +57,8 @@ public class NativeExecutionTaskFactory
             ScheduledExecutorService updateScheduledExecutor,
             JsonCodec<TaskInfo> taskInfoCodec,
             JsonCodec<PlanFragment> planFragmentCodec,
-            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec)
+            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec,
+            TaskManagerConfig taskManagerConfig)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.coreExecutor = requireNonNull(coreExecutor, "coreExecutor is null");
@@ -64,6 +67,7 @@ public class NativeExecutionTaskFactory
         this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
         this.planFragmentCodec = requireNonNull(planFragmentCodec, "planFragmentCodec is null");
         this.taskUpdateRequestCodec = requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
+        this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
     }
 
     public NativeExecutionTask createNativeExecutionTask(
@@ -86,7 +90,8 @@ public class NativeExecutionTaskFactory
                 updateScheduledExecutor,
                 taskInfoCodec,
                 planFragmentCodec,
-                taskUpdateRequestCodec);
+                taskUpdateRequestCodec,
+                taskManagerConfig);
     }
 
     @PreDestroy


### PR DESCRIPTION
Currently we timeout our fetcher http requests on the fetcher's future level. This is not right because when the future times out the actual http request might still be executing. It will lead to a lingering http request thread at large. Instead we should move the timeout to HttpClient level so that threads execution is fully controlled.
```
== NO RELEASE NOTE ==
```
