### PR TITLE
Fix PullConstantsAboveGroupBy for empty input

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantsAboveGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantsAboveGroupBy.java
@@ -97,6 +97,15 @@ public class PullConstantsAboveGroupBy
             return Result.empty();
         }
 
+        // Can't pull up constant grouping keys if there are no other
+        // grouping keys because it will turn the aggregation into a global
+        // aggregation, which has different semantics on an empty input.
+        // A grouped aggregation with 0 rows of input will output 0 rows, but
+        // a global aggregation will always return one row
+        if (newGroupingKeys.isEmpty()) {
+            return Result.empty();
+        }
+
         AggregationNode newAgg = new AggregationNode(
                 parent.getSourceLocation(),
                 parent.getId(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
@@ -93,6 +93,23 @@ public class TestPullConstantsAboveGroupBy
     }
 
     @Test
+    public void testOnlyConstantKeysDoesNotFire()
+    {
+        tester().assertThat(new PullConstantsAboveGroupBy())
+                .on(p -> p.aggregation(ab -> ab
+                        .source(
+                                p.project(
+                                        Assignments.builder()
+                                                .put(p.variable("COL"), p.rowExpression("COL"))
+                                                .put(p.variable("CONST_COL"), p.rowExpression("1"))
+                                                .build(),
+                                        p.values(p.variable("COL"))))
+                        .addAggregation(p.variable("AVG", DOUBLE), p.rowExpression("avg(COL)"))
+                        .singleGroupingSet(p.variable("CONST_COL"))))
+                .doesNotFire();
+    }
+
+    @Test
     public void testSingleConstColumn()
     {
         tester().assertThat(new PullConstantsAboveGroupBy())

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4903,6 +4903,7 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT cnt FROM (SELECT col, count(*) as cnt FROM (SELECT 'bla' as col from nation) GROUP BY col)");
         assertQuery("SELECT MIN(10), 1 as col1 GROUP BY 2");
         assertQuery("SELECT col, 'bla' as const_col, count(*) FROM (SELECT 1 as col) GROUP BY 1,2");
+        assertQuery("SELECT 'bla' as const_col, count(*) FROM (SELECT 1 as col LIMIT 0) GROUP BY 1");
         assertQuery("SELECT AVG(x) FROM (SELECT 1 AS x, orderstatus FROM orders) GROUP BY x, orderstatus");
     }
 


### PR DESCRIPTION
If all the grouping keys are constants, we cannot pull them above the group by or the aggregation will become a global aggregation.  A global aggregation always returns one row, but a grouped aggregation won't return any rows if the input is empty.

Test plan - new unit tests


```
== NO RELEASE NOTE ==
```
