### PR TITLE
[native] Add more semi- and anti-join e2e tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveJoinQueries.java
@@ -54,6 +54,11 @@ public class TestHiveJoinQueries
 
         assertQuery(partitionedJoin, "SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
         assertQuery(broadcastJoin, "SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+
+        assertQuery(partitionedJoin, "SELECT * FROM lineitem " +
+                "WHERE linenumber = 3 OR orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+        assertQuery(broadcastJoin, "SELECT linenumber, quantity FROM lineitem " +
+                "WHERE linenumber = 3 OR orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
     }
 
     @Test
@@ -64,6 +69,11 @@ public class TestHiveJoinQueries
 
         assertQuery(partitionedJoin, "SELECT * FROM lineitem WHERE orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
         assertQuery(broadcastJoin, "SELECT * FROM lineitem WHERE orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+
+        assertQuery(partitionedJoin, "SELECT * FROM lineitem " +
+                "WHERE linenumber = 3 OR orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+        assertQuery(broadcastJoin, "SELECT * FROM lineitem " +
+                "WHERE linenumber = 3 OR orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
     }
 
     @Test


### PR DESCRIPTION
Velox added support for semi project joins which enable queries like

```
SELECT * FROM t WHERE a > 5 OR b IN (SELECT x FROM u)
```

```
== NO RELEASE NOTE ==
```
