### PR TITLE
Add support for Unbounded Varchar in HiveTypeTranslator

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -201,19 +201,19 @@ public final class HiveType
         return new HiveType(typeInfo);
     }
 
-    public static HiveType toHiveType(
-            Type type)
+    public static HiveType toHiveType(Type type, boolean useUnboundedVarchar)
     {
-        return toHiveType(type, Optional.empty());
+        return toHiveType(type, Optional.empty(), useUnboundedVarchar);
     }
 
     public static HiveType toHiveType(
             Type type,
-            Optional<HiveType> defaultHiveType)
+            Optional<HiveType> defaultHiveType,
+            boolean useUnboundedVarchar)
     {
         requireNonNull(type, "type is null");
         requireNonNull(defaultHiveType, "defaultHiveType is null");
-        return new HiveType(translate(type, defaultHiveType));
+        return new HiveType(translate(type, useUnboundedVarchar, defaultHiveType));
     }
 
     private static TypeSignature getTypeSignature(TypeInfo typeInfo)

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/PartitionFilterBuilder.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/PartitionFilterBuilder.java
@@ -132,6 +132,6 @@ public class PartitionFilterBuilder
 
     private Column getColumn(String name, Type type)
     {
-        return new Column(name, HiveType.toHiveType(type), Optional.empty(), Optional.empty());
+        return new Column(name, HiveType.toHiveType(type, false), Optional.empty(), Optional.empty());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -69,6 +69,7 @@ public class HiveMetadataFactory
     private final HivePartitionStats hivePartitionStats;
     private final HiveFileRenamer hiveFileRenamer;
     private final ColumnConverterProvider columnConverterProvider;
+    private final boolean useUnboundedVarchar;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -127,7 +128,8 @@ public class HiveMetadataFactory
                 encryptionInformationProvider,
                 hivePartitionStats,
                 hiveFileRenamer,
-                columnConverterProvider);
+                columnConverterProvider,
+                false);
     }
 
     public HiveMetadataFactory(
@@ -161,7 +163,8 @@ public class HiveMetadataFactory
             HiveEncryptionInformationProvider encryptionInformationProvider,
             HivePartitionStats hivePartitionStats,
             HiveFileRenamer hiveFileRenamer,
-            ColumnConverterProvider columnConverterProvider)
+            ColumnConverterProvider columnConverterProvider,
+            boolean useUnboundedVarchar)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -194,6 +197,7 @@ public class HiveMetadataFactory
         this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
         this.hiveFileRenamer = requireNonNull(hiveFileRenamer, "hiveFileRenamer is null");
         this.columnConverterProvider = requireNonNull(columnConverterProvider, "columnConverterProvider is null");
+        this.useUnboundedVarchar = useUnboundedVarchar;
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -239,6 +243,7 @@ public class HiveMetadataFactory
                 partitionObjectBuilder,
                 encryptionInformationProvider,
                 hivePartitionStats,
-                hiveFileRenamer);
+                hiveFileRenamer,
+                useUnboundedVarchar);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
@@ -221,7 +221,7 @@ public class HivePartialAggregationPushdown
                 CallExpression callExpression = aggregationEntry.getValue().getCall();
                 String columnName;
                 int columnIndex;
-                HiveType hiveType = HiveType.toHiveType(callExpression.getType());
+                HiveType hiveType = HiveType.toHiveType(callExpression.getType(), false);
                 if (callExpression.getArguments().isEmpty()) {
                     columnName = "count_star";
                     columnIndex = DUMMY_AGGREGATED_COLUMN_INDEX;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1025,7 +1025,8 @@ public abstract class AbstractTestHiveClient
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                false);
         transactionManager = new HiveTransactionManager();
         encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());
         splitManager = new HiveSplitManager(
@@ -1469,7 +1470,7 @@ public abstract class AbstractTestHiveClient
             Table oldTable = transaction.getMetastore().getTable(metastoreContext, schemaName, tableName).get();
             List<Column> dataColumns = tableAfter.stream()
                     .filter(columnMetadata -> !columnMetadata.getName().equals("ds"))
-                    .map(columnMetadata -> new Column(columnMetadata.getName(), toHiveType(columnMetadata.getType()), Optional.empty(), Optional.empty()))
+                    .map(columnMetadata -> new Column(columnMetadata.getName(), toHiveType(columnMetadata.getType(), false), Optional.empty(), Optional.empty()))
                     .collect(toList());
             Table.Builder newTable = Table.builder(oldTable)
                     .setDataColumns(dataColumns);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -261,7 +261,8 @@ public class TestHiveCommitHandleOutput
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                false);
         return hiveMetadataFactory.get();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -168,23 +168,27 @@ public class TestHiveIntegrationSmokeTest
     private final String catalog;
     private final Session bucketedSession;
     private final Session materializeExchangesSession;
+    private final boolean useUnboundedVarchar;
 
     @SuppressWarnings("unused")
     public TestHiveIntegrationSmokeTest()
     {
         this(createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
                 createMaterializeExchangesSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
-                HIVE_CATALOG);
+                HIVE_CATALOG,
+                false);
     }
 
     protected TestHiveIntegrationSmokeTest(
             Session bucketedSession,
             Session materializeExchangesSession,
-            String catalog)
+            String catalog,
+            boolean useUnboundedVarchar)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.bucketedSession = requireNonNull(bucketedSession, "bucketSession is null");
         this.materializeExchangesSession = requireNonNull(materializeExchangesSession, "materializeExchangesSession is null");
+        this.useUnboundedVarchar = useUnboundedVarchar;
     }
 
     @Override
@@ -5904,7 +5908,7 @@ public class TestHiveIntegrationSmokeTest
 
     private Type canonicalizeType(Type type)
     {
-        HiveType hiveType = HiveType.toHiveType(type);
+        HiveType hiveType = HiveType.toHiveType(type, useUnboundedVarchar);
         return FUNCTION_AND_TYPE_MANAGER.getType(hiveType.getTypeSignature());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -139,7 +139,8 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                false);
 
         metastore.createDatabase(METASTORE_CONTEXT, Database.builder()
                 .setDatabaseName(TEST_DB_NAME)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
@@ -37,7 +37,8 @@ public class TestHivePushdownIntegrationSmokeTest
     {
         super(createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
                 createMaterializeExchangesSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
-                HIVE_CATALOG);
+                HIVE_CATALOG,
+                false);
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -512,7 +512,8 @@ public class TestHiveSplitManager
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                false);
 
         HiveSplitManager splitManager = new HiveSplitManager(
                 new TestingHiveTransactionManager(metadataFactory),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -426,7 +426,7 @@ public enum FileFormat
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
-            columnHandles.add(new HiveColumnHandle(columnName, toHiveType(columnType), columnType.getTypeSignature(), i, REGULAR, Optional.empty(), Optional.empty()));
+            columnHandles.add(new HiveColumnHandle(columnName, toHiveType(columnType, false), columnType.getTypeSignature(), i, REGULAR, Optional.empty(), Optional.empty()));
         }
 
         RecordCursor recordCursor = cursorProvider
@@ -461,7 +461,7 @@ public enum FileFormat
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
-            columnHandles.add(new HiveColumnHandle(columnName, toHiveType(columnType), columnType.getTypeSignature(), i, REGULAR, Optional.empty(), Optional.empty()));
+            columnHandles.add(new HiveColumnHandle(columnName, toHiveType(columnType, false), columnType.getTypeSignature(), i, REGULAR, Optional.empty(), Optional.empty()));
         }
 
         SchemaTableName tableName = new SchemaTableName("hive", "testtable");
@@ -547,7 +547,7 @@ public enum FileFormat
         schema.setProperty(META_TABLE_COLUMNS, columnNames.stream()
                 .collect(joining(",")));
         schema.setProperty(META_TABLE_COLUMN_TYPES, columnTypes.stream()
-                .map(type -> toHiveType(type))
+                .map(type -> toHiveType(type, false))
                 .map(HiveType::getHiveTypeName)
                 .map(HiveTypeName::toString)
                 .collect(joining(":")));


### PR DESCRIPTION
HiveMetadata was used as a library outside presto repository. 
Last PR https://github.com/prestodb/presto/pull/18106 removed this. 
In this PR, the HiveTypeTranslator is enhanced to support unbounded
varchar via a flag.

Test plan - 
Existing and new tests.

```
== NO RELEASE NOTE ==
```
