### PR TITLE
Add fail fast on validation config

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/reloading/ReloadingResourceGroupConfig.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/reloading/ReloadingResourceGroupConfig.java
@@ -24,6 +24,7 @@ public class ReloadingResourceGroupConfig
 {
     private boolean exactMatchSelectorEnabled;
     private Duration maxRefreshInterval = new Duration(1, HOURS);
+    private boolean failFastOnValidation;
 
     @MinDuration("10s")
     public Duration getMaxRefreshInterval()
@@ -49,6 +50,19 @@ public class ReloadingResourceGroupConfig
     public ReloadingResourceGroupConfig setExactMatchSelectorEnabled(boolean exactMatchSelectorEnabled)
     {
         this.exactMatchSelectorEnabled = exactMatchSelectorEnabled;
+        return this;
+    }
+
+    public boolean isFailFastOnValidation()
+    {
+        return failFastOnValidation;
+    }
+
+    @Config("resource-groups.fail-fast-on-validation")
+    @ConfigDescription("If enabled, any validation errors would be fatal failures.")
+    public ReloadingResourceGroupConfig setFailFastOnValidation(boolean failFastOnValidation)
+    {
+        this.failFastOnValidation = failFastOnValidation;
         return this;
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/reloading/ReloadingResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/reloading/ReloadingResourceGroupConfigurationManager.java
@@ -80,6 +80,8 @@ public class ReloadingResourceGroupConfigurationManager
     private final AtomicLong lastRefresh = new AtomicLong();
     private final Duration maxRefreshInterval;
     private final boolean exactMatchSelectorEnabled;
+    private final boolean failFastOnValidation;
+
 
     private final CounterStat refreshFailures = new CounterStat();
 
@@ -90,6 +92,7 @@ public class ReloadingResourceGroupConfigurationManager
         requireNonNull(memoryPoolManager, "memoryPoolManager is null");
         this.maxRefreshInterval = config.getMaxRefreshInterval();
         this.exactMatchSelectorEnabled = config.getExactMatchSelectorEnabled();
+        this.failFastOnValidation = config.isFailFastOnValidation();
         this.managerSpecProvider = requireNonNull(managerSpecProvider, "provider is null");
         load();
     }
@@ -219,6 +222,12 @@ public class ReloadingResourceGroupConfigurationManager
             log.error(e, "Error loading configuration from source");
             if (lastRefresh.get() != 0) {
                 log.debug("Last successful configuration loading was %s ago", succinctNanos(System.nanoTime() - lastRefresh.get()).toString());
+            }
+
+            if(failFastOnValidation)
+            {
+                log.error(e, "Fail fast mode is enabled. Failing the loading operation");
+                throw e;
             }
         }
     }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfig.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfig.java
@@ -32,7 +32,8 @@ public class TestReloadingResourceGroupConfig
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(ReloadingResourceGroupConfig.class)
                 .setMaxRefreshInterval(new Duration(1, HOURS))
-                .setExactMatchSelectorEnabled(false));
+                .setExactMatchSelectorEnabled(false)
+                .setFailFastOnValidation(false));
     }
 
     @Test
@@ -41,10 +42,12 @@ public class TestReloadingResourceGroupConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("resource-groups.max-refresh-interval", "1m")
                 .put("resource-groups.exact-match-selector-enabled", "true")
+                .put("resource-groups.fail-fast-on-validation", "true")
                 .build();
         ReloadingResourceGroupConfig expected = new ReloadingResourceGroupConfig()
                 .setMaxRefreshInterval(new Duration(1, MINUTES))
-                .setExactMatchSelectorEnabled(true);
+                .setExactMatchSelectorEnabled(true)
+                        .setFailFastOnValidation(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Adding a fail fast on validation configuration for resource groups. If enabled, any validation failure on the resource groups would result in to fatal failure.

```
== RELEASE NOTES ==

General Changes
* Add a ``fail-fast-on-validation`` configuration in the ``ReloadingResourceGroupConfig``
```
