### PR TITLE
Fix broken "Function Namespace Managers" links

### DIFF
--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -94,4 +94,4 @@ Name                                        Description
 See Also
 --------
 
-:doc:`create-function`, :doc:`alter-function`, :doc:`drop-function`, :doc:`show-functions`
+:doc:`/sql/create-function`, :doc:`/sql/alter-function`, :doc:`/sql/drop-function`, :doc:`/sql/show-functions`


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
