### PR TITLE
Add native execution related properties to config classes

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -112,6 +112,9 @@ import com.facebook.presto.spark.execution.NativeExecutionTaskFactory;
 import com.facebook.presto.spark.execution.PrestoSparkBroadcastTableCacheManager;
 import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
+import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
+import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
+import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.node.PrestoSparkInternalNodeManager;
 import com.facebook.presto.spark.node.PrestoSparkNodePartitioningManager;
 import com.facebook.presto.spark.node.PrestoSparkQueryManager;
@@ -244,6 +247,9 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
         configBinder(binder).bindConfig(PrestoSparkConfig.class);
         configBinder(binder).bindConfig(TracingConfig.class);
+        configBinder(binder).bindConfig(NativeExecutionSystemConfig.class);
+        configBinder(binder).bindConfig(NativeExecutionNodeConfig.class);
+        configBinder(binder).bindConfig(NativeExecutionConnectorConfig.class);
 
         // json codecs
         jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConnectorConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConnectorConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+
+import java.util.Map;
+
+/**
+ * This config class corresponds to catalog/<catalog-name>.properties for native execution process. Properties inside will be used in PrestoServer.cpp
+ */
+public class NativeExecutionConnectorConfig
+{
+    private static final String CACHE_ENABLED = "cache.enabled";
+    private static final String CACHE_MAX_CACHE_SIZE = "cache.max-cache-size";
+    private static final String CONNECTOR_NAME = "connector.name";
+
+    private boolean cacheEnabled;
+    private DataSize maxCacheSize = new DataSize(0, DataSize.Unit.GIGABYTE);
+    private String connectorName = "hive";
+
+    public Map<String, String> getAllProperties()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        return builder.put(CACHE_ENABLED, String.valueOf(isCacheEnabled()))
+                .put(CACHE_MAX_CACHE_SIZE, String.valueOf(getMaxCacheSize()))
+                .put(CONNECTOR_NAME, getConnectorName())
+                .build();
+    }
+
+    public boolean isCacheEnabled()
+    {
+        return cacheEnabled;
+    }
+
+    @Config(CACHE_ENABLED)
+    public NativeExecutionConnectorConfig setCacheEnabled(boolean cacheEnabled)
+    {
+        this.cacheEnabled = cacheEnabled;
+        return this;
+    }
+
+    public DataSize getMaxCacheSize()
+    {
+        return maxCacheSize;
+    }
+
+    @Config(CACHE_MAX_CACHE_SIZE)
+    public NativeExecutionConnectorConfig setMaxCacheSize(DataSize maxCacheSize)
+    {
+        this.maxCacheSize = maxCacheSize;
+        return this;
+    }
+
+    public String getConnectorName()
+    {
+        return connectorName;
+    }
+
+    @Config(CONNECTOR_NAME)
+    public NativeExecutionConnectorConfig setConnectorName(String connectorName)
+    {
+        this.connectorName = connectorName;
+        return this;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionNodeConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionNodeConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * This config class corresponds to node.properties for native execution process. Properties inside will be used in Configs::NodeConfig in Configs.h/cpp
+ */
+public class NativeExecutionNodeConfig
+{
+    private static final String NODE_ENVIRONMENT = "node.environment";
+    private static final String NODE_ID = "node.id";
+    private static final String NODE_LOCATION = "node.location";
+    private static final String NODE_IP = "node.ip";
+    private static final String NODE_MEMORY_GB = "node.memory_gb";
+
+    private String nodeEnvironment = "spark-velox";
+    private String nodeLocation = "/dummy/location";
+    private String nodeIp = "0.0.0.0";
+    private int nodeId;
+    private int nodeMemoryGb = 10;
+
+    public Map<String, String> getAllProperties()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        return builder.put(NODE_ENVIRONMENT, getNodeEnvironment())
+                .put(NODE_ID, String.valueOf(getNodeId()))
+                .put(NODE_LOCATION, getNodeLocation())
+                .put(NODE_IP, getNodeIp())
+                .put(NODE_MEMORY_GB, String.valueOf(getNodeMemoryGb())).build();
+    }
+
+    public String getNodeEnvironment()
+    {
+        return nodeEnvironment;
+    }
+
+    @Config(NODE_ENVIRONMENT)
+    public NativeExecutionNodeConfig setNodeEnvironment(String nodeEnvironment)
+    {
+        this.nodeEnvironment = nodeEnvironment;
+        return this;
+    }
+
+    public String getNodeLocation()
+    {
+        return nodeLocation;
+    }
+
+    @Config(NODE_LOCATION)
+    public NativeExecutionNodeConfig setNodeLocation(String nodeLocation)
+    {
+        this.nodeLocation = nodeLocation;
+        return this;
+    }
+
+    public String getNodeIp()
+    {
+        return nodeIp;
+    }
+
+    @Config(NODE_IP)
+    public NativeExecutionNodeConfig setNodeIp(String nodeIp)
+    {
+        this.nodeIp = nodeIp;
+        return this;
+    }
+
+    public int getNodeId()
+    {
+        return nodeId;
+    }
+
+    @Config(NODE_ID)
+    public NativeExecutionNodeConfig setNodeId(int nodeId)
+    {
+        this.nodeId = nodeId;
+        return this;
+    }
+
+    public int getNodeMemoryGb()
+    {
+        return nodeMemoryGb;
+    }
+
+    @Config(NODE_MEMORY_GB)
+    public NativeExecutionNodeConfig setNodeMemoryGb(int nodeMemoryGb)
+    {
+        this.nodeMemoryGb = nodeMemoryGb;
+        return this;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * This config class corresponds to config.properties for native execution process. Properties inside will be used in Configs::SystemConfig in Configs.h/cpp
+ */
+public class NativeExecutionSystemConfig
+{
+    private static final String CONCURRENT_LIFESPANS_PER_TASK = "concurrent-lifespans-per-task";
+    private static final String ENABLE_SERIALIZED_PAGE_CHECKSUM = "enable-serialized-page-checksum";
+    private static final String ENABLE_VELOX_EXPRESSION_LOGGING = "enable_velox_expression_logging";
+    private static final String ENABLE_VELOX_TASK_LOGGING = "enable_velox_task_logging";
+    private static final String HTTP_SERVER_HTTP_PORT = "http-server.http.port";
+    private static final String HTTP_EXEC_THREADS = "http_exec_threads";
+    private static final String NUM_IO_THREADS = "num-io-threads";
+    private static final String PRESTO_VERSION = "presto.version";
+    private static final String SHUTDOWN_ONSET_SEC = "shutdown-onset-sec";
+    private static final String SYSTEM_MEMORY_GB = "system-memory-gb";
+    private static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
+    private static final String DISCOVERY_URI = "discovery.uri";
+
+    private boolean enableSerializedPageChecksum = true;
+    private boolean enableVeloxExpressionLogging;
+    private boolean enableVeloxTaskLogging = true;
+    private int httpServerPort = 7777;
+    private int httpExecThreads = 32;
+    private int numIoThreads = 30;
+    private int shutdownOnsetSec = 10;
+    private int systemMemoryGb = 10;
+    private int concurrentLifespansPerTask = 5;
+    private int maxDriversPerTask = 15;
+    private String prestoVersion = "dummy.presto.version";
+    private String discoveryUri = "http://127.0.0.1";
+
+    public Map<String, String> getAllProperties()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        return builder.put(CONCURRENT_LIFESPANS_PER_TASK, String.valueOf(getConcurrentLifespansPerTask()))
+                .put(ENABLE_SERIALIZED_PAGE_CHECKSUM, String.valueOf(isEnableSerializedPageChecksum()))
+                .put(ENABLE_VELOX_EXPRESSION_LOGGING, String.valueOf(isEnableVeloxExpressionLogging()))
+                .put(ENABLE_VELOX_TASK_LOGGING, String.valueOf(isEnableVeloxTaskLogging()))
+                .put(HTTP_SERVER_HTTP_PORT, String.valueOf(getHttpServerPort()))
+                .put(HTTP_EXEC_THREADS, String.valueOf(getHttpExecThreads()))
+                .put(NUM_IO_THREADS, String.valueOf(getNumIoThreads()))
+                .put(PRESTO_VERSION, getPrestoVersion())
+                .put(SHUTDOWN_ONSET_SEC, String.valueOf(getShutdownOnsetSec()))
+                .put(SYSTEM_MEMORY_GB, String.valueOf(getSystemMemoryGb()))
+                .put(TASK_MAX_DRIVERS_PER_TASK, String.valueOf(getMaxDriversPerTask()))
+                .put(DISCOVERY_URI, getDiscoveryUri())
+                .build();
+    }
+
+    @Config(ENABLE_SERIALIZED_PAGE_CHECKSUM)
+    public NativeExecutionSystemConfig setEnableSerializedPageChecksum(boolean enableSerializedPageChecksum)
+    {
+        this.enableSerializedPageChecksum = enableSerializedPageChecksum;
+        return this;
+    }
+
+    public boolean isEnableSerializedPageChecksum()
+    {
+        return enableSerializedPageChecksum;
+    }
+
+    @Config(ENABLE_VELOX_EXPRESSION_LOGGING)
+    public NativeExecutionSystemConfig setEnableVeloxExpressionLogging(boolean enableVeloxExpressionLogging)
+    {
+        this.enableVeloxExpressionLogging = enableVeloxExpressionLogging;
+        return this;
+    }
+
+    public boolean isEnableVeloxExpressionLogging()
+    {
+        return enableVeloxExpressionLogging;
+    }
+
+    @Config(ENABLE_VELOX_TASK_LOGGING)
+    public NativeExecutionSystemConfig setEnableVeloxTaskLogging(boolean enableVeloxTaskLogging)
+    {
+        this.enableVeloxTaskLogging = enableVeloxTaskLogging;
+        return this;
+    }
+
+    public boolean isEnableVeloxTaskLogging()
+    {
+        return enableVeloxTaskLogging;
+    }
+
+    @Config(HTTP_SERVER_HTTP_PORT)
+    public NativeExecutionSystemConfig setHttpServerPort(int httpServerPort)
+    {
+        this.httpServerPort = httpServerPort;
+        return this;
+    }
+
+    public int getHttpServerPort()
+    {
+        return httpServerPort;
+    }
+
+    @Config(HTTP_EXEC_THREADS)
+    public NativeExecutionSystemConfig setHttpExecThreads(int httpExecThreads)
+    {
+        this.httpExecThreads = httpExecThreads;
+        return this;
+    }
+
+    public int getHttpExecThreads()
+    {
+        return httpExecThreads;
+    }
+
+    @Config(NUM_IO_THREADS)
+    public NativeExecutionSystemConfig setNumIoThreads(int numIoThreads)
+    {
+        this.numIoThreads = numIoThreads;
+        return this;
+    }
+
+    public int getNumIoThreads()
+    {
+        return numIoThreads;
+    }
+
+    @Config(SHUTDOWN_ONSET_SEC)
+    public NativeExecutionSystemConfig setShutdownOnsetSec(int shutdownOnsetSec)
+    {
+        this.shutdownOnsetSec = shutdownOnsetSec;
+        return this;
+    }
+
+    public int getShutdownOnsetSec()
+    {
+        return shutdownOnsetSec;
+    }
+
+    @Config(SYSTEM_MEMORY_GB)
+    public NativeExecutionSystemConfig setSystemMemoryGb(int systemMemoryGb)
+    {
+        this.systemMemoryGb = systemMemoryGb;
+        return this;
+    }
+
+    public int getSystemMemoryGb()
+    {
+        return systemMemoryGb;
+    }
+
+    @Config(DISCOVERY_URI)
+    public NativeExecutionSystemConfig setDiscoveryUri(String discoveryUri)
+    {
+        this.discoveryUri = discoveryUri;
+        return this;
+    }
+
+    public String getDiscoveryUri()
+    {
+        return discoveryUri;
+    }
+
+    @Config(CONCURRENT_LIFESPANS_PER_TASK)
+    public NativeExecutionSystemConfig setConcurrentLifespansPerTask(int concurrentLifespansPerTask)
+    {
+        this.concurrentLifespansPerTask = concurrentLifespansPerTask;
+        return this;
+    }
+
+    public int getConcurrentLifespansPerTask()
+    {
+        return concurrentLifespansPerTask;
+    }
+
+    @Config(TASK_MAX_DRIVERS_PER_TASK)
+    public NativeExecutionSystemConfig setMaxDriversPerTask(int maxDriversPerTask)
+    {
+        this.maxDriversPerTask = maxDriversPerTask;
+        return this;
+    }
+
+    public int getMaxDriversPerTask()
+    {
+        return maxDriversPerTask;
+    }
+
+    @Config(PRESTO_VERSION)
+    public NativeExecutionSystemConfig setPrestoVersion(String prestoVersion)
+    {
+        this.prestoVersion = prestoVersion;
+        return this;
+    }
+
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
+    }
+}


### PR DESCRIPTION
Add XXXConfig classes for properties needed to be populated by native execution. This way we can leverage the existing property propagation framework to pass down the properties for the use of NativeExecutionOperator.
Each class corresponds to a property file:

NativeExecutionSystemConfig -> config.properties
NativeExecutionNodeConfig -> node.properties
NativeExecutionConnectorConfig -> catalog/catalog-name.properties

```
== NO RELEASE NOTE ==
```
