### PR TITLE
Update with new QueryCtx interface and advance Velox version

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
       maxUserMemoryPerNode, maxSystemMemoryPerNode, maxTotalMemoryPerNode));
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
-      executor(),
+      executor().get(),
       config,
       connectorConfigs,
       memory::MappedMemory::getInstance(),

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -171,8 +171,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       const std::string& taskId,
       core::PlanNodePtr planNode,
       int destination) {
-    auto queryCtx =
-        core::QueryCtx::createForTest(std::make_shared<core::MemConfig>());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     core::PlanFragment planFragment{planNode};
     return std::make_shared<exec::Task>(
         taskId, std::move(planFragment), destination, std::move(queryCtx));


### PR DESCRIPTION
Remove the use of QueryCtx::createForTest and will deprecate
it from Velox lib next.

Test plan - test code change so covered.

== NO RELEASE NOTE ==
