### PR TITLE
Remove use of QueryCtx::createForTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -171,8 +171,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       const std::string& taskId,
       core::PlanNodePtr planNode,
       int destination) {
-    auto queryCtx =
-        core::QueryCtx::createForTest(std::make_shared<core::MemConfig>());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     core::PlanFragment planFragment{planNode};
     return std::make_shared<exec::Task>(
         taskId, std::move(planFragment), destination, std::move(queryCtx));
@@ -323,6 +322,10 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     }
     velox::exec::test::assertEqualResults(expectedOutputVectors, outputVectors);
   }
+
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
 };
 
 TEST_F(UnsafeRowShuffleTest, operators) {


### PR DESCRIPTION
Remove the use of QueryCtx::createForTest and will deprecate
it from Velox lib next.

Test plan - test code change so covered.

```
== NO RELEASE NOTE ==
```
