### PR TITLE
Fix MIN(x, n) and MAX(x, n) returning NULL on window aggregations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -171,6 +171,7 @@ public abstract class AbstractMinMaxNAggregationFunction
         for (int i = reversedBlockBuilder.getPositionCount() - 1; i >= 0; i--) {
             elementType.appendTo(reversedBlockBuilder, i, arrayBlockBuilder);
         }
+        heap.addAll(reversedBlockBuilder);
         out.closeEntry();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestMinMaxNFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestMinMaxNFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.window;
+
+import com.facebook.presto.common.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+
+public class TestMinMaxNFunction
+        extends AbstractTestWindowFunction
+{
+    @Test
+    public void testMaxByGlobalWindow()
+    {
+        assertWindowQuery(
+                "max(orderkey, 3) OVER()",
+                resultBuilder(TEST_SESSION, BIGINT, VarcharType.createVarcharType(1), mapType(BIGINT, VarcharType.createVarcharType(1)))
+                        .row(1, "O", ImmutableList.of(34, 33, 32))
+                        .row(2, "O", ImmutableList.of(34, 33, 32))
+                        .row(3, "F", ImmutableList.of(34, 33, 32))
+                        .row(4, "O", ImmutableList.of(34, 33, 32))
+                        .row(5, "F", ImmutableList.of(34, 33, 32))
+                        .row(6, "F", ImmutableList.of(34, 33, 32))
+                        .row(7, "O", ImmutableList.of(34, 33, 32))
+                        .row(32, "O", ImmutableList.of(34, 33, 32))
+                        .row(33, "F", ImmutableList.of(34, 33, 32))
+                        .row(34, "O", ImmutableList.of(34, 33, 32))
+                        .build());
+    }
+
+    @Test
+    public void testMaxByWithPartition()
+    {
+        assertWindowQuery(
+                "max(orderkey, 3) OVER(PARTITION BY orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VarcharType.createVarcharType(1), mapType(BIGINT, VarcharType.createVarcharType(1)))
+                        .row(1, "O", ImmutableList.of(34, 32, 7))
+                        .row(2, "O", ImmutableList.of(34, 32, 7))
+                        .row(3, "F", ImmutableList.of(33, 6, 5))
+                        .row(4, "O", ImmutableList.of(34, 32, 7))
+                        .row(5, "F", ImmutableList.of(33, 6, 5))
+                        .row(6, "F", ImmutableList.of(33, 6, 5))
+                        .row(7, "O", ImmutableList.of(34, 32, 7))
+                        .row(32, "O", ImmutableList.of(34, 32, 7))
+                        .row(33, "F", ImmutableList.of(33, 6, 5))
+                        .row(34, "O", ImmutableList.of(34, 32, 7))
+                        .build());
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1785,6 +1785,20 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testMinMaxN()
+    {
+        assertQuery("" +
+                "SELECT x FROM (" +
+                "SELECT min(orderkey, 3) t FROM orders" +
+                ") CROSS JOIN UNNEST(t) AS a(x)",
+                "VALUES 1, 2, 3");
+
+        assertQuery(
+                "SELECT orderkey, min(orderkey, 3) over() AS t FROM orders",
+                "SELECT orderkey, ARRAY[cast(1 as bigint), cast(2 as bigint), cast(3 as bigint)] t FROM orders");
+    }
+
+    @Test
     public void testRowNumberFilterAndLimit()
     {
         MaterializedResult actual = computeActual("" +


### PR DESCRIPTION
These functions have an odd behaviour when used on window aggregations. They return NULL for all rows except the first one in the window, because the heap is being cleared by popAll [here](https://github.com/prestodb/presto/blob/b6c7a1e46992e3c703213818eb5256bce9d3498f/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java#L167), so calling output() a second time will return NULL. We add a call to recover the state of the heap after building the output array.

Test plan -
Before
![Screenshot 2022-11-03 at 12 09 02](https://user-images.githubusercontent.com/23248585/199722596-1807e650-6433-416e-865b-fbbeac62f31b.png)

After
![Screenshot 2022-11-03 at 12 09 08](https://user-images.githubusercontent.com/23248585/199722620-ef91906f-c9e3-4dde-8c3c-479f7a51d052.png)

Unit test: `mvn test -Dtest=TestMinMaxNFunction` + non regression `mvn test -Dtest=TestMinMaxByNAggregation`

```
== RELEASE NOTES ==

General Changes
* Fix max(x, n) and min(x, n) returning NULL on window aggregations
```
