### PR TITLE
Fix Disaggregated Coordinator Weighted Scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -932,7 +932,7 @@ public class InternalResourceGroup
 
     private long computeSchedulingWeight()
     {
-        if (runningQueries.size() + descendantRunningQueries >= softConcurrencyLimit) {
+        if (getAggregatedRunningQueries() >= softConcurrencyLimit) {
             return schedulingWeight;
         }
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
@@ -41,7 +41,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1, false)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of(), 1, false, false)) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
@@ -55,7 +55,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2, ImmutableMap.of(), 1, false)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2, ImmutableMap.of(), 1, false, false)) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);


### PR DESCRIPTION
Resource group manager was considering locally running queries count to decide on the group weight and prioritze next running query or eligible group. With the fix, it considers all queries running in the cluster for a given resource group to decide the scheduling weight.

Test plan - unit test

```
== RELEASE NOTES ==

General Changes
* Fix weighted scheduling for disaggregated coordinator
