### PR TITLE
Reuse the buffer during the serialization

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
@@ -49,6 +49,7 @@ public class PagesSerde
     private final boolean checksumEnabled;
 
     private byte[] compressionBuffer;
+    private SliceOutput serializationBuffer;
 
     public PagesSerde(BlockEncodingSerde blockEncodingSerde, Optional<PageCompressor> compressor, Optional<PageDecompressor> decompressor, Optional<SpillCipher> spillCipher)
     {
@@ -68,7 +69,12 @@ public class PagesSerde
 
     public SerializedPage serialize(Page page)
     {
-        SliceOutput serializationBuffer = new DynamicSliceOutput(toIntExact(page.getSizeInBytes() + Integer.BYTES)); // block length is an int
+        if (serializationBuffer == null) {
+            serializationBuffer = new DynamicSliceOutput(toIntExact(page.getSizeInBytes() + Integer.BYTES));
+        }
+        else {
+            serializationBuffer.reset();
+        }
         writeRawPage(page, serializationBuffer, blockEncodingSerde);
 
         return wrapSlice(serializationBuffer.slice(), page.getPositionCount());


### PR DESCRIPTION
The serialize method is creating a DynamicSliceOutput object every time. This PR would reuse the DynamicSliceOutput similar to compressionBuffer. When I did the perf testing, reusing the DynamicSliceOutput object resulted in 6% less objects.



Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
