### PR TITLE
Refactor HiveTableLayoutHandle

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
@@ -247,24 +247,7 @@ public class HivePartialAggregationPushdown
             }
 
             HiveTableLayoutHandle oldTableLayoutHandle = (HiveTableLayoutHandle) oldTableHandle.getLayout().get();
-            HiveTableLayoutHandle newTableLayoutHandle = new HiveTableLayoutHandle(
-                    oldTableLayoutHandle.getSchemaTableName(),
-                    oldTableLayoutHandle.getTablePath(),
-                    oldTableLayoutHandle.getPartitionColumns(),
-                    oldTableLayoutHandle.getDataColumns(),
-                    oldTableLayoutHandle.getTableParameters(),
-                    oldTableLayoutHandle.getPartitions().get(),
-                    oldTableLayoutHandle.getDomainPredicate(),
-                    oldTableLayoutHandle.getRemainingPredicate(),
-                    oldTableLayoutHandle.getPredicateColumns(),
-                    oldTableLayoutHandle.getPartitionColumnPredicate(),
-                    oldTableLayoutHandle.getBucketHandle(),
-                    oldTableLayoutHandle.getBucketFilter(),
-                    oldTableLayoutHandle.isPushdownFilterEnabled(),
-                    oldTableLayoutHandle.getLayoutString(),
-                    oldTableLayoutHandle.getRequestedColumns(),
-                    true,
-                    oldTableLayoutHandle.isAppendRowNumberEnabled());
+            HiveTableLayoutHandle newTableLayoutHandle = oldTableLayoutHandle.builder().setPartialAggregationsPushedDown(true).build();
 
             TableHandle newTableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -55,26 +56,8 @@ public class HiveAddRequestedColumnsToLayout
             }
 
             HiveTableLayoutHandle hiveLayout = (HiveTableLayoutHandle) layout.get();
-            HiveTableLayoutHandle hiveLayoutWithDesiredColumns = new HiveTableLayoutHandle(
-                    hiveLayout.getSchemaTableName(),
-                    hiveLayout.getTablePath(),
-                    hiveLayout.getPartitionColumns(),
-                    hiveLayout.getDataColumns(),
-                    hiveLayout.getTableParameters(),
-                    hiveLayout.getPartitions().get(),
-                    hiveLayout.getDomainPredicate(),
-                    hiveLayout.getRemainingPredicate(),
-                    hiveLayout.getPredicateColumns(),
-                    hiveLayout.getPartitionColumnPredicate(),
-                    hiveLayout.getBucketHandle(),
-                    hiveLayout.getBucketFilter(),
-                    hiveLayout.isPushdownFilterEnabled(),
-                    hiveLayout.getLayoutString(),
-                    Optional.of(tableScan.getOutputVariables().stream()
-                            .map(output -> (HiveColumnHandle) tableScan.getAssignments().get(output))
-                            .collect(toImmutableSet())),
-                    hiveLayout.isPartialAggregationsPushedDown(),
-                    hiveLayout.isAppendRowNumberEnabled());
+            Optional<Set<HiveColumnHandle>> requestedColumns = Optional.of(tableScan.getOutputVariables().stream().map(output -> (HiveColumnHandle) tableScan.getAssignments().get(output)).collect(toImmutableSet()));
+            HiveTableLayoutHandle hiveLayoutWithDesiredColumns = hiveLayout.builder().setRequestedColumns(requestedColumns).build();
 
             return new TableScanNode(
                     tableScan.getSourceLocation(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -816,24 +816,25 @@ public abstract class AbstractTestHiveClient
 
         invalidClientId = "hive";
         invalidTableHandle = new HiveTableHandle(database, INVALID_TABLE);
-        invalidTableLayoutHandle = new HiveTableLayoutHandle(
-                invalidTable,
-                "path",
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableMap.of(),
-                ImmutableList.of(new HivePartition(invalidTable, "unknown", ImmutableMap.of())),
-                TupleDomain.all(),
-                TRUE_CONSTANT,
-                ImmutableMap.of(),
-                TupleDomain.all(),
-                Optional.empty(),
-                Optional.empty(),
-                false,
-                "layout",
-                Optional.empty(),
-                false,
-                false);
+        invalidTableLayoutHandle = new HiveTableLayoutHandle.Builder()
+                .setSchemaTableName(invalidTable)
+                .setTablePath("path")
+                .setPartitionColumns(ImmutableList.of())
+                .setDataColumns(ImmutableList.of())
+                .setTableParameters(ImmutableMap.of())
+                .setDomainPredicate(TupleDomain.all())
+                .setRemainingPredicate(TRUE_CONSTANT)
+                .setPredicateColumns(ImmutableMap.of())
+                .setPartitionColumnPredicate(TupleDomain.all())
+                .setPartitions(ImmutableList.of(new HivePartition(invalidTable, "unknown", ImmutableMap.of())))
+                .setBucketHandle(Optional.empty())
+                .setBucketFilter(Optional.empty())
+                .setPushdownFilterEnabled(false)
+                .setLayoutString("layout")
+                .setRequestedColumns(Optional.empty())
+                .setPartialAggregationsPushedDown(false)
+                .setAppendRowNumberEnabled(false)
+                .build();
 
         int partitionColumnIndex = MAX_PARTITION_KEY_COLUMN_INDEX;
         dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), partitionColumnIndex--, PARTITION_KEY, Optional.empty(), Optional.empty());
@@ -877,33 +878,33 @@ public abstract class AbstractTestHiveClient
         tupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29"))));
         TupleDomain<Subfield> domainPredicate = tupleDomain.transform(HiveColumnHandle.class::cast)
                 .transform(column -> new Subfield(column.getName(), ImmutableList.of()));
+        List<Column> dataColumns = ImmutableList.of(
+                new Column("t_string", HIVE_STRING, Optional.empty(), Optional.empty()),
+                new Column("t_tinyint", HIVE_BYTE, Optional.empty(), Optional.empty()),
+                new Column("t_smallint", HIVE_SHORT, Optional.empty(), Optional.empty()),
+                new Column("t_int", HIVE_INT, Optional.empty(), Optional.empty()),
+                new Column("t_bigint", HIVE_LONG, Optional.empty(), Optional.empty()),
+                new Column("t_float", HIVE_FLOAT, Optional.empty(), Optional.empty()),
+                new Column("t_double", HIVE_DOUBLE, Optional.empty(), Optional.empty()),
+                new Column("t_boolean", HIVE_BOOLEAN, Optional.empty(), Optional.empty()));
         tableLayout = new ConnectorTableLayout(
-                new HiveTableLayoutHandle(
-                        tablePartitionFormat,
-                        "path",
-                        partitionColumns,
-                        ImmutableList.of(
-                                new Column("t_string", HIVE_STRING, Optional.empty(), Optional.empty()),
-                                new Column("t_tinyint", HIVE_BYTE, Optional.empty(), Optional.empty()),
-                                new Column("t_smallint", HIVE_SHORT, Optional.empty(), Optional.empty()),
-                                new Column("t_int", HIVE_INT, Optional.empty(), Optional.empty()),
-                                new Column("t_bigint", HIVE_LONG, Optional.empty(), Optional.empty()),
-                                new Column("t_float", HIVE_FLOAT, Optional.empty(), Optional.empty()),
-                                new Column("t_double", HIVE_DOUBLE, Optional.empty(), Optional.empty()),
-                                new Column("t_boolean", HIVE_BOOLEAN, Optional.empty(), Optional.empty())),
-                        ImmutableMap.of(),
-                        partitions,
-                        domainPredicate,
-                        TRUE_CONSTANT,
-                        ImmutableMap.of(dsColumn.getName(), dsColumn),
-                        tupleDomain,
-                        Optional.empty(),
-                        Optional.empty(),
-                        false,
-                        "layout",
-                        Optional.empty(),
-                        false,
-                        false),
+                new HiveTableLayoutHandle.Builder()
+                        .setSchemaTableName(tablePartitionFormat).setTablePath("path")
+                        .setPartitionColumns(partitionColumns)
+                        .setDataColumns(dataColumns)
+                        .setTableParameters(ImmutableMap.of())
+                        .setDomainPredicate(domainPredicate)
+                        .setRemainingPredicate(TRUE_CONSTANT)
+                        .setPredicateColumns(ImmutableMap.of(dsColumn.getName(), dsColumn))
+                        .setPartitionColumnPredicate(tupleDomain)
+                        .setPartitions(partitions).setBucketHandle(Optional.empty())
+                        .setBucketFilter(Optional.empty())
+                        .setPushdownFilterEnabled(false)
+                        .setLayoutString("layout")
+                        .setRequestedColumns(Optional.empty())
+                        .setPartialAggregationsPushedDown(false)
+                        .setAppendRowNumberEnabled(false)
+                        .build(),
                 Optional.empty(),
                 withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -930,26 +931,28 @@ public abstract class AbstractTestHiveClient
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 4L)), false)))))),
                 ImmutableList.of());
         List<HivePartition> unpartitionedPartitions = ImmutableList.of(new HivePartition(tableUnpartitioned));
-        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(
-                tableUnpartitioned,
-                "path",
-                ImmutableList.of(),
-                ImmutableList.of(
-                        new Column("t_string", HIVE_STRING, Optional.empty(), Optional.empty()),
-                        new Column("t_tinyint", HIVE_BYTE, Optional.empty(), Optional.empty())),
-                ImmutableMap.of(),
-                unpartitionedPartitions,
-                TupleDomain.all(),
-                TRUE_CONSTANT,
-                ImmutableMap.of(),
-                TupleDomain.all(),
-                Optional.empty(),
-                Optional.empty(),
-                false,
-                "layout",
-                Optional.empty(),
-                false,
-                false));
+        unpartitionedTableLayout = new ConnectorTableLayout(
+                new HiveTableLayoutHandle.Builder()
+                        .setSchemaTableName(tableUnpartitioned)
+                        .setTablePath("path")
+                        .setPartitionColumns(ImmutableList.of())
+                        .setDataColumns(ImmutableList.of(
+                            new Column("t_string", HIVE_STRING, Optional.empty(), Optional.empty()),
+                            new Column("t_tinyint", HIVE_BYTE, Optional.empty(), Optional.empty())))
+                        .setTableParameters(ImmutableMap.of())
+                        .setDomainPredicate(TupleDomain.all())
+                        .setRemainingPredicate(TRUE_CONSTANT)
+                        .setPredicateColumns(ImmutableMap.of())
+                        .setPartitionColumnPredicate(TupleDomain.all())
+                        .setPartitions(unpartitionedPartitions)
+                        .setBucketHandle(Optional.empty())
+                        .setBucketFilter(Optional.empty())
+                        .setPushdownFilterEnabled(false)
+                        .setLayoutString("layout")
+                        .setRequestedColumns(Optional.empty())
+                        .setPartialAggregationsPushedDown(false)
+                        .setAppendRowNumberEnabled(false)
+                        .build());
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(timeZoneId)));
     }
 
@@ -2130,24 +2133,9 @@ public abstract class AbstractTestHiveClient
             HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) getTableLayout(session, transaction.getMetadata(), hiveTableHandle, Constraint.alwaysTrue(), transaction).getHandle();
             HiveBucketHandle bucketHandle = layoutHandle.getBucketHandle().get();
 
-            HiveTableLayoutHandle modifiedReadBucketCountLayoutHandle = new HiveTableLayoutHandle(
-                    layoutHandle.getSchemaTableName(),
-                    layoutHandle.getTablePath(),
-                    layoutHandle.getPartitionColumns(),
-                    layoutHandle.getDataColumns(),
-                    layoutHandle.getTableParameters(),
-                    layoutHandle.getPartitions().get(),
-                    layoutHandle.getDomainPredicate(),
-                    layoutHandle.getRemainingPredicate(),
-                    layoutHandle.getPredicateColumns(),
-                    layoutHandle.getPartitionColumnPredicate(),
-                    Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), 2)),
-                    layoutHandle.getBucketFilter(),
-                    false,
-                    "layout",
-                    Optional.empty(),
-                    false,
-                    false);
+            HiveTableLayoutHandle modifiedReadBucketCountLayoutHandle = layoutHandle.builder()
+                    .setBucketHandle(Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), 2)))
+                    .build();
 
             List<ConnectorSplit> splits = getAllSplits(session, transaction, modifiedReadBucketCountLayoutHandle);
             assertEquals(splits.size(), 16);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
@@ -161,29 +161,30 @@ public class TestDynamicPruning
                 ImmutableSet.of(),
                 SplitWeight.standard());
 
+        HiveTableLayoutHandle tableLayoutHandle = new HiveTableLayoutHandle.Builder()
+                .setSchemaTableName(new SchemaTableName(SCHEMA_NAME, TABLE_NAME))
+                .setTablePath("path")
+                .setPartitionColumns(ImmutableList.of(PARTITION_HIVE_COLUMN_HANDLE))
+                .setDataColumns(getColumnHandles().stream().map(column -> new Column(column.getName(), column.getHiveType(), Optional.empty(), Optional.empty())).collect(toImmutableList()))
+                .setTableParameters(ImmutableMap.of())
+                .setDomainPredicate(TupleDomain.all())
+                .setRemainingPredicate(TRUE_CONSTANT)
+                .setPredicateColumns(ImmutableMap.of())
+                .setPartitionColumnPredicate(TupleDomain.all())
+                .setBucketHandle(Optional.empty())
+                .setBucketFilter(Optional.empty())
+                .setPushdownFilterEnabled(false)
+                .setLayoutString("layout")
+                .setRequestedColumns(Optional.empty())
+                .setPartialAggregationsPushedDown(false)
+                .setAppendRowNumberEnabled(false)
+                .setPartitions(Optional.empty())
+                .build();
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),
                 new HiveTableHandle(SCHEMA_NAME, TABLE_NAME),
                 transaction,
-                Optional.of(new HiveTableLayoutHandle(
-                        new SchemaTableName(SCHEMA_NAME, TABLE_NAME),
-                        "path",
-                        ImmutableList.of(PARTITION_HIVE_COLUMN_HANDLE),
-                        getColumnHandles().stream()
-                                .map(column -> new Column(column.getName(), column.getHiveType(), Optional.empty(), Optional.empty()))
-                                .collect(toImmutableList()),
-                        ImmutableMap.of(),
-                        TupleDomain.all(),
-                        TRUE_CONSTANT,
-                        ImmutableMap.of(),
-                        TupleDomain.all(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        false,
-                        "layout",
-                        Optional.empty(),
-                        false,
-                        false)));
+                Optional.of(tableLayoutHandle));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), splitContext);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -263,29 +263,30 @@ public class TestHivePageSink
                 ImmutableSet.of(),
                 SplitWeight.standard());
 
+        HiveTableLayoutHandle layoutHandle = new HiveTableLayoutHandle.Builder()
+                .setSchemaTableName(new SchemaTableName(SCHEMA_NAME, TABLE_NAME))
+                .setTablePath("path")
+                .setPartitionColumns(ImmutableList.of())
+                .setDataColumns(getColumnHandles().stream().map(column -> new Column(column.getName(), column.getHiveType(), Optional.empty(), Optional.empty())).collect(toImmutableList()))
+                .setTableParameters(ImmutableMap.of())
+                .setDomainPredicate(TupleDomain.all())
+                .setRemainingPredicate(TRUE_CONSTANT)
+                .setPredicateColumns(ImmutableMap.of())
+                .setPartitionColumnPredicate(TupleDomain.all())
+                .setBucketHandle(Optional.empty())
+                .setBucketFilter(Optional.empty())
+                .setPushdownFilterEnabled(false)
+                .setLayoutString("layout")
+                .setRequestedColumns(Optional.empty())
+                .setPartialAggregationsPushedDown(false)
+                .setAppendRowNumberEnabled(false)
+                .setPartitions(Optional.empty())
+                .build();
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),
                 new HiveTableHandle(SCHEMA_NAME, TABLE_NAME),
                 transaction,
-                Optional.of(new HiveTableLayoutHandle(
-                        new SchemaTableName(SCHEMA_NAME, TABLE_NAME),
-                        "path",
-                        ImmutableList.of(),
-                        getColumnHandles().stream()
-                                .map(column -> new Column(column.getName(), column.getHiveType(), Optional.empty(), Optional.empty()))
-                                .collect(toImmutableList()),
-                        ImmutableMap.of(),
-                        TupleDomain.all(),
-                        TRUE_CONSTANT,
-                        ImmutableMap.of(),
-                        TupleDomain.all(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        false,
-                        "layout",
-                        Optional.empty(),
-                        false,
-                        false)));
+                Optional.of(layoutHandle));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), NON_CACHEABLE);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -549,29 +549,30 @@ public class TestHiveSplitManager
                 .transform(HiveColumnHandle.class::cast)
                 .transform(column -> new Subfield(column.getName(), ImmutableList.of()));
 
+        HiveTableLayoutHandle layoutHandle = new HiveTableLayoutHandle.Builder()
+                .setSchemaTableName(new SchemaTableName("test_schema", "test_table"))
+                .setTablePath("test_path")
+                .setPartitionColumns(ImmutableList.of(partitionColumn))
+                .setDataColumns(COLUMNS)
+                .setTableParameters(ImmutableMap.of())
+                .setDomainPredicate(domainPredicate)
+                .setRemainingPredicate(TRUE_CONSTANT)
+                .setPredicateColumns(ImmutableMap.of(partitionColumn.getName(), partitionColumn, columnHandle.getName(), columnHandle))
+                .setPartitionColumnPredicate(queryTupleDomain)
+                .setPartitions(partitions)
+                .setBucketHandle(Optional.empty())
+                .setBucketFilter(Optional.empty())
+                .setPushdownFilterEnabled(false)
+                .setLayoutString("layout")
+                .setRequestedColumns(Optional.empty())
+                .setPartialAggregationsPushedDown(false)
+                .setAppendRowNumberEnabled(false)
+                .build();
+
         ConnectorSplitSource splitSource = splitManager.getSplits(
                 new HiveTransactionHandle(),
                 new TestingConnectorSession(new HiveSessionProperties(hiveClientConfig, new OrcFileWriterConfig(), new ParquetFileWriterConfig(), new CacheConfig()).getSessionProperties()),
-                new HiveTableLayoutHandle(
-                        new SchemaTableName("test_schema", "test_table"),
-                        "test_path",
-                        ImmutableList.of(partitionColumn),
-                        COLUMNS,
-                        ImmutableMap.of(),
-                        partitions,
-                        domainPredicate,
-                        TRUE_CONSTANT,
-                        ImmutableMap.of(
-                                partitionColumn.getName(), partitionColumn,
-                                columnHandle.getName(), columnHandle),
-                        queryTupleDomain,
-                        Optional.empty(),
-                        Optional.empty(),
-                        false,
-                        "layout",
-                        Optional.empty(),
-                        false,
-                        false),
+                layoutHandle,
                 SPLIT_SCHEDULING_CONTEXT);
         List<Set<ColumnHandle>> actualRedundantColumnDomains = splitSource.getNextBatch(NOT_PARTITIONED, 100).get().getSplits().stream()
                 .map(HiveSplit.class::cast)


### PR DESCRIPTION
HiveTableLayoutHandle has 2 constructors, one with partition and one without partition. If callers use the wrong constructor it will throw.

HiveTableLayoutHandle is modified at multiple places and all these places would change one or two parameters, but copy the rest of the other parameters. It is very hard to say, what is the intentional change what others are modified.

When introducing new parameters, all places change and it is hard.

The main breaking reason for this PR:
When there are classes that derive from hiveTableHandleLayout these modifications convert them to base class and mess up the behavior.

To fix all of this, the class supports builder pattern for mutation.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
