### PR TITLE
Implement fragmented execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -99,7 +99,7 @@ import static com.facebook.presto.execution.buffer.OutputBuffers.createDiscardin
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.execution.scheduler.StreamingPlanSection.extractStreamingSections;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.facebook.presto.sql.planner.PlanFragmenterUtils.ROOT_FRAGMENT_ID;
+import static com.facebook.presto.sql.planner.PlanFragmenterUtils.isRootFragment;
 import static com.facebook.presto.sql.planner.SchedulingOrderVisitor.scheduleOrder;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.jsonFragmentPlan;
 import static com.google.common.base.Preconditions.checkState;
@@ -728,11 +728,6 @@ public class SqlQueryScheduler
             });
             stageExecution.addFinalStageInfoListener(status -> queryStateMachine.updateQueryInfo(Optional.of(getStageInfo())));
         }
-    }
-
-    private static boolean isRootFragment(PlanFragment fragment)
-    {
-        return fragment.getId().getId() == ROOT_FRAGMENT_ID;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -272,4 +272,9 @@ public class PlanFragmenterUtils
                     node.getEnforcedConstraint());
         }
     }
+
+    public static boolean isRootFragment(PlanFragment fragment)
+    {
+        return fragment.getId().getId() == ROOT_FRAGMENT_ID;
+    }
 }

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -162,6 +162,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.pcollections</groupId>
+            <artifactId>pcollections</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/FragmentExecutionResult.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/FragmentExecutionResult.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spark.PrestoSparkServiceWaitTimeMetrics;
+import com.facebook.presto.spark.RddAndMore;
+import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
+import org.apache.spark.MapOutputStatistics;
+import org.apache.spark.SimpleFutureAction;
+import org.apache.spark.SparkException;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/*
+    Represents result of a fragment/sub-plan's execution.
+    It contains RDD, execution stats and methods to extract result.
+
+ */
+public class FragmentExecutionResult<T extends PrestoSparkTaskOutput>
+{
+    private final RddAndMore<T> rddAndMore;
+    private final Optional<SimpleFutureAction<MapOutputStatistics>> mapOutputStatisticsFutureAction;
+
+    public FragmentExecutionResult(RddAndMore<T> rddAndMore, Optional<SimpleFutureAction<MapOutputStatistics>> mapOutputStatisticsFutureAction)
+    {
+        this.rddAndMore = rddAndMore;
+        this.mapOutputStatisticsFutureAction = mapOutputStatisticsFutureAction;
+    }
+
+    public List<Tuple2<MutablePartitionId, T>> collectResult(long timeout, TimeUnit timeUnit, Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
+            throws SparkException, TimeoutException
+    {
+        return this.rddAndMore.collectAndDestroyDependenciesWithTimeout(timeout, timeUnit, waitTimeMetrics);
+    }
+
+    public RddAndMore<T> getRddAndMore()
+    {
+        return rddAndMore;
+    }
+
+    public Optional<SimpleFutureAction<MapOutputStatistics>> getMapOutputStatisticsFutureAction()
+    {
+        return mapOutputStatisticsFutureAction;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
@@ -238,7 +239,8 @@ public class PrestoSparkStaticQueryExecution
         return rootRdd.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics);
     }
 
-    private SubPlan createFragmentedPlan()
+    @VisibleForTesting
+    public SubPlan createFragmentedPlan()
     {
         SubPlan rootFragmentedPlan = planFragmenter.fragmentQueryPlan(session, planAndMore.getPlan(), warningCollector);
         queryMonitor.queryUpdatedEvent(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskRdd;
+import com.facebook.presto.spark.execution.FragmentExecutionResult;
+import com.facebook.presto.spark.execution.PrestoSparkStaticQueryExecution;
+import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.apache.spark.Dependency;
+import org.apache.spark.MapOutputStatistics;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.rdd.ShuffledRDD;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.STORAGE_BASED_BROADCAST_JOIN_ENABLED;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+
+public class TestPrestoSparkQueryExecution
+        extends AbstractTestQueryFramework
+{
+    PrestoSparkQueryRunner prestoSparkQueryRunner;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        prestoSparkQueryRunner = PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner();
+        return prestoSparkQueryRunner;
+    }
+
+    private IPrestoSparkQueryExecution getPrestoSparkQueryExecution(Session session, String sql)
+    {
+        return prestoSparkQueryRunner.createPrestoSparkQueryExecution(session, sql, Optional.empty());
+    }
+
+    @Test
+    public void testRddCreationForPartitionedJoinWithoutShuffle()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .build();
+        String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey";
+        validateFragmentedRddCreation(session, sql);
+    }
+
+    @Test
+    public void testRddCreationForPartitionedJoinWithShuffle()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .build();
+        String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey UNION ALL select * from lineitem l join orders o on l.orderkey = o.orderkey";
+        validateFragmentedRddCreation(session, sql);
+    }
+
+    @Test
+    public void testRddCreationForMemoryBasedBroadcastJoin()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "broadcast")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "false")
+                .build();
+        String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey";
+        validateFragmentedRddCreation(session, sql);
+    }
+
+    @Test
+    public void testRddCreationForStorageBasedBroadcastJoin()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "broadcast")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "true")
+                .build();
+        String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey";
+        validateFragmentedRddCreation(session, sql);
+    }
+
+    @Test
+    public void testMapOutputStatsExtraction()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "broadcast")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .build();
+        String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey";
+        PrestoSparkStaticQueryExecution execution = (PrestoSparkStaticQueryExecution) getPrestoSparkQueryExecution(session, sql);
+        Optional<PlanNodeStatsEstimate> planNodeStatsEstimate;
+
+        // Empty stats case
+        planNodeStatsEstimate = execution.createRuntimeStats(Optional.empty());
+        assertFalse(planNodeStatsEstimate.isPresent());
+
+        // Empty partition array
+        planNodeStatsEstimate = execution.createRuntimeStats(Optional.of(new MapOutputStatistics(0, new long[] {})));
+        assertEquals(planNodeStatsEstimate.get().getOutputSizeInBytes(), 0);
+
+        // One partition case
+        planNodeStatsEstimate = execution.createRuntimeStats(Optional.of(new MapOutputStatistics(0, new long[] {23})));
+        assertEquals(planNodeStatsEstimate.get().getOutputSizeInBytes(), 23);
+
+        // Multiple partition case
+        planNodeStatsEstimate = execution.createRuntimeStats(Optional.of(new MapOutputStatistics(0, new long[] {23, 520, 190})));
+        assertEquals(planNodeStatsEstimate.get().getOutputSizeInBytes(), 733);
+    }
+
+    private void validateFragmentedRddCreation(Session session, String sql)
+    {
+        PrestoSparkStaticQueryExecution execution = (PrestoSparkStaticQueryExecution) getPrestoSparkQueryExecution(session, sql);
+        RddAndMore rddAndMoreStatic = null;
+        RddAndMore rddAndMoreFromFragmentedExecution = null;
+        try {
+            SubPlan rootFragmentedPlan = execution.createFragmentedPlan();
+            TableWriteInfo tableWriteInfo = execution.getTableWriteInfo(session, rootFragmentedPlan);
+            rddAndMoreStatic = execution.createRdd(rootFragmentedPlan, PrestoSparkSerializedPage.class, tableWriteInfo);
+            FragmentExecutionResult fragmentExecutionResult = executeInStages(execution, rootFragmentedPlan, tableWriteInfo);
+            rddAndMoreFromFragmentedExecution = fragmentExecutionResult.getRddAndMore();
+        }
+        catch (Exception e) {
+            fail("Failed while creating RDD", e);
+        }
+
+        assertRddAndMoreEquals(rddAndMoreStatic, rddAndMoreFromFragmentedExecution);
+    }
+
+    // For testing purpose, execute plan by executing sub-plans starting at(in the same order) :
+    // 1. Level 2
+    // 2. Level 1
+    // 3. level 0
+    // For plans with more than 3 levels, it will execute child lvels in same step
+    // todo - this can be updated in future with methods in Adaptive execution to get subplans at shuffle boundaries
+    private FragmentExecutionResult executeInStages(PrestoSparkStaticQueryExecution execution,
+            SubPlan rootFragmentedPlan,
+            TableWriteInfo tableWriteInfo)
+    {
+        // Level 2
+        rootFragmentedPlan.getChildren().stream()
+                .map(SubPlan::getChildren)
+                .flatMap(Collection::stream)
+                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo));
+
+        // Level 1
+        rootFragmentedPlan.getChildren().stream()
+                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo));
+
+        // Level 0 - Root
+        return excecuteSubPlanWithUncheckedException(execution, rootFragmentedPlan, tableWriteInfo);
+    }
+
+    // This exists as forEach can't handle methods with checked exception
+    private FragmentExecutionResult excecuteSubPlanWithUncheckedException(PrestoSparkStaticQueryExecution execution,
+            SubPlan subPlan,
+            TableWriteInfo tableWriteInfo)
+    {
+        try {
+            return execution.executeFragment(subPlan, tableWriteInfo);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertRddAndMoreEquals(RddAndMore rddAndMore1, RddAndMore rddAndMore2)
+    {
+        assertEquals(rddAndMore1.getBroadcastDependencies().size(), rddAndMore2.getBroadcastDependencies().size());
+        assertRddEquals(rddAndMore1.getRdd().rdd(), rddAndMore2.getRdd().rdd());
+    }
+
+    private void assertRddEquals(RDD rdd1, RDD rdd2)
+    {
+        assertEquals(rdd1.name(), rdd2.name());
+        assertEquals(rdd1.getClass(), rdd2.getClass());
+        assertEquals(rdd1.getDependencies().size(), rdd2.getDependencies().size());
+        assertEquals(rdd1.getNumPartitions(), rdd2.getNumPartitions());
+
+        // type specific assertions
+        if (rdd1 instanceof PrestoSparkTaskRdd) {
+            assertPrestoSparkTaskRddEquals((PrestoSparkTaskRdd) rdd1, (PrestoSparkTaskRdd) rdd2);
+        }
+        else if (rdd1 instanceof ShuffledRDD) {
+            assertShuffledRddEquals((ShuffledRDD) rdd1, (ShuffledRDD) rdd2);
+        }
+    }
+
+    private void assertShuffledRddEquals(ShuffledRDD shuffledRDD1, ShuffledRDD shuffledRDD2)
+    {
+        assertEquals(shuffledRDD1.getNumPartitions(), shuffledRDD2.getNumPartitions());
+        assertRddEquals(shuffledRDD1.prev(), shuffledRDD2.prev());
+        for (int i = 0; i < shuffledRDD1.getDependencies().size(); i++) {
+            assertRddEquals(
+                    ((Dependency) shuffledRDD1.getDependencies().apply(i)).rdd(),
+                    ((Dependency) shuffledRDD2.getDependencies().apply(i)).rdd());
+        }
+    }
+
+    private void assertPrestoSparkTaskRddEquals(PrestoSparkTaskRdd prestoSparkTaskRdd1, PrestoSparkTaskRdd prestoSparkTaskRdd2)
+    {
+        assertEquals(
+                prestoSparkTaskRdd1.getShuffleInputRdds().size(),
+                prestoSparkTaskRdd2.getShuffleInputRdds().size(),
+                "Expected same number of shuffle inputs");
+
+        assertEquals(
+                prestoSparkTaskRdd1.getShuffleInputFragmentIds().stream().collect(Collectors.toSet()),
+                prestoSparkTaskRdd2.getShuffleInputFragmentIds().stream().collect(Collectors.toSet()),
+                "Expected same input fragment ids");
+
+        assertEquals(
+                prestoSparkTaskRdd1.getTaskSourceRdd() == null,
+                prestoSparkTaskRdd2.getTaskSourceRdd() == null,
+                "Expected both RDDs to either contain TaskSourceRdd or not contain it");
+
+        for (int i = 0; i < prestoSparkTaskRdd1.getShuffleInputRdds().size(); i++) {
+            assertRddEquals((RDD) prestoSparkTaskRdd1.getShuffleInputRdds().get(i), (RDD) prestoSparkTaskRdd2.getShuffleInputRdds().get(i));
+        }
+
+        for (int i = 0; i < prestoSparkTaskRdd1.getDependencies().size(); i++) {
+            assertRddEquals(
+                    ((Dependency) prestoSparkTaskRdd1.getDependencies().apply(i)).rdd(),
+                    ((Dependency) prestoSparkTaskRdd2.getDependencies().apply(i)).rdd());
+        }
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
@@ -145,4 +145,19 @@ public class PrestoSparkTaskRdd<T extends PrestoSparkTaskOutput>
         taskSourceRdd = null;
         taskProcessor = null;
     }
+
+    public List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> getShuffleInputRdds()
+    {
+        return shuffleInputRdds;
+    }
+
+    public PrestoSparkTaskSourceRdd getTaskSourceRdd()
+    {
+        return taskSourceRdd;
+    }
+
+    public List<String> getShuffleInputFragmentIds()
+    {
+        return shuffleInputFragmentIds;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+/**
+ * Describes plan statistics which are derived at runtime.
+ */
+public class RuntimeSourceInfo
+        extends SourceInfo
+{
+    public RuntimeSourceInfo() {}
+
+    @Override
+    public int hashCode()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return getClass() == obj.getClass();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RuntimeSourceInfo{}";
+    }
+
+    @Override
+    public boolean isConfident()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
For Adaptive Query Execution in Presto on Spark, We want to execute a fragmented sub plan. This PR adds method to execute a subplan and return execution stats if there is shuffle in the subplan.
The flow is : 
1. Take a subplan for execution
2. Create RDDs
3. Execute RDDs with shuffle dependency
4. Return stats for optimizer

Note - This PR doesn't add support for proactively executing broadcast and returning stats. It will be handled in separate PR

```
== NO RELEASE NOTE ==
```
