### PR TITLE
Add shuffle info interfaces for native execution needs

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/BatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/BatchTaskUpdateRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.server.TaskUpdateRequest;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class BatchTaskUpdateRequest
+{
+    private final TaskUpdateRequest taskUpdateRequest;
+    // Map from plan node id to serialized ShuffleReadInfo
+    private final Optional<Map<String, byte[]>> shuffleReadInfos;
+    private final Optional<byte[]> shuffleWriteInfo;
+
+    @JsonCreator
+    public BatchTaskUpdateRequest(
+            @JsonProperty("taskUpdateRequest") TaskUpdateRequest taskUpdateRequest,
+            @JsonProperty("shuffleReadInfos") Optional<Map<String, byte[]>> shuffleReadInfos,
+            @JsonProperty("shuffleWriteInfo") Optional<byte[]> shuffleWriteInfo)
+    {
+        this.taskUpdateRequest = requireNonNull(taskUpdateRequest, "taskUpdateRequest is null");
+        this.shuffleReadInfos = requireNonNull(shuffleReadInfos, "shuffleReadInfos is null");
+        this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
+    }
+
+    @JsonProperty
+    public TaskUpdateRequest getTaskUpdateRequest()
+    {
+        return taskUpdateRequest;
+    }
+
+    @JsonProperty
+    public Optional<Map<String, byte[]>> getShuffleReadInfos()
+    {
+        return shuffleReadInfos;
+    }
+
+    @JsonProperty
+    public Optional<byte[]> getShuffleWriteInfo()
+    {
+        return shuffleWriteInfo;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("taskUpdateRequest", taskUpdateRequest)
+                .add("shuffleReadInfos", shuffleReadInfos)
+                .add("shuffleWriteInfo", shuffleWriteInfo)
+                .toString();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleInfoSerializer.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleInfoSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkLocalShuffleInfoSerializer
+        implements PrestoSparkShuffleInfoSerializer
+{
+    private final JsonCodec<PrestoSparkLocalShuffleReadInfo> readInfoJsonCodec;
+    private final JsonCodec<PrestoSparkLocalShuffleWriteInfo> writeInfoJsonCodec;
+
+    //TODO: bind json codec in module.
+    @Inject
+    public PrestoSparkLocalShuffleInfoSerializer(
+            JsonCodec<PrestoSparkLocalShuffleReadInfo> readInfoJsonCodec,
+            JsonCodec<PrestoSparkLocalShuffleWriteInfo> writeInfoJsonCodec)
+    {
+        this.readInfoJsonCodec = requireNonNull(readInfoJsonCodec, "readInfoJsonCodec is null");
+        this.writeInfoJsonCodec = requireNonNull(writeInfoJsonCodec, "writeInfoJsonCodec is null");
+    }
+
+    @Override
+    public byte[] serializeReadInfo(PrestoSparkShuffleReadInfo readInfo)
+    {
+        return readInfoJsonCodec.toBytes((PrestoSparkLocalShuffleReadInfo) readInfo);
+    }
+
+    @Override
+    public byte[] serializeWriteInfo(PrestoSparkShuffleWriteInfo writeInfo)
+    {
+        return writeInfoJsonCodec.toBytes((PrestoSparkLocalShuffleWriteInfo) writeInfo);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleReadInfo.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleReadInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkLocalShuffleReadInfo
+        implements PrestoSparkShuffleReadInfo
+{
+    private final int maxBytesPerPartition;
+    private final int numPartitions;
+    private final int partitionId;
+    private final String rootPath;
+
+    @JsonCreator
+    public PrestoSparkLocalShuffleReadInfo(
+            @JsonProperty("maxBytesPerPartition") int maxBytesPerPartition,
+            @JsonProperty("numPartitions") int numPartitions,
+            @JsonProperty("partitionId") int partitionId,
+            @JsonProperty("rootPath") String rootPath)
+    {
+        this.maxBytesPerPartition = maxBytesPerPartition;
+        this.numPartitions = numPartitions;
+        this.partitionId = partitionId;
+        this.rootPath = requireNonNull(rootPath, "rootPath is null");
+    }
+
+    @JsonProperty
+    public int getMaxBytesPerPartition()
+    {
+        return maxBytesPerPartition;
+    }
+
+    @JsonProperty
+    public int getNumPartitions()
+    {
+        return numPartitions;
+    }
+
+    @JsonProperty
+    public int getPartitionId()
+    {
+        return partitionId;
+    }
+
+    @JsonProperty
+    public String getRootPath()
+    {
+        return rootPath;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("maxBytesPerPartition", maxBytesPerPartition)
+                .add("numPartitions", numPartitions)
+                .add("partitionId", partitionId)
+                .add("rootPath", rootPath)
+                .toString();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleWriteInfo.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleWriteInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkLocalShuffleWriteInfo
+        implements PrestoSparkShuffleWriteInfo
+{
+    private final long maxBytesPerPartition;
+    private final int numPartitions;
+    private final String rootPath;
+
+    @JsonCreator
+    public PrestoSparkLocalShuffleWriteInfo(
+            @JsonProperty("maxBytesPerPartition") long maxBytesPerPartition,
+            @JsonProperty("numPartitions") int numPartitions,
+            @JsonProperty("rootPath") String rootPath)
+    {
+        this.maxBytesPerPartition = maxBytesPerPartition;
+        this.numPartitions = numPartitions;
+        this.rootPath = requireNonNull(rootPath, "rootPath is null");
+    }
+
+    @JsonProperty
+    public long getMaxBytesPerPartition()
+    {
+        return maxBytesPerPartition;
+    }
+
+    @JsonProperty
+    public int getNumPartitions()
+    {
+        return numPartitions;
+    }
+
+    @JsonProperty
+    public String getRootPath()
+    {
+        return rootPath;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("maxBytesPerPartition", maxBytesPerPartition)
+                .add("numPartitions", numPartitions)
+                .add("rootPath", rootPath)
+                .toString();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleInfoSerializer.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleInfoSerializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+public interface PrestoSparkShuffleInfoSerializer
+{
+    byte[] serializeReadInfo(PrestoSparkShuffleReadInfo readInfo);
+
+    byte[] serializeWriteInfo(PrestoSparkShuffleWriteInfo writeInfo);
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleReadInfo.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleReadInfo.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+public interface PrestoSparkShuffleReadInfo
+{
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleWriteInfo.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShuffleWriteInfo.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+public interface PrestoSparkShuffleWriteInfo
+{
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.server.TaskUpdateRequest;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.testing.TestingSession;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.execution.TaskTestUtils.createPlanFragment;
+import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
+import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static org.testng.Assert.assertEquals;
+
+public class TestBatchTaskUpdateRequest
+{
+    private static final JsonCodec<PlanFragment> PLAN_FRAGMENT_JSON_CODEC = JsonCodec.jsonCodec(PlanFragment.class);
+    private static final JsonCodec<BatchTaskUpdateRequest> BATCH_TASK_UPDATE_REQUEST_JSON_CODEC = JsonCodec.jsonCodec(BatchTaskUpdateRequest.class);
+
+    @Test
+    public void testJsonConversion()
+    {
+        List<TaskSource> sources = new ArrayList<>();
+        Session session = TestingSession.testSessionBuilder().build();
+        TaskUpdateRequest updateRequest = new TaskUpdateRequest(
+                session.toSessionRepresentation(),
+                session.getIdentity().getExtraCredentials(),
+                Optional.of(createPlanFragment().toBytes(PLAN_FRAGMENT_JSON_CODEC)),
+                sources,
+                createInitialEmptyOutputBuffers(PARTITIONED),
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+        Map<String, byte[]> shuffleReadInfos = new HashMap<>();
+        shuffleReadInfos.put("dummy-plan-node-id-0", "dummy-shuffle-read-info".getBytes());
+        String shuffleWriteInfo = "dummy-shuffle-write-info";
+        BatchTaskUpdateRequest batchUpdateRequest = new BatchTaskUpdateRequest(updateRequest, Optional.of(shuffleReadInfos), Optional.of(shuffleWriteInfo.getBytes()));
+        byte[] batchUpdateRequestJson = BATCH_TASK_UPDATE_REQUEST_JSON_CODEC.toBytes(batchUpdateRequest);
+        BatchTaskUpdateRequest recoveredBatchUpdateRequest = BATCH_TASK_UPDATE_REQUEST_JSON_CODEC.fromBytes(batchUpdateRequestJson);
+
+        assertEquals(
+                recoveredBatchUpdateRequest
+                        .getShuffleReadInfos()
+                        .get()
+                        .get("dummy-plan-node-id-0"),
+                batchUpdateRequest
+                        .getShuffleReadInfos()
+                        .get()
+                        .get("dummy-plan-node-id-0"));
+        assertEquals(batchUpdateRequest.getShuffleWriteInfo().get(), recoveredBatchUpdateRequest.getShuffleWriteInfo().get());
+        assertEquals(batchUpdateRequest.getTaskUpdateRequest().getExtraCredentials(), recoveredBatchUpdateRequest.getTaskUpdateRequest().getExtraCredentials());
+        assertEquals(batchUpdateRequest.getTaskUpdateRequest().getSession().getCatalog(), recoveredBatchUpdateRequest.getTaskUpdateRequest().getSession().getCatalog());
+    }
+}


### PR DESCRIPTION
Adds following interfaces:

* PrestoSparkShuffleSerializer
* PrestoSparkShuffleReadInfo
* PrestoSparkShuffleWriteInfo

These interfaces are going to be used to pass read/write shuffle information to native execution process, so that shuffle operators get what is needed to do its job at source/sink locations.

```
== NO RELEASE NOTE ==
```
