### PR TITLE
Fix last scheduling cycle run time metric

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -96,7 +96,7 @@ public final class InternalResourceGroupManager<C>
     private final Map<String, ResourceGroupConfigurationManagerFactory> configurationManagerFactories = new ConcurrentHashMap<>();
     private final AtomicBoolean taskLimitExceeded = new AtomicBoolean();
     private final int maxTotalRunningTaskCountToNotExecuteNewQuery;
-    private final AtomicLong lastSchedulingCycleRunTimeMs = new AtomicLong(currentTimeMillis());
+    private final AtomicLong lastSchedulingCycleRunTimeMs = new AtomicLong(0L);
     private final ResourceGroupService resourceGroupService;
     private final AtomicReference<Map<ResourceGroupId, ResourceGroupRuntimeInfo>> resourceGroupRuntimeInfos = new AtomicReference<>(ImmutableMap.of());
     private final AtomicReference<Map<ResourceGroupId, ResourceGroupRuntimeInfo>> resourceGroupRuntimeInfosSnapshot = new AtomicReference<>(ImmutableMap.of());
@@ -414,7 +414,9 @@ public final class InternalResourceGroupManager<C>
     @Managed
     public long getLastSchedulingCycleRuntimeDelayMs()
     {
-        return currentTimeMillis() - lastSchedulingCycleRunTimeMs.get();
+        // When coordinator restarts/deploy, the initial 0 value make sure the metric won't spike. Without it, the first metric published will have larger value
+        // due to the delay from the initialization to the actual successful run of refreshAndStartQueries method
+        return lastSchedulingCycleRunTimeMs.get() == 0L ? lastSchedulingCycleRunTimeMs.get() : currentTimeMillis() - lastSchedulingCycleRunTimeMs.get();
     }
 
     private int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)


### PR DESCRIPTION
For disagg coordinator, when cluster restarts and if resource managers take some time to come up, coordinators will end up having a spike in scheduling cycle run time due to coordinator not able to reach to resource managers. With this change, we avoid having this spike and return 0 value till coordinator able to reach to resource manager first time.

Test plan - n/a

```
== NO RELEASE NOTE ==
```
