### PR TITLE
Use exact size when using history based statistics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
@@ -112,7 +112,7 @@ public class CostCalculatorWithEstimatedExchanges
         public LocalCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             PlanNode source = node.getSource();
-            double inputSizeInBytes = getStats(source).getOutputSizeInBytes(source.getOutputVariables());
+            double inputSizeInBytes = getStats(source).getOutputSizeInBytes(source);
 
             LocalCostEstimate remoteRepartitionCost = calculateRemoteRepartitionCost(inputSizeInBytes);
             LocalCostEstimate localRepartitionCost = calculateLocalRepartitionCost(inputSizeInBytes);
@@ -161,7 +161,7 @@ public class CostCalculatorWithEstimatedExchanges
             // that is not always true
             // but this estimate is better that returning UNKNOWN, as it sets
             // cumulative cost to unknown
-            double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputVariables());
+            double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node);
             return calculateRemoteGatherCost(inputSizeInBytes);
         }
 
@@ -169,7 +169,7 @@ public class CostCalculatorWithEstimatedExchanges
         public LocalCostEstimate visitIntersect(IntersectNode node, Void context)
         {
             // Similar to Union
-            double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputVariables());
+            double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node);
             return calculateRemoteGatherCost(inputSizeInBytes);
         }
 
@@ -228,8 +228,8 @@ public class CostCalculatorWithEstimatedExchanges
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
-        double probeSizeInBytes = stats.getStats(probe).getOutputSizeInBytes(probe.getOutputVariables());
-        double buildSizeInBytes = stats.getStats(build).getOutputSizeInBytes(build.getOutputVariables());
+        double probeSizeInBytes = stats.getStats(probe).getOutputSizeInBytes(probe);
+        double buildSizeInBytes = stats.getStats(build).getOutputSizeInBytes(build);
         if (replicated) {
             // assuming the probe side of a replicated join is always source distributed
             LocalCostEstimate replicateCost = calculateRemoteReplicateCost(buildSizeInBytes, estimatedSourceDistributedTaskCount);
@@ -257,8 +257,8 @@ public class CostCalculatorWithEstimatedExchanges
         PlanNodeStatsEstimate probeStats = stats.getStats(probe);
         PlanNodeStatsEstimate buildStats = stats.getStats(build);
 
-        double buildSideSize = buildStats.getOutputSizeInBytes(build.getOutputVariables());
-        double probeSideSize = probeStats.getOutputSizeInBytes(probe.getOutputVariables());
+        double buildSideSize = buildStats.getOutputSizeInBytes(build);
+        double probeSideSize = probeStats.getOutputSizeInBytes(probe);
 
         double cpuCost = probeSideSize + buildSideSize * buildSizeMultiplier;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -91,7 +91,7 @@ public class DetermineJoinDistributionType
 
         PlanNode buildSide = joinNode.getRight();
         PlanNodeStatsEstimate buildSideStatsEstimate = context.getStatsProvider().getStats(buildSide);
-        double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide.getOutputVariables());
+        double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide);
         return buildSideSizeInBytes <= joinMaxBroadcastTableSize.toBytes()
             || (isSizeBasedJoinDistributionTypeEnabled(context.getSession())
                 && getSourceTablesSizeInBytes(buildSide, context) <= joinMaxBroadcastTableSize.toBytes());
@@ -183,7 +183,7 @@ public class DetermineJoinDistributionType
                 .findAll();
 
         return sourceNodes.stream()
-                .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputSizeInBytes(sourceNode.getOutputVariables()))
+                .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputSizeInBytes(sourceNode))
                 .sum();
     }
 
@@ -210,8 +210,7 @@ public class DetermineJoinDistributionType
                 return Stream.of(planNode);
             })
             .mapToDouble(resolvedNode -> {
-                double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(
-                        resolvedNode.getOutputVariables());
+                double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(resolvedNode);
                 if (!isNaN(outputSizeInBytes)) {
                     return outputSizeInBytes;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -135,7 +135,7 @@ public class DetermineSemiJoinDistributionType
 
         PlanNode buildSide = node.getFilteringSource();
         PlanNodeStatsEstimate buildSideStatsEstimate = context.getStatsProvider().getStats(buildSide);
-        double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide.getOutputVariables());
+        double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide);
         return buildSideSizeInBytes <= joinMaxBroadcastTableSize.toBytes()
             || (isSizeBasedJoinDistributionTypeEnabled(context.getSession())
                 && getSourceTablesSizeInBytes(buildSide, context) <= joinMaxBroadcastTableSize.toBytes());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -295,8 +295,8 @@ public class PushPartialAggregationThroughExchange
         StatsProvider stats = context.getStatsProvider();
         PlanNodeStatsEstimate exchangeStats = stats.getStats(exchangeNode);
         PlanNodeStatsEstimate aggregationStats = stats.getStats(aggregationNode);
-        double inputBytes = exchangeStats.getOutputSizeInBytes(exchangeNode.getOutputVariables());
-        double outputBytes = aggregationStats.getOutputSizeInBytes(aggregationNode.getOutputVariables());
+        double inputBytes = exchangeStats.getOutputSizeInBytes(exchangeNode);
+        double outputBytes = aggregationStats.getOutputSizeInBytes(aggregationNode);
         double byteReductionThreshold = getPartialAggregationByteReductionThreshold(context.getSession());
 
         return exchangeStats.isConfident() && outputBytes > inputBytes * byteReductionThreshold;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
@@ -100,8 +100,8 @@ public class RuntimeReorderJoinSides
         }
         if (Double.isNaN(leftOutputSizeInBytes) || Double.isNaN(rightOutputSizeInBytes)) {
             // Per-column estimate left and right output size for complex plans or when size statistics is unavailable.
-            leftOutputSizeInBytes = statsProvider.getStats(joinNode.getLeft()).getOutputSizeInBytes(joinNode.getLeft().getOutputVariables());
-            rightOutputSizeInBytes = statsProvider.getStats(joinNode.getRight()).getOutputSizeInBytes(joinNode.getRight().getOutputVariables());
+            leftOutputSizeInBytes = statsProvider.getStats(joinNode.getLeft()).getOutputSizeInBytes(joinNode.getLeft());
+            rightOutputSizeInBytes = statsProvider.getStats(joinNode.getRight()).getOutputSizeInBytes(joinNode.getRight());
         }
 
         if (Double.isNaN(leftOutputSizeInBytes) || Double.isNaN(rightOutputSizeInBytes)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToRightEarlyOutJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToRightEarlyOutJoin.java
@@ -175,8 +175,8 @@ public class TransformDistinctInnerJoinToRightEarlyOutJoin
         PlanNodeStatsEstimate joinStats = stats.getStats(joinNode);
         PlanNodeStatsEstimate leftStats = stats.getStats(joinNode.getLeft());
 
-        double inputBytes = leftStats.getOutputSizeInBytes(joinNode.getLeft().getOutputVariables());
-        double outputBytes = joinStats.getOutputSizeInBytes(joinNode.getOutputVariables());
+        double inputBytes = leftStats.getOutputSizeInBytes(joinNode.getLeft());
+        double outputBytes = joinStats.getOutputSizeInBytes(joinNode);
         return outputBytes <= inputBytes * getPushAggregationBelowJoinByteReductionThreshold(context.getSession());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
@@ -66,6 +66,11 @@ class PlanRepresentation
         return Optional.ofNullable(nodeInfo.get(id));
     }
 
+    public PlanNode getPlanNodeRoot()
+    {
+        return root;
+    }
+
     public void addNode(NodeRepresentation node)
     {
         nodeInfo.put(node.getId(), node);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -221,7 +221,7 @@ public class TextRenderer
 
             output.append(format("{rows: %s (%s), cpu: %s, memory: %s, network: %s}",
                     formatAsLong(stats.getOutputRowCount()),
-                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node.getOutputs())),
+                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(plan.getPlanNodeRoot())),
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMaxMemory()),
                     formatDouble(cost.getNetworkCost())));

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -652,7 +652,7 @@ public final class GraphvizPrinter
             output.append("Estimates: ");
             output.append(format("{rows: %s (%s), cpu: %s, memory: %s, network: %s}",
                     formatAsLong(stats.getOutputRowCount()),
-                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node.getOutputVariables())),
+                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node)),
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMaxMemory()),
                     formatDouble(cost.getNetworkCost())));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -690,6 +690,12 @@ public final class PlanMatchPattern
         return this;
     }
 
+    public PlanMatchPattern withOutputSize(double expectedOutputSize)
+    {
+        matchers.add(new StatsOutputSizeMatcher(expectedOutputSize));
+        return this;
+    }
+
     public static RvalueMatcher columnReference(String tableName, String columnName)
     {
         return new ColumnReference(tableName, columnName);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsOutputSizeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsOutputSizeMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+
+public class StatsOutputSizeMatcher
+        implements Matcher
+{
+    private final double expectedOutputSize;
+
+    StatsOutputSizeMatcher(double expectedOutputSize)
+    {
+        this.expectedOutputSize = expectedOutputSize;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return true;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return new MatchResult(Double.compare(stats.getStats(node).getOutputSizeInBytes(node), expectedOutputSize) == 0);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "expectedOutputSize(" + expectedOutputSize + ")";
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
@@ -19,7 +19,12 @@ package com.facebook.presto.spi.statistics;
 public class CostBasedSourceInfo
         extends SourceInfo
 {
-    public CostBasedSourceInfo() {}
+    private boolean confident;
+
+    public CostBasedSourceInfo(boolean confident)
+    {
+        this.confident = confident;
+    }
 
     @Override
     public int hashCode()
@@ -37,5 +42,11 @@ public class CostBasedSourceInfo
     public String toString()
     {
         return "CostBasedSourceInfo{}";
+    }
+
+    @Override
+    public boolean isConfident()
+    {
+        return confident;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoryBasedSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoryBasedSourceInfo.java
@@ -62,4 +62,10 @@ public class HistoryBasedSourceInfo
     {
         return Objects.hash(hash, inputTableStatistics);
     }
+
+    @Override
+    public boolean isConfident()
+    {
+        return true;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
@@ -19,4 +19,5 @@ package com.facebook.presto.spi.statistics;
  */
 public abstract class SourceInfo
 {
+    public abstract boolean isConfident();
 }


### PR DESCRIPTION
Previously we used #rows from histories and computed size using CBO framework which uses estimates size of columns. We now improve upon it to use exact sizes from HBO.

```
== NO RELEASE NOTE ==
```
