### PR TITLE
Adding support for ARRAY_SORT_DESC to Presto

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -151,6 +151,15 @@ Array Functions
                                        -1,
                                        IF(cardinality(x) = cardinality(y), 0, 1))); -- [[1, 2], [2, 3, 1], [4, 2, 1, 4]]
 
+.. function:: array_sort_desc(x) -> array
+
+    Returns the ``array`` sorted in the descending order. Elements of the ``array`` must be orderable.
+    Null elements will be placed at the end of the returned array.
+
+        SELECT array_sort_desc(ARRAY [100, 1, 10, 50]); -- [100, 50, 10, 1]
+        SELECT array_sort_desc(ARRAY [null, 100, null, 1, 10, 50]); -- [100, 50, 10, 1, null, null]
+        SELECT array_sort_desc(ARRAY [ARRAY ["a", null], null, ARRAY ["a"]); -- [["a", null], ["a"], null]
+
 .. function:: array_sum(array(T)) -> bigint/double
 
     Returns the sum of all non-null elements of the ``array``. If there is no non-null elements, returns ``0``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -116,4 +116,14 @@ public class ArraySqlFunctions
                 "array_min(zip_with(transform(input, f), sequence(1, cardinality(input)), (x, y)->IF(x IS NULL, NULL, (x, y))))[2]" +
                 "]";
     }
+
+    @SqlInvokedScalarFunction(value = "array_sort_desc", deterministic = true, calledOnNullInput = true)
+    @Description("Sorts the given array in descending order according to the natural ordering of its elements.")
+    @TypeParameter("T")
+    @SqlParameter(name = "input", type = "array(T)")
+    @SqlType("array<T>")
+    public static String arraySortDesc()
+    {
+        return "RETURN reverse(array_sort(remove_nulls(input))) || filter(input, x -> x is null)";
+    }
 }


### PR DESCRIPTION
Adding an UDF for sorting array elements in the descending order. The elements of array must be orderable. Null elements will be placed at the end of the returned array.

array_sort_desc(array(T)) -> array(T)

Test plan
Added unit tests.
Build successfully using the following terminal command
- `mvn -Dtest=TestArraySqlFunctions install`

```
== RELEASE NOTES ==

General Changes
* Add :func:`array_sort_desc` function to sort an array in the descending order
```
