### PR TITLE
Update release notes script to specify a version

### DIFF
--- a/src/release/release-notes.sh
+++ b/src/release/release-notes.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-if [[ "$#" -ne 2 ]]; then
-    echo "Usage: $0 <github_user> <github_access_token>"
+if [[ "$#" -ne 3 ]]; then
+    echo "Usage: $0 <github_user> <github_access_token> <version>"
     exit 1
 fi
 
 curl -L -o /tmp/presto_release "https://oss.sonatype.org/service/local/artifact/maven/redirect?g=com.facebook.presto&a=presto-release-tools&v=RELEASE&r=releases&c=executable&e=jar"
 chmod 755 /tmp/presto_release
-/tmp/presto_release release-notes --github-user $1 --github-access-token $2
+/tmp/presto_release release-notes --github-user $1 --github-access-token $2 --version $3


### PR DESCRIPTION
The release notes script needs to be able to accept an explicit version so that the release oncall can start making the release notes immediately without having to wait for the state of master to be updated. Especially now that the cut process creates a pull request to update the version of master, instead of committing stright to master.

Test plan - 

Run the script with a version: `./release-notes.sh g1y TESTTEST 0.200`

The script picks up that version and is using it in its config.
```
2022-10-28T16:26:04.149-0700	INFO	main	Bootstrap	release-notes.version                                             ----                                                                       0.200
```

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
