### PR TITLE
Enable Estimated Stats on Query Plan for Instrumentation Monitoring

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4302,7 +4302,7 @@ public class TestHiveIntegrationSmokeTest
                     .size();
             if (actualRemoteExchangesCount != expectedRemoteExchangesCount) {
                 Metadata metadata = queryRunner.getCoordinator().getMetadata();
-                String formattedPlan = textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), StatsAndCosts.empty(), session, 0);
+                String formattedPlan = textLogicalPlan(plan.getRoot(), plan.getTypes(), StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 0);
                 throw new AssertionError(format(
                         "Expected [\n%s\n] remote exchanges but found [\n%s\n] remote exchanges. Actual plan is [\n\n%s\n]",
                         expectedRemoteExchangesCount,

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -24,8 +24,10 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 import com.facebook.presto.spi.statistics.SourceInfo;
+import com.facebook.presto.sql.Serialization;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
@@ -194,6 +196,7 @@ public class PlanNodeStatsEstimate
         return variableStatistics.getOrDefault(variable, VariableStatsEstimate.unknown());
     }
 
+    @JsonSerialize(keyUsing = Serialization.VariableReferenceExpressionSerializer.class)
     @JsonProperty
     public Map<VariableReferenceExpression, VariableStatsEstimate> getVariableStatistics()
     {

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -145,6 +145,7 @@ public class QueryMonitor
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
+                                Optional.empty(),
                                 ImmutableList.of(),
                                 queryInfo.getSession().getTraceToken())));
     }
@@ -165,6 +166,7 @@ public class QueryMonitor
                         queryInfo.getPreparedQuery(),
                         queryInfo.getState().toString(),
                         queryInfo.getSelf(),
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
@@ -271,6 +273,7 @@ public class QueryMonitor
                 queryInfo.getSelf(),
                 createTextQueryPlan(queryInfo),
                 createJsonQueryPlan(queryInfo),
+                createGraphvizQueryPlan(queryInfo),
                 queryInfo.getOutputStage().flatMap(stage -> stageInfoCodec.toJsonWithLengthLimit(stage, maxJsonLimit)),
                 queryInfo.getRuntimeOptimizedStages().orElse(ImmutableList.of()).stream()
                         .map(stageId -> String.valueOf(stageId.getId()))

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -75,6 +75,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizDistributedPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.jsonDistributedPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textDistributedPlan;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -403,12 +404,30 @@ public class QueryMonitor
         try {
             if (queryInfo.getOutputStage().isPresent()) {
                 return Optional.of(jsonDistributedPlan(
-                        queryInfo.getOutputStage().get()));
+                        queryInfo.getOutputStage().get(),
+                        functionAndTypeManager));
             }
         }
         catch (Exception e) {
             // Don't fail to create event if the plan can not be created
             log.warn(e, "Error creating json plan for query %s: %s", queryInfo.getQueryId(), e);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> createGraphvizQueryPlan(QueryInfo queryInfo)
+    {
+        try {
+            if (queryInfo.getOutputStage().isPresent()) {
+                return Optional.of(graphvizDistributedPlan(
+                        queryInfo.getOutputStage().get(),
+                        functionAndTypeManager,
+                        queryInfo.getSession().toSession(sessionPropertyManager)));
+            }
+        }
+        catch (Exception e) {
+            // Don't fail to create event if the graphviz plan can not be created
+            log.warn(e, "Error creating graphviz plan for query %s: %s", queryInfo.getQueryId(), e);
         }
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.execution.BasicStageExecutionStats;
 import com.facebook.presto.execution.LocationFactory;
 import com.facebook.presto.execution.PartialResultQueryManager;
@@ -609,6 +610,7 @@ public class LegacySqlQueryScheduler
             newRoot = optimizer.optimize(newRoot, session, variableAllocator.getTypes(), variableAllocator, idAllocator, warningCollector);
         }
         if (newRoot != fragment.getRoot()) {
+            StatsAndCosts estimatedStatsAndCosts = fragment.getStatsAndCosts();
             return Optional.of(
                     // The partitioningScheme should stay the same
                     // even if the root's outputVariable layout is changed.
@@ -621,8 +623,8 @@ public class LegacySqlQueryScheduler
                             fragment.getPartitioningScheme(),
                             fragment.getStageExecutionDescriptor(),
                             fragment.isOutputTableWriterFragment(),
-                            fragment.getStatsAndCosts(),
-                            Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), functionAndTypeManager, session))));
+                            estimatedStatsAndCosts,
+                            Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), estimatedStatsAndCosts, functionAndTypeManager, session))));
         }
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.execution.BasicStageExecutionStats;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.LocationFactory;
@@ -497,6 +498,7 @@ public class SqlQueryScheduler
             newRoot = optimizer.optimize(newRoot, session, variableAllocator.getTypes(), variableAllocator, idAllocator, warningCollector);
         }
         if (newRoot != fragment.getRoot()) {
+            StatsAndCosts estimatedStatsAndCosts = fragment.getStatsAndCosts();
             return Optional.of(
                     // The partitioningScheme should stay the same
                     // even if the root's outputVariable layout is changed.
@@ -509,8 +511,8 @@ public class SqlQueryScheduler
                             fragment.getPartitioningScheme(),
                             fragment.getStageExecutionDescriptor(),
                             fragment.isOutputTableWriterFragment(),
-                            fragment.getStatsAndCosts(),
-                            Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), functionAndTypeManager, session))));
+                            estimatedStatsAndCosts,
+                            Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), estimatedStatsAndCosts, functionAndTypeManager, session))));
         }
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -127,7 +127,7 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), plan.getStatsAndCosts(), session, 0, verbose);
+                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), plan.getStatsAndCosts(), metadata.getFunctionAndTypeManager(), session, 0, verbose);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
                 return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionAndTypeManager(), session, verbose);
@@ -153,10 +153,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), plan.getStatsAndCosts(), session, metadata.getFunctionAndTypeManager());
+                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), plan.getStatsAndCosts(), metadata.getFunctionAndTypeManager(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return graphvizDistributedPlan(subPlan, session, metadata.getFunctionAndTypeManager());
+                return graphvizDistributedPlan(subPlan, metadata.getFunctionAndTypeManager(), session);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }
@@ -179,7 +179,7 @@ public class QueryExplainer
                 return jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), plan.getStatsAndCosts(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return jsonDistributedPlan(subPlan);
+                return jsonDistributedPlan(subPlan, metadata.getFunctionAndTypeManager());
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -153,7 +153,7 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), session, metadata.getFunctionAndTypeManager());
+                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), plan.getStatsAndCosts(), session, metadata.getFunctionAndTypeManager());
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
                 return graphvizDistributedPlan(subPlan, session, metadata.getFunctionAndTypeManager());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -193,7 +193,7 @@ public abstract class BasePlanFragmenter
                 StageExecutionDescriptor.ungroupedExecution(),
                 outputTableWriterFragment,
                 statsAndCosts.getForSubplan(root),
-                Optional.of(jsonFragmentPlan(root, fragmentVariableTypes, metadata.getFunctionAndTypeManager(), session)));
+                Optional.of(jsonFragmentPlan(root, fragmentVariableTypes, statsAndCosts.getForSubplan(root), metadata.getFunctionAndTypeManager(), session)));
 
         return new SubPlan(fragment, properties.getChildren());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -417,7 +417,7 @@ public class PlanPrinter
         return builder.toString();
     }
 
-    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types, Session session, FunctionAndTypeManager functionAndTypeManager)
+    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types, StatsAndCosts estimatedStatsAndCosts, Session session, FunctionAndTypeManager functionAndTypeManager)
     {
         // TODO: This should move to something like GraphvizRenderer
         PlanFragment fragment = new PlanFragment(
@@ -429,7 +429,7 @@ public class PlanPrinter
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), plan.getOutputVariables()),
                 StageExecutionDescriptor.ungroupedExecution(),
                 false,
-                StatsAndCosts.empty(),
+                estimatedStatsAndCosts,
                 Optional.empty());
         return GraphvizPrinter.printLogical(ImmutableList.of(fragment), session, functionAndTypeManager);
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -838,7 +838,7 @@ public class LocalQueryRunner
     private List<Driver> createDrivers(Session session, Plan plan, OutputFactory outputFactory, TaskContext taskContext)
     {
         if (printPlan) {
-            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), plan.getStatsAndCosts(), session, 0, false));
+            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), plan.getStatsAndCosts(), metadata.getFunctionAndTypeManager(), session, 0, false));
         }
 
         SubPlan subplan = createSubPlans(session, plan, true);

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -41,6 +41,7 @@ import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
@@ -116,6 +117,7 @@ public final class GraphvizPrinter
         INDEX_SOURCE,
         UNNEST,
         ANALYZE_FINISH,
+        EXPLAIN_ANALYZE,
     }
 
     private static final Map<NodeType, String> NODE_COLORS = immutableEnumMap(ImmutableMap.<NodeType, String>builder()
@@ -141,6 +143,7 @@ public final class GraphvizPrinter
             .put(NodeType.UNNEST, "crimson")
             .put(NodeType.SAMPLE, "goldenrod4")
             .put(NodeType.ANALYZE_FINISH, "plum")
+            .put(NodeType.EXPLAIN_ANALYZE, "cadetblue1")
             .build());
 
     static {
@@ -291,6 +294,13 @@ public final class GraphvizPrinter
         public Void visitTableFinish(TableFinishNode node, Void context)
         {
             printNode(node, format("TableFinish[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.TABLE_FINISH));
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Void visitExplainAnalyze(ExplainAnalyzeNode node, Void context)
+        {
+            printNode(node, format("ExplainAnalyze[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.EXPLAIN_ANALYZE));
             return node.getSource().accept(this, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -149,7 +149,7 @@ public final class GraphvizPrinter
 
     private GraphvizPrinter() {}
 
-    public static String printLogical(List<PlanFragment> fragments, Session session, FunctionAndTypeManager functionAndTypeManager)
+    public static String printLogical(List<PlanFragment> fragments, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
         Map<PlanFragmentId, PlanFragment> fragmentsById = Maps.uniqueIndex(fragments, PlanFragment::getId);
         PlanNodeIdGenerator idGenerator = new PlanNodeIdGenerator();
@@ -158,7 +158,7 @@ public final class GraphvizPrinter
         output.append("digraph logical_plan {\n");
 
         for (PlanFragment fragment : fragments) {
-            printFragmentNodes(output, fragment, idGenerator, session, functionAndTypeManager);
+            printFragmentNodes(output, fragment, idGenerator, functionAndTypeManager, session);
         }
 
         for (PlanFragment fragment : fragments) {
@@ -170,7 +170,7 @@ public final class GraphvizPrinter
         return output.toString();
     }
 
-    public static String printDistributed(SubPlan plan, Session session, FunctionAndTypeManager functionAndTypeManager)
+    public static String printDistributed(SubPlan plan, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
         List<PlanFragment> fragments = plan.getAllFragments();
         Map<PlanFragmentId, PlanFragment> fragmentsById = Maps.uniqueIndex(fragments, PlanFragment::getId);
@@ -179,10 +179,26 @@ public final class GraphvizPrinter
         StringBuilder output = new StringBuilder();
         output.append("digraph distributed_plan {\n");
 
-        printSubPlan(plan, fragmentsById, idGenerator, output, session, functionAndTypeManager);
+        printSubPlan(plan, fragmentsById, idGenerator, output, functionAndTypeManager, session);
 
         output.append("}\n");
 
+        return output.toString();
+    }
+    public static String printDistributedFromFragments(List<PlanFragment> allFragments, FunctionAndTypeManager functionAndTypeManager, Session session)
+    {
+        PlanNodeIdGenerator idGenerator = new PlanNodeIdGenerator();
+        Map<PlanFragmentId, PlanFragment> fragmentsById = Maps.uniqueIndex(allFragments, PlanFragment::getId);
+
+        StringBuilder output = new StringBuilder();
+        output.append("digraph distributed_plan {\n");
+
+        for (PlanFragment planFragment : allFragments) {
+            printFragmentNodes(output, planFragment, idGenerator, functionAndTypeManager, session);
+            planFragment.getRoot().accept(new EdgePrinter(output, fragmentsById, idGenerator), null);
+        }
+
+        output.append("}\n");
         return output.toString();
     }
 
@@ -191,19 +207,19 @@ public final class GraphvizPrinter
             Map<PlanFragmentId, PlanFragment> fragmentsById,
             PlanNodeIdGenerator idGenerator,
             StringBuilder output,
-            Session session,
-            FunctionAndTypeManager functionAndTypeManager)
+            FunctionAndTypeManager functionAndTypeManager,
+            Session session)
     {
         PlanFragment fragment = plan.getFragment();
-        printFragmentNodes(output, fragment, idGenerator, session, functionAndTypeManager);
+        printFragmentNodes(output, fragment, idGenerator, functionAndTypeManager, session);
         fragment.getRoot().accept(new EdgePrinter(output, fragmentsById, idGenerator), null);
 
         for (SubPlan child : plan.getChildren()) {
-            printSubPlan(child, fragmentsById, idGenerator, output, session, functionAndTypeManager);
+            printSubPlan(child, fragmentsById, idGenerator, output, functionAndTypeManager, session);
         }
     }
 
-    private static void printFragmentNodes(StringBuilder output, PlanFragment fragment, PlanNodeIdGenerator idGenerator, Session session, FunctionAndTypeManager functionAndTypeManager)
+    private static void printFragmentNodes(StringBuilder output, PlanFragment fragment, PlanNodeIdGenerator idGenerator, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
         String clusterId = "cluster_" + fragment.getId();
         output.append("subgraph ")
@@ -215,7 +231,7 @@ public final class GraphvizPrinter
                 .append('\n');
 
         PlanNode plan = fragment.getRoot();
-        plan.accept(new NodePrinter(output, idGenerator, session, functionAndTypeManager, fragment.getStatsAndCosts()), null);
+        plan.accept(new NodePrinter(output, idGenerator, fragment.getStatsAndCosts(), functionAndTypeManager, session), null);
 
         output.append("}")
                 .append('\n');
@@ -230,7 +246,7 @@ public final class GraphvizPrinter
         private final Function<RowExpression, String> formatter;
         StatsAndCosts estimatedStatsAndCosts;
 
-        public NodePrinter(StringBuilder output, PlanNodeIdGenerator idGenerator, Session session, FunctionAndTypeManager functionAndTypeManager, StatsAndCosts estimatedStatsAndCosts)
+        public NodePrinter(StringBuilder output, PlanNodeIdGenerator idGenerator, StatsAndCosts estimatedStatsAndCosts, FunctionAndTypeManager functionAndTypeManager, Session session)
         {
             this.output = output;
             this.idGenerator = idGenerator;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -52,7 +52,7 @@ public final class PlanAssert
         // TODO (Issue #13231) add back printing unresolved plan once we have no need to translate OriginalExpression to RowExpression
         if (!matches.isMatch()) {
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
-            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), metadata.getFunctionAndTypeManager(), StatsAndCosts.empty(), session, 0);
+            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 0);
             throw new AssertionError(format(
                     "Plan does not match, expected [\n\n%s\n] but found [\n\n%s\n]",
                     pattern,
@@ -66,7 +66,7 @@ public final class PlanAssert
         // TODO (Issue #13231) add back printing unresolved plan once we have no need to translate OriginalExpression to RowExpression
         if (matches.isMatch()) {
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
-            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), metadata.getFunctionAndTypeManager(), StatsAndCosts.empty(), session, 0);
+            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 0);
             throw new AssertionError(format(
                     "Plan unexpectedly matches the pattern, pattern is [\n\n%s\n] and plan is [\n\n%s\n]",
                     pattern,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -147,7 +147,7 @@ public class RuleAssert
             fail(String.format(
                     "Expected %s to not fire for:\n%s",
                     rule.getClass().getName(),
-                    inTransaction(session -> textLogicalPlan(plan, ruleApplication.types, metadata.getFunctionAndTypeManager(), StatsAndCosts.empty(), session, 2))));
+                    inTransaction(session -> textLogicalPlan(plan, ruleApplication.types, StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 2))));
         }
     }
 
@@ -243,7 +243,7 @@ public class RuleAssert
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session);
-        return inTransaction(session -> textLogicalPlan(translateExpressions(plan, types), types, metadata.getFunctionAndTypeManager(), StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false));
+        return inTransaction(session -> textLogicalPlan(translateExpressions(plan, types), types, StatsAndCosts.create(plan, statsProvider, costProvider), metadata.getFunctionAndTypeManager(), session, 2, false));
     }
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.planPrinter;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.testing.TestingHandle;
+import com.facebook.presto.testing.TestingMetadata;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.AbstractMockMetadata.dummyMetadata;
+import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+
+public class TestJsonRenderer
+{
+    private static final PlanBuilder PLAN_BUILDER = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), dummyMetadata());
+    private static final VariableReferenceExpression COLUMN_VARIABLE = new VariableReferenceExpression(Optional.empty(), "column", VARCHAR);
+    private static final ColumnHandle COLUMN_HANDLE = new TestingMetadata.TestingColumnHandle("column");
+    private static final PlanVariableAllocator VARIABLE_ALLOCATOR = new PlanVariableAllocator();
+    private static final JsonRenderer JSON_RENDERER = new JsonRenderer(FUNCTION_AND_TYPE_MANAGER);
+    private static final TableHandle TABLE_HANDLE_WITH_LAYOUT = new TableHandle(
+            new ConnectorId("testConnector"),
+            new TestingMetadata.TestingTableHandle(),
+            TestingTransactionHandle.create(),
+            Optional.of(TestingHandle.INSTANCE));
+    private static final JsonCodec<JsonRenderer.JsonRenderedNode> PLAN_CODEC;
+
+    static {
+        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
+        provider.setKeyDeserializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionDeserializer(FUNCTION_AND_TYPE_MANAGER)));
+        JsonCodecFactory codecFactory = new JsonCodecFactory(provider, true);
+        PLAN_CODEC = codecFactory.jsonCodec(JsonRenderer.JsonRenderedNode.class);
+    }
+
+    @Test
+    public void testRoundtrip()
+    {
+        Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> mapper = buildSimpleNodePlan();
+        verify(mapper);
+        mapper = buildMultiNodePlan();
+        verify(mapper);
+    }
+
+    private PlanRepresentation getPlanRepresentation(PlanNode root)
+    {
+        return new PlanRepresentation(
+                root,
+                VARIABLE_ALLOCATOR.getTypes(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private NodeRepresentation getNodeRepresentation(PlanNode root, List<PlanNodeId> planNodeIds)
+    {
+        return new NodeRepresentation(
+                Optional.empty(),
+                root.getId(),
+                root.getClass().getName(),
+                root.getClass().getSimpleName(),
+                "",
+                root.getOutputVariables(),
+                Optional.empty(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                planNodeIds,
+                ImmutableList.of());
+    }
+
+    private Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> buildPlanResult(PlanNode root)
+    {
+        ImmutableMap.Builder<PlanRepresentation, JsonRenderer.JsonRenderedNode> result = ImmutableMap.builder();
+        List<PlanNodeId> childrenIds = root.getSources().stream().map(PlanNode::getId).collect(toImmutableList());
+        PlanRepresentation key = getPlanRepresentation(root);
+        NodeRepresentation nodeRepresentation = getNodeRepresentation(root, childrenIds);
+        key.addNode(nodeRepresentation);
+        // deserialize string to json
+        JsonRenderer.JsonRenderedNode value = JSON_RENDERER.renderJson(key, nodeRepresentation);
+        // put json as value for verify
+        result.put(key, value);
+        return result.build();
+    }
+
+    private Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> buildSimpleNodePlan()
+    {
+        TableScanNode scanNode = PLAN_BUILDER.tableScan(
+                TABLE_HANDLE_WITH_LAYOUT,
+                ImmutableList.of(COLUMN_VARIABLE),
+                ImmutableMap.of(COLUMN_VARIABLE, COLUMN_HANDLE),
+                TupleDomain.all(),
+                TupleDomain.all());
+
+        List<PlanNodeId> childrenIds = scanNode.getSources().stream().map(PlanNode::getId).collect(toImmutableList());
+        PlanRepresentation key = getPlanRepresentation(scanNode);
+        NodeRepresentation nodeRepresentation = getNodeRepresentation(scanNode, childrenIds);
+        key.addNode(nodeRepresentation);
+
+        return buildPlanResult(scanNode);
+    }
+
+    private Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> buildMultiNodePlan()
+    {
+        ImmutableMap.Builder<PlanRepresentation, JsonRenderer.JsonRenderedNode> result = ImmutableMap.builder();
+        ImmutableMap<VariableReferenceExpression, RowExpression> map = ImmutableMap.of(
+                COLUMN_VARIABLE,
+                COLUMN_VARIABLE);
+        TableScanNode scan = PLAN_BUILDER.tableScan(
+                TABLE_HANDLE_WITH_LAYOUT,
+                ImmutableList.of(COLUMN_VARIABLE),
+                ImmutableMap.of(COLUMN_VARIABLE, COLUMN_HANDLE));
+        LimitNode limit = PLAN_BUILDER.limit(10, scan);
+        ProjectNode root = PLAN_BUILDER.project(new Assignments(map), limit);
+
+        return buildPlanResult(root);
+    }
+
+    private void verify(Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> mapper)
+    {
+        for (PlanRepresentation key : mapper.keySet()) {
+            // serialize json to string
+            String originKey = JSON_RENDERER.render(key);
+            JsonRenderer.JsonRenderedNode result = PLAN_CODEC.fromJson(originKey);
+            JsonRenderer.JsonRenderedNode originValue = mapper.get(key);
+            assertEquals(result, originValue);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -36,7 +36,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.operator.StageExecutionDescriptor.ungroupedExecution;
@@ -45,6 +47,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DI
 import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.GraphvizPrinter.printDistributed;
+import static com.facebook.presto.util.GraphvizPrinter.printDistributedFromFragments;
 import static com.facebook.presto.util.GraphvizPrinter.printLogical;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -115,6 +118,31 @@ public class TestGraphvizPrinter
                 "}",
                 "");
         assertEquals(actualNestedSubPlan, expectedNestedSubPlan);
+    }
+
+    @Test
+    public void testPrintDistributedFromFragments()
+    {
+        List<PlanFragment> allFragments = new ArrayList<>();
+        allFragments.add(createTestPlanFragment(0, TEST_TABLE_SCAN_NODE));
+        allFragments.add(createTestPlanFragment(1, TEST_TABLE_SCAN_NODE));
+        String actual = printDistributedFromFragments(
+                allFragments,
+                FUNCTION_AND_TYPE_MANAGER,
+                testSessionBuilder().build());
+        String expected = "digraph distributed_plan {\n" +
+                "subgraph cluster_0 {\n" +
+                "label = \"SOURCE\"\n" +
+                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "}\n" +
+                "subgraph cluster_1 {\n" +
+                "label = \"SOURCE\"\n" +
+                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
+                "}\n" +
+                "}\n";
+        assertEquals(actual, expected);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -39,10 +39,10 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.Optional;
 
-import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.operator.StageExecutionDescriptor.ungroupedExecution;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.GraphvizPrinter.printDistributed;
 import static com.facebook.presto.util.GraphvizPrinter.printLogical;
@@ -74,8 +74,8 @@ public class TestGraphvizPrinter
     {
         String actual = printLogical(
                 ImmutableList.of(createTestPlanFragment(0, TEST_TABLE_SCAN_NODE)),
-                testSessionBuilder().build(),
-                createTestFunctionAndTypeManager());
+                FUNCTION_AND_TYPE_MANAGER,
+                testSessionBuilder().build());
         String expected = join(
                 System.lineSeparator(),
                 "digraph logical_plan {",
@@ -99,8 +99,8 @@ public class TestGraphvizPrinter
                 ImmutableList.of(tableScanNodeSubPlan));
         String actualNestedSubPlan = printDistributed(
                 nestedSubPlan,
-                testSessionBuilder().build(),
-                createTestFunctionAndTypeManager());
+                FUNCTION_AND_TYPE_MANAGER,
+                testSessionBuilder().build());
         String expectedNestedSubPlan = join(
                 System.lineSeparator(),
                 "digraph distributed_plan {",
@@ -141,8 +141,8 @@ public class TestGraphvizPrinter
 
         String actual = printLogical(
                 ImmutableList.of(createTestPlanFragment(0, node)),
-                testSessionBuilder().build(),
-                createTestFunctionAndTypeManager());
+                FUNCTION_AND_TYPE_MANAGER,
+                testSessionBuilder().build());
 
         String expected = "digraph logical_plan {\n" +
                 "subgraph cluster_0 {\n" +

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
@@ -38,6 +38,7 @@ public class QueryMetadata
 
     private final Optional<String> jsonPlan;
 
+    private final Optional<String> graphvizPlan;
     private final Optional<String> payload;
 
     private final List<String> runtimeOptimizedStages;
@@ -52,6 +53,7 @@ public class QueryMetadata
             URI uri,
             Optional<String> plan,
             Optional<String> jsonPlan,
+            Optional<String> graphvizPlan,
             Optional<String> payload,
             List<String> runtimeOptimizedStages,
             Optional<String> tracingId)
@@ -65,6 +67,7 @@ public class QueryMetadata
         this.uri = requireNonNull(uri, "uri is null");
         this.plan = requireNonNull(plan, "plan is null");
         this.jsonPlan = requireNonNull(jsonPlan, "jsonPlan is null");
+        this.graphvizPlan = requireNonNull(graphvizPlan, "graphvizPlan is null");
         this.payload = requireNonNull(payload, "payload is null");
         this.runtimeOptimizedStages = requireNonNull(runtimeOptimizedStages, "runtimeOptimizedStages is null");
         this.tracingId = requireNonNull(tracingId, "tracingId is null");
@@ -122,6 +125,12 @@ public class QueryMetadata
     public Optional<String> getJsonPlan()
     {
         return jsonPlan;
+    }
+
+    @JsonProperty
+    public Optional<String> getGraphvizPlan()
+    {
+        return graphvizPlan;
     }
 
     @JsonProperty

--- a/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
@@ -66,8 +66,8 @@ public class PlanDeterminismChecker
             return PlanPrinter.textLogicalPlan(
                     plan.getRoot(),
                     plan.getTypes(),
-                    localQueryRunner.getMetadata().getFunctionAndTypeManager(),
                     plan.getStatsAndCosts(),
+                    localQueryRunner.getMetadata().getFunctionAndTypeManager(),
                     transactionSession,
                     0,
                     false);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
@@ -14,6 +14,10 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.Serialization;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.planPrinter.JsonRenderer.JsonRenderedNode;
 import com.facebook.presto.sql.tree.Explain;
@@ -25,13 +29,14 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.sql.tree.ExplainFormat.Type.JSON;
+import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.verifier.framework.ExplainMatchResult.MatchType;
 import static com.facebook.presto.verifier.framework.ExplainMatchResult.MatchType.DETAILS_MISMATCH;
 import static com.facebook.presto.verifier.framework.ExplainMatchResult.MatchType.MATCH;
@@ -45,7 +50,7 @@ public class ExplainVerification
         extends AbstractVerification<QueryBundle, ExplainMatchResult, String>
 {
     private static final ResultSetConverter<String> QUERY_PLAN_RESULT_SET_CONVERTER = resultSet -> Optional.of(resultSet.getString("Query Plan"));
-    private static final JsonCodec<JsonRenderedNode> PLAN_CODEC = jsonCodec(JsonRenderedNode.class);
+    private static JsonCodec<JsonRenderedNode> planCodec;
     private final SqlParser sqlParser;
 
     public ExplainVerification(
@@ -59,6 +64,11 @@ public class ExplainVerification
     {
         super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.of(QUERY_PLAN_RESULT_SET_CONVERTER), verifierConfig, executor);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
+        provider.setJsonSerializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionSerializer()));
+        provider.setKeyDeserializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionDeserializer(FUNCTION_AND_TYPE_MANAGER)));
+        JsonCodecFactory codecFactory = new JsonCodecFactory(provider, true);
+        planCodec = codecFactory.jsonCodec(JsonRenderedNode.class);
     }
 
     @Override
@@ -81,8 +91,8 @@ public class ExplainVerification
         checkArgument(controlQueryResult.isPresent(), "control query plan is missing");
         checkArgument(testQueryResult.isPresent(), "test query plan is missing");
 
-        JsonRenderedNode controlPlan = PLAN_CODEC.fromJson(getOnlyElement(controlQueryResult.get().getResults()));
-        JsonRenderedNode testPlan = PLAN_CODEC.fromJson(getOnlyElement(testQueryResult.get().getResults()));
+        JsonRenderedNode controlPlan = planCodec.fromJson(getOnlyElement(controlQueryResult.get().getResults()));
+        JsonRenderedNode testPlan = planCodec.fromJson(getOnlyElement(testQueryResult.get().getResults()));
 
         return new ExplainMatchResult(match(controlPlan, testPlan));
     }
@@ -114,7 +124,8 @@ public class ExplainVerification
             return STRUCTURE_MISMATCH;
         }
 
-        boolean detailsMismatched = !Objects.equals(controlPlan.getDetails(), testPlan.getDetails());
+        boolean detailsMismatched = !Objects.equals(controlPlan.getDetails(), testPlan.getDetails())
+                || !Objects.equals(controlPlan.getEstimates(), testPlan.getEstimates());
         for (int i = 0; i < controlPlan.getChildren().size(); i++) {
             MatchType childMatchType = match(controlPlan.getChildren().get(i), testPlan.getChildren().get(i));
             if (childMatchType == STRUCTURE_MISMATCH) {


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
Enforce a testcase to verify the plan entirety with stats info using graphviz format and json format


```
== RELEASE NOTES ==

General Changes
* Add estimated stats on plan output for EXPLAIN format in GRAPHVIZ and JSON
```

**Before Change:**
```
                                                                                                                    Query Plan
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {
   "id" : "5",
   "name" : "Output",
   "identifier" : "[key1, value1]",
   "details" : "",
   "children" : [ {
     "id" : "80",
     "name" : "RemoteStreamingExchange",
     "identifier" : "[GATHER]",
     "details" : "",
     "children" : [ {
       "id" : "0",
       "name" : "TableScan",
       "identifier" : "[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=default, tableName=test_grouped_join1, analyzePartitionValues=Optional.empty}', layout='Optional[default.test_grouped_join1{buckets=13}]'}]",
       "details" : "LAYOUT: default.test_grouped_join1{buckets=13}\nvalue1 := value1:varchar(79):1:REGULAR (1:37)\nkey1 := key1:bigint:0:REGULAR (1:37)\n",
       "children" : [ ],
       "remoteSources" : [ ]
     } ],
     "remoteSources" : [ ]
   } ],
   "remoteSources" : [ ]
 }
(1 row)

Query 20221212_231733_00000_2kdqx, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

```

**After Change:**
```
                                                                                                                    Query Plan
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {
   "id" : "5",
   "name" : "Output",
   "identifier" : "[key1, value1]",
   "details" : "",
   "children" : [ {
     "id" : "80",
     "name" : "RemoteStreamingExchange",
     "identifier" : "[GATHER]",
     "details" : "",
     "children" : [ {
       "id" : "0",
       "name" : "TableScan",
       "identifier" : "[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=default, tableName=test_grouped_join1, analyzePartitionValues=Optional.empty}', layout='Optional[default.test_grouped_join1{buckets=13}]'}]",
       "details" : "LAYOUT: default.test_grouped_join1{buckets=13}\nvalue1 := value1:varchar(79):1:REGULAR (1:37)\nkey1 := key1:bigint:0:REGULAR (1:37)\n",
       "children" : [ ],
       "remoteSources" : [ ],
       "estimates" : [ {
         "outputRowCount" : 15000.0,
         "totalSize" : 1057364.0,
         "confident" : true,
         "variableStatistics" : {
           "value1<varchar(79)>" : {
             "lowValue" : "-Infinity",
             "highValue" : "Infinity",
             "nullsFraction" : 0.0,
             "averageRowSize" : 48.49093333333333,
             "distinctValuesCount" : 15000.0
           },
           "key1<bigint>" : {
             "lowValue" : 1.0,
             "highValue" : 60000.0,
             "nullsFraction" : 0.0,
             "averageRowSize" : "NaN",
             "distinctValuesCount" : 15000.0
           }
         }
       } ]
     } ],
     "remoteSources" : [ ],
     "estimates" : [ {
       "outputRowCount" : 15000.0,
       "totalSize" : 1057364.0,
       "confident" : true,
       "variableStatistics" : {
         "value1<varchar(79)>" : {
           "lowValue" : "-Infinity",
           "highValue" : "Infinity",
           "nullsFraction" : 0.0,
           "averageRowSize" : 48.49093333333333,
           "distinctValuesCount" : 15000.0
         },
         "key1<bigint>" : {
           "lowValue" : 1.0,
           "highValue" : 60000.0,
           "nullsFraction" : 0.0,
           "averageRowSize" : "NaN",
           "distinctValuesCount" : 15000.0
         }
       }
     } ]
   } ],
   "remoteSources" : [ ],
   "estimates" : [ {
     "outputRowCount" : 15000.0,
     "totalSize" : 1057364.0,
     "confident" : true,
     "variableStatistics" : {
       "value1<varchar(79)>" : {
         "lowValue" : "-Infinity",
         "highValue" : "Infinity",
         "nullsFraction" : 0.0,
         "averageRowSize" : 48.49093333333333,
         "distinctValuesCount" : 15000.0
       },
       "key1<bigint>" : {
         "lowValue" : 1.0,
         "highValue" : 60000.0,
         "nullsFraction" : 0.0,
         "averageRowSize" : "NaN",
         "distinctValuesCount" : 15000.0
       }
     }
   } ]
 }
(1 row)
```