### PR TITLE
[native] Fix test native failure

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -73,6 +73,12 @@ jobs:
           cd ${GITHUB_WORKSPACE}/presto-native-execution/_build/debug
           ctest -j 1 -VV --output-on-failure --exclude-regex velox.*
 
+      - name: Delete build files
+        run: |
+          cd ${GITHUB_WORKSPACE}/presto-native-execution/_build/debug
+          # Delete static libraries
+          rm `find ./ -name lib\*.a` 
+
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v3


### PR DESCRIPTION
Test native CI run is failing due to "No space left on device".
Cleaning up some of the unnecessary build files will give more space.

```
== NO RELEASE NOTE ==
```

Resolves https://github.com/prestodb/presto/issues/18619