### PR TITLE
 Fix leaked query count reporting in the disaggregated coordinators codepath

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
@@ -17,22 +17,19 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.Objects.requireNonNull;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.Seconds.secondsBetween;
 
@@ -48,76 +45,46 @@ public class ClusterMemoryLeakDetector
     @GuardedBy("this")
     private Set<QueryId> leakedQueries;
 
+    @GuardedBy("this")
+    private long leakedBytes;
+
     /**
-     * @param queryInfoSupplier All queries that the coordinator knows about.
+     * @param queryIdToInfo All queries that the coordinator knows about, along with their optional query info.
      * @param queryMemoryReservations The memory reservations of queries in the GENERAL cluster memory pool.
      */
-    void checkForMemoryLeaks(Supplier<List<BasicQueryInfo>> queryInfoSupplier, Map<QueryId, Long> queryMemoryReservations)
+    void checkForMemoryLeaks(Map<QueryId, Optional<BasicQueryInfo>> queryIdToInfo, Map<QueryId, Long> queryMemoryReservations)
     {
-        requireNonNull(queryInfoSupplier);
-        requireNonNull(queryMemoryReservations);
-
-        Map<QueryId, BasicQueryInfo> queryIdToInfo = Maps.uniqueIndex(queryInfoSupplier.get(), BasicQueryInfo::getQueryId);
-
         Map<QueryId, Long> leakedQueryReservations = queryMemoryReservations.entrySet()
                 .stream()
                 .filter(entry -> entry.getValue() > 0)
                 .filter(entry -> isLeaked(queryIdToInfo, entry.getKey()))
                 .collect(toImmutableMap(Entry::getKey, Entry::getValue));
 
+        long leakedBytesThisTime = leakedQueryReservations.values().stream().reduce(0L, Long::sum);
         if (!leakedQueryReservations.isEmpty()) {
-            log.debug("Memory leak detected. The following queries are already finished, " +
-                    "but they have memory reservations on some worker node(s): %s", leakedQueryReservations);
+            log.warn("Memory leak of %s detected. The following queries are already finished, " +
+                    "but they have memory reservations on some worker node(s): %s",
+                    DataSize.succinctBytes(leakedBytes), leakedQueryReservations);
         }
 
         synchronized (this) {
             leakedQueries = ImmutableSet.copyOf(leakedQueryReservations.keySet());
+            leakedBytes = leakedBytesThisTime;
         }
     }
 
-    /**
-     *
-     * @param runningQueriesSupplier All running queries on a cluster.
-     * @param queryMemoryReservations The memory reservations of queries in the GENERAL cluster memory pool.
-     */
-    void checkForClusterMemoryLeaks(Supplier<Optional<List<QueryId>>> runningQueriesSupplier, Map<QueryId, Long> queryMemoryReservations)
+    private static boolean isLeaked(Map<QueryId, Optional<BasicQueryInfo>> queryIdToInfo, QueryId queryId)
     {
-        requireNonNull(runningQueriesSupplier);
-        requireNonNull(queryMemoryReservations);
+        Optional<BasicQueryInfo> queryInfo = queryIdToInfo.get(queryId);
 
-        Optional<List<QueryId>> runningQueries = runningQueriesSupplier.get();
-
-        Map<QueryId, Long> leakedQueryReservations = queryMemoryReservations.entrySet()
-                .stream()
-                .filter(entry -> entry.getValue() > 0)
-                .filter(entry -> !runningQueries.isPresent() || !runningQueries.get().contains(entry.getKey()))
-                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
-
-        if (!leakedQueryReservations.isEmpty()) {
-            log.debug("Memory leak detected. The following queries are already finished, " +
-                    "but they have memory reservations on some worker node(s): %s", leakedQueryReservations);
-        }
-
-        synchronized (this) {
-            leakedQueries = ImmutableSet.copyOf(leakedQueryReservations.keySet());
-        }
-    }
-
-    private static boolean isLeaked(Map<QueryId, BasicQueryInfo> queryIdToInfo, QueryId queryId)
-    {
-        BasicQueryInfo queryInfo = queryIdToInfo.get(queryId);
-
+        // if the query is not even found then it is definitely leaked
         if (queryInfo == null) {
             return true;
         }
 
-        DateTime queryEndTime = queryInfo.getQueryStats().getEndTime();
+        Optional<DateTime> queryEndTime = queryInfo.flatMap(qi -> Optional.ofNullable(qi.getState() == RUNNING ? null : qi.getQueryStats().getEndTime()));
 
-        if (queryInfo.getState() == RUNNING || queryEndTime == null) {
-            return false;
-        }
-
-        return secondsBetween(queryEndTime, now()).getSeconds() >= DEFAULT_LEAK_CLAIM_DELTA_SEC;
+        return queryEndTime.map(ts -> secondsBetween(ts, now()).getSeconds() >= DEFAULT_LEAK_CLAIM_DELTA_SEC).orElse(false);
     }
 
     synchronized boolean wasQueryPossiblyLeaked(QueryId queryId)
@@ -128,5 +95,10 @@ public class ClusterMemoryLeakDetector
     synchronized int getNumberOfLeakedQueries()
     {
         return leakedQueries.size();
+    }
+
+    synchronized long getLeakedBytes()
+    {
+        return leakedBytes;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -42,6 +42,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.google.common.io.Closer;
 import io.airlift.units.DataSize;
@@ -89,6 +90,7 @@ import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
 import static com.facebook.presto.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.common.collect.Sets.difference;
@@ -99,6 +101,7 @@ import static java.lang.String.format;
 import static java.util.AbstractMap.SimpleEntry;
 import static java.util.Comparator.comparingLong;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 
 public class ClusterMemoryManager
@@ -234,19 +237,10 @@ public class ClusterMemoryManager
         return pools.containsKey(poolId);
     }
 
-    public synchronized void process(Iterable<QueryExecution> runningQueries, Supplier<List<BasicQueryInfo>> allQueryInfoSupplier)
+    public synchronized void process(Iterable<QueryExecution> runningQueries)
     {
         if (!enabled) {
             return;
-        }
-
-        // TODO revocable memory reservations can also leak and may need to be detected in the future
-        // We are only concerned about the leaks in general pool.
-        if (memoryManagerService.isPresent()) {
-            memoryLeakDetector.checkForClusterMemoryLeaks(pools.get(GENERAL_POOL).getClusterInfo()::getRunningQueries, pools.get(GENERAL_POOL).getQueryMemoryReservations());
-        }
-        else {
-            memoryLeakDetector.checkForMemoryLeaks(allQueryInfoSupplier, pools.get(GENERAL_POOL).getQueryMemoryReservations());
         }
 
         boolean outOfMemory = isClusterOutOfMemory();
@@ -336,6 +330,32 @@ public class ClusterMemoryManager
             assignmentsRequest = new MemoryPoolAssignmentsRequest(coordinatorId, Long.MIN_VALUE, ImmutableList.of());
         }
         updateNodes(assignmentsRequest);
+    }
+
+    public synchronized void checkForLeaks(Supplier<List<BasicQueryInfo>> allQueryInfoSupplier)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        Map<QueryId, Optional<BasicQueryInfo>> allRunningQueries;
+        if (memoryManagerService.isPresent()) {
+            // We are in the multi-coordinator codepath, and thus care about the globally running queries
+            allRunningQueries = getClusterInfo(GENERAL_POOL)
+                            .getRunningQueries()
+                            .orElse(ImmutableList.of())
+                            .stream().collect(toImmutableMap(identity(), t -> Optional.empty()));
+        }
+        else {
+            // We are in the single coordinator setup, and thus care about the local queries. Ie, global queries
+            // does not make sense.
+            allRunningQueries = Maps.uniqueIndex(
+                    allQueryInfoSupplier.get().stream()
+                        .map(Optional::of)
+                        .iterator(),
+                    queryInfo -> queryInfo.get().getQueryId());
+        }
+        memoryLeakDetector.checkForMemoryLeaks(allRunningQueries, pools.get(GENERAL_POOL).getQueryMemoryReservations());
     }
 
     private synchronized void callOomKiller(Iterable<QueryExecution> runningQueries)
@@ -635,6 +655,12 @@ public class ClusterMemoryManager
     public int getNumberOfLeakedQueries()
     {
         return memoryLeakDetector.getNumberOfLeakedQueries();
+    }
+
+    @Managed
+    public long getLeakedBytes()
+    {
+        return memoryLeakDetector.getLeakedBytes();
     }
 
     @Managed


### PR DESCRIPTION
Summary: Currently in disaggregated codepath, all running queries show up as leaked queries. After this change, the number of leaked queries reported by coordinators in the disaggregated codepath is at least eventually consistent: Due to the eventual consistence nature of the design, some amount of false positives of leaked queries are expected since the coordinator has a stale view of the running queries and the memory state across each worker. 

Also made the leak check logging be WARN logging and pulled out the check to be every minute instead of it being every second.  

Added logging of the leaked bytes in addition to the leaked queries. 

Test plan - (Please fill in how you tested your changes)

Added unit tests. 

Checked the metrics in a production environment, that the number of leaked queries is now usually one or two both in disaggregated and normal codepaths. 

```
== NO RELEASE NOTE ==
```
