### PR TITLE
[native] Use Release configuration instead of Debug for native-test.

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -65,7 +65,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/presto-native-execution
           make velox-submodule
           cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          ninja -C _build/debug -j 2
+          ninja -C _build/debug -j 1
           ccache -s
 
       - name: Run unit tests


### PR DESCRIPTION
Test plan - Build and tests.

Debug tests fail on the link stage (low memory), so trying using Release configuration here.

```
== NO RELEASE NOTE ==
```
