### PR TITLE
User builder for ParquetReader

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -595,4 +595,109 @@ public class ParquetReader
         }
         return pageRanges;
     }
+
+    public static Builder builder(
+            MessageColumnIO messageColumnIO,
+            List<BlockMetaData> block,
+            ParquetDataSource dataSource,
+            AggregatedMemoryContext systemMemoryContext)
+    {
+        return new Builder(messageColumnIO, block, dataSource, systemMemoryContext);
+    }
+    public static class Builder
+    {
+        private final MessageColumnIO messageColumnIO;
+        private final List<BlockMetaData> blocks;
+        protected final ParquetDataSource dataSource;
+        private final AggregatedMemoryContext systemMemoryContext;
+        private Optional<List<Long>> firstRowsOfBlocks = Optional.empty();
+        private DataSize maxReadBlockSize;
+        private boolean batchReadEnabled;
+        private boolean enableVerification;
+        private Predicate parquetPredicate;
+        private List<ColumnIndexStore> blockIndexStores;
+        private boolean columnIndexFilterEnabled;
+        private Optional<InternalFileDecryptor> fileDecryptor = Optional.empty();
+
+        private Builder(
+                MessageColumnIO messageColumnIO,
+                List<BlockMetaData> block,
+                ParquetDataSource dataSource,
+                AggregatedMemoryContext systemMemoryContext)
+        {
+            this.messageColumnIO = messageColumnIO;
+            this.blocks = block;
+            this.dataSource = dataSource;
+            this.systemMemoryContext = systemMemoryContext;
+        }
+
+        public Builder withFirstRowOfBlocks(Optional<List<Long>> firstRowsOfBlocks)
+        {
+            this.firstRowsOfBlocks = firstRowsOfBlocks;
+            return this;
+        }
+
+        public Builder withMaxReadBlockSize(DataSize maxReadBlockSize)
+        {
+            this.maxReadBlockSize = maxReadBlockSize;
+            return this;
+        }
+
+        public Builder withBatchReadEnabled(boolean batchReadEnabled)
+        {
+            this.batchReadEnabled = batchReadEnabled;
+            return this;
+        }
+
+        public Builder withEnableVerification(boolean enableVerification)
+        {
+            this.enableVerification = enableVerification;
+            return this;
+        }
+
+        public Builder withPredicate(Predicate parquetPredicate)
+        {
+            this.parquetPredicate = parquetPredicate;
+            return this;
+        }
+
+        public Builder withBlockIndexStores(List<ColumnIndexStore> blockIndexStores)
+        {
+            this.blockIndexStores = blockIndexStores;
+            return this;
+        }
+
+        public Builder withColumnIndexEnabled(boolean columnIndexFilterEnabled)
+        {
+            this.columnIndexFilterEnabled = columnIndexFilterEnabled;
+            return this;
+        }
+
+        public Builder withFileDecryptor(Optional<InternalFileDecryptor> fileDecryptor)
+        {
+            this.fileDecryptor = fileDecryptor;
+            return this;
+        }
+
+        public ParquetReader build()
+        {
+            requireNonNull(maxReadBlockSize, "maxReadBlockSize is null, please call withMaxReadBlockSize()");
+            requireNonNull(parquetPredicate, "parquetPredicate is null, please call withPredicate()");
+            requireNonNull(blockIndexStores, "blockIndexStores is null, please call withBlockIndexStores()");
+
+            return new ParquetReader(
+                    this.messageColumnIO,
+                    this.blocks,
+                    this.firstRowsOfBlocks,
+                    this.dataSource,
+                    this.systemMemoryContext,
+                    this.maxReadBlockSize,
+                    this.batchReadEnabled,
+                    this.enableVerification,
+                    this.parquetPredicate,
+                    this.blockIndexStores,
+                    this.columnIndexFilterEnabled,
+                    this.fileDecryptor);
+        }
+    }
 }


### PR DESCRIPTION
ParquetReader() method has a long list of parameters. It is cumbersome to use it as it needs to remember the parameters and orders. This is a perfect candidate to use Java builder to make it easier.  

```
== NO RELEASE NOTE ==
```
