### PR TITLE
[native] Rename two Presto operators in operator stats.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -64,6 +64,21 @@ protocol::RuntimeUnit toPrestoRuntimeUnit(RuntimeCounter::Unit unit) {
   }
 }
 
+// Presto has certain query stats logic depending on the operator names.
+// To leverage this logic we need to supply Presto's operator names.
+std::string toPrestoOperatorType(const std::string& operatorType) {
+  if (operatorType == "MergeExchange") {
+    return "MergeOperator";
+  }
+  if (operatorType == "Exchange") {
+    return "ExchangeOperator";
+  }
+  if (operatorType == "TableScan") {
+    return "TableScanOperator";
+  }
+  return operatorType;
+}
+
 void setTiming(
     const CpuWallTiming& timing,
     int64_t& count,
@@ -260,7 +275,7 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
       opOut.pipelineId = i;
       opOut.planNodeId = op.planNodeId;
       opOut.operatorId = op.operatorId;
-      opOut.operatorType = op.operatorType;
+      opOut.operatorType = toPrestoOperatorType(op.operatorType);
 
       opOut.totalDrivers = op.numDrivers;
       opOut.inputPositions = op.inputPositions;


### PR DESCRIPTION
Rename operators in OperatorStats that we return to Presto Coordinator:
"TableScan" -> "TableScanOperator"
"MergeExchange" -> "MergeOperator"
"Exchange" -> "ExchangeOperator"
Presto Coordinator uses these names to process stats in a
special way.

Test plan - tested in a Meta's test cluster.

```
== NO RELEASE NOTE ==
```
