### PR TITLE
Add NativeExecutionShuffleManager for presto spark native execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
@@ -20,6 +20,7 @@ import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -211,6 +212,11 @@ public class PlanFragment
     {
         for (PlanNode source : node.getSources()) {
             findRemoteSourceNodes(source, builder);
+        }
+
+        if (node instanceof NativeExecutionNode) {
+            findRemoteSourceNodes(((NativeExecutionNode) node).getSubPlan(), builder);
+            return;
         }
 
         if (node instanceof RemoteSourceNode) {

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -100,7 +100,7 @@
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-client</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
@@ -315,6 +315,7 @@
                                 <exclude>**/TestPrestoSparkWindowQueries.java</exclude>
                                 <exclude>**/TestPrestoSparkSpilledAggregations.java</exclude>
                                 <exclude>**/TestPrestoSparkSpilledJoinQueries.java</exclude>
+                                <exclude>**/TestPrestoSparkNativeExecution.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -14,15 +14,29 @@
 package com.facebook.presto.spark;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.sort.BypassMergeSortShuffleHandle;
 import org.testng.annotations.Test;
 
+import java.util.Map;
+import java.util.Optional;
+
 import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestPrestoSparkNativeExecution
         extends AbstractTestQueryFramework
 {
+    private static final String SPARK_SHUFFLE_MANAGER = "spark.shuffle.manager";
+    private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -41,5 +55,42 @@ public class TestPrestoSparkNativeExecution
 
         // Expecting 0 row updated since currently the NativeExecutionOperator is dummy.
         assertUpdate(session, "CREATE TABLE test_tablescan as SELECT orderkey, custkey FROM orders", 0);
+    }
+
+    @Test(priority = 2, dependsOnMethods = "testNativeExecutionWithTableWrite")
+    public void testNativeExecutionShuffleManager()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .setSystemProperty("table_writer_merge_operator_enabled", "false")
+                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
+                .build();
+
+        PrestoSparkQueryRunner queryRunner = (PrestoSparkQueryRunner) getQueryRunner();
+
+        // Reset the spark context to register the native execution shuffle manager. We want to let the query runner use the default spark shuffle
+        // manager to generate the test tables and only test the new native execution shuffle manager on the test below test cases.
+        queryRunner.resetSparkContext(getNativeExecutionShuffleConfigs());
+        // Expecting 0 row updated since currently the NativeExecutionOperator is dummy.
+        queryRunner.execute(session, "CREATE TABLE test_aggregate as SELECT  partkey, count(*) c FROM lineitem WHERE partkey % 10 = 1 GROUP BY partkey");
+
+        assertNotNull(SparkEnv.get());
+        assertTrue(SparkEnv.get().shuffleManager() instanceof PrestoSparkNativeExecutionShuffleManager);
+        PrestoSparkNativeExecutionShuffleManager shuffleManager = (PrestoSparkNativeExecutionShuffleManager) SparkEnv.get().shuffleManager();
+        Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(0);
+        assertTrue(shuffleHandle.isPresent());
+        assertTrue(shuffleHandle.get() instanceof BypassMergeSortShuffleHandle);
+        BypassMergeSortShuffleHandle<?, ?> bypassMergeSortShuffleHandle = (BypassMergeSortShuffleHandle<?, ?>) shuffleHandle.get();
+        int shuffleId = shuffleHandle.get().shuffleId();
+        assertEquals(0, shuffleId);
+        assertEquals(shuffleManager.getNumOfPartitions(shuffleId), bypassMergeSortShuffleHandle.numMaps());
+    }
+
+    private Map<String, String> getNativeExecutionShuffleConfigs()
+    {
+        ImmutableMap.Builder<String, String> sparkConfigs = ImmutableMap.builder();
+        sparkConfigs.put(SPARK_SHUFFLE_MANAGER, "com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager");
+        sparkConfigs.put(FALLBACK_SPARK_SHUFFLE_MANAGER, "org.apache.spark.shuffle.sort.SortShuffleManager");
+        return sparkConfigs.build();
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeExecutionShuffleManager.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeExecutionShuffleManager.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.TaskContext;
+import org.apache.spark.scheduler.MapStatus;
+import org.apache.spark.scheduler.MapStatus$;
+import org.apache.spark.shuffle.ShuffleBlockResolver;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.ShuffleManager;
+import org.apache.spark.shuffle.ShuffleReader;
+import org.apache.spark.shuffle.ShuffleWriter;
+import org.apache.spark.storage.BlockManager;
+import scala.Option;
+import scala.Product2;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static java.lang.String.format;
+
+/*
+ * {@link PrestoSparkNativeExecutionShuffleManager} is the shuffle manager implementing the Spark shuffle manager interface specifically for native execution. The reasons we have this
+ *  new shuffle manager are:
+ * 1. To bypass calling into Spark java shuffle writer/reader since the actual shuffle read/write will happen in C++ side. In PrestoSparkNativeExecutionShuffleManager, we registered
+ *    a pair of no-op shuffle reader/writer to hook-up with regular Spark shuffle workflow.
+ * 2. To capture the shuffle metadata (eg. {@link ShuffleHandle}) for later use. These metadata are only available during shuffle writer creation internally which is beyond the whole
+ *    Presto-Spark native execution flow. By using the {@link PrestoSparkNativeExecutionShuffleManager}, we capture and store these metadata inside the shuffle manager and provide
+ *    the APIs to allow native execution runtime access.
+ * */
+public class PrestoSparkNativeExecutionShuffleManager
+        implements ShuffleManager
+{
+    private final Map<Integer, ShuffleHandle> shuffleDependencyMap = new ConcurrentHashMap<>();
+    private final Map<Integer, Integer> shuffleNumMaps = new ConcurrentHashMap<>();
+    private final ShuffleManager fallbackShuffleManager;
+    private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
+
+    public PrestoSparkNativeExecutionShuffleManager(SparkConf conf)
+    {
+        fallbackShuffleManager = instantiateClass(conf.get(FALLBACK_SPARK_SHUFFLE_MANAGER), conf);
+    }
+
+    // Create an instance of the class with the given name, possibly initializing it with our conf
+    private static <T> T instantiateClass(String className, SparkConf conf)
+    {
+        try {
+            return (T) (Class.forName(className).getConstructor(SparkConf.class).newInstance(conf));
+        }
+        catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(format("%s class not found", className), e);
+        }
+    }
+
+    @Override
+    public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency)
+    {
+        shuffleNumMaps.put(shuffleId, numMaps);
+        return fallbackShuffleManager.registerShuffle(shuffleId, numMaps, dependency);
+    }
+
+    @Override
+    public <K, V> ShuffleWriter<K, V> getWriter(ShuffleHandle handle, int mapId, TaskContext context)
+    {
+        shuffleDependencyMap.put(mapId, handle);
+        int shuffleId = handle.shuffleId();
+        return new EmptyShuffleWriter<>(getNumOfPartitions(shuffleId));
+    }
+
+    @Override
+    public <K, C> ShuffleReader<K, C> getReader(ShuffleHandle handle, int startPartition, int endPartition, TaskContext context)
+    {
+        return new EmptyShuffleReader<>();
+    }
+
+    @Override
+    public boolean unregisterShuffle(int shuffleId)
+    {
+        fallbackShuffleManager.unregisterShuffle(shuffleId);
+        return true;
+    }
+
+    @Override
+    public ShuffleBlockResolver shuffleBlockResolver()
+    {
+        return fallbackShuffleManager.shuffleBlockResolver();
+    }
+
+    @Override
+    public void stop()
+    {
+        fallbackShuffleManager.stop();
+    }
+
+    /*
+     * This method can only be called inside Rdd's compute method otherwise the shuffleDependencyMap may not contain corresponding ShuffleHandle object.
+     * The reason is that in Spark's ShuffleMapTask, it's guaranteed to call writer.getWriter(handle, mapId, context) first before calling the Rdd.compute()
+     * method, therefore, the ShuffleHandle object will always be added to shuffleDependencyMap in getWriter before Rdd.compute().
+     */
+    public Optional<ShuffleHandle> getShuffleHandle(int partitionId)
+    {
+        return Optional.ofNullable(shuffleDependencyMap.getOrDefault(partitionId, null));
+    }
+
+    public int getNumOfPartitions(int shuffleId)
+    {
+        if (!shuffleNumMaps.containsKey(shuffleId)) {
+            throw new RuntimeException(format("shuffleId=[%s] is not registered", shuffleId));
+        }
+        return shuffleNumMaps.get(shuffleId);
+    }
+
+    static class EmptyShuffleReader<K, V>
+            implements ShuffleReader<K, V>
+    {
+        @Override
+        public Iterator<Product2<K, V>> read()
+        {
+            return emptyScalaIterator();
+        }
+    }
+
+    static class EmptyShuffleWriter<K, V>
+            extends ShuffleWriter<K, V>
+    {
+        private final long[] mapStatus;
+
+        public EmptyShuffleWriter(int totalMapStages)
+        {
+            this.mapStatus = new long[totalMapStages];
+        }
+
+        @Override
+        public void write(Iterator<Product2<K, V>> records)
+                throws IOException
+        {
+            if (records.hasNext()) {
+                throw new RuntimeException("EmptyShuffleWriter can only take empty write input.");
+            }
+        }
+
+        @Override
+        public Option<MapStatus> stop(boolean success)
+        {
+            BlockManager blockManager = SparkEnv.get().blockManager();
+            return Option.apply(MapStatus$.MODULE$.apply(blockManager.blockManagerId(), mapStatus));
+        }
+    }
+}


### PR DESCRIPTION
PrestoSparkNativeExecutionShuffleManager is the shuffle manager implementing the Spark shuffle manager interface specifically for native execution. The reasons we have this new shuffle manager are:
1. To bypass calling into Spark java shuffle writer/reader since the actual shuffle read/write will happen in C++ side. In PrestoSparkNativeExecutionShuffleManager, we registered a pair of no-op shuffle reader/writer to hook-up with regular Spark shuffle workflow.
2. To capture the shuffle metadata (eg. {@link ShuffleHandle}) for later use. These metadata are only available during shuffle writer creation internally which is beyond the whole Presto-Spark native execution flow. By using the {@link PrestoSparkNativeExecutionShuffleManager}, we capture and store these metadata inside the shuffle manager and provide the APIs to allow native execution runtime access.