### PR TITLE
[native] Fix gitattributes

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/.gitattributes
+++ b/presto-native-execution/presto_cpp/main/thrift/.gitattributes
@@ -2,7 +2,7 @@ presto_thrift.json -diff -merge
 presto_thrift.json linguist-generated=true
 presto_protocol-to-thrift-json.json -diff -merge
 presto_protocol-to-thrift-json.json linguist-generated=true
-ProtocolToThrift.cpp -diff -merge
+ProtocolToThrift.cpp -merge
 ProtocolToThrift.cpp linguist-generated=true
-ProtocolToThrift.h -diff -merge
+ProtocolToThrift.h -merge
 ProtocolToThrift.h linguist-generated=true

--- a/presto-native-execution/presto_cpp/main/types/.gitattributes
+++ b/presto-native-execution/presto_cpp/main/types/.gitattributes
@@ -1,2 +1,2 @@
-antlr/*     -diff -merge
+antlr/*     -merge
 antlr/*     linguist-generated=true

--- a/presto-native-execution/presto_cpp/presto_protocol/.gitattributes
+++ b/presto-native-execution/presto_cpp/presto_protocol/.gitattributes
@@ -1,6 +1,6 @@
-presto_protocol.h     -diff -merge
+presto_protocol.h     -merge
 presto_protocol.h     linguist-generated=true
-presto_protocol.cpp   -diff -merge
+presto_protocol.cpp   -merge
 presto_protocol.cpp   linguist-generated=true
 presto_protocol.proto -diff -merge
 presto_protocol.proto linguist-generated=true


### PR DESCRIPTION
This is causing problems when importing these commits to a Meta internal repo.

These files are not actually binary (despite being marked as `-diff`) but they are automatically generated (so `-merge` is correct) so this should be a no-op.

These files seem reasonably stable so I'm reasonably confident this is a no-op for OSS, it just affects Meta internals