### PR TITLE
Make log of rules triggered to be per query in iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizerInformationCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizerInformationCollector.java
@@ -14,21 +14,27 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.LinkedList;
 import java.util.List;
 
+@ThreadSafe
 public class OptimizerInformationCollector
 {
-    private final List<PlanOptimizerInformation> optimizationInfo = new LinkedList<PlanOptimizerInformation>();
+    @GuardedBy("this")
+    private final List<PlanOptimizerInformation> optimizationInfo = new LinkedList<>();
 
-    public void addInformation(PlanOptimizerInformation optimizerInformation)
+    public synchronized void addInformation(PlanOptimizerInformation optimizerInformation)
     {
         this.optimizationInfo.add(optimizerInformation);
     }
 
-    public List<PlanOptimizerInformation> getOptimizationInfo()
+    public synchronized List<PlanOptimizerInformation> getOptimizationInfo()
     {
-        return optimizationInfo;
+        return ImmutableList.copyOf(optimizationInfo);
     }
 }


### PR DESCRIPTION
Sample test failure https://github.com/prestodb/presto/actions/runs/3452381058/jobs/5762250996

Optimizers are singleton in coordinator shared with all queries, make the logging part to be per query by adding logging code to context in iterative optimizer.

Also make access to optimizer information collector to be synchronized (although it should not be a problem as it's a new instance for each session), but still make it safe here just in case.


```
== NO RELEASE NOTE ==
```
