### PR TITLE
Add support for CPP UDF

### DIFF
--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.drift</groupId>
             <artifactId>drift-api</artifactId>
             <scope>provided</scope>
@@ -58,6 +63,11 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -301,6 +301,8 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
             case JAVA:
                 throw new IllegalStateException(
                         format("SqlInvokedFunction %s has BUILTIN implementation type but %s cannot manage BUILTIN functions", function.getSignature().getName(), this.getClass()));
+            case CPP:
+                throw new IllegalStateException(format("Presto coordinator can not resolve implementation of CPP UDF functions"));
             default:
                 throw new IllegalStateException(format("Unknown function implementation type: %s", implementationType));
         }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/FunctionNamespaceManagerPlugin.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/FunctionNamespaceManagerPlugin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.functionNamespace;
 
+import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerFactory;
 import com.facebook.presto.functionNamespace.mysql.MySqlFunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
@@ -24,6 +25,6 @@ public class FunctionNamespaceManagerPlugin
     @Override
     public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
     {
-        return ImmutableList.of(new MySqlFunctionNamespaceManagerFactory());
+        return ImmutableList.of(new MySqlFunctionNamespaceManagerFactory(), new JsonFileBasedFunctionNamespaceManagerFactory());
     }
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/NoopSqlFunctionExecutionModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/NoopSqlFunctionExecutionModule.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.execution;
+
+import com.facebook.presto.spi.function.SqlFunctionExecutor;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+public class NoopSqlFunctionExecutionModule
+        extends SqlFunctionExecutionModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(SqlFunctionExecutor.class).to(NoopSqlFunctionExecutor.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/NoopSqlFunctionExecutorsModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/NoopSqlFunctionExecutorsModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.execution;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.spi.function.FunctionImplementationType;
+import com.facebook.presto.spi.function.RoutineCharacteristics.Language;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.TypeLiteral;
+
+import java.util.Map;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static java.util.Objects.requireNonNull;
+
+public class NoopSqlFunctionExecutorsModule
+        extends AbstractConfigurationAwareModule
+{
+    private final SqlFunctionExecutionModule sqlFunctionExecutorModule;
+
+    public NoopSqlFunctionExecutorsModule()
+    {
+        this(new NoopSqlFunctionExecutionModule());
+    }
+
+    public NoopSqlFunctionExecutorsModule(SqlFunctionExecutionModule sqlFunctionExecutorModule)
+    {
+        this.sqlFunctionExecutorModule = requireNonNull(sqlFunctionExecutorModule, "sqlFunctionExecutorModule is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        SqlInvokedFunctionNamespaceManagerConfig config = buildConfigObject(SqlInvokedFunctionNamespaceManagerConfig.class);
+        ImmutableMap.Builder<Language, FunctionImplementationType> languageImplementationTypeMap = ImmutableMap.builder();
+        ImmutableMap.Builder<String, FunctionImplementationType> supportedLanguages = ImmutableMap.builder();
+        for (String languageName : config.getSupportedFunctionLanguages()) {
+            Language language = new Language(languageName);
+            FunctionImplementationType implementationType = buildConfigObject(SqlFunctionLanguageConfig.class).getFunctionImplementationType();
+            languageImplementationTypeMap.put(language, implementationType);
+            supportedLanguages.put(languageName, implementationType);
+        }
+
+        // for SqlFunctionExecutor
+        sqlFunctionExecutorModule.setSupportedLanguages(supportedLanguages.build());
+        install(sqlFunctionExecutorModule);
+
+        // for SqlFunctionExecutors
+        binder.bind(SqlFunctionExecutors.class).in(SINGLETON);
+        binder.bind(new TypeLiteral<Map<Language, FunctionImplementationType>>() {}).toInstance(languageImplementationTypeMap.build());
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonBasedUdfFunctionMetadata.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonBasedUdfFunctionMetadata.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The function meta data provided by the Json file to the {@link JsonFileBasedFunctionNamespaceManager}.
+ */
+public class JsonBasedUdfFunctionMetadata
+{
+    /**
+     * Description of the function.
+     */
+    private final String docString;
+    /**
+     * Output type of the function.
+     */
+    private final String outputType;
+    /**
+     * Input types of the function
+     */
+    private final List<String> paramTypes;
+    /**
+     * Schema the function belongs to. Catalog.schema.function uniquely identifies a function.
+     */
+    private final String schema;
+    /**
+     * Implement language of the function.
+     */
+    private final RoutineCharacteristics routineCharacteristics;
+
+    @JsonCreator
+    public JsonBasedUdfFunctionMetadata(
+            @JsonProperty("docString") String docString,
+            @JsonProperty("outputType") String outputType,
+            @JsonProperty("paramTypes") List<String> paramTypes,
+            @JsonProperty("schema") String schema,
+            @JsonProperty("routineCharacteristics") RoutineCharacteristics routineCharacteristics)
+    {
+        this.docString = requireNonNull(docString, "docString is null");
+        this.outputType = requireNonNull(outputType, "outputType is null");
+        this.paramTypes = ImmutableList.copyOf(requireNonNull(paramTypes, "paramTypes is null"));
+        this.schema = requireNonNull(schema, "schema is null");
+        this.routineCharacteristics = requireNonNull(routineCharacteristics, "routineCharacteristics is null");
+    }
+
+    public String getDocString()
+    {
+        return docString;
+    }
+
+    public String getOutputType()
+    {
+        return outputType;
+    }
+
+    public List<String> getParamNames()
+    {
+        return IntStream.range(0, paramTypes.size()).boxed().map(idx -> "input" + idx).collect(toImmutableList());
+    }
+
+    public List<String> getParamTypes()
+    {
+        return paramTypes;
+    }
+
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    public RoutineCharacteristics getRoutineCharacteristics()
+    {
+        return routineCharacteristics;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonBasedUdfFunctionSignatureMap.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonBasedUdfFunctionSignatureMap.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonBasedUdfFunctionSignatureMap
+{
+    private final Map<String, List<JsonBasedUdfFunctionMetadata>> udfSignatureMap;
+
+    @JsonCreator
+    public JsonBasedUdfFunctionSignatureMap(
+            @JsonProperty("UDFSignatureMap") Map<String, List<JsonBasedUdfFunctionMetadata>> udfSignatureMap)
+    {
+        this.udfSignatureMap = ImmutableMap.copyOf(requireNonNull(udfSignatureMap, "udfSignatureMap is null"));
+    }
+
+    public boolean isEmpty()
+    {
+        return this.udfSignatureMap.isEmpty();
+    }
+
+    public Map<String, List<JsonBasedUdfFunctionMetadata>> getUDFSignatureMap()
+    {
+        return udfSignatureMap;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.UserDefinedType;
+import com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager;
+import com.facebook.presto.functionNamespace.ServingCatalog;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.plugin.base.JsonUtils.parseJson;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.lang.Long.parseLong;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JsonFileBasedFunctionNamespaceManager
+        extends AbstractSqlInvokedFunctionNamespaceManager
+{
+    private static final Logger log = Logger.get(JsonFileBasedFunctionNamespaceManager.class);
+
+    private final Map<SqlFunctionId, SqlInvokedFunction> latestFunctions = new ConcurrentHashMap<>();
+    private final Map<QualifiedObjectName, UserDefinedType> userDefinedTypes = new ConcurrentHashMap<>();
+    private final JsonFileBasedFunctionNamespaceManagerConfig managerConfig;
+
+    @Inject
+    public JsonFileBasedFunctionNamespaceManager(
+            @ServingCatalog String catalogName,
+            SqlFunctionExecutors sqlFunctionExecutors,
+            SqlInvokedFunctionNamespaceManagerConfig config,
+            JsonFileBasedFunctionNamespaceManagerConfig managerConfig)
+    {
+        super(catalogName, sqlFunctionExecutors, config);
+        this.managerConfig = requireNonNull(managerConfig, "managerConfig is null");
+        bootstrapNamespaceFromFile();
+    }
+
+    private static SqlInvokedFunction copyFunction(SqlInvokedFunction function)
+    {
+        return new SqlInvokedFunction(
+                function.getSignature().getName(),
+                function.getParameters(),
+                function.getSignature().getReturnType(),
+                function.getDescription(),
+                function.getRoutineCharacteristics(),
+                function.getBody(),
+                function.getVersion());
+    }
+
+    private void bootstrapNamespaceFromFile()
+    {
+        try {
+            // We can change how to load the function definition file here, to support other formats of input in addition to json if needed.
+            JsonBasedUdfFunctionSignatureMap jsonBasedUdfFunctionSignatureMap = parseJson(Paths.get(managerConfig.getFunctionDefinitionFile()), JsonBasedUdfFunctionSignatureMap.class);
+            if (jsonBasedUdfFunctionSignatureMap.isEmpty()) {
+                return;
+            }
+            populateNameSpaceManager(jsonBasedUdfFunctionSignatureMap);
+        }
+        catch (Exception e) {
+            log.info("Failed to load function definition for JsonFileBasedFunctionNamespaceManager " + e.getMessage());
+        }
+    }
+
+    private void populateNameSpaceManager(JsonBasedUdfFunctionSignatureMap jsonBasedUdfFunctionSignatureMap)
+    {
+        Map<String, List<JsonBasedUdfFunctionMetadata>> udfSignatureMap = jsonBasedUdfFunctionSignatureMap.getUDFSignatureMap();
+        udfSignatureMap.forEach((name, metaInfoList) -> {
+            List<SqlInvokedFunction> functions = metaInfoList.stream().map(metaInfo -> createSqlInvokedFunction(name, metaInfo)).collect(toImmutableList());
+            functions.forEach(function -> createFunction(function, false));
+        });
+    }
+
+    private SqlInvokedFunction createSqlInvokedFunction(String functionName, JsonBasedUdfFunctionMetadata jsonBasedUdfFunctionMetaData)
+    {
+        checkState(jsonBasedUdfFunctionMetaData.getRoutineCharacteristics().getLanguage().equals(CPP), "JsonFileBasedInMemoryFunctionNameSpaceManager only supports CPP UDF");
+        QualifiedObjectName qualifiedFunctionName = QualifiedObjectName.valueOf(new CatalogSchemaName(getCatalogName(), jsonBasedUdfFunctionMetaData.getSchema()), functionName);
+        List<String> parameterNameList = jsonBasedUdfFunctionMetaData.getParamNames();
+        List<String> parameterTypeList = jsonBasedUdfFunctionMetaData.getParamTypes();
+
+        ImmutableList.Builder<Parameter> parameterBuilder = ImmutableList.builder();
+        for (int i = 0; i < parameterNameList.size(); i++) {
+            parameterBuilder.add(new Parameter(parameterNameList.get(i), parseTypeSignature(parameterTypeList.get(i))));
+        }
+
+        return new SqlInvokedFunction(
+                qualifiedFunctionName,
+                parameterBuilder.build(),
+                parseTypeSignature(jsonBasedUdfFunctionMetaData.getOutputType()),
+                jsonBasedUdfFunctionMetaData.getDocString(),
+                jsonBasedUdfFunctionMetaData.getRoutineCharacteristics(),
+                "",
+                notVersioned());
+    }
+
+    @Override
+    protected Collection<SqlInvokedFunction> fetchFunctionsDirect(QualifiedObjectName functionName)
+    {
+        return latestFunctions.values().stream()
+                .filter(function -> function.getSignature().getName().equals(functionName))
+                .map(JsonFileBasedFunctionNamespaceManager::copyFunction)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    protected UserDefinedType fetchUserDefinedTypeDirect(QualifiedObjectName typeName)
+    {
+        return userDefinedTypes.get(typeName);
+    }
+
+    @Override
+    protected FunctionMetadata fetchFunctionMetadataDirect(SqlFunctionHandle functionHandle)
+    {
+        return fetchFunctionsDirect(functionHandle.getFunctionId().getFunctionName()).stream()
+                .filter(function -> function.getRequiredFunctionHandle().equals(functionHandle))
+                .map(this::sqlInvokedFunctionToMetadata)
+                .collect(onlyElement());
+    }
+
+    @Override
+    protected ScalarFunctionImplementation fetchFunctionImplementationDirect(SqlFunctionHandle functionHandle)
+    {
+        return fetchFunctionsDirect(functionHandle.getFunctionId().getFunctionName()).stream()
+                .filter(function -> function.getRequiredFunctionHandle().equals(functionHandle))
+                .map(this::sqlInvokedFunctionToImplementation)
+                .collect(onlyElement());
+    }
+
+    @Override
+    public void createFunction(SqlInvokedFunction function, boolean replace)
+    {
+        checkFunctionLanguageSupported(function);
+        SqlFunctionId functionId = function.getFunctionId();
+        if (!replace && latestFunctions.containsKey(function.getFunctionId())) {
+            throw new PrestoException(GENERIC_USER_ERROR, format("Function '%s' already exists", functionId.getId()));
+        }
+
+        SqlInvokedFunction replacedFunction = latestFunctions.get(functionId);
+        long version = 1;
+        if (replacedFunction != null) {
+            version = parseLong(replacedFunction.getRequiredVersion()) + 1;
+        }
+        latestFunctions.put(functionId, function.withVersion(String.valueOf(version)));
+    }
+
+    @Override
+    public void alterFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "Drop Function is not supported in JsonFileBasedInMemoryFunctionNameSpaceManager");
+    }
+
+    @Override
+    public void dropFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, boolean exists)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "Drop Function is not supported in JsonFileBasedInMemoryFunctionNameSpaceManager");
+    }
+
+    @Override
+    public Collection<SqlInvokedFunction> listFunctions(Optional<String> likePattern, Optional<String> escape)
+    {
+        return latestFunctions.values();
+    }
+
+    @Override
+    public void addUserDefinedType(UserDefinedType userDefinedType)
+    {
+        QualifiedObjectName name = userDefinedType.getUserDefinedTypeName();
+        checkArgument(
+                !userDefinedTypes.containsKey(name),
+                "Parametric type %s already registered",
+                name);
+        userDefinedTypes.put(name, userDefinedType);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class JsonFileBasedFunctionNamespaceManagerConfig
+{
+    private String functionDefinitionFile = "";
+
+    @NotNull
+    public String getFunctionDefinitionFile()
+    {
+        return functionDefinitionFile;
+    }
+
+    @Config("json-based-function-manager.path-to-function-definition")
+    @ConfigDescription("Path to the Json file which the namespace manager load function data from")
+    public JsonFileBasedFunctionNamespaceManagerConfig setFunctionDefinitionFile(String functionDefinitionFile)
+    {
+        this.functionDefinitionFile = functionDefinitionFile;
+        return this;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.functionNamespace.FunctionNamespaceManagerPlugin;
+import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutorsModule;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerContext;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+/**
+ * Factory class to create instance of {@link JsonFileBasedFunctionNamespaceManager}.
+ * This factor is registered in {@link FunctionNamespaceManagerPlugin#getFunctionNamespaceManagerFactories()}.
+ */
+public class JsonFileBasedFunctionNamespaceManagerFactory
+        implements FunctionNamespaceManagerFactory
+{
+    public static final String NAME = "json_file";
+
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public FunctionHandleResolver getHandleResolver()
+    {
+        return HANDLE_RESOLVER;
+    }
+
+    @Override
+    public FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config, FunctionNamespaceManagerContext context)
+    {
+        try {
+            Bootstrap app = new Bootstrap(
+                    new JsonFileBasedFunctionNamespaceManagerModule(catalogName),
+                    new NoopSqlFunctionExecutorsModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+            return injector.getInstance(JsonFileBasedFunctionNamespaceManager.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerModule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.json;
+
+import com.facebook.presto.functionNamespace.ServingCatalog;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.functionNamespace.execution.SqlFunctionLanguageConfig;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+import static java.util.Objects.requireNonNull;
+
+public class JsonFileBasedFunctionNamespaceManagerModule
+        implements Module
+{
+    private final String catalogName;
+
+    public JsonFileBasedFunctionNamespaceManagerModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(new TypeLiteral<String>() {}).annotatedWith(ServingCatalog.class).toInstance(catalogName);
+
+        configBinder(binder).bindConfig(JsonFileBasedFunctionNamespaceManagerConfig.class);
+        configBinder(binder).bindConfig(SqlInvokedFunctionNamespaceManagerConfig.class);
+        configBinder(binder).bindConfig(SqlFunctionLanguageConfig.class);
+        binder.bind(JsonFileBasedFunctionNamespaceManager.class).in(SINGLETON);
+    }
+}

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutorsModule;
+import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManager;
+import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerModule;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.TEST_CATALOG;
+import static org.testng.Assert.assertEquals;
+
+public class TestJsonFileBasedFunctionNamespaceManager
+{
+    @Test
+    public void testLoadFunctions()
+    {
+        JsonFileBasedFunctionNamespaceManager jsonFileBasedFunctionNameSpaceManager = createFunctionNamespaceManager();
+        Collection<SqlInvokedFunction> functionList = jsonFileBasedFunctionNameSpaceManager.listFunctions(Optional.empty(), Optional.empty());
+        assertEquals(functionList.size(), 7);
+    }
+
+    private JsonFileBasedFunctionNamespaceManager createFunctionNamespaceManager()
+    {
+        Bootstrap app = new Bootstrap(
+                new JsonFileBasedFunctionNamespaceManagerModule(TEST_CATALOG),
+                new NoopSqlFunctionExecutorsModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(ImmutableMap.of("json-based-function-manager.path-to-function-definition", getPath("json_udf_function_definition.json"), "supported-function-languages", "CPP"))
+                .initialize();
+        return injector.getInstance(JsonFileBasedFunctionNamespaceManager.class);
+    }
+
+    private String getPath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+}

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/execution/TestSqlFunctionLanguageConfig.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/execution/TestSqlFunctionLanguageConfig.java
@@ -42,4 +42,16 @@ public class TestSqlFunctionLanguageConfig
 
         assertFullMapping(properties, expected);
     }
+
+    @Test
+    public void testCPPType()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("function-implementation-type", "CPP")
+                .build();
+        SqlFunctionLanguageConfig expected = new SqlFunctionLanguageConfig()
+                .setFunctionImplementationType("CPP");
+
+        assertFullMapping(properties, expected);
+    }
 }

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
@@ -1,0 +1,109 @@
+{
+"UDFSignatureMap": {
+"add_ARRAY_element_wise":[
+         {
+            "docString":"function to add two string vectors element-wise",
+            "outputType": "ARRAY<ARRAY<BOOLEAN>>",
+            "paramTypes":[
+                 "ARRAY<ARRAY<BOOLEAN>>",
+                 "ARRAY<ARRAY<BOOLEAN>>"
+            ],
+           "schema":"f3",
+           "routineCharacteristics": {
+             "language":"CPP",
+             "determinism":"DETERMINISTIC",
+             "nullCallClause":"CALLED_ON_NULL_INPUT"
+           }
+         },
+         {
+            "docString":"function to add two float vectors element-wise",
+            "outputType": "ARRAY<ARRAY<BIGINT>>",
+            "paramTypes":[
+                "ARRAY<ARRAY<BIGINT>>",
+                 "ARRAY<ARRAY<BIGINT>>"
+            ],
+           "schema":"f3",
+           "routineCharacteristics": {
+             "language":"CPP",
+             "determinism":"DETERMINISTIC",
+             "nullCallClause":"CALLED_ON_NULL_INPUT"
+           }
+         },
+         {
+            "docString":"function to add two int64_t vectors element-wise",
+            "outputType": "ARRAY<DOUBLE>",
+            "paramTypes":[
+                 "ARRAY<DOUBLE>",
+                 "ARRAY<DOUBLE>"
+            ],
+           "schema":"f3",
+           "routineCharacteristics": {
+             "language":"CPP",
+             "determinism":"DETERMINISTIC",
+             "nullCallClause":"CALLED_ON_NULL_INPUT"
+           }
+         }
+      ],
+ "ads_product_types_transform":[
+         {
+            "docString":"gff ads product types transform",
+            "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+            "paramTypes":[
+                 "ARRAY<map<BIGINT, DOUBLE>>",
+                 "ARRAY<varchar>"
+            ],
+           "schema":"f3",
+           "routineCharacteristics": {
+             "language":"CPP",
+             "determinism":"DETERMINISTIC",
+             "nullCallClause":"CALLED_ON_NULL_INPUT"
+           }
+         },
+         {
+            "docString":"gff ads product types transform",
+            "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+            "paramTypes":[
+                 "ARRAY<map<BIGINT, DOUBLE>>",
+                 "ARRAY<ARRAY<BOOLEAN>>",
+                 "ARRAY<varchar>"
+            ],
+           "schema":"f3",
+           "routineCharacteristics": {
+             "language":"CPP",
+             "determinism":"DETERMINISTIC",
+             "nullCallClause":"CALLED_ON_NULL_INPUT"
+           }
+         }
+      ],
+  "square": [
+    {
+      "docString":"square an integer",
+      "outputType": "int",
+      "paramTypes":[
+        "int"
+      ],
+      "schema":"f3",
+      "routineCharacteristics": {
+        "language":"CPP",
+        "determinism":"DETERMINISTIC",
+        "nullCallClause":"CALLED_ON_NULL_INPUT"
+      }
+    },
+    {
+      "docString":"square a double",
+      "outputType": "double",
+      "paramTypes":[
+        "double"
+      ],
+      "schema":"f3",
+      "routineCharacteristics": {
+        "language":"CPP",
+        "determinism":"DETERMINISTIC",
+        "nullCallClause":"CALLED_ON_NULL_INPUT"
+      }
+    }
+  ]
+ }
+}
+
+

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -94,7 +94,7 @@ public final class ExpressionTreeUtils
 
     private static Predicate<FunctionCall> isExternalFunctionPredicate(Map<NodeRef<FunctionCall>, FunctionHandle> functionHandles, FunctionAndTypeManager functionAndTypeManager)
     {
-        return functionCall -> functionAndTypeManager.getFunctionMetadata(functionHandles.get(NodeRef.of(functionCall))).getImplementationType().isExternal();
+        return functionCall -> functionAndTypeManager.getFunctionMetadata(functionHandles.get(NodeRef.of(functionCall))).getImplementationType().isExternalExecution();
     }
 
     private static <T extends Expression> List<T> extractExpressions(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -943,8 +943,8 @@ public class ExpressionInterpreter
             Object result;
 
             FunctionImplementationType implementationType = functionMetadata.getImplementationType();
-            if (implementationType.isExternal()) {
-                // do not interpret remote functions on coordinator
+            if (!implementationType.canBeEvaluatedInCoordinator()) {
+                // do not interpret remote functions or cpp UDF on coordinator
                 return new FunctionCall(node.getName(), node.getWindow(), node.isDistinct(), node.isIgnoreNulls(), toExpressions(argumentValues, argumentTypes));
             }
             else if (implementationType.equals(JAVA)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -268,8 +268,8 @@ public class RowExpressionInterpreter
 
             Object value;
             FunctionImplementationType implementationType = functionMetadata.getImplementationType();
-            if (implementationType.isExternal()) {
-                // do not interpret remote functions on coordinator
+            if (!implementationType.canBeEvaluatedInCoordinator()) {
+                // do not interpret remote functions or cpp UDF on coordinator
                 return call(node.getDisplayName(), functionHandle, node.getType(), toRowExpressions(argumentValues, node.getArguments()));
             }
             else if (implementationType.equals(JAVA)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
@@ -247,7 +247,7 @@ public class PlanRemoteProjections
         public List<ProjectionContext> visitCall(CallExpression call, Void context)
         {
             FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle());
-            boolean local = !functionMetadata.getImplementationType().isExternal();
+            boolean local = !functionMetadata.getImplementationType().isExternalExecution();
 
             // Break function arguments into local and remote projections first
             ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
@@ -39,7 +39,7 @@ public class ExternalCallExpressionChecker
     public Boolean visitCall(CallExpression call, Void context)
     {
         FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle());
-        if (functionMetadata.getImplementationType().isExternal()) {
+        if (functionMetadata.getImplementationType().isExternalExecution()) {
             return true;
         }
         return call.getArguments().stream().anyMatch(argument -> argument.accept(this, null));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionImplementationType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionImplementationType.java
@@ -15,20 +15,28 @@ package com.facebook.presto.spi.function;
 
 public enum FunctionImplementationType
 {
-    JAVA(false),
-    SQL(false),
-    THRIFT(true),
-    GRPC(true);
+    JAVA(false, true),
+    SQL(false, true),
+    THRIFT(true, false),
+    GRPC(true, false),
+    CPP(false, false);
 
-    private final boolean external;
+    private final boolean externalExecution;
+    private final boolean evaluatedInCoordinator;
 
-    FunctionImplementationType(boolean external)
+    FunctionImplementationType(boolean externalExecution, boolean evaluatedInCoordinator)
     {
-        this.external = external;
+        this.externalExecution = externalExecution;
+        this.evaluatedInCoordinator = evaluatedInCoordinator;
     }
 
-    public boolean isExternal()
+    public boolean isExternalExecution()
     {
-        return external;
+        return externalExecution;
+    }
+
+    public boolean canBeEvaluatedInCoordinator()
+    {
+        return evaluatedInCoordinator;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
@@ -32,6 +32,7 @@ public class RoutineCharacteristics
     public static class Language
     {
         public static final Language SQL = new Language("SQL");
+        public static final Language CPP = new Language("CPP");
 
         private final String language;
 


### PR DESCRIPTION
### What's the change?

Replaces #18385  Co-authored-by: Sourav Pal <souravpal@users.noreply.github.com>

There are two changes:
* Add CPP UDF type

Currently Presto has built-in and non built-in UDFs. For non built-in UDFs, it has three types, SQL, thrift and grpc. For SQL UDF, it will be evaluated in coordinator, and sent to local worker for execution. For thrift and grpc UDFs, they will not be evaluated in coordinator and will be sent to remote servers instead of local workers for evaluation.

In this PR, I add one new UDF type, CPP. This UDF is only used when the local worker is CPP worker instead of JAVA worker. This UDF will not
be evaluated in coordinator, and will be sent to local cpp worker for evaluation.

* Add Json file based function namespace manager

Add a function namespace manager which loads function definitions from json file. Currently this function namespace manager only supports the CPP type UDF. 

### What's the test?

Add a few unit test.

This PR only deals with the UDF load and registration part. 

```
== NO RELEASE NOTE ==
```
