### PR TITLE
Expose Filter push down support

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/DynamicFilters.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/DynamicFilters.java
@@ -77,32 +77,6 @@ public final class DynamicFilters
         return new DynamicFilterExtractResult(staticConjuncts.build(), dynamicConjuncts.build());
     }
 
-    public static RowExpression extractDynamicConjuncts(List<RowExpression> conjuncts, LogicalRowExpressions logicalRowExpressions)
-    {
-        ImmutableList.Builder<RowExpression> dynamicConjuncts = ImmutableList.builder();
-        for (RowExpression conjunct : conjuncts) {
-            Optional<DynamicFilterPlaceholder> placeholder = getPlaceholder(conjunct);
-            if (placeholder.isPresent()) {
-                dynamicConjuncts.add(conjunct);
-            }
-        }
-
-        return logicalRowExpressions.combineConjuncts(dynamicConjuncts.build());
-    }
-
-    public static RowExpression extractStaticConjuncts(List<RowExpression> conjuncts, LogicalRowExpressions logicalRowExpressions)
-    {
-        ImmutableList.Builder<RowExpression> staticConjuncts = ImmutableList.builder();
-        for (RowExpression conjunct : conjuncts) {
-            Optional<DynamicFilterPlaceholder> placeholder = getPlaceholder(conjunct);
-            if (!placeholder.isPresent()) {
-                staticConjuncts.add(conjunct);
-            }
-        }
-
-        return logicalRowExpressions.combineConjuncts(staticConjuncts.build());
-    }
-
     public static boolean isDynamicFilter(RowExpression expression)
     {
         return getPlaceholder(expression).isPresent();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -66,6 +66,7 @@ import com.facebook.presto.hive.orc.OrcSelectivePageSource;
 import com.facebook.presto.hive.pagefile.PageFilePageSource;
 import com.facebook.presto.hive.parquet.ParquetPageSource;
 import com.facebook.presto.hive.rcfile.RcFilePageSource;
+import com.facebook.presto.hive.rule.HiveFilterPushdown;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -105,9 +106,12 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.constraints.PrimaryKeyConstraint;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.constraints.UniqueConstraint;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -278,7 +282,6 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues
 import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
 import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
-import static com.facebook.presto.hive.rule.HiveFilterPushdown.pushdownFilter;
 import static com.facebook.presto.spi.SplitContext.NON_CACHEABLE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
@@ -2287,6 +2290,22 @@ public abstract class AbstractTestHiveClient
                     Optional.empty());
             assertBucketTableEvolutionResult(result, columnHandles, ImmutableSet.of(6), rowCount);
         }
+    }
+
+    private static HiveFilterPushdown.ConnectorPushdownFilterResult pushdownFilter(
+            ConnectorSession session,
+            ConnectorMetadata metadata,
+            SemiTransactionalHiveMetastore metastore,
+            RowExpressionService rowExpressionService,
+            StandardFunctionResolution functionResolution,
+            HivePartitionManager partitionManager,
+            FunctionMetadataManager functionMetadataManager,
+            ConnectorTableHandle tableHandle,
+            RowExpression filter,
+            Optional<ConnectorTableLayoutHandle> currentLayoutHandle)
+    {
+        HiveFilterPushdown filterPushdown = new HiveFilterPushdown(new HiveTransactionManager(), rowExpressionService, functionResolution, partitionManager, functionMetadataManager);
+        return filterPushdown.pushdownFilter(session, metadata, metastore, tableHandle, filter, currentLayoutHandle);
     }
 
     private static void assertBucketTableEvolutionResult(MaterializedResult result, List<ColumnHandle> columnHandles, Set<Integer> bucketIds, int rowCount)


### PR DESCRIPTION
For computed/dynamic columns, expression should not be pushed
inside the TableScan. The expression should be applied as a 
FilterNode after the table scan. This change exposes a method to
control what expressions are pushed inside the TableScan.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
