### PR TITLE
Add Feature Toggles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,8 @@
         <module>presto-router</module>
         <module>presto-open-telemetry</module>
         <module>redis-hbo-provider</module>
+        <module>presto-feature-toggle</module>
+        <module>presto-feature-toggle-plugin</module>
     </modules>
 
     <dependencyManagement>
@@ -325,6 +327,18 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-iceberg</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-feature-toggle</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-feature-toggle-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-feature-toggle-plugin/pom.xml
+++ b/presto-feature-toggle-plugin/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.284-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>presto-feature-toggle-plugin</artifactId>
+    <name>presto-feature-toggle-plugin</name>
+    <description>Presto - Feature Toggle Plugin</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-feature-toggle</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/config/ConfigurationParser.java
+++ b/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/config/ConfigurationParser.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isReadable;
+
+public class ConfigurationParser
+{
+    private static final String JSON = "JSON";
+    private static final String PROPERTIES = "PROPERTIES";
+    private static final String FEATURE = "feature";
+    private static final String FEATURE_S = "feature.%s.";
+    private static final String ENABLED = "enabled";
+    private static final String HOT_RELOADABLE = "hot-reloadable";
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+    private static final String FEATURE_CLASS = "featureClass";
+    private static final String FEATURE_INSTANCES = "featureInstances";
+    private static final String CURRENT_INSTANCE = "currentInstance";
+    private static final String DEFAULT_INSTANCE = "defaultInstance";
+    private static final String STRATEGY = "strategy";
+    private static final String STRATEGY_DOT = "strategy.";
+    private static final String REGEX_DOT = "\\.";
+    private static final String EMPTY_STRING = "";
+    private static final String COMMA = ",";
+
+    private ConfigurationParser() {}
+
+    public static Map<String, FeatureConfiguration> parseConfiguration(FeatureToggleConfig config)
+    {
+        String configSource = config.getConfigSource();
+        String configType = config.getConfigType();
+        return parseConfiguration(configSource, configType);
+    }
+
+    public static Map<String, FeatureConfiguration> parseConfiguration(String configSource, String configType)
+    {
+        Map<String, FeatureConfiguration> featureConfigurationMap = new ConcurrentHashMap<>();
+        Path path = Paths.get(configSource);
+        if (!path.isAbsolute()) {
+            path = path.toAbsolutePath();
+        }
+        checkArgument(exists(path), "File does not exist: %s", path);
+        checkArgument(isReadable(path), "File is not readable: %s", path);
+        if (JSON.equalsIgnoreCase(configType)) {
+            parseJsonConfiguration(path, featureConfigurationMap);
+        }
+        else if (PROPERTIES.equalsIgnoreCase(configType)) {
+            parsePropertiesConfiguration(path, featureConfigurationMap);
+        }
+        return featureConfigurationMap;
+    }
+
+    static void parsePropertiesConfiguration(Path path, Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        try {
+            Map<String, String> properties = loadPropertiesFrom(path.toString());
+            Map<String, Map<String, String>> featurePropertyMap = new TreeMap<>();
+            properties.forEach((key, value) -> {
+                List<String> keyList = Arrays.asList(key.split(REGEX_DOT));
+                if (FEATURE.equals(keyList.get(0))) {
+                    String featureId = keyList.get(1);
+                    if (!featurePropertyMap.containsKey(featureId)) {
+                        featurePropertyMap.put(featureId, new TreeMap<>());
+                    }
+                    String property = key.replace(format(FEATURE_S, featureId), EMPTY_STRING);
+                    featurePropertyMap.get(featureId).put(property, value);
+                }
+            });
+            featurePropertyMap.forEach((featureId, featureMap) -> featureConfigurationMap.put(featureId,
+                    new FeatureConfiguration(
+                            featureId,
+                            Boolean.parseBoolean(featureMap.getOrDefault(ENABLED, TRUE)),
+                            Boolean.parseBoolean(featureMap.getOrDefault(HOT_RELOADABLE, FALSE)),
+                            featureMap.get(FEATURE_CLASS),
+                            Arrays.asList(featureMap.getOrDefault(FEATURE_INSTANCES, EMPTY_STRING).split(COMMA)),
+                            featureMap.get(CURRENT_INSTANCE),
+                            featureMap.get(DEFAULT_INSTANCE),
+                            parseStrategy(featureMap))));
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Error reading Properties file '%s'", path), e);
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(format("Invalid Properties file format '%s'", path), e);
+        }
+    }
+
+    private static FeatureToggleStrategyConfig parseStrategy(Map<String, String> featureMap)
+    {
+        if (!featureMap.containsKey(STRATEGY)) {
+            return null;
+        }
+        Map<String, String> strategyMap = new ConcurrentHashMap<>();
+        featureMap.keySet().stream()
+                .filter(key -> key.startsWith(STRATEGY))
+                .forEach(key -> strategyMap.put(key.replace(STRATEGY_DOT, EMPTY_STRING), featureMap.get(key)));
+
+        return new FeatureToggleStrategyConfig(featureMap.get(STRATEGY), strategyMap);
+    }
+
+    static void parseJsonConfiguration(Path path, Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        try {
+            ObjectMapper mapper = new JsonObjectMapperProvider().get()
+                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            List<FeatureConfiguration> configurationList = Arrays.asList(mapper.readValue(path.toFile(), FeatureConfiguration[].class));
+            configurationList.forEach(f ->
+                    featureConfigurationMap.put(f.getFeatureClass(), f));
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Invalid JSON file '%s'", path), e);
+        }
+    }
+}

--- a/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/plugin/FeatureToggleFileConfigurationSource.java
+++ b/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/plugin/FeatureToggleFileConfigurationSource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.plugin;
+
+import com.facebook.presto.features.config.DefaultFeatureToggleConfiguration;
+import com.facebook.presto.spi.features.ConfigurationSource;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.Map;
+
+import static com.facebook.presto.features.config.ConfigurationParser.parseConfiguration;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * The "file" Feature Toggle configuration source.
+ * Configuration source loads Feature toggle configuration form file.
+ * File can be in properties or json format.
+ * Configuration Source takes two parameter type (properties or json) and location (physical location of the file)
+ */
+public class FeatureToggleFileConfigurationSource
+        implements ConfigurationSource
+{
+    public static final String NAME = "file";
+    public static final String FEATURES_CONFIG_SOURCE = "features.config-source";
+    public static final String FEATURES_CONFIG_SOURCE_TYPE = "features.config-type";
+
+    private final String location;
+    private final String type;
+
+    public FeatureToggleFileConfigurationSource(String location, String type)
+    {
+        this.location = location;
+        this.type = type;
+    }
+
+    @Override
+    public FeatureToggleConfiguration getConfiguration()
+    {
+        return new DefaultFeatureToggleConfiguration(parseConfiguration(location, type));
+    }
+
+    public static class Factory
+            implements ConfigurationSourceFactory
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public ConfigurationSource create(Map<String, String> config)
+        {
+            String location = config.get(FEATURES_CONFIG_SOURCE);
+            checkState(location != null, "Configuration source path configuration must contain the '%s' property", FEATURES_CONFIG_SOURCE);
+            String type = config.get(FEATURES_CONFIG_SOURCE_TYPE);
+            checkState(type != null, "Configuration type configuration must contain the '%s' property", FEATURES_CONFIG_SOURCE_TYPE);
+            return new FeatureToggleFileConfigurationSource(location, type);
+        }
+    }
+}

--- a/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/plugin/FeatureTogglePlugin.java
+++ b/presto-feature-toggle-plugin/src/main/java/com/facebook/presto/features/plugin/FeatureTogglePlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.plugin;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
+import com.google.common.collect.ImmutableList;
+
+public final class FeatureTogglePlugin
+        implements Plugin
+{
+    public Iterable<ConfigurationSourceFactory> getConfigurationSourceFactories()
+    {
+        return ImmutableList.of(new FeatureToggleFileConfigurationSource.Factory());
+    }
+}

--- a/presto-feature-toggle/README.md
+++ b/presto-feature-toggle/README.md
@@ -1,0 +1,234 @@
+# Feature Toggles
+
+Feature Toggles should allow teams to modify system behavior without changing code. Feature Toggles are configured using Google Guice. The basic definition of toggles is created
+using FeatureToggleBinder. FeatureToggleBinder creates FeatureToggle, and additional configuration can be done using feature configuration.
+
+## Contents
+
+1. [Configuration](#configuration)
+2. [Defining Feature Toggles](#defining-feature-toggles)
+    1. [Simple feature toggle definition](#simple-feature-toggle-definition)
+    2. [Hot reloadable feature toggle definition](#hot-reloadable-feature-toggle-definition)
+    3. [Strategy-based Feature Toggling](#strategy-based-feature-toggling)
+3. [Examples](#examples)
+    1. [Query Cancel Feature](#query-cancel-feature)
+    2. [feature-config.properties file example](#feature-toggle-config-file-example)
+
+## Configuration
+
+To allow feature toggle configuration four lines are needed in the config.properties file
+
+```
+    features.config-source-type=file
+    features.config-source=/etc/feature-config.properties
+    features.config-type=properties
+    features.refresh-period=30s
+```
+
+- `configuration-source-type` is the source type for Feature Toggles configuration
+- `features.config-source` is a source (file) of the configuration
+- `features.config-type` format in which configuration is stored (JSON or properties)
+- `features.refresh-period` configuration refresh period
+
+## Defining Feature Toggles
+
+Feature toggle definition is done in the Google guice module using `FeatureToggleBinder`
+
+## Simple feature toggle definition
+
+```
+    featureToggleBinder(binder)
+        .featureId("featureXX")
+        .bind()
+```
+
+This example creates bindings for `@FeatureToggle("featureXX") Supplier<Boolean> isFeatureXXEnabled.`
+
+```   
+    @Inject
+    public Runner(@FeatureToggle("featureXX") Supplier<Boolean> isFeatureXXEnabled)
+    {
+        this.isFeatureXXEnabled = isFeatureXXEnabled;
+    }
+```
+
+Supplier&lt;Boolean&gt; `isFeatureXXEnabled` can be used to test if the feature is enabled or disabled:
+
+```
+    boolean testFeatureXXEnabled()
+    {
+     return isFeatureXXEnabled.get();
+    }
+```
+
+Switching the feature toggle on/off is done by changing the enabled value from true to false in the configuration source file:
+
+```
+    feature.featureXX.enabled=true
+```
+
+After the refresh period value of `isFeatureXXEnabled.get();`  is changed.
+
+## Hot reloadable feature toggle definition
+
+```
+    featureToggleBinder(binder, Feature01.class)
+        .featureId("feature01")
+        .baseClass(Feature01.class)
+        .defaultClass(Feature01Impl01.class)
+        .allOf(Feature01Impl01.class, Feature01Impl02.class)
+        .bind()
+```
+
+```
+    class Runner
+    {
+        private final Provider<Feature01> feature01;
+    
+    @Inject
+    public Runner(
+        @FeatureToggle("feature01") Provider<Feature01> feature01)
+        {
+            this.feature01 = feature01;
+        }
+
+        public String testFeature01()
+        {
+            return feature01.get().test();
+        }
+    }
+```
+
+## Strategy-based Feature Toggling
+
+Strategy-based Toggling allows us to Implement custom predicates (Strategy Pattern) to evaluate if a feature is enabled.
+
+Some are provided out of the box: AllowAll, OS-based toggle, and AllowList toggle strategy.
+
+The current implementation allows us to define various strategies and register them during application initialization.
+
+To use feature toggle strategies we must register strategy.
+This should be used only once (subsequent registration doesn't have an effect).
+
+```
+    featureToggleBinder(binder)
+        .registerToggleStrategy("AllowList", AllowListToggleStrategy.class)
+        .bind();
+```
+
+Feature toggle definition with toggle strategy registration.
+
+```
+    public class RegisterStrategyModule
+        implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            featureToggleBinder(binder)
+                .featureId("query-cancel")
+                .enabled(true)
+                .toggleStrategy("AllowList")
+                .registerToggleStrategy("AllowList", AllowListToggleStrategy.class)
+                .toggleStrategyConfig(ImmutableMap.of("allow-list-source", ".IDEA.", "allow-list-user", ".*prestodb"))
+                .bind();
+        }
+    }
+```
+
+Feature toggle definition with already registered toggle strategy.
+
+```
+    public class RegisterStrategyModule
+        implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            featureToggleBinder(binder)
+                .featureId("query-cancel")
+                .enabled(true)
+                .toggleStrategy("AllowList")
+                .toggleStrategyConfig(ImmutableMap.of("allow-list-source", ".IDEA.", "allow-list-user", ".*prestodb"))
+                .bind();
+        }
+    }
+```
+
+Toggle strategy configuration params can be updated on runtime, by changing strategy configuration param values.
+
+In this case, we can change `feature.query-cancel.strategy.allow-list-source` and `feature.query-cancel.strategy.allow-list-user` param values.
+
+# Examples
+
+## Query Cancel Feature
+
+```
+    feature.query-cancel.enable=true
+    feature.query-cancel.strategy=AllowList
+    feature.query-cancel.strategy.allow-list-source=.*IDEA.*
+    feature.query-cancel.strategy.allow-list-user=.*prestodb
+```
+
+Feature Toggle Strategies are evaluated each time we check if the feature toggle is enabled.
+The result of the Feature Toggle Strategy evaluation overrides the `enabled` status of the Feature Toggle.
+
+Simple Feature toggle check Example:
+
+```
+    class ClassWithQueryCancel
+    {
+        private final Supplier<Boolean> isQueryCancelEnabled;
+        private final Function<Object, Boolean> isQueryCancelEnabledForQueryId;
+
+        @Inject
+        public SupplierInjectionRunner(
+            @FeatureToggle("query-cancel") Supplier<Boolean> isQueryCancelEnabled,
+            @FeatureToggle("FunctionInjectionFeature") Function<Object, Boolean> isQueryCancelEnabledForQueryId)
+        {
+            this.isQueryCancelEnabledForQueryId = isQueryCancelEnabledForQueryId;
+            this.isQueryCancelEnabled = isQueryCancelEnabled;
+        }
+
+        /**
+        * simple check: checks enabled param of the configuration
+        */
+        public boolean testSimpleFeatureEnabled()
+        {
+            return isQueryCancelEnabled.get();
+        }
+
+        /**
+        * feature toggle check using a strategy that accepts input param
+        */
+         public boolean testFunctionInjectionFeatureEnabled(String queryId)
+        {
+            return isQueryCancelEnabledForQueryId.apply(queryId);
+        }
+    }
+```
+
+## Feature Toggle config file example
+
+Any change of the configuration in the configuration file (source) overrides the feature toggle configuration.
+Allowed configuration params are:
+
+- enable
+- strategy.<param>
+
+```
+# feature.query-cancel
+feature.query-cancel.enable=true
+feature.query-cancel.strategy=AllowList
+feature.query-cancel.strategy.allow-list-source=.*IDEA.*
+feature.query-cancel.strategy.allow-list-user=.*prestodb
+```
+
+Configuration properties always start with a `feature` followed by a dot and the feature id.
+
+Feature Toggle strategy properties start with `feature.featureId.strategy`. Property `feature.featureId.strategy` defines feature toggle strategy class (declared by registered
+name).
+After that, we can declare key-value pairs for parameters allowed for a given strategy.
+
+In this example for feature `query-cancel`, changing the value of feature.query-cancel.enabled to `false` will 'disable' this feature.
+Changes will be effective within the refresh period. 

--- a/presto-feature-toggle/pom.xml
+++ b/presto-feature-toggle/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.284-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>presto-feature-toggle</artifactId>
+    <name>presto-feature-toggle</name>
+    <description>Presto - Feature Toggle</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggle.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggle.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.annotations;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+public @interface FeatureToggle
+{
+    String value() default "";
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggleImpl.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggleImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.annotations;
+
+import com.google.inject.internal.Annotations;
+
+import java.lang.annotation.Annotation;
+
+import static java.util.Objects.requireNonNull;
+
+public class FeatureToggleImpl
+        implements FeatureToggle
+{
+    private final String value;
+
+    public FeatureToggleImpl(String value)
+    {
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    @Override
+    public String value()
+    {
+        return this.value;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        // This is specified in java.lang.Annotation.
+        return (127 * "value".hashCode()) ^ value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof FeatureToggle)) {
+            return false;
+        }
+
+        FeatureToggle other = (FeatureToggle) o;
+        return value.equals(other.value());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "@" + FeatureToggle.class.getName() + "(value=" + Annotations.memberValueString(value) + ")";
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType()
+    {
+        return FeatureToggle.class;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggles.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/annotations/FeatureToggles.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.annotations;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+
+import java.util.Map;
+
+/**
+ * Utility methods for use with @FeatureToggle.
+ */
+public class FeatureToggles
+{
+    private FeatureToggles() {}
+
+    /**
+     * Creates a {@link FeatureToggle} annotation with {@code name} as the value.
+     */
+    public static FeatureToggle named(String value)
+    {
+        return new FeatureToggleImpl(value);
+    }
+
+    /**
+     * Creates a constant binding to {@code @FeatureToggle(name)} for each entry in {@code properties}.
+     */
+    public static void bindProperties(Binder binder, Map<String, String> properties)
+    {
+        binder = binder.skipSources(FeatureToggles.class);
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            binder.bind(Key.get(String.class, new FeatureToggleImpl(key))).toInstance(value);
+        }
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/Feature.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/Feature.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+
+import static java.util.Objects.requireNonNull;
+
+public class Feature<T>
+{
+    private final String featureId;
+    private final Class<T> baseClass;
+    private final FeatureConfiguration configuration;
+    private PrestoFeatureToggle prestoFeatureToggle;
+
+    public Feature(String featureId, Class<T> baseClass, FeatureConfiguration configuration)
+    {
+        this.featureId = requireNonNull(featureId, "feature ID is null");
+        this.baseClass = baseClass;
+        this.configuration = requireNonNull(configuration, "feature configuration is null");
+    }
+
+    public String getFeatureId()
+    {
+        return featureId;
+    }
+
+    public boolean isEnabled()
+    {
+        return prestoFeatureToggle.isEnabled(featureId);
+    }
+
+    public FeatureConfiguration getConfiguration()
+    {
+        return configuration;
+    }
+
+    public void setContext(PrestoFeatureToggle prestoFeatureToggle)
+    {
+        this.prestoFeatureToggle = prestoFeatureToggle;
+    }
+
+    public boolean check(Object object)
+    {
+        return prestoFeatureToggle.isEnabled(featureId, object);
+    }
+
+    public T getCurrentInstance(String featureId)
+    {
+        if (baseClass == null) {
+            return null;
+        }
+        if (prestoFeatureToggle == null) {
+            return null;
+        }
+        return baseClass.cast(prestoFeatureToggle.getCurrentInstance(featureId));
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/FeatureToggleBinder.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/FeatureToggleBinder.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.annotations.FeatureToggles;
+import com.facebook.presto.features.strategy.FeatureToggleStrategy;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.inject.Binder;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static java.util.Objects.requireNonNull;
+
+public class FeatureToggleBinder<T>
+{
+    private final Binder binder;
+    private Class<T> baseClass;
+    private Class<? extends T> defaultClass;
+    private Set<Class<? extends T>> classes = new HashSet<>();
+    private boolean hotReloadable;
+    private String strategy;
+    private String featureId;
+    private boolean enabled = true;
+    private Map<String, String> strategyConfigMap = new ConcurrentHashMap<>();
+
+    public FeatureToggleBinder(Binder binder, Class<T> baseClass, Class<? extends T> defaultClass, Set<Class<? extends T>> classes, boolean hotReloadable, String strategy, String featureId, boolean enabled, Map<String, String> strategyConfigMap)
+    {
+        this.binder = binder;
+        this.baseClass = baseClass;
+        this.defaultClass = defaultClass;
+        this.classes = classes;
+        this.hotReloadable = hotReloadable;
+        this.strategy = strategy;
+        this.featureId = featureId;
+        this.enabled = enabled;
+        this.strategyConfigMap = strategyConfigMap;
+    }
+
+    private FeatureToggleBinder(Binder binder)
+    {
+        this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
+    }
+
+    public FeatureToggleBinder(Binder binder, Class<T> klass)
+    {
+        this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
+        this.baseClass = klass;
+    }
+
+    public static <T> FeatureToggleBinder<T> featureToggleBinder(Binder binder, Class<T> klass)
+    {
+        return new FeatureToggleBinder<>(binder, klass);
+    }
+
+    public static <T> FeatureToggleBinder<T> featureToggleBinder(Binder binder)
+    {
+        return new FeatureToggleBinder<>(binder);
+    }
+
+    public FeatureToggleBinder<T> baseClass(Class<T> baseClass)
+    {
+        requireNonNull(baseClass, "base class is null");
+        return new FeatureToggleBinder<>(binder, baseClass, defaultClass, classes, hotReloadable, strategy, featureId, enabled, strategyConfigMap);
+    }
+
+    public FeatureToggleBinder<T> featureId(String featureId)
+    {
+        this.featureId = requireNonNull(featureId, "feature ID is null");
+        return this;
+    }
+
+    public FeatureToggleBinder<T> defaultClass(Class<? extends T> defaultClass)
+    {
+        this.defaultClass = requireNonNull(defaultClass, "default class is null");
+        this.classes.add(defaultClass);
+        return this;
+    }
+
+    @SafeVarargs
+    public final FeatureToggleBinder<T> allOf(Class<? extends T>... classes)
+    {
+        requireNonNull(classes, "classes are null");
+        this.classes = new HashSet<>(Arrays.asList(classes));
+        return this;
+    }
+
+    public FeatureToggleBinder<T> enabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public FeatureToggleBinder<T> toggleStrategy(String strategy)
+    {
+        this.strategy = requireNonNull(strategy, "strategy is null");
+        return this;
+    }
+
+    public FeatureToggleBinder<T> toggleStrategyConfig(Map<String, String> strategyConfigMap)
+    {
+        this.strategyConfigMap = requireNonNull(strategyConfigMap, "strategy config map is null");
+        return this;
+    }
+
+    public void init()
+    {
+        newMapBinder(binder, String.class, Object.class, FeatureToggles.named("feature-instance-map"));
+        newMapBinder(binder, new TypeLiteral<String>() {}, new TypeLiteral<Feature<?>>() {}, FeatureToggles.named("feature-map"));
+        newMapBinder(binder, String.class, FeatureToggleStrategy.class);
+    }
+
+    public void bind()
+    {
+        MapBinder<String, Object> featureInstanceMap = newMapBinder(binder, String.class, Object.class, FeatureToggles.named("feature-instance-map"));
+        MapBinder<String, Feature<?>> featureMap = newMapBinder(binder, new TypeLiteral<String>() {}, new TypeLiteral<Feature<?>>() {}, FeatureToggles.named("feature-map"));
+        classes.forEach(klass -> featureInstanceMap.addBinding(klass.getName()).to(klass));
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = null;
+        if (strategy != null) {
+            featureToggleStrategyConfig = new FeatureToggleStrategyConfig(strategy, strategyConfigMap);
+        }
+        FeatureConfiguration configuration = new FeatureConfiguration(
+                featureId,
+                enabled,
+                hotReloadable,
+                baseClass == null ? null : baseClass.getName(),
+                classes.stream().map(Class::getName).collect(Collectors.toList()),
+                defaultClass == null ? null : defaultClass.getName(),
+                defaultClass == null ? null : defaultClass.getName(),
+                featureToggleStrategyConfig);
+        Feature<T> feature = new Feature<>(featureId, baseClass, configuration);
+        featureMap.addBinding(featureId).toInstance(feature);
+
+        // bind supplier for simple toggle check
+        binder.bind(new TypeLiteral<Supplier<Boolean>>() {}).annotatedWith(FeatureToggles.named(featureId)).toInstance(feature::isEnabled);
+
+        // bind function toggle check while passing object
+        binder.bind(new TypeLiteral<Function<Object, Boolean>>() {}).annotatedWith(FeatureToggles.named(featureId)).toInstance(feature::check);
+
+        if (baseClass != null) {
+            checkState(defaultClass != null, "Invalid Feature Toggle binding: base class without default class");
+            // bind providers
+            if (classes != null && !classes.isEmpty()) {
+                binder.bind(baseClass).annotatedWith(FeatureToggles.named(featureId)).toProvider(() -> baseClass.cast(feature.getCurrentInstance(featureId)));
+                configuration.setHotReloadable(true);
+            }
+            // simple implementation binding
+            if (defaultClass != null) {
+                binder.bind(baseClass).to(defaultClass);
+            }
+        }
+    }
+
+    public FeatureToggleBinder<T> registerToggleStrategy(String strategyName, Class<? extends FeatureToggleStrategy> featureToggleStrategyClass)
+    {
+        MapBinder<String, FeatureToggleStrategy> featureToggleStrategyMap = newMapBinder(binder, String.class, FeatureToggleStrategy.class);
+        featureToggleStrategyMap.addBinding(strategyName).to(featureToggleStrategyClass);
+        return this;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/PrestoFeatureToggle.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/binder/PrestoFeatureToggle.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.annotations.FeatureToggle;
+import com.facebook.presto.features.strategy.FeatureToggleStrategy;
+import com.facebook.presto.features.strategy.FeatureToggleStrategyFactory;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoFeatureToggle
+{
+    private final Map<String, Feature<?>> featureMap;
+    private final Map<String, Object> featureInstanceMap;
+    private final FeatureToggleStrategyFactory featureToggleStrategyFactory;
+    private final FeatureToggleConfiguration featureToggleConfiguration;
+
+    @Inject
+    public PrestoFeatureToggle(
+            @FeatureToggle("feature-map") Map<String, Feature<?>> featureMap,
+            @FeatureToggle("feature-instance-map") Map<String, Object> featureInstanceMap,
+            FeatureToggleStrategyFactory featureToggleStrategyFactory,
+            FeatureToggleConfiguration featureToggleConfiguration)
+    {
+        this.featureMap = requireNonNull(featureMap);
+        this.featureInstanceMap = requireNonNull(featureInstanceMap);
+        this.featureToggleStrategyFactory = requireNonNull(featureToggleStrategyFactory);
+        this.featureToggleConfiguration = requireNonNull(featureToggleConfiguration);
+        this.featureMap.values().forEach(f -> f.setContext(this));
+    }
+
+    public boolean isEnabled(String featureId)
+    {
+        Feature<?> feature = featureMap.get(featureId);
+        FeatureConfiguration featureConfiguration = feature.getConfiguration();
+        AtomicBoolean enabled = new AtomicBoolean(true);
+        FeatureConfiguration configuration = featureToggleConfiguration.getFeatureConfiguration(featureId);
+        if (configuration != null) {
+            if (!configuration.isEnabled()) {
+                return false;
+            }
+            enabled.set(configuration.isEnabled());
+            if (configuration.getFeatureToggleStrategyConfig().isPresent()) {
+                String toggleStrategyClass = configuration.getFeatureToggleStrategyConfig().get().getToggleStrategyName();
+                if (toggleStrategyClass != null) {
+                    FeatureToggleStrategy strategy = featureToggleStrategyFactory.get(toggleStrategyClass);
+                    if (strategy != null) {
+                        return enabled.get() && strategy.check(configuration);
+                    }
+                    else {
+                        return enabled.get();
+                    }
+                }
+            }
+        }
+        else if (featureConfiguration.getFeatureToggleStrategyConfig().isPresent()) {
+            FeatureToggleStrategyConfig featureToggleStrategyConfig = featureConfiguration.getFeatureToggleStrategyConfig().get();
+            String toggleStrategyClass = featureToggleStrategyConfig.getToggleStrategyName();
+            if (toggleStrategyClass != null) {
+                FeatureToggleStrategy strategy = featureToggleStrategyFactory.get(toggleStrategyClass);
+                if (strategy != null) {
+                    return enabled.get() && strategy.check(featureConfiguration);
+                }
+                else {
+                    return enabled.get();
+                }
+            }
+        }
+        return enabled.get();
+    }
+
+    public boolean isEnabled(String featureId, Object object)
+    {
+        Feature<?> feature = featureMap.get(featureId);
+        FeatureConfiguration featureConfiguration = feature.getConfiguration();
+        AtomicBoolean enabled = new AtomicBoolean(feature.isEnabled());
+        FeatureConfiguration configuration = featureToggleConfiguration.getFeatureConfiguration(featureId);
+        if (configuration != null) {
+            enabled.set(configuration.isEnabled());
+            if (configuration.getFeatureToggleStrategyConfig().isPresent()) {
+                String toggleStrategyClass = configuration.getFeatureToggleStrategyConfig().get().getToggleStrategyName();
+                if (toggleStrategyClass != null) {
+                    FeatureToggleStrategy strategy = featureToggleStrategyFactory.get(toggleStrategyClass);
+                    if (strategy != null) {
+                        return enabled.get() && strategy.check(configuration, object);
+                    }
+                    else {
+                        return enabled.get();
+                    }
+                }
+            }
+        }
+        else if (featureConfiguration.getFeatureToggleStrategyConfig().isPresent()) {
+            FeatureToggleStrategyConfig featureToggleStrategyConfig = featureConfiguration.getFeatureToggleStrategyConfig().get();
+            String toggleStrategyClass = featureToggleStrategyConfig.getToggleStrategyName();
+            if (toggleStrategyClass != null) {
+                FeatureToggleStrategy strategy = featureToggleStrategyFactory.get(toggleStrategyClass);
+                if (strategy != null) {
+                    return enabled.get() && strategy.check(featureConfiguration, object);
+                }
+                else {
+                    return enabled.get();
+                }
+            }
+        }
+        return enabled.get();
+    }
+
+    public Object getCurrentInstance(String featureId)
+    {
+        if (featureToggleConfiguration.getFeatureConfiguration(featureId) != null) {
+            String currentInstance = featureToggleConfiguration.getCurrentInstance(featureId);
+            if (currentInstance != null) {
+                return featureInstanceMap.get(currentInstance);
+            }
+        }
+        Feature<?> feature = featureMap.get(featureId);
+        String defaultInstance = feature.getConfiguration().getDefaultInstance();
+        if (defaultInstance != null) {
+            return featureInstanceMap.get(defaultInstance);
+        }
+        else if (feature.getConfiguration().getFeatureInstances() != null && !feature.getConfiguration().getFeatureInstances().isEmpty()) {
+            return featureInstanceMap.get(feature.getConfiguration().getFeatureInstances().get(0));
+        }
+        else {
+            return null;
+        }
+    }
+
+    public Map<String, Feature<?>> getFeatureMap()
+    {
+        return featureMap;
+    }
+
+    public FeatureToggleConfiguration getFeatureToggleConfiguration()
+    {
+        return featureToggleConfiguration;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/DefaultConfigurationSource.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/DefaultConfigurationSource.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.spi.features.ConfigurationSource;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.Map;
+
+public class DefaultConfigurationSource
+        implements ConfigurationSource
+{
+    public static final String NAME = "default";
+
+    @Override
+    public FeatureToggleConfiguration getConfiguration()
+    {
+        return new NullFeatureConfiguration();
+    }
+
+    public static class Factory
+            implements ConfigurationSourceFactory
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public ConfigurationSource create(Map<String, String> config)
+        {
+            return new DefaultConfigurationSource();
+        }
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/DefaultFeatureToggleConfiguration.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/DefaultFeatureToggleConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.Map;
+
+public class DefaultFeatureToggleConfiguration
+        implements FeatureToggleConfiguration
+{
+    private final Map<String, FeatureConfiguration> featureConfigurationMap;
+
+    public DefaultFeatureToggleConfiguration(Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        this.featureConfigurationMap = featureConfigurationMap;
+    }
+
+    @Override
+    public FeatureConfiguration getFeatureConfiguration(String featureId)
+    {
+        return featureConfigurationMap.get(featureId);
+    }
+
+    @Override
+    public String getCurrentInstance(String featureId)
+    {
+        return getFeatureConfiguration(featureId).getCurrentInstance();
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleConfig.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+public class FeatureToggleConfig
+{
+    public static final String FEATURES_CONFIG_SOURCE = "features.config-source";
+    public static final String FEATURES_CONFIG_SOURCE_TYPE = "features.config-source-type";
+    public static final String FEATURES_CONFIG_TYPE = "features.config-type";
+    public static final String FEATURES_REFRESH_PERIOD = "features.refresh-period";
+    public static final String FEATURE_CONFIGURATION_SOURCES_DIRECTORY = "features.configuration-directory";
+
+    private String configSourceType;
+    private String configSource;
+    private String configType;
+    private String configDirectory;
+    private Duration refreshPeriod;
+
+    public String getConfigSource()
+    {
+        return configSource;
+    }
+
+    @Config(FEATURES_CONFIG_SOURCE)
+    public FeatureToggleConfig setConfigSource(String configSource)
+    {
+        this.configSource = configSource;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getRefreshPeriod()
+    {
+        return refreshPeriod;
+    }
+
+    @Config(FEATURES_REFRESH_PERIOD)
+    public FeatureToggleConfig setRefreshPeriod(Duration refreshPeriod)
+    {
+        this.refreshPeriod = refreshPeriod;
+        return this;
+    }
+
+    public String getConfigType()
+    {
+        return configType;
+    }
+
+    @Config(FEATURES_CONFIG_TYPE)
+    public FeatureToggleConfig setConfigType(String configType)
+    {
+        this.configType = configType;
+        return this;
+    }
+
+    public String getConfigSourceType()
+    {
+        return configSourceType;
+    }
+
+    @Config(FEATURES_CONFIG_SOURCE_TYPE)
+    public FeatureToggleConfig setConfigSourceType(String configSourceType)
+    {
+        this.configSourceType = configSourceType;
+        return this;
+    }
+
+    public String getConfigDirectory()
+    {
+        return configDirectory;
+    }
+
+    @Config(FEATURE_CONFIGURATION_SOURCES_DIRECTORY)
+    public FeatureToggleConfig setConfigDirectory(String configDirectory)
+    {
+        this.configDirectory = configDirectory;
+        return this;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleConfigurationManager.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleConfigurationManager.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.features.ConfigurationSource;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.io.Files.getNameWithoutExtension;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class FeatureToggleConfigurationManager
+{
+    private static final Logger log = Logger.get(FeatureToggleConfigurationManager.class);
+    public static final String FEATURE_TOGGLE_CONFIGURATION_FACTORY_NAME = "features.config-source-type";
+    private static final File FEATURE_TOGGLE_CONFIGURATION_DIR = new File("etc/feature-toggle/");
+    private final Map<String, ConfigurationSourceFactory> configurationSourceFactories = new ConcurrentHashMap<>();
+    private final Map<String, ConfigurationSource> loadedConfigurationSources = new ConcurrentHashMap<>();
+    private final AtomicBoolean configurationLoading = new AtomicBoolean();
+    private final String configDir;
+
+    @Inject
+    public FeatureToggleConfigurationManager(FeatureToggleConfig featureToggleConfig)
+    {
+        requireNonNull(featureToggleConfig, "Feature Toggle Config is null");
+        this.configDir = featureToggleConfig.getConfigDirectory();
+        loadedConfigurationSources.put(DefaultConfigurationSource.NAME, new DefaultConfigurationSource.Factory().create(ImmutableMap.of()));
+    }
+
+    private static List<File> listFiles(File dir)
+    {
+        if (dir != null && dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                return ImmutableList.copyOf(files);
+            }
+        }
+        return ImmutableList.of();
+    }
+
+    public void addConfigurationSourceFactory(ConfigurationSourceFactory configurationSourceFactory)
+    {
+        requireNonNull(configurationSourceFactory, "configurationSourceFactory is null");
+        if (configurationSourceFactories.putIfAbsent(configurationSourceFactory.getName(), configurationSourceFactory) != null) {
+            throw new IllegalArgumentException(format("Feature Toggle Configuration Source '%s' is already registered", configurationSourceFactory.getName()));
+        }
+    }
+
+    public ConfigurationSource getConfigurationSource(String name)
+    {
+        ConfigurationSource configurationSource = loadedConfigurationSources.get(name);
+        checkState(configurationSource != null, "configurationSource %s was not loaded", name);
+        return configurationSource;
+    }
+
+    public void loadConfigurationSources()
+            throws IOException
+    {
+        ImmutableMap.Builder<String, Map<String, String>> configurationProperties = ImmutableMap.builder();
+        File configDirectory;
+        if (configDir == null) {
+            configDirectory = FEATURE_TOGGLE_CONFIGURATION_DIR;
+        }
+        else {
+            configDirectory = new File(configDir);
+        }
+        for (File file : listFiles(configDirectory)) {
+            if (file.isFile() && file.getName().endsWith(".properties")) {
+                String name = getNameWithoutExtension(file.getName());
+                Map<String, String> properties = loadPropertiesFrom(file.getPath());
+                configurationProperties.put(name, properties);
+            }
+        }
+        loadConfigurationSources(configurationProperties.build());
+    }
+
+    public void loadConfigurationSources(Map<String, Map<String, String>> configurationProperties)
+    {
+        if (!configurationLoading.compareAndSet(false, true)) {
+            return;
+        }
+        configurationProperties.forEach(this::loadConfigurationSource);
+    }
+
+    protected void loadConfigurationSource(String name, Map<String, String> properties)
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(properties, "properties is null");
+
+        log.info(format("-- Loading configuration source %s --", name));
+
+        String configurationSourceFactoryName = null;
+        ImmutableMap.Builder<String, String> configurationSourceProperties = ImmutableMap.builder();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey().equals(FEATURE_TOGGLE_CONFIGURATION_FACTORY_NAME)) {
+                configurationSourceFactoryName = entry.getValue();
+            }
+            else {
+                configurationSourceProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        checkState(configurationSourceFactoryName != null, "Configuration for Configuration source %s does not contain features.config-source-type", name);
+
+        ConfigurationSourceFactory factory = configurationSourceFactories.get(configurationSourceFactoryName);
+        checkState(factory != null, "Configuration Source Factory %s is not registered", configurationSourceFactoryName);
+
+        ConfigurationSource configurationSource = factory.create(configurationSourceProperties.build());
+        if (loadedConfigurationSources.putIfAbsent(name, configurationSource) != null) {
+            throw new IllegalArgumentException(format("Configuration Source '%s' is already loaded", name));
+        }
+
+        log.info(format("-- Loaded Configuration Source %s --", name));
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleModule.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/FeatureToggleModule.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.features.http.FeatureToggleInfo;
+import com.facebook.presto.features.strategy.FeatureToggleStrategyFactory;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import io.airlift.units.Duration;
+
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class FeatureToggleModule
+        implements Module
+{
+    private static final String DEFAULT_DURATION = "60s";
+
+    @Override
+    public void configure(Binder binder)
+    {
+        jaxrsBinder(binder).bind(FeatureToggleInfo.class);
+        binder.bind(FeatureToggleStrategyFactory.class);
+        binder.bind(PrestoFeatureToggle.class).in(Scopes.SINGLETON);
+        binder.bind(FeatureToggleConfigurationManager.class).in(Scopes.SINGLETON);
+    }
+
+    @Inject
+    @Provides
+    public FeatureToggleConfiguration getFeaturesConfiguration(FeatureToggleConfig config, FeatureToggleConfigurationManager configurationManager)
+    {
+        String configSourceType;
+        if (config.getConfigSourceType() == null) {
+            configSourceType = DefaultConfigurationSource.NAME;
+        }
+        else {
+            configSourceType = config.getConfigSourceType();
+        }
+
+        Duration refreshPeriod;
+        if (config.getRefreshPeriod() == null) {
+            refreshPeriod = Duration.valueOf(DEFAULT_DURATION);
+        }
+        else {
+            refreshPeriod = config.getRefreshPeriod();
+        }
+        return ForwardingFeaturesConfiguration.of(memoizeWithExpiration(
+                () -> configurationManager.getConfigurationSource(configSourceType).getConfiguration(),
+                refreshPeriod.toMillis(),
+                MILLISECONDS));
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/ForwardingFeaturesConfiguration.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/ForwardingFeaturesConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class ForwardingFeaturesConfiguration
+        implements FeatureToggleConfiguration
+{
+    public static ForwardingFeaturesConfiguration of(Supplier<FeatureToggleConfiguration> featureToggleConfiguration)
+    {
+        requireNonNull(featureToggleConfiguration, "featureToggleConfiguration is null");
+        return new ForwardingFeaturesConfiguration()
+        {
+            @Override
+            protected FeatureToggleConfiguration delegate()
+            {
+                return featureToggleConfiguration.get();
+            }
+        };
+    }
+
+    protected abstract FeatureToggleConfiguration delegate();
+
+    @Override
+    public String getCurrentInstance(String featureId)
+    {
+        return delegate().getCurrentInstance(featureId);
+    }
+
+    @Override
+    public FeatureConfiguration getFeatureConfiguration(String featureId)
+    {
+        return delegate().getFeatureConfiguration(featureId);
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/NullFeatureConfiguration.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/config/NullFeatureConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+public class NullFeatureConfiguration
+        implements FeatureToggleConfiguration
+{
+    @Override
+    public FeatureConfiguration getFeatureConfiguration(String featureId)
+    {
+        return null;
+    }
+
+    @Override
+    public String getCurrentInstance(String featureId)
+    {
+        return null;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureDetails.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureDetails.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.http;
+
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@ThriftStruct
+public class FeatureDetails
+{
+    private final FeatureInfo initialConfiguration;
+    private final FeatureInfo configurationOverride;
+    private final FeatureInfo activeConfiguration;
+
+    public FeatureDetails(FeatureInfo initialConfiguration, FeatureInfo configurationOverride, FeatureInfo activeConfiguration)
+    {
+        this.initialConfiguration = initialConfiguration;
+        this.configurationOverride = configurationOverride;
+        this.activeConfiguration = activeConfiguration;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public FeatureInfo getInitialConfiguration()
+    {
+        return initialConfiguration;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public FeatureInfo getConfigurationOverride()
+    {
+        return configurationOverride;
+    }
+
+    @JsonProperty
+    @ThriftField(3)
+    public FeatureInfo getActiveConfiguration()
+    {
+        return activeConfiguration;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureInfo.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureInfo.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.http;
+
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.facebook.presto.features.binder.Feature;
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@ThriftStruct
+public class FeatureInfo
+{
+    private final String featureId;
+    private final boolean enabled;
+    private final String featureClass;
+    private final List<String> featureInstances;
+    private final String currentInstance;
+    private final String defaultInstance;
+    private final FeatureStrategyInfo strategy;
+
+    public FeatureInfo(
+            String featureId,
+            boolean enabled,
+            String featureClass,
+            List<String> featureInstances,
+            String currentInstance,
+            String defaultInstance,
+            FeatureStrategyInfo strategy)
+    {
+        this.featureId = featureId;
+        this.enabled = enabled;
+        this.featureClass = featureClass;
+        this.featureInstances = featureInstances;
+        this.currentInstance = currentInstance;
+        this.defaultInstance = defaultInstance;
+        this.strategy = strategy;
+    }
+
+    static List<FeatureInfo> featureInfos(PrestoFeatureToggle prestoFeatureToggle)
+    {
+        Map<String, Feature<?>> featureMap = prestoFeatureToggle.getFeatureMap();
+        return featureMap.values().stream()
+                .map(feature -> getActiveFeatureInfo(feature, prestoFeatureToggle))
+                .collect(Collectors.toList());
+    }
+
+    static FeatureInfo getActiveFeatureInfo(Feature<?> feature, PrestoFeatureToggle prestoFeatureToggle)
+    {
+        String featureId = feature.getFeatureId();
+        Object featureCurrentInstance = feature.getCurrentInstance(featureId);
+        String currentInstanceClass = null;
+        if (featureCurrentInstance != null) {
+            currentInstanceClass = featureCurrentInstance.getClass().getName();
+        }
+
+        FeatureToggleConfiguration featureToggleConfiguration = prestoFeatureToggle.getFeatureToggleConfiguration();
+        FeatureStrategyInfo featureStrategyInfo = FeatureStrategyInfo.activeFeatureStrategyInfo(feature, featureToggleConfiguration);
+
+        return new FeatureInfo(
+                featureId,
+                prestoFeatureToggle.isEnabled(featureId),
+                feature.getConfiguration().getFeatureClass(),
+                feature.getConfiguration().getFeatureInstances(),
+                currentInstanceClass,
+                feature.getConfiguration().getDefaultInstance(),
+                featureStrategyInfo);
+    }
+
+    static FeatureInfo getOverrideFeatureInfo(Feature<?> feature, PrestoFeatureToggle prestoFeatureToggle)
+    {
+        FeatureToggleConfiguration featureToggleConfiguration = prestoFeatureToggle.getFeatureToggleConfiguration();
+        FeatureConfiguration featureConfigurationOverride = featureToggleConfiguration.getFeatureConfiguration(feature.getFeatureId());
+        String currentInstanceClass = featureConfigurationOverride.getCurrentInstance();
+        FeatureStrategyInfo overrideFeatureStrategyInfo = FeatureStrategyInfo.overrideFeatureStrategyInfo(feature, featureToggleConfiguration);
+        return new FeatureInfo(
+                feature.getFeatureId(),
+                featureConfigurationOverride.isEnabled(),
+                null,
+                null,
+                currentInstanceClass,
+                null,
+                overrideFeatureStrategyInfo);
+    }
+
+    static FeatureInfo getInitialFeatureInfo(Feature<?> feature)
+    {
+        FeatureStrategyInfo featureStrategyInfo = FeatureStrategyInfo.initialFeatureStrategyInfo(feature);
+        return new FeatureInfo(
+                feature.getFeatureId(),
+                feature.isEnabled(),
+                feature.getConfiguration().getFeatureClass(),
+                feature.getConfiguration().getFeatureInstances(),
+                feature.getConfiguration().getDefaultInstance(),
+                feature.getConfiguration().getDefaultInstance(),
+                featureStrategyInfo);
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getFeatureId()
+    {
+        return featureId;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getFeatureClass()
+    {
+        return featureClass;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public List<String> getFeatureInstances()
+    {
+        return featureInstances;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getCurrentInstance()
+    {
+        return currentInstance;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getDefaultInstance()
+    {
+        return defaultInstance;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public FeatureStrategyInfo getStrategy()
+    {
+        return strategy;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureStrategyInfo.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureStrategyInfo.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.http;
+
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.facebook.presto.features.binder.Feature;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@ThriftStruct
+public class FeatureStrategyInfo
+{
+    private static final String ACTIVE = "active";
+
+    private final boolean active;
+    private final String strategyName;
+    private final Map<String, String> config;
+
+    public FeatureStrategyInfo(boolean active, String strategyName, Map<String, String> config)
+    {
+        this.active = active;
+        this.strategyName = strategyName;
+        this.config = config;
+    }
+
+    static FeatureStrategyInfo activeFeatureStrategyInfo(Feature<?> feature, FeatureToggleConfiguration configuration)
+    {
+        Optional<FeatureToggleStrategyConfig> strategyConfigOptional = feature.getConfiguration().getFeatureToggleStrategyConfig();
+        if (strategyConfigOptional.isPresent()) {
+            FeatureToggleStrategyConfig strategyConfig = strategyConfigOptional.get();
+            boolean active = strategyConfig.active();
+            String toggleStrategyName = strategyConfig.getToggleStrategyName();
+            Map<String, String> configMap = new HashMap<>(strategyConfig.getConfigurationMap());
+            if (configuration != null) {
+                Optional<FeatureToggleStrategyConfig> featureToggleStrategyConfigOptional = configuration.getFeatureConfiguration(feature.getFeatureId()).getFeatureToggleStrategyConfig();
+                if (featureToggleStrategyConfigOptional.isPresent()) {
+                    FeatureToggleStrategyConfig featureToggleStrategyConfig = featureToggleStrategyConfigOptional.get();
+                    configMap.putAll(featureToggleStrategyConfig.getConfigurationMap());
+                    if (configMap.containsKey(ACTIVE)) {
+                        active = Boolean.parseBoolean(configMap.get(ACTIVE));
+                    }
+                    toggleStrategyName = featureToggleStrategyConfig.getToggleStrategyName();
+                }
+            }
+            return new FeatureStrategyInfo(active, toggleStrategyName, configMap);
+        }
+        else {
+            return null;
+        }
+    }
+
+    static FeatureStrategyInfo overrideFeatureStrategyInfo(Feature<?> feature, FeatureToggleConfiguration configuration)
+    {
+        Optional<FeatureToggleStrategyConfig> strategyConfigOptional = feature.getConfiguration().getFeatureToggleStrategyConfig();
+        if (strategyConfigOptional.isPresent()) {
+            FeatureToggleStrategyConfig strategyConfig = strategyConfigOptional.get();
+            Map<String, String> configMap = new HashMap<>(strategyConfig.getConfigurationMap());
+            if (configuration != null) {
+                boolean active = false;
+                String toggleStrategyName;
+                Optional<FeatureToggleStrategyConfig> featureToggleStrategyConfigOptional = configuration.getFeatureConfiguration(feature.getFeatureId()).getFeatureToggleStrategyConfig();
+                if (featureToggleStrategyConfigOptional.isPresent()) {
+                    FeatureToggleStrategyConfig featureToggleStrategyConfig = featureToggleStrategyConfigOptional.get();
+                    configMap.putAll(featureToggleStrategyConfig.getConfigurationMap());
+                    if (configMap.containsKey(ACTIVE)) {
+                        active = Boolean.parseBoolean(configMap.get(ACTIVE));
+                    }
+                    toggleStrategyName = featureToggleStrategyConfig.getToggleStrategyName();
+                    return new FeatureStrategyInfo(active, toggleStrategyName, configMap);
+                }
+            }
+        }
+        return null;
+    }
+
+    static FeatureStrategyInfo initialFeatureStrategyInfo(Feature<?> feature)
+    {
+        Optional<FeatureToggleStrategyConfig> strategyConfigOptional = feature.getConfiguration().getFeatureToggleStrategyConfig();
+        if (strategyConfigOptional.isPresent()) {
+            FeatureToggleStrategyConfig strategyConfig = strategyConfigOptional.get();
+            boolean active = strategyConfig.active();
+            String toggleStrategyName = strategyConfig.getToggleStrategyName();
+            Map<String, String> configMap = new HashMap<>(strategyConfig.getConfigurationMap());
+            return new FeatureStrategyInfo(active, toggleStrategyName, configMap);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public boolean isActive()
+    {
+        return active;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public String getStrategyName()
+    {
+        return strategyName;
+    }
+
+    @JsonProperty
+    @ThriftField(3)
+    public Map<String, String> getConfig()
+    {
+        return config;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureToggleInfo.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/http/FeatureToggleInfo.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.http;
+
+import com.facebook.presto.features.binder.Feature;
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.google.inject.Inject;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.features.http.FeatureInfo.getActiveFeatureInfo;
+import static com.facebook.presto.features.http.FeatureInfo.getInitialFeatureInfo;
+import static com.facebook.presto.features.http.FeatureInfo.getOverrideFeatureInfo;
+
+@Path("/v1/features")
+public class FeatureToggleInfo
+{
+    private final PrestoFeatureToggle featureToggle;
+
+    @Inject
+    public FeatureToggleInfo(PrestoFeatureToggle featureToggle)
+    {
+        this.featureToggle = featureToggle;
+    }
+
+    /**
+     * HTTP endpoint for retrieving list of all defined feature toggles
+     * <p>
+     * endpoint accepts two query params:
+     *     <ul>
+     *         <li>enabled (boolean)</li>
+     *         <li>featureId (String)</li>
+     *     </ul>
+     * <p>
+     * example: no params -> returns list of all feature toggles
+     * <pre>{@code
+     *     https://server:port/v1/features
+     * }</pre>
+     * response:
+     * <pre>{@code
+     * [
+     *   {
+     *     "featureId": "query-rate-limiter",
+     *     "enabled": true,
+     *     "featureClass": "com.facebook.presto.server.protocol.QueryRateLimiter",
+     *     "featureInstances": [
+     *       "com.facebook.presto.server.protocol.QueryBlockingRateLimiter",
+     *       "com.facebook.presto.server.protocol.AnotherQueryBlockingRateLimiter"
+     *     ],
+     *     "currentInstance": "com.facebook.presto.server.protocol.AnotherQueryBlockingRateLimiter",
+     *     "defaultInstance": "com.facebook.presto.server.protocol.QueryBlockingRateLimiter"
+     *   },
+     *   {
+     *     "featureId": "query-logger",
+     *     "enabled": false,
+     *     "featureInstances": []
+     *   },
+     *   {
+     *     "featureId": "circuit-breaker",
+     *     "enabled": true,
+     *     "featureClass": "com.facebook.presto.server.protocol.RetryCircuitBreakerInt",
+     *     "featureInstances": [
+     *       "com.facebook.presto.server.protocol.RetryCircuitBreaker"
+     *     ],
+     *     "currentInstance": "com.facebook.presto.server.protocol.RetryCircuitBreaker",
+     *     "defaultInstance": "com.facebook.presto.server.protocol.RetryCircuitBreaker"
+     *   },
+     *   {
+     *     "featureId": "query-cancel",
+     *     "enabled": true,
+     *     "featureInstances": [],
+     *     "strategy": {
+     *       "active": true,
+     *       "strategyName": "AllowList",
+     *       "config": {
+     *         "strategy": "AllowList",
+     *         "allow-list-user": ".*bane",
+     *         "allow-list-source": ".*cli.*"
+     *       }
+     *     }
+     *   },
+     *   {
+     *     "featureId": "memory-feature",
+     *     "enabled": true,
+     *     "featureClass": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterface",
+     *     "featureInstances": [
+     *       "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl"
+     *     ],
+     *     "currentInstance": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl",
+     *     "defaultInstance": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl"
+     *   }
+     * ]
+     * }</pre>
+     * example filter by "featureId": returns list of all feature toggles where feature id contains given featureId
+     * <pre>{@code
+     *     https://server:port/v1/features?featureId=memory
+     * }</pre>
+     * response:
+     * <pre>{@code
+     * [
+     *   {
+     *     "featureId": "memory-feature",
+     *     "enabled": true,
+     *     "featureClass": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterface",
+     *     "featureInstances": [
+     *       "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl"
+     *     ],
+     *     "currentInstance": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl",
+     *     "defaultInstance": "com.facebook.presto.memory.context.ft.MemoryFeatureToggleInterfaceImpl"
+     *   }
+     * ]
+     * }</pre>
+     * example filter by "enabled":
+     * <pre>{@code
+     *     https://server:port/v1/features?enabled=false
+     * }</pre>
+     * response:
+     * <pre>{@code
+     * [
+     *   {
+     *     "featureId": "query-logger",
+     *     "enabled": false,
+     *     "featureInstances": []
+     *   }
+     * ]
+     * }</pre>
+     * <p>
+     *
+     * @param enabled the query param, if given filters result list by enabled status
+     * @param featureId the query param, if given filters result list by feature id (or part of the feature id)
+     * @returns returns JSON response with list of filtered feature toggles
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response info(@QueryParam("enabled") Boolean enabled, @QueryParam("featureId") String featureId)
+    {
+        List<FeatureInfo> infoList = FeatureInfo.featureInfos(featureToggle);
+        if (enabled != null) {
+            infoList = infoList.stream()
+                    .filter(feature -> {
+                        if (enabled) {
+                            return feature.isEnabled();
+                        }
+                        else {
+                            return !feature.isEnabled();
+                        }
+                    })
+                    .collect(Collectors.toList());
+        }
+        if (featureId != null) {
+            infoList = infoList.stream()
+                    .filter(f -> f.getFeatureId().toLowerCase(Locale.US).contains(featureId.toLowerCase(Locale.US)))
+                    .collect(Collectors.toList());
+        }
+        return Response.ok().entity(infoList).build();
+    }
+
+    /**
+     * Returns detailed information about feature toggle with given feature id
+     * <p>
+     * endpoint accepts one path param:
+     *     <ul>
+     *         <li>featureId (String)</li>
+     *     </ul>
+     * <p>
+     * response contains three objects:
+     *     <ul>
+     *         <li>initialConfiguration : initial configuration defined in featureBinder</li>
+     *         <li>configurationOverride : configuration override in feature toggle configuration file (source></li>
+     *         <li>activeConfiguration : active feature toggle configuration</li>
+     *     </ul>
+     * <p>
+     * example:
+     * <pre>{@code
+     *     https://server:port/v1/features/query-cancel
+     * }</pre>
+     * response:
+     * <pre>{@code
+     * {
+     *   "initialConfiguration": {
+     *     "featureId": "query-cancel",
+     *     "enabled": true,
+     *     "strategy": {
+     *       "active": true,
+     *       "strategyName": "AllowList",
+     *       "config": {
+     *         "allow-list-user": ".*prestodb",
+     *         "allow-list-source": ".*IDEA.*"
+     *       }
+     *     }
+     *   },
+     *   "configurationOverride": {
+     *     "featureId": "query-cancel",
+     *     "enabled": true,
+     *     "strategy": {
+     *       "active": true,
+     *       "strategyName": "AllowList",
+     *       "config": {
+     *         "strategy": "AllowList",
+     *         "allow-list-user": ".*bane",
+     *         "allow-list-source": ".*cli.*"
+     *       }
+     *     }
+     *   },
+     *   "activeConfiguration": {
+     *     "featureId": "query-cancel",
+     *     "enabled": true,
+     *     "featureInstances": [],
+     *     "strategy": {
+     *       "active": true,
+     *       "strategyName": "AllowList",
+     *       "config": {
+     *         "strategy": "AllowList",
+     *         "allow-list-user": ".*bane",
+     *         "allow-list-source": ".*cli.*"
+     *       }
+     *     }
+     *   }
+     * }
+     * }</pre>
+     *
+     * @param featureId the query param: the feature id
+     * @return the JSON response with detailed information about feature toggle
+     */
+    @GET
+    @Path("/{featureId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response details(@PathParam("featureId") String featureId)
+    {
+        if (featureToggle.getFeatureMap().get(featureId) != null) {
+            Feature<?> feature = featureToggle.getFeatureMap().get(featureId);
+            FeatureInfo initialFeatureInfo = getInitialFeatureInfo(feature);
+            FeatureInfo overrideFeatureInfo = getOverrideFeatureInfo(feature, featureToggle);
+            FeatureInfo activeFeatureInfo = getActiveFeatureInfo(feature, featureToggle);
+            return Response.ok().entity(new FeatureDetails(initialFeatureInfo, overrideFeatureInfo, activeFeatureInfo)).build();
+        }
+        return Response.noContent().build();
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/AllowAllStrategy.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/AllowAllStrategy.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+/**
+ * Dummy implementation of the FeatureToggle Strategy
+ * <p>
+ * Using this feature toggle strategy doesn't affect feature toggle status
+ */
+@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
+public class AllowAllStrategy
+        implements FeatureToggleStrategy
+{
+    public static final String ALLOW_ALL = "AllowAll";
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/FeatureToggleStrategy.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/FeatureToggleStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+
+public interface FeatureToggleStrategy
+{
+    default boolean check(FeatureConfiguration featureConfiguration)
+    {
+        return true;
+    }
+
+    default boolean check(FeatureConfiguration featureConfiguration, Object object)
+    {
+        return true;
+    }
+}

--- a/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/FeatureToggleStrategyFactory.java
+++ b/presto-feature-toggle/src/main/java/com/facebook/presto/features/strategy/FeatureToggleStrategyFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.google.inject.Inject;
+
+import java.util.Map;
+
+public class FeatureToggleStrategyFactory
+{
+    private final Map<String, FeatureToggleStrategy> featureToggleStrategyMap;
+
+    @Inject
+    public FeatureToggleStrategyFactory(Map<String, FeatureToggleStrategy> featureToggleStrategyMap)
+    {
+        this.featureToggleStrategyMap = featureToggleStrategyMap;
+    }
+
+    public FeatureToggleStrategy get(String strategyName)
+    {
+        return featureToggleStrategyMap.get(strategyName);
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/TestUtils.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/TestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features;
+
+public class TestUtils
+{
+    private TestUtils() {}
+
+    /**
+     * utility method - puts current thread to sleep for 6 second since TestFeatureToggleModule reload configuration every 5 seconds
+     */
+    public static void sleep()
+    {
+        try {
+            Thread.sleep(6000);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/FeatureToggleTests.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/FeatureToggleTests.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.annotations.FeatureToggle;
+import com.facebook.presto.features.classes.HotReloadFeature;
+import com.facebook.presto.features.classes.HotReloadFeatureImpl01;
+import com.facebook.presto.features.classes.HotReloadFeatureImpl02;
+import com.facebook.presto.features.classes.ProviderFeature;
+import com.facebook.presto.features.classes.ProviderFeatureImpl;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.features.TestUtils.sleep;
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class FeatureToggleTests
+{
+    /**
+     * map is configuration provider for dynamic configuration parameters
+     */
+    private final Map<String, FeatureConfiguration> map = new HashMap<>();
+
+    /**
+     * test hot swapping of implementations of the base interface {@link HotReloadFeature}
+     * <p>
+     * definition of hot reloadable (hot swappable) feature toggle with id  "HotReloadFeature"
+     * <pre>{@code
+     *  binder -> featureToggleBinder(binder, HotReloadFeature.class) // creates new feature toggle
+     *               .featureId("HotReloadFeature")              // sets feature id
+     *               .baseClass(HotReloadFeature.class)          // defines base interface of the feature
+     *               .defaultClass(HotReloadFeatureImpl01.class) // defines default implementation for the feature
+     *               // defines list of implementations of the base interface that can be hot swapped on runtime
+     *               .allOf(HotReloadFeatureImpl01.class, HotReloadFeatureImpl02.class)
+     *              .bind()
+     * }</pre>
+     * <p>
+     * Feature Toggles injects default implementation of the HotReloadFeature interface to provider annotated with @FeatureToggle("HotReloadFeature")
+     * <pre>{@code
+     *         @Inject
+     *         public HotReloadRunner(@FeatureToggle("HotReloadFeature") Provider<HotReloadFeature> hotReloadFeature)
+     *         {
+     *             this.hotReloadFeature = hotReloadFeature;
+     *         }
+     * }</pre>
+     * <p>
+     * in first test default implementation is provided in HotReloadRunner instance
+     * then we change run time configuration for feature, changing parameter currentInstance to HotReloadFeatureImpl02.class
+     * <pre>{@code
+     *     map.put("HotReloadFeature", FeatureConfiguration.builder().featureId("HotReloadFeature").currentInstance(HotReloadFeatureImpl02.class).build());
+     * }</pre>
+     * it is same as changing configuration param feature.{featureId}.currentInstance
+     * <pre>
+     *     feature.HotReloadFeature.currentInstance=com.facebook.presto.features.classes.HotReloadFeatureImpl02
+     * </pre>
+     * after configuration refresh period new implementation is provided in HotReloadRunner instance.
+     * For hot reloadable feature toggles only allowed configuration change is changing current instance.
+     * This type of feature toggle is enabled by default, and cannot be disabled on runtime.
+     */
+    @Test
+    public void testHotReload()
+    {
+        map.clear();
+
+        Injector injector = Guice.createInjector(
+                // bind Feature Toggle module
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder, HotReloadFeature.class)
+                        .featureId("HotReloadFeature")                          // sets feature id
+                        .baseClass(HotReloadFeature.class)                      // defines base interface of the feature
+                        .defaultClass(HotReloadFeatureImpl01.class)             // defines default implementation for the feature
+                        // defines list of implementations of the base interface that can be hot swapped on runtime
+                        .allOf(HotReloadFeatureImpl01.class, HotReloadFeatureImpl02.class)
+                        .bind(),
+                // bind Feature Toggle run-time configuration
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        Provider<HotReloadRunner> runner = injector.getProvider(HotReloadRunner.class);
+
+        // fallback to default instance
+        String className = runner.get().testHotReloadFeature();
+        assertEquals("HotReloadFeatureImpl01", className);
+
+        // change configuration
+        map.put("HotReloadFeature", FeatureConfiguration.builder().featureId("HotReloadFeature").currentInstance(HotReloadFeatureImpl02.class).build());
+        // wait for configuration to reload
+        sleep();
+
+        className = runner.get().testHotReloadFeature();
+        assertEquals("HotReloadFeatureImpl02", className);
+    }
+
+    /**
+     * test provider injection for base class. Binding is similar to "HotReloadFeature", but alternative implementations are not provided
+     * <p>
+     * definition of provider injection of feature toggle with id "ProviderFeature"
+     * <pre>{@code
+     *  binder -> featureToggleBinder(binder, ProviderFeature.class)
+     *                    .featureId("ProviderFeature")
+     *                    // base interface
+     *                    .baseClass(ProviderFeature.class)
+     *                    // implementation will be injected as provider
+     *                    .defaultClass(ProviderFeatureImpl.class)
+     *                    .bind()
+     * }</pre>
+     * <p>
+     * Feature Toggles injects default implementation of the ProviderFeature interface to provider annotated with @FeatureToggle("ProviderFeature")
+     * <pre>{@code
+     *         @Inject
+     *         public ProviderInjectionRunner(
+     *                 @FeatureToggle("ProviderFeature") Provider<ProviderFeature> providerFeature)
+     *         {
+     *             this.providerFeature = providerFeature;
+     *         }
+     * }</pre>
+     * <p>
+     * in test default implementation is provided in ProviderFeature instance.
+     * implementation cannot be changed on runtime.
+     */
+    @Test
+    public void testProviderInjection()
+    {
+        map.clear();
+
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder, ProviderFeature.class)
+                        .featureId("ProviderFeature")
+                        .baseClass(ProviderFeature.class)
+                        .defaultClass(ProviderFeatureImpl.class)
+                        .bind(),
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        Provider<ProviderInjectionRunner> runner = injector.getProvider(ProviderInjectionRunner.class);
+
+        String className = runner.get().testProviderFeature();
+        assertEquals("ProviderFeatureImpl", className);
+    }
+
+    /**
+     * test injection of boolean supplier. Supplier can be used to test if the feature is enabled or disabled
+     * <p>
+     * definition of supplier injection of feature toggle with id "SimpleFeature"
+     * <pre>{@code
+     *        binder -> featureToggleBinder(binder)
+     *                         .featureId("SimpleFeature")
+     *                         .bind()
+     * }</pre>
+     * <p>
+     * Feature Toggles injects boolean supplier to param annotated with @FeatureToggle("SimpleFeature")
+     * <pre>{@code
+     *          @Inject
+     *         public SupplierInjectionRunner(@FeatureToggle("SimpleFeature") Supplier<Boolean> isSimpleFeatureEnabled)
+     *         {
+     *             this.isSimpleFeatureEnabled = isSimpleFeatureEnabled;
+     *         }
+     * }</pre>
+     * <p>
+     * in first test feature with id "SimpleFeature" is enabled by default
+     * <pre>{@code
+     *      isSimpleFeatureEnabled.get() will return true
+     * </pre>
+     * then we change run time configuration for feature, changing parameter enabled to "false"
+     * <pre>{@code
+     *     map.put("SimpleFeature", FeatureConfiguration.builder().enabled(false).build());
+     * }</pre>
+     * it is same as changing configuration param feature.{SimpleFeature}.enabled
+     * <pre>
+     *     feature.SimpleFeature.enable=false
+     * </pre>
+     * after configuration refresh period supplier will return false
+     * <pre>{@code
+     *      isSimpleFeatureEnabled.get() will return false
+     * </pre>
+     */
+    @Test
+    public void testSupplierInjection()
+    {
+        map.clear();
+
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder)
+                        .featureId("SimpleFeature")
+                        .bind(),
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        Provider<SupplierInjectionRunner> runner = injector.getProvider(SupplierInjectionRunner.class);
+
+        boolean enabled = runner.get().testSimpleFeatureEnabled();
+        assertTrue(enabled);
+
+        // change configuration and wait 6 seconds to feature toggle reloads configuration
+        map.put("SimpleFeature", FeatureConfiguration.builder().enabled(false).build());
+        sleep();
+
+        enabled = runner.get().testSimpleFeatureEnabled();
+        assertFalse(enabled);
+    }
+
+    /**
+     * test injection function that accepts object as parameter
+     * <p>
+     * This function is used to evaluate given parameter in Feature Toggle Strategy.
+     * <p>
+     * definition of the feature toggle with id "FunctionInjectionFeature"
+     * <pre>{@code
+     *        binder -> featureToggleBinder(binder)
+     *                         .featureId("FunctionInjectionFeature")
+     *                         .bind()
+     * }</pre>
+     * <p>
+     * Feature Toggles injects function to parameter annotated with @FeatureToggle("FunctionInjectionFeature")
+     * <pre>{@code
+     *         @Inject
+     *         public FunctionInjectionRunner(@FeatureToggle("FunctionInjectionFeature") Function<Object, Boolean> isFunctionInjectionFeatureEnabled)
+     *         {
+     *             this.isFunctionInjectionFeatureEnabled = isFunctionInjectionFeatureEnabled;
+     *         }
+     * }</pre>
+     * <p>
+     * in first test feature with id "FunctionInjectionFeature" is enabled by default
+     * <pre>{@code
+     *      isFunctionInjectionFeatureEnabled.apply("string") will return true
+     * </pre>
+     * then we change run time configuration for feature, changing parameter enabled to "false"
+     * <pre>{@code
+     *     map.put("FunctionInjectionFeature", FeatureConfiguration.builder().enabled(false).build());
+     * }</pre>
+     * it is same as changing configuration param feature.{FunctionInjectionFeature}.enabled
+     * <pre>
+     *     feature.FunctionInjectionFeature.enable=false
+     * </pre>
+     * after configuration refresh period supplier will return false
+     * <pre>{@code
+     *      isSimpleFeatureEnabled.get() will return false
+     * </pre>
+     */
+    @Test
+    public void testFunctionInjection()
+    {
+        map.clear();
+
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder)
+                        .featureId("FunctionInjectionFeature")
+                        .bind(),
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        Provider<FunctionInjectionRunner> runner = injector.getProvider(FunctionInjectionRunner.class);
+
+        boolean enabled = runner.get().testFunctionInjectionFeatureEnabled();
+        assertTrue(enabled);
+
+        // change configuration
+        map.put("FunctionInjectionFeature", FeatureConfiguration.builder().enabled(false).build());
+        sleep();
+
+        enabled = runner.get().testFunctionInjectionFeatureEnabled();
+        assertFalse(enabled);
+    }
+
+    /**
+     * test injection function that accepts object as parameter. Function is used to evaluate
+     * <p>
+     * This function is used to evaluate given parameter in Feature Toggle Strategy.
+     * <p>
+     * definition of the feature toggle with id "FunctionInjectionFeature"
+     * <pre>{@code
+     *      binder -> featureToggleBinder(binder)
+     *                         .featureId("FunctionInjectionWithStrategy")
+     *                         // AllowAll is a dummy strategy that will never evaluate to false
+     *                         .toggleStrategy("AllowAll")
+     *                         // dummy params
+     *                         .toggleStrategyConfig(ImmutableMap.of("key", "value", "key2", "value2"))
+     *                         .bind()
+     * }</pre>
+     * <p>
+     * Feature Toggles injects function to parameter annotated with @FeatureToggle("FunctionInjectionWithStrategy")
+     * <pre>{@code
+     *         @Inject
+     *         public FunctionInjectionRunner(@FeatureToggle("FunctionInjectionFeature") Function<Object, Boolean> isFunctionInjectionFeatureEnabled)
+     *         {
+     *            this.isFunctionInjectionFeatureEnabled = isFunctionInjectionFeatureEnabled;
+     *         }
+     * }</pre>
+     * <p>
+     * in first test feature with id "FunctionInjectionWithStrategy" is enabled by default
+     * <pre>{@code
+     *      isFunctionInjectionWithStrategyEnabled.apply("string") will return true
+     * </pre>
+     * then we change run time configuration for feature, changing parameter enabled to "false"
+     * <pre>{@code
+     *     map.put("FunctionInjectionWithStrategy", FeatureConfiguration.builder().enabled(false).build());
+     * }</pre>
+     * it is same as changing configuration param feature.{FunctionInjectionWithStrategy}.enabled
+     * <pre>
+     *     feature.FunctionInjectionWithStrategy.enable=false
+     * </pre>
+     * after configuration refresh period supplier will return false
+     * <pre>{@code
+     *      isSimpleFeatureEnabled.get() will return false
+     * </pre>
+     */
+    @Test
+    public void testFunctionInjectionWithStrategy()
+    {
+        map.clear();
+
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder)
+                        .featureId("FunctionInjectionWithStrategy")
+                        .toggleStrategy("AllowAll")
+                        .toggleStrategyConfig(ImmutableMap.of("key", "value", "key2", "value2"))
+                        .bind(),
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        Provider<FunctionInjectionWithStrategyRunner> runner = injector.getProvider(FunctionInjectionWithStrategyRunner.class);
+
+        boolean enabled = runner.get().testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+
+        // change configuration
+        map.put("FunctionInjectionWithStrategy", FeatureConfiguration.builder().enabled(false).build());
+        sleep();
+
+        enabled = runner.get().testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+    }
+
+    private static class HotReloadRunner
+    {
+        private final Provider<HotReloadFeature> hotReloadFeature;
+
+        @Inject
+        public HotReloadRunner(
+                @FeatureToggle("HotReloadFeature") Provider<HotReloadFeature> hotReloadFeature)
+        {
+            this.hotReloadFeature = hotReloadFeature;
+        }
+
+        public String testHotReloadFeature()
+        {
+            return hotReloadFeature.get().test();
+        }
+    }
+
+    private static class ProviderInjectionRunner
+    {
+        private final Provider<ProviderFeature> providerFeature;
+
+        @Inject
+        public ProviderInjectionRunner(
+                @FeatureToggle("ProviderFeature") Provider<ProviderFeature> providerFeature)
+        {
+            this.providerFeature = providerFeature;
+        }
+
+        public String testProviderFeature()
+        {
+            return providerFeature.get().test();
+        }
+    }
+
+    private static class SupplierInjectionRunner
+    {
+        private final Supplier<Boolean> isSimpleFeatureEnabled;
+
+        @Inject
+        public SupplierInjectionRunner(@FeatureToggle("SimpleFeature") Supplier<Boolean> isSimpleFeatureEnabled)
+        {
+            this.isSimpleFeatureEnabled = isSimpleFeatureEnabled;
+        }
+
+        public boolean testSimpleFeatureEnabled()
+        {
+            return isSimpleFeatureEnabled.get();
+        }
+    }
+
+    private static class FunctionInjectionRunner
+    {
+        private final Function<Object, Boolean> isFunctionInjectionFeatureEnabled;
+
+        @Inject
+        public FunctionInjectionRunner(@FeatureToggle("FunctionInjectionFeature") Function<Object, Boolean> isFunctionInjectionFeatureEnabled)
+        {
+            this.isFunctionInjectionFeatureEnabled = isFunctionInjectionFeatureEnabled;
+        }
+
+        public boolean testFunctionInjectionFeatureEnabled()
+        {
+            return isFunctionInjectionFeatureEnabled.apply("string");
+        }
+    }
+
+    private static class FunctionInjectionWithStrategyRunner
+    {
+        private final Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled;
+
+        @Inject
+        public FunctionInjectionWithStrategyRunner(@FeatureToggle("FunctionInjectionWithStrategy") Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled)
+        {
+            this.isFunctionInjectionWithStrategyEnabled = isFunctionInjectionWithStrategyEnabled;
+        }
+
+        public boolean testFunctionInjectionWithStrategyEnabled()
+        {
+            return isFunctionInjectionWithStrategyEnabled.apply("string");
+        }
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/PrestoFeatureToggleTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/PrestoFeatureToggleTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.config.TestFeatureToggleConfiguration;
+import com.facebook.presto.features.strategy.BooleanStringStrategy;
+import com.facebook.presto.features.strategy.FeatureToggleStrategyFactory;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class PrestoFeatureToggleTest
+{
+    private static final String simpleFeatureId = "simple-feature";
+    private static final String simpleFeatureWithStrategyToggleId = "simple-feature-with-strategy-toggle";
+    /**
+     * map is configuration provider for dynamic configuration parameters
+     */
+    private final Map<String, FeatureConfiguration> config = new HashMap<>();
+    private final Map<String, Object> featureInstanceMap = new HashMap<>();
+    private final FeatureToggleStrategyFactory featureToggleStrategyFactory = new FeatureToggleStrategyFactory(ImmutableMap.of("BooleanString", new BooleanStringStrategy()));
+    private Map<String, Feature<?>> featureMap;
+    private FeatureToggleConfiguration featureToggleConfiguration;
+
+    @BeforeMethod
+    public void prepare()
+    {
+        config.clear();
+        featureMap = new HashMap<>();
+        FeatureToggleStrategyConfig booleanStringStrategyConfig = new FeatureToggleStrategyConfig("BooleanString", ImmutableMap.of("allow-values", "yes,no"));
+
+        FeatureConfiguration simpleFeatureConfiguration = FeatureConfiguration.builder()
+                .featureId(simpleFeatureId)
+                .build();
+        Feature<String> simpleFeature = new Feature<>(simpleFeatureId, null, simpleFeatureConfiguration);
+        featureMap.put(simpleFeatureId, simpleFeature);
+
+        FeatureConfiguration simpleFeatureWithStrategyToggleConfiguration = FeatureConfiguration.builder()
+                .featureId(simpleFeatureWithStrategyToggleId)
+                .featureToggleStrategyConfig(booleanStringStrategyConfig)
+                .build();
+        Feature<String> simpleFeatureWithStrategyToggle = new Feature<>(simpleFeatureWithStrategyToggleId, null, simpleFeatureWithStrategyToggleConfiguration);
+        featureMap.put(simpleFeatureWithStrategyToggleId, simpleFeatureWithStrategyToggle);
+
+        featureToggleConfiguration = new TestFeatureToggleConfiguration(config);
+    }
+
+    @Test
+    public void testSimpleEnabledDisableToggle()
+    {
+        PrestoFeatureToggle prestoFeatureToggle = new PrestoFeatureToggle(featureMap, featureInstanceMap, featureToggleStrategyFactory, featureToggleConfiguration);
+        boolean enabled;
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureId);
+        assertTrue(enabled);
+
+        // change configuration
+        config.put(simpleFeatureId, FeatureConfiguration.builder().featureId(simpleFeatureId).enabled(false).build());
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureId);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void testSimpleEnabledDisabledToggleWithStrategy()
+    {
+        PrestoFeatureToggle prestoFeatureToggle = new PrestoFeatureToggle(featureMap, featureInstanceMap, featureToggleStrategyFactory, featureToggleConfiguration);
+        boolean enabled;
+        // features are enabled by default
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertTrue(enabled);
+
+        // change configuration set enabled to false
+        config.put(simpleFeatureWithStrategyToggleId, FeatureConfiguration.builder().featureId(simpleFeatureWithStrategyToggleId).enabled(false).build());
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void testStrategyEnabledDisabledToggleWithStrategy()
+    {
+        PrestoFeatureToggle prestoFeatureToggle = new PrestoFeatureToggle(featureMap, featureInstanceMap, featureToggleStrategyFactory, featureToggleConfiguration);
+        boolean enabled;
+
+        // feature with id = simpleFeatureWithStrategyToggleId is configured to use BooleanStringStrategy feature toggle strategy
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertTrue(enabled);
+
+        // initially feature is configured to use BooleanStringStrategy with allowed values "yes,no"
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "yes");
+        assertTrue(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "no");
+        assertFalse(enabled);
+
+        // change configuration sets feature to disabled
+        config.put(simpleFeatureWithStrategyToggleId, FeatureConfiguration.builder()
+                .featureId(simpleFeatureWithStrategyToggleId)
+                .enabled(false)
+                .build());
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertFalse(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "yes");
+        assertFalse(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "no");
+        assertFalse(enabled);
+
+        // change configuration
+        FeatureToggleStrategyConfig booleanStringStrategyConfigTrueFalse = new FeatureToggleStrategyConfig("BooleanString", ImmutableMap.of("allow-values", "true,false"));
+        config.put(simpleFeatureWithStrategyToggleId, FeatureConfiguration.builder()
+                .featureId(simpleFeatureWithStrategyToggleId)
+                .enabled(true)
+                .featureToggleStrategyConfig(booleanStringStrategyConfigTrueFalse).build());
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertTrue(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "yes");
+        assertFalse(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "no");
+        assertFalse(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "true");
+        assertTrue(enabled);
+
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId, "false");
+        assertFalse(enabled);
+
+        // change configuration
+        config.put(simpleFeatureWithStrategyToggleId, FeatureConfiguration.builder().featureId(simpleFeatureWithStrategyToggleId).enabled(false).build());
+        enabled = prestoFeatureToggle.isEnabled(simpleFeatureWithStrategyToggleId);
+        assertFalse(enabled);
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/TestFeatureToggleModule.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/TestFeatureToggleModule.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.config.ForwardingFeaturesConfiguration;
+import com.facebook.presto.features.config.TestFeatureToggleConfiguration;
+import com.facebook.presto.features.http.FeatureToggleInfo;
+import com.facebook.presto.features.strategy.AllowAllStrategy;
+import com.facebook.presto.features.strategy.FeatureToggleStrategy;
+import com.facebook.presto.features.strategy.FeatureToggleStrategyFactory;
+import com.facebook.presto.features.strategy.OsToggleStrategy;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
+
+import java.util.Map;
+
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * TestFeatureToggleModule configures base Feature Toggle strategies and configures providers for FeatureToggleStrategyFactory and FeatureToggleConfiguration
+ */
+public class TestFeatureToggleModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        MapBinder<String, FeatureToggleStrategy> featureToggleStrategyMap = MapBinder.newMapBinder(binder, String.class, FeatureToggleStrategy.class);
+        featureToggleStrategyMap.addBinding(AllowAllStrategy.ALLOW_ALL).to(AllowAllStrategy.class);
+        featureToggleStrategyMap.addBinding(OsToggleStrategy.OS_TOGGLE).to(OsToggleStrategy.class);
+        jaxrsBinder(binder).bind(FeatureToggleInfo.class);
+        binder.bind(FeatureToggleStrategyFactory.class);
+        binder.bind(PrestoFeatureToggle.class).in(Singleton.class);
+    }
+
+    @Inject
+    @Provides
+    public FeatureToggleConfiguration getFeaturesConfiguration(Map<String, FeatureConfiguration> config)
+    {
+        return ForwardingFeaturesConfiguration.of(memoizeWithExpiration(
+                () -> new TestFeatureToggleConfiguration(config),
+                5000L,
+                MILLISECONDS));
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/TestFileBasedFeatureToggleModule.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/binder/TestFileBasedFeatureToggleModule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.binder;
+
+import com.facebook.presto.features.config.FeatureToggleConfig;
+import com.facebook.presto.features.config.ForwardingFeaturesConfiguration;
+import com.facebook.presto.features.config.TestFeatureToggleConfiguration;
+import com.facebook.presto.features.strategy.AllowAllStrategy;
+import com.facebook.presto.features.strategy.FeatureToggleStrategy;
+import com.facebook.presto.features.strategy.OsToggleStrategy;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
+
+import static com.facebook.presto.features.config.TestConfigurationParser.parseConfiguration;
+import static com.facebook.presto.features.strategy.AllowAllStrategy.ALLOW_ALL;
+import static com.facebook.presto.features.strategy.OsToggleStrategy.OS_TOGGLE;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * TestFeatureToggleModule configures base Feature Toggle strategies and configures providers for FeatureToggleStrategyFactory and FeatureToggleConfiguration
+ */
+public class TestFileBasedFeatureToggleModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        MapBinder<String, FeatureToggleStrategy> featureToggleStrategyMap = MapBinder.newMapBinder(binder, String.class, FeatureToggleStrategy.class);
+        featureToggleStrategyMap.addBinding(ALLOW_ALL).to(AllowAllStrategy.class);
+        featureToggleStrategyMap.addBinding(OS_TOGGLE).to(OsToggleStrategy.class);
+        binder.bind(PrestoFeatureToggle.class).in(Singleton.class);
+    }
+
+    @Inject
+    @Provides
+    public FeatureToggleConfiguration getFeaturesConfiguration(FeatureToggleConfig config)
+    {
+        if (config.getRefreshPeriod() != null) {
+            return ForwardingFeaturesConfiguration.of(memoizeWithExpiration(
+                    () -> new TestFeatureToggleConfiguration(parseConfiguration(config)),
+                    config.getRefreshPeriod().toMillis(),
+                    MILLISECONDS));
+        }
+        return new TestFeatureToggleConfiguration(parseConfiguration(config));
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeature.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeature.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public interface HotReloadFeature
+{
+    default String test()
+    {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeatureImpl01.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeatureImpl01.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public class HotReloadFeatureImpl01
+        implements HotReloadFeature
+{
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeatureImpl02.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/HotReloadFeatureImpl02.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public class HotReloadFeatureImpl02
+        implements HotReloadFeature
+{
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/ProviderFeature.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/ProviderFeature.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public interface ProviderFeature
+{
+    default String test()
+    {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/ProviderFeatureImpl.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/ProviderFeatureImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public class ProviderFeatureImpl
+        implements ProviderFeature
+{
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/SimpleFeature.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/SimpleFeature.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public interface SimpleFeature
+{
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/SimpleFeatureImpl.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/classes/SimpleFeatureImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.classes;
+
+public class SimpleFeatureImpl
+        implements SimpleFeature
+{
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/FeatureToggleConfigTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/FeatureToggleConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.presto.features.config.FeatureToggleConfig.FEATURES_CONFIG_SOURCE;
+import static com.facebook.presto.features.config.FeatureToggleConfig.FEATURES_CONFIG_SOURCE_TYPE;
+import static com.facebook.presto.features.config.FeatureToggleConfig.FEATURES_CONFIG_TYPE;
+import static com.facebook.presto.features.config.FeatureToggleConfig.FEATURES_REFRESH_PERIOD;
+import static com.facebook.presto.features.config.FeatureToggleConfig.FEATURE_CONFIGURATION_SOURCES_DIRECTORY;
+
+public class FeatureToggleConfigTest
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(FeatureToggleConfig.class)
+                .setConfigSource(null)
+                .setConfigSourceType(null)
+                .setConfigType(null)
+                .setRefreshPeriod(null)
+                .setConfigDirectory(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put(FEATURES_CONFIG_SOURCE, "/test.json")
+                .put(FEATURES_REFRESH_PERIOD, "1s")
+                .put(FEATURES_CONFIG_TYPE, "json")
+                .put(FEATURES_CONFIG_SOURCE_TYPE, "file")
+                .put(FEATURE_CONFIGURATION_SOURCES_DIRECTORY, "etc/feature-toggle/")
+                .build();
+
+        FeatureToggleConfig expected = new FeatureToggleConfig()
+                .setConfigSource("/test.json")
+                .setRefreshPeriod(new Duration(1, TimeUnit.SECONDS))
+                .setConfigSourceType("file")
+                .setConfigType("json")
+                .setConfigDirectory("etc/feature-toggle/");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/TestConfigurationParser.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/TestConfigurationParser.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isReadable;
+
+public class TestConfigurationParser
+{
+    private static final String JSON = "JSON";
+    private static final String PROPERTIES = "PROPERTIES";
+    private static final String FEATURE = "feature";
+    private static final String FEATURE_S = "feature.%s.";
+    private static final String ENABLED = "enabled";
+    private static final String HOT_RELOADABLE = "hot-reloadable";
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+    private static final String FEATURE_CLASS = "featureClass";
+    private static final String FEATURE_INSTANCES = "featureInstances";
+    private static final String CURRENT_INSTANCE = "currentInstance";
+    private static final String DEFAULT_INSTANCE = "defaultInstance";
+    private static final String STRATEGY = "strategy";
+    private static final String STRATEGY_DOT = "strategy.";
+    private static final String REGEX_DOT = "\\.";
+    private static final String EMPTY_STRING = "";
+    private static final String COMMA = ",";
+
+    private TestConfigurationParser() {}
+
+    public static Map<String, FeatureConfiguration> parseConfiguration(FeatureToggleConfig config)
+    {
+        String configSource = config.getConfigSource();
+        String configType = config.getConfigType();
+        return parseConfiguration(configSource, configType);
+    }
+
+    public static Map<String, FeatureConfiguration> parseConfiguration(String configSource, String configType)
+    {
+        Map<String, FeatureConfiguration> featureConfigurationMap = new ConcurrentHashMap<>();
+        Path path = Paths.get(configSource);
+        if (!path.isAbsolute()) {
+            path = path.toAbsolutePath();
+        }
+        checkArgument(exists(path), "File does not exist: %s", path);
+        checkArgument(isReadable(path), "File is not readable: %s", path);
+        if (JSON.equalsIgnoreCase(configType)) {
+            parseJsonConfiguration(path, featureConfigurationMap);
+        }
+        else if (PROPERTIES.equalsIgnoreCase(configType)) {
+            parsePropertiesConfiguration(path, featureConfigurationMap);
+        }
+        return featureConfigurationMap;
+    }
+
+    static void parsePropertiesConfiguration(Path path, Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        try {
+            Map<String, String> properties = loadPropertiesFrom(path.toString());
+            Map<String, Map<String, String>> featurePropertyMap = new TreeMap<>();
+            properties.forEach((key, value) -> {
+                List<String> keyList = Arrays.asList(key.split(REGEX_DOT));
+                if (FEATURE.equals(keyList.get(0))) {
+                    String featureId = keyList.get(1);
+                    if (!featurePropertyMap.containsKey(featureId)) {
+                        featurePropertyMap.put(featureId, new TreeMap<>());
+                    }
+                    String property = key.replace(format(FEATURE_S, featureId), EMPTY_STRING);
+                    featurePropertyMap.get(featureId).put(property, value);
+                }
+            });
+            featurePropertyMap.forEach((featureId, featureMap) -> featureConfigurationMap.put(featureId,
+                    new FeatureConfiguration(
+                            featureId,
+                            Boolean.parseBoolean(featureMap.getOrDefault(ENABLED, TRUE)),
+                            Boolean.parseBoolean(featureMap.getOrDefault(HOT_RELOADABLE, FALSE)),
+                            featureMap.get(FEATURE_CLASS),
+                            Arrays.asList(featureMap.getOrDefault(FEATURE_INSTANCES, EMPTY_STRING).split(COMMA)),
+                            featureMap.get(CURRENT_INSTANCE),
+                            featureMap.get(DEFAULT_INSTANCE),
+                            parseStrategy(featureMap))));
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Error reading Properties file '%s'", path), e);
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(format("Invalid Properties file format '%s'", path), e);
+        }
+    }
+
+    private static FeatureToggleStrategyConfig parseStrategy(Map<String, String> featureMap)
+    {
+        if (!featureMap.containsKey(STRATEGY)) {
+            return null;
+        }
+        Map<String, String> strategyMap = new ConcurrentHashMap<>();
+        featureMap.keySet().stream()
+                .filter(key -> key.startsWith(STRATEGY))
+                .forEach(key -> strategyMap.put(key.replace(STRATEGY_DOT, EMPTY_STRING), featureMap.get(key)));
+
+        return new FeatureToggleStrategyConfig(featureMap.get(STRATEGY), strategyMap);
+    }
+
+    static void parseJsonConfiguration(Path path, Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        try {
+            ObjectMapper mapper = new JsonObjectMapperProvider().get()
+                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            List<FeatureConfiguration> configurationList = Arrays.asList(mapper.readValue(path.toFile(), FeatureConfiguration[].class));
+            configurationList.forEach(f ->
+                    featureConfigurationMap.put(f.getFeatureClass(), f));
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Invalid JSON file '%s'", path), e);
+        }
+    }
+
+    public static void updateProperty(FeatureToggleConfig config, String key, String value)
+    {
+        Properties props = new Properties();
+        URL url = TestConfigurationParser.class.getClassLoader().getResource(config.getConfigSource());
+        assert url != null;
+        try (InputStream in = Files.newInputStream(Paths.get(url.toURI()))) {
+            props.load(in);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        try (OutputStream out = Files.newOutputStream(Paths.get(url.toURI()))) {
+            props.setProperty(key, value);
+            props.store(out, null);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        try (InputStream in = Files.newInputStream(Paths.get(url.toURI()))) {
+            props.load(in);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/TestFeatureToggleConfiguration.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/config/TestFeatureToggleConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.config;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.Map;
+
+public class TestFeatureToggleConfiguration
+        implements FeatureToggleConfiguration
+{
+    private final Map<String, FeatureConfiguration> featureConfigurationMap;
+
+    public TestFeatureToggleConfiguration(Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        this.featureConfigurationMap = featureConfigurationMap;
+    }
+
+    @Override
+    public FeatureConfiguration getFeatureConfiguration(String featureId)
+    {
+        return featureConfigurationMap.get(featureId);
+    }
+
+    @Override
+    public String getCurrentInstance(String featureId)
+    {
+        return getFeatureConfiguration(featureId).getCurrentInstance();
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/AllowAllStrategyTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/AllowAllStrategyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class AllowAllStrategyTest
+{
+    @Test
+    public void test()
+    {
+        boolean enabled;
+        AllowAllStrategy allowAllStrategy = new AllowAllStrategy();
+        enabled = allowAllStrategy.check(FeatureConfiguration.builder().featureId("test feature").build());
+        assertTrue(enabled);
+        enabled = allowAllStrategy.check(FeatureConfiguration.builder().featureId("test feature").build(), new Object());
+        assertTrue(enabled);
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/BooleanStringStrategy.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/BooleanStringStrategy.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test strategy that accepts String as parameter
+ * <p>
+ * For the test we created a {@link BooleanStringStrategy }. Strategy configuration has one parameter "allow-values" and accepts only two values "yes,no" and "true,false".
+ * Based on "allow-values" value, strategy tries to parse boolean value for input parameter string
+ */
+public class BooleanStringStrategy
+        implements FeatureToggleStrategy
+{
+    public static final String NAME = "BooleanString";
+    public static final String ALLOW_VALUES = "allow-values";
+    public static final String YES_NO = "yes,no";
+    public static final String TRUE_FALSE = "true,false";
+
+    /**
+     * Takes parameter string and tries to parse boolean from input string.
+     * Method can use "yes,no" or "true,false" values based on strategy configuration
+     * <p>
+     * First method will check if configuration for feature exists -> if not it will return true
+     * After that method checks if strategy is active -> if not returns true
+     * Then it checks which values are allowed and tries to parse boolean from input string
+     *
+     * @param featureConfiguration the feature configuration
+     * @param object the string parameter with string representation of boolean
+     * @return boolean value based on parameter string
+     */
+    @Override
+    public boolean check(FeatureConfiguration featureConfiguration, Object object)
+    {
+        if (!featureConfiguration.getFeatureToggleStrategyConfig().isPresent()) {
+            return true;
+        }
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = featureConfiguration.getFeatureToggleStrategyConfig().get();
+        if (!featureToggleStrategyConfig.active()) {
+            return true;
+        }
+        String stringBoolean = (String) object;
+        AtomicBoolean allow = new AtomicBoolean(false);
+        Optional<String> allowValues = featureToggleStrategyConfig.get(ALLOW_VALUES);
+        allowValues.ifPresent(allowedValues ->
+        {
+            switch (allowedValues) {
+                case YES_NO:
+                    if ("YES".equalsIgnoreCase(stringBoolean)) {
+                        allow.set(true);
+                        break;
+                    }
+                case TRUE_FALSE:
+                    allow.set(Boolean.parseBoolean(stringBoolean));
+                    break;
+                default:
+                    break;
+            }
+        });
+        return allow.get();
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/BooleanStringStrategyTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/BooleanStringStrategyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class BooleanStringStrategyTest
+{
+    @Test
+    public void testYesNo()
+    {
+        boolean enabled;
+        BooleanStringStrategy booleanStringStrategy = new BooleanStringStrategy();
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = new FeatureToggleStrategyConfig("BooleanStringStrategy", ImmutableMap.of("allow-values", "yes,no"));
+        FeatureConfiguration featureConfiguration = FeatureConfiguration.builder().featureId("yes,no feature").featureToggleStrategyConfig(featureToggleStrategyConfig).build();
+        enabled = booleanStringStrategy.check(featureConfiguration);
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "yes");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "no");
+        assertFalse(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "not sure");
+        assertFalse(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, null);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void testNotActive()
+    {
+        boolean enabled;
+        BooleanStringStrategy booleanStringStrategy = new BooleanStringStrategy();
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = new FeatureToggleStrategyConfig("BooleanStringStrategy", ImmutableMap.of("allow-values", "yes,no", "active", "false"));
+        FeatureConfiguration featureConfiguration = FeatureConfiguration.builder().featureId("yes,no feature").featureToggleStrategyConfig(featureToggleStrategyConfig).build();
+        enabled = booleanStringStrategy.check(featureConfiguration);
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "yes");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "no");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "not sure");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, null);
+        assertTrue(enabled);
+    }
+
+    @Test
+    public void testNoConfiguration()
+    {
+        boolean enabled;
+        BooleanStringStrategy booleanStringStrategy = new BooleanStringStrategy();
+        FeatureConfiguration featureConfiguration = FeatureConfiguration.builder().featureId("yes,no feature").build();
+        enabled = booleanStringStrategy.check(featureConfiguration);
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "yes");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "no");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, "not sure");
+        assertTrue(enabled);
+        enabled = booleanStringStrategy.check(featureConfiguration, null);
+        assertTrue(enabled);
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/FeatureToggleStrategyTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/FeatureToggleStrategyTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.features.annotations.FeatureToggle;
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.features.binder.TestFeatureToggleModule;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.facebook.presto.features.TestUtils.sleep;
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class FeatureToggleStrategyTest
+{
+    private final Map<String, FeatureConfiguration> map = new HashMap<>();
+
+    /**
+     * test injection function that accepts object as parameter.
+     * <p>
+     * Function is used to evaluate string in BooleanStringStrategy feature toggle strategy
+     * <p>
+     * definition of the feature toggle with id "FunctionInjectionWithStrategy".
+     * BooleanStringStrategy will evaluate input string to enable or disable this Feature
+     * <pre>{@code
+     *      binder -> featureToggleBinder(binder)
+     *                         .registerToggleStrategy("BooleanStringStrategy", BooleanStringStrategy.class)
+     *                         .featureId("FunctionInjectionWithStrategy")
+     *                         .toggleStrategy("BooleanStringStrategy")
+     *                         .toggleStrategyConfig(ImmutableMap.of("allow-values", "yes,no"))
+     *                         .bind(),
+     * }</pre>
+     * <p>
+     * Feature Toggles injects function to parameter annotated with @FeatureToggle("FunctionInjectionWithStrategy")
+     * <pre>{@code
+     *         @Inject
+     *         public FunctionInjectionRunner(@FeatureToggle("FunctionInjectionFeature") Function<Object, Boolean> isFunctionInjectionFeatureEnabled)
+     *         {
+     *            this.isFunctionInjectionFeatureEnabled = isFunctionInjectionFeatureEnabled;
+     *         }
+     * }</pre>
+     * <p>
+     * Next, we will define binding of string provider to simulate dynamic change of value to be evaluated
+     * <pre>{@code
+     *          binder -> binder.bind(String.class).annotatedWith(Names.named("allowed")).toProvider(allowedReference::get)
+     * }</pre>
+     * allowed reference is container of the string value
+     * <pre>{@code
+     *          AtomicReference<String> allowedReference = new AtomicReference<>("");
+     * }</pre>
+     * <p>
+     * in first set of tests feature with id "BooleanStringStrategy" accepts "yes,no" values,
+     * if input param is yes strategy will evaluate this as true, in other cases will evaluate as false
+     * <pre>{@code
+     *      isFunctionInjectionWithStrategyEnabled.apply("yes") will return true
+     * }</pre>
+     * then we change run time configuration for feature, changing parameter "allow-values" to "true,false"
+     * <pre>{@code
+     *     FeatureToggleStrategyConfig featureToggleStrategyConfig = new FeatureToggleStrategyConfig("BooleanStringStrategy", ImmutableMap.of("allow-values", "true,false"));
+     *     map.put("FunctionInjectionWithStrategy", FeatureConfiguration.builder().featureToggleStrategyConfig(featureToggleStrategyConfig).build());
+     * }</pre>
+     * it is same as changing configuration param feature.{FunctionInjectionWithStrategy}.strategy.allow-values=yes,no
+     * <pre>{@code
+     *    feature.FunctionInjectionWithStrategy.strategy.allow-values=yes,no
+     * }</pre>
+     * after configuration change if input param is "true" strategy will evaluate this as true, in other cases will evaluate as false
+     * <pre>{@code
+     *           isFunctionInjectionWithStrategyEnabled.apply("true") // will return true
+     *           isFunctionInjectionWithStrategyEnabled.apply("yes") // will return false
+     *  }</pre>
+     */
+    @Test
+    public void testRegisterStrategy()
+    {
+        AtomicReference<String> allowedReference = new AtomicReference<>("");
+        map.clear();
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder)
+                        .registerToggleStrategy("BooleanStringStrategy", BooleanStringStrategy.class)
+                        .featureId("FunctionInjectionWithStrategy")
+                        .toggleStrategy("BooleanStringStrategy")
+                        .toggleStrategyConfig(ImmutableMap.of("allow-values", "yes,no"))
+                        .bind(),
+                binder -> binder.bind(String.class).annotatedWith(Names.named("allowed")).toProvider(allowedReference::get),
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        FunctionInjectionWithBooleanStrategyRunner runner = injector.getProvider(FunctionInjectionWithBooleanStrategyRunner.class).get();
+
+        boolean enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        allowedReference.set("yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        allowedReference.set("no");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("not sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set(null);
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        // change configuration
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = new FeatureToggleStrategyConfig("BooleanStringStrategy", ImmutableMap.of("allow-values", "true,false"));
+        map.put("FunctionInjectionWithStrategy", FeatureConfiguration.builder().featureToggleStrategyConfig(featureToggleStrategyConfig).build());
+        sleep();
+
+        allowedReference.set("yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("true");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        allowedReference.set("false");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("not sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set(null);
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+    }
+
+    private static class FunctionInjectionWithBooleanStrategyRunner
+    {
+        private final Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled;
+        private final Provider<String> allowed;
+
+        @Inject
+        public FunctionInjectionWithBooleanStrategyRunner(
+                @FeatureToggle("FunctionInjectionWithStrategy") Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled,
+                @Named("allowed") Provider<String> allowed)
+        {
+            this.isFunctionInjectionWithStrategyEnabled = isFunctionInjectionWithStrategyEnabled;
+            this.allowed = allowed;
+        }
+
+        public boolean testFunctionInjectionWithStrategyEnabled()
+        {
+            return isFunctionInjectionWithStrategyEnabled.apply(allowed.get());
+        }
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/FileBasedFeatureToggleStrategyTest.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/FileBasedFeatureToggleStrategyTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.features.annotations.FeatureToggle;
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.features.binder.TestFileBasedFeatureToggleModule;
+import com.facebook.presto.features.config.FeatureToggleConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import io.airlift.units.Duration;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.facebook.presto.features.TestUtils.sleep;
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
+import static com.facebook.presto.features.config.TestConfigurationParser.updateProperty;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test for feature toggles using {@link BooleanStringStrategy} toggle strategy
+ * <p>
+ * Test uses FeatureToggleConfig which simulates feature toggle configuration in presto config.properties file
+ * <pre>{@code
+ *   features.config-source-type=file
+ *   features.config-source=feature-toggle.properties
+ *   features.config-type=properties
+ *   features.refresh-period=5s
+ * }</pre>
+ * Feature Toggle configuration is stored in classpath file feature-toggle.properties.
+ * Initial values in feature toggle configuration file:
+ * <pre>{@code
+ *   feature.FunctionInjectionWithStrategy.enabled=true
+ *   feature.FunctionInjectionWithStrategy.strategy=BooleanString
+ *   feature.FunctionInjectionWithStrategy.strategy.allow-values=yes,no
+ * }</pre>
+ * inside test method configuration file is updated and thread is put to sleep for 6 seconds allowing PrestoFeatureToggle to reload configuration from file
+ */
+public class FileBasedFeatureToggleStrategyTest
+{
+    private static final String FEATURE_ID = "FunctionInjectionWithStrategy";
+
+    @BeforeTest
+    public void prepare()
+    {
+        /*
+            from presto configuration file:
+            features.config-source-type=file
+            features.config-source=feature-toggle.properties
+            features.config-type=properties
+            features.refresh-period=5s
+         */
+        FeatureToggleConfig config = new FeatureToggleConfig();
+        config.setConfigSourceType("file");
+        config.setConfigSource("feature-toggle.properties");
+        config.setConfigType("properties");
+        config.setRefreshPeriod(Duration.valueOf("5s"));
+
+        // actual file for test is located in target/test-classes/feature-toggle.properties
+        // sets feature toggle initial values
+        // in case of consecutive runs, values can be set to invalid values
+        updateProperty(config, "feature.FunctionInjectionWithStrategy.enabled", "true");
+        updateProperty(config, "feature.FunctionInjectionWithStrategy.strategy", "BooleanString");
+        updateProperty(config, "feature.FunctionInjectionWithStrategy.strategy.allow-values", "yes,no");
+    }
+
+    @Test
+    public void testRegisterStrategy()
+    {
+        // variable to hold current value to be tested in runner
+        AtomicReference<String> allowedReference = new AtomicReference<>("");
+        /*
+            from presto configuration file:
+            features.config-source-type=file
+            features.config-source=feature-toggle.properties
+            features.config-type=properties
+            features.refresh-period=5s
+         */
+        FeatureToggleConfig config = new FeatureToggleConfig();
+        config.setConfigSourceType("file");
+        config.setConfigSource("feature-toggle.properties");
+        config.setConfigType("properties");
+        config.setRefreshPeriod(Duration.valueOf("5s"));
+
+        // default value for allow-values is yes,no
+        // feature.FunctionInjectionWithStrategy.strategy.allow-values=yes,no
+
+        Injector injector = Guice.createInjector(
+                // file based Feature Toggle Module reads feature toggle configuration from classpath file
+                new TestFileBasedFeatureToggleModule(),
+                // defines feature "FunctionInjectionWithStrategy"
+                // with toggle strategy "BooleanStringStrategy" and strategy param "allow-values" set to "yes,no"
+                binder -> featureToggleBinder(binder)
+                        .registerToggleStrategy(BooleanStringStrategy.NAME, BooleanStringStrategy.class)
+                        .featureId(FEATURE_ID)
+                        .toggleStrategy(BooleanStringStrategy.NAME)
+                        // default strategy configuration, configuration is overridden by values in configuration file
+                        .toggleStrategyConfig(ImmutableMap.of(BooleanStringStrategy.ALLOW_VALUES, BooleanStringStrategy.YES_NO))
+                        .bind(),
+                // binds string annotated with @Named("allowed") to provider
+                binder -> binder.bind(String.class).annotatedWith(Names.named("allowed")).toProvider(allowedReference::get),
+                // sets feature toggle configuration
+                binder -> binder.bind(FeatureToggleConfig.class).toInstance(config));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        FunctionInjectionWithBooleanStrategyRunner runner = injector.getProvider(FunctionInjectionWithBooleanStrategyRunner.class).get();
+
+        boolean enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        allowedReference.set("yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        allowedReference.set("no");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("not sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set(null);
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        // change configuration property
+        // feature.FunctionInjectionWithStrategy.strategy.allow-values=true,false
+        updateProperty(config, "feature.FunctionInjectionWithStrategy.strategy.allow-values", "true,false");
+        sleep();
+
+        allowedReference.set("yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("true");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        allowedReference.set("false");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("not sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set(null);
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        // change configuration property
+        // disabling feature
+        // if feature is disabled, toggle strategy is not evaluated
+        // feature.FunctionInjectionWithStrategy.enabled=false
+        updateProperty(config, "feature.FunctionInjectionWithStrategy.enabled", "false");
+        sleep();
+
+        allowedReference.set("yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("true");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("false");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set("not sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        allowedReference.set(null);
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+    }
+
+    private static class FunctionInjectionWithBooleanStrategyRunner
+    {
+        private final Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled;
+        private final Provider<String> allowed;
+
+        @Inject
+        public FunctionInjectionWithBooleanStrategyRunner(
+                @FeatureToggle(FEATURE_ID) Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled,
+                @Named("allowed") Provider<String> allowed)
+        {
+            this.isFunctionInjectionWithStrategyEnabled = isFunctionInjectionWithStrategyEnabled;
+            this.allowed = allowed;
+        }
+
+        public boolean testFunctionInjectionWithStrategyEnabled()
+        {
+            return isFunctionInjectionWithStrategyEnabled.apply(allowed.get());
+        }
+    }
+}

--- a/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/OsToggleStrategy.java
+++ b/presto-feature-toggle/src/test/java/com/facebook/presto/features/strategy/OsToggleStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+public class OsToggleStrategy
+        implements FeatureToggleStrategy
+{
+    public static final String OS_TOGGLE = "OsToggle";
+
+    private static final String OS_NAME = "os_name";
+    private static final String OS_VERSION = "os_version";
+    private static final String OS_ARCH = "os_arch";
+
+    @Override
+    public boolean check(FeatureConfiguration configuration)
+    {
+        Optional<FeatureToggleStrategyConfig> featureToggleStrategyConfigOptional = configuration.getFeatureToggleStrategyConfig();
+        if (!featureToggleStrategyConfigOptional.isPresent()) {
+            return true;
+        }
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = featureToggleStrategyConfigOptional.get();
+        if (!featureToggleStrategyConfig.active()) {
+            return true;
+        }
+        String osName = System.getProperty("os.name");
+        String osVersion = System.getProperty("os.version");
+        String osArch = System.getProperty("os.arch");
+
+        Optional<String> osPattern = featureToggleStrategyConfig.get(OS_NAME);
+        Optional<String> versionPattern = featureToggleStrategyConfig.get(OS_VERSION);
+        Optional<String> archPattern = featureToggleStrategyConfig.get(OS_ARCH);
+
+        AtomicBoolean allow = new AtomicBoolean(false);
+        osPattern.ifPresent(p ->
+                allow.set(allow.get() || Pattern.compile(p).matcher(osName).matches()));
+        versionPattern.ifPresent(p ->
+                allow.set(allow.get() || Pattern.compile(p).matcher(osVersion).matches()));
+        archPattern.ifPresent(p ->
+                allow.set(allow.get() || Pattern.compile(p).matcher(osArch).matches()));
+        return allow.get();
+    }
+}

--- a/presto-feature-toggle/src/test/resources/feature-toggle.properties
+++ b/presto-feature-toggle/src/test/resources/feature-toggle.properties
@@ -1,0 +1,4 @@
+# feature FunctionInjectionWithStrategy with BooleanStringStrategy toggle strategy
+feature.FunctionInjectionWithStrategy.enabled=true
+feature.FunctionInjectionWithStrategy.strategy=BooleanString
+feature.FunctionInjectionWithStrategy.strategy.allow-values=yes,no

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -49,7 +49,8 @@ plugin.bundles=\
   ../presto-node-ttl-fetchers/pom.xml,\
   ../presto-hive-function-namespace/pom.xml,\
   ../presto-delta/pom.xml,\
-  ../presto-hudi/pom.xml
+  ../presto-hudi/pom.xml,\
+  ../presto-feature-toggle-plugin/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -447,6 +447,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-feature-toggle</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-plugin-toolkit</artifactId>
         </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/features/strategy/AllowListToggleStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/features/strategy/AllowListToggleStrategy.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.google.inject.Inject;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * AllowListToggleStrategy accepts {@link QueryId} as parameter to evaluate if action is allowed based on strategy configuration parameters.
+ * <p>
+ * Strategy uses {@link QueryManager} to extract user and source from query.
+ * Strategy configuration has two parameters:
+ * <ul>
+ *     <li>"allow-list-source" : regex pattern for matching query source</li>
+ *     <li>"allow-list-user" : regex pattern for matching query user</li>
+ * </ul>
+ * <p>
+ * If strategy configuration is not defined for current feature evaluation is skipped.
+ * Strategy uses query manager to extract query user and query source for given QueryId.
+ * Method then checks if user and source patters are configured, and then matches query user and source against given patterns.
+ * If either of conditions are met, method will return true.
+ */
+public class AllowListToggleStrategy
+        implements FeatureToggleStrategy
+{
+    public static final String ALLOW_LIST_SOURCE = "allow-list-source";
+    public static final String ALLOW_LIST_USER = "allow-list-user";
+
+    private final QueryManager queryManager;
+
+    @Inject
+    public AllowListToggleStrategy(QueryManager queryManager)
+    {
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+    }
+
+    /**
+     * Evaluates strategy configuration parameters against given {@link QueryId} object
+     *
+     * @param featureConfiguration the feature configuration
+     * @param queryId the {@link QueryId}
+     * @return result of evaluation
+     */
+    @Override
+    public boolean check(FeatureConfiguration featureConfiguration, Object queryId)
+    {
+        /*
+         * If strategy configuration is not defined for current feature evaluation is skipped.
+         */
+        if (!featureConfiguration.getFeatureToggleStrategyConfig().isPresent()) {
+            return true;
+        }
+        /*
+         * If strategy configuration is defined for current feature evaluation, and is set to not active.
+         */
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = featureConfiguration.getFeatureToggleStrategyConfig().get();
+        if (!featureToggleStrategyConfig.active()) {
+            return true;
+        }
+        SessionRepresentation session = queryManager.getQueryInfo((QueryId) queryId).getSession();
+        String user = session.getUser();
+        Optional<String> source = session.getSource();
+        Optional<String> userPattern = featureToggleStrategyConfig.get(ALLOW_LIST_USER);
+        Optional<String> sourcePattern = featureToggleStrategyConfig.get(ALLOW_LIST_SOURCE);
+        AtomicBoolean allow = new AtomicBoolean(false);
+        userPattern.ifPresent(p ->
+                allow.set(allow.get() || Pattern.compile(p).matcher(user).matches()));
+        sourcePattern.ifPresent(p ->
+                source.ifPresent(s ->
+                        allow.set(allow.get() || Pattern.compile(p).matcher(source.get()).matches())));
+        return allow.get();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.features.config.FeatureToggleConfigurationManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
@@ -32,6 +33,7 @@ import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
@@ -125,6 +127,7 @@ public class PluginManager
     private final TracerProviderManager tracerProviderManager;
     private final AnalyzerProviderManager analyzerProviderManager;
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
+    private final FeatureToggleConfigurationManager featureToggleConfigurationManager;
 
     @Inject
     public PluginManager(
@@ -145,7 +148,8 @@ public class PluginManager
             ClusterTtlProviderManager clusterTtlProviderManager,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
             TracerProviderManager tracerProviderManager,
-            NodeStatusNotificationManager nodeStatusNotificationManager)
+            NodeStatusNotificationManager nodeStatusNotificationManager,
+            FeatureToggleConfigurationManager featureToggleConfigurationManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -176,6 +180,7 @@ public class PluginManager
         this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
         this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
+        this.featureToggleConfigurationManager = requireNonNull(featureToggleConfigurationManager, "featureToggleConfigurationManager is null");
     }
 
     public void loadPlugins()
@@ -325,6 +330,11 @@ public class PluginManager
         for (NodeStatusNotificationProviderFactory nodeStatusNotificationProviderFactory : plugin.getNodeStatusNotificationProviderFactory()) {
             log.info("Registering node status notification provider %s", nodeStatusNotificationProviderFactory.getName());
             nodeStatusNotificationManager.addNodeStatusNotificationProviderFactory(nodeStatusNotificationProviderFactory);
+        }
+
+        for (ConfigurationSourceFactory configurationSourceFactory : plugin.getConfigurationSourceFactories()) {
+            log.info("Registering Feature Toggle Configuration source factory %s", configurationSourceFactory.getName());
+            featureToggleConfigurationManager.addConfigurationSourceFactory(configurationSourceFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -37,6 +37,7 @@ import com.facebook.presto.eventlistener.EventListenerModule;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorModule;
+import com.facebook.presto.features.config.FeatureToggleConfigurationManager;
 import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
@@ -177,6 +178,7 @@ public class PrestoServer
             injector.getInstance(TracerProviderManager.class).loadTracerProvider();
             injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
+            injector.getInstance(FeatureToggleConfigurationManager.class).loadConfigurationSources();
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -77,6 +77,8 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerExporter;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
+import com.facebook.presto.features.config.FeatureToggleConfig;
+import com.facebook.presto.features.config.FeatureToggleModule;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManagerExporter;
@@ -253,6 +255,7 @@ import static com.facebook.drift.codec.guice.ThriftCodecBinder.thriftCodecBinder
 import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.FLAT;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
 import static com.facebook.presto.server.ServerConfig.POOL_TYPE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -753,6 +756,11 @@ public class ServerMainModule
                         .bind(SingleStreamSpillerFactory.class)
                         .to(TempStorageSingleStreamSpillerFactory.class)
                         .in(Scopes.SINGLETON)));
+
+        // Feature Toggle
+        configBinder(binder).bindConfig(FeatureToggleConfig.class);
+        install(new FeatureToggleModule());
+        featureToggleBinder(binder).init();
 
         // Thrift RPC
         binder.install(new DriftNettyServerModule());

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -506,7 +506,8 @@ public class LocalQueryRunner
                 new ThrowingClusterTtlProviderManager(),
                 historyBasedPlanStatisticsManager,
                 new TracerProviderManager(new TracingConfig()),
-                new NodeStatusNotificationManager());
+                new NodeStatusNotificationManager(),
+                new TestingFeatureToggleConfigurationManager());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingFeatureToggleConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingFeatureToggleConfigurationManager.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
+
+import com.facebook.presto.features.config.FeatureToggleConfig;
+import com.facebook.presto.features.config.FeatureToggleConfigurationManager;
+
+public class TestingFeatureToggleConfigurationManager
+        extends FeatureToggleConfigurationManager
+{
+    public TestingFeatureToggleConfigurationManager()
+    {
+        super(new FeatureToggleConfig());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/features/strategy/AllowListToggleStrategyTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/features/strategy/AllowListToggleStrategyTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.features.annotations.FeatureToggle;
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.BasicQueryStats;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleStrategyConfig;
+import com.facebook.presto.spi.session.ResourceEstimates;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
+import static com.facebook.presto.features.strategy.TestUtils.sleep;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class AllowListToggleStrategyTest
+{
+    private static final String QUERY_USER_SOURCE_SEPARATOR = "___";
+    private static final String FUNCTION_INJECTION_WITH_STRATEGY_FEATURE_ID = "FunctionInjectionWithStrategy";
+    private static final String QUERY = "query";
+    private static final String ALLOW_LIST_TOGGLE_STRATEGY = "AllowListToggleStrategy";
+    private final Map<String, FeatureConfiguration> map = new HashMap<>();
+
+    /**
+     * Simple class to demonstrate FeatureToggle injection of function that accepts QueryId as parameter and evaluates condition using Feature Toggle evaluation strategy
+     */
+    private static class FunctionInjectionWithAllowListStrategyRunner
+    {
+        private final Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled;
+        private final Provider<String> query;
+
+        @Inject
+        public FunctionInjectionWithAllowListStrategyRunner(
+                @FeatureToggle(FUNCTION_INJECTION_WITH_STRATEGY_FEATURE_ID) Function<Object, Boolean> isFunctionInjectionWithStrategyEnabled,
+                @Named(QUERY) Provider<String> query)
+        {
+            this.isFunctionInjectionWithStrategyEnabled = isFunctionInjectionWithStrategyEnabled;
+            this.query = query;
+        }
+
+        public boolean testFunctionInjectionWithStrategyEnabled()
+        {
+            return isFunctionInjectionWithStrategyEnabled.apply(QueryId.valueOf(query.get()));
+        }
+    }
+
+    /**
+     * Stub for QueryManager
+     * <p>
+     * Overrides method getQueryInfo to extract user and source from QueryId.
+     * QueryId id string is built from user and source separated by "___".
+     * Method builds BasicQueryInfo with extracted query user and query source
+     */
+    private static class StubQueryManager
+            extends NoOpQueryManager
+    {
+        @Override
+        public BasicQueryInfo getQueryInfo(QueryId queryId)
+                throws NoSuchElementException
+        {
+            String id = queryId.getId();
+            String[] splits = id.split(QUERY_USER_SOURCE_SEPARATOR);
+            String user = splits[0];
+            String source = splits[1];
+            SessionRepresentation stubSessionRepresentation = new SessionRepresentation(queryId.toString(), Optional.of(TransactionId.create()), false, user, Optional.of(user), Optional.of(source), Optional.of("null"), Optional.of("null"), Optional.of("null"), TimeZoneKey.UTC_KEY, Locale.US, Optional.of("null"), Optional.of("null"), Optional.of("null"), new HashSet<>(), new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), 0L, new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
+            BasicQueryStats basicQueryStats = new BasicQueryStats(DateTime.now(), DateTime.now(), Duration.valueOf("1s"), Duration.valueOf("1s"), Duration.valueOf("1s"), Duration.valueOf("1s"), 0, 0, 0, 0, 0, 0, new DataSize(1.0, DataSize.Unit.BYTE), 0L, 0.0, 0.0, new DataSize(1.0, DataSize.Unit.BYTE), new DataSize(1.0, DataSize.Unit.BYTE), new DataSize(1.0, DataSize.Unit.BYTE), new DataSize(1.0, DataSize.Unit.BYTE), new DataSize(1.0, DataSize.Unit.BYTE), new DataSize(1.0, DataSize.Unit.BYTE), Duration.valueOf("1s"), Duration.valueOf("1s"), false, new HashSet<>(), new DataSize(1.0, DataSize.Unit.BYTE), OptionalDouble.empty());
+            return new BasicQueryInfo(queryId, stubSessionRepresentation, Optional.empty(), QueryState.RUNNING, null, false, URI.create(""), "SELECT * FROM TABLE", basicQueryStats, null, null, null, Optional.empty(), new ArrayList<>(), Optional.empty());
+        }
+    }
+
+    @Test
+    public void testAllowListStrategy()
+    {
+        AtomicReference<String> queryReference = new AtomicReference<>("");
+        map.clear();
+        Injector injector = Guice.createInjector(
+                new TestFeatureToggleModule(),
+                binder -> featureToggleBinder(binder)
+                        // register new Feature Toggle strategy
+                        .registerToggleStrategy(ALLOW_LIST_TOGGLE_STRATEGY, AllowListToggleStrategy.class)
+                        // define new Feature
+                        .featureId(FUNCTION_INJECTION_WITH_STRATEGY_FEATURE_ID)
+                        // attach Feature Toggle evaluation strategy
+                        .toggleStrategy(ALLOW_LIST_TOGGLE_STRATEGY)
+                        // configure Feature Toggle evaluation strategy
+                        .toggleStrategyConfig(ImmutableMap.of(AllowListToggleStrategy.ALLOW_LIST_SOURCE, ".*idea.*", AllowListToggleStrategy.ALLOW_LIST_USER, ".*prestodb"))
+                        .bind(),
+                // AllowListToggleStrategy uses QueryManager to evaluate condition
+                binder -> binder.bind(QueryManager.class).to(StubQueryManager.class),
+                // we will set query id value using provider
+                binder -> binder.bind(String.class).annotatedWith(Names.named(QUERY)).toProvider(queryReference::get),
+                // we are binding Feature configuration to map instance
+                binder -> binder.bind(new TypeLiteral<Map<String, FeatureConfiguration>>() {}).toInstance(map));
+        injector.getProvider(PrestoFeatureToggle.class).get();
+        FunctionInjectionWithAllowListStrategyRunner runner = injector.getProvider(FunctionInjectionWithAllowListStrategyRunner.class).get();
+
+        // setting query user and source: user, cli
+        queryReference.set("user___cli");
+        boolean enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        // setting query user and source: prestodb, idea
+        queryReference.set("user_prestodb___idea");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        queryReference.set("no___yes");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        queryReference.set("not___sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+
+        // change configuration on runtime
+        // feature.FunctionInjectionWithStrategy.strategy=AllowList
+        // same as changing configuration file property values to
+        // feature.FunctionInjectionWithStrategy.strategy.allow-list-source=.*cli.*
+        // feature.FunctionInjectionWithStrategy.strategy.strategy.allow-list-user=.*user
+        FeatureToggleStrategyConfig featureToggleStrategyConfig = new FeatureToggleStrategyConfig(ALLOW_LIST_TOGGLE_STRATEGY, ImmutableMap.of(AllowListToggleStrategy.ALLOW_LIST_SOURCE, ".*cli.*", AllowListToggleStrategy.ALLOW_LIST_USER, ".*user"));
+        map.put(FUNCTION_INJECTION_WITH_STRATEGY_FEATURE_ID, FeatureConfiguration.builder().featureToggleStrategyConfig(featureToggleStrategyConfig).build());
+        sleep();
+
+        queryReference.set("user___cli");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertTrue(enabled);
+        queryReference.set("prestodb___idea");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        queryReference.set("___false");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+        queryReference.set("not___sure");
+        enabled = runner.testFunctionInjectionWithStrategyEnabled();
+        assertFalse(enabled);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/features/strategy/TestFeatureToggleConfiguration.java
+++ b/presto-main/src/test/java/com/facebook/presto/features/strategy/TestFeatureToggleConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+
+import java.util.Map;
+
+public class TestFeatureToggleConfiguration
+        implements FeatureToggleConfiguration
+{
+    private final Map<String, FeatureConfiguration> featureConfigurationMap;
+
+    public TestFeatureToggleConfiguration(Map<String, FeatureConfiguration> featureConfigurationMap)
+    {
+        this.featureConfigurationMap = featureConfigurationMap;
+    }
+
+    @Override
+    public FeatureConfiguration getFeatureConfiguration(String featureId)
+    {
+        return featureConfigurationMap.get(featureId);
+    }
+
+    @Override
+    public String getCurrentInstance(String featureId)
+    {
+        return getFeatureConfiguration(featureId).getCurrentInstance();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/features/strategy/TestFeatureToggleModule.java
+++ b/presto-main/src/test/java/com/facebook/presto/features/strategy/TestFeatureToggleModule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+import com.facebook.presto.features.binder.PrestoFeatureToggle;
+import com.facebook.presto.features.config.ForwardingFeaturesConfiguration;
+import com.facebook.presto.spi.features.FeatureConfiguration;
+import com.facebook.presto.spi.features.FeatureToggleConfiguration;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
+
+import java.util.Map;
+
+import static com.facebook.presto.features.strategy.AllowAllStrategy.ALLOW_ALL;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * TestFeatureToggleModule configures base Feature Toggle strategies and configures providers for FeatureToggleStrategyFactory and FeatureToggleConfiguration
+ */
+public class TestFeatureToggleModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        MapBinder<String, FeatureToggleStrategy> featureToggleStrategyMap = MapBinder.newMapBinder(binder, String.class, FeatureToggleStrategy.class);
+        featureToggleStrategyMap.addBinding(ALLOW_ALL).to(AllowAllStrategy.class);
+        binder.bind(PrestoFeatureToggle.class).in(Singleton.class);
+    }
+
+    @Inject
+    @Provides
+    public FeatureToggleStrategyFactory getFeatureToggleStrategyFactory(Map<String, FeatureToggleStrategy> featureToggleStrategyMap)
+    {
+        return new FeatureToggleStrategyFactory(featureToggleStrategyMap);
+    }
+
+    @Inject
+    @Provides
+    public FeatureToggleConfiguration getFeaturesConfiguration(Map<String, FeatureConfiguration> config)
+    {
+        return ForwardingFeaturesConfiguration.of(memoizeWithExpiration(
+                () -> new TestFeatureToggleConfiguration(config),
+                5000L,
+                MILLISECONDS));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/features/strategy/TestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/features/strategy/TestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.features.strategy;
+
+public class TestUtils
+{
+    private TestUtils() {}
+
+    /**
+     * utility method - puts current thread to sleep for 6 second since TestFeatureToggleModule reload configuration every 5 seconds
+     */
+    public static void sleep()
+    {
+        try {
+            Thread.sleep(6000);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -85,6 +85,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-feature-toggle</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -20,6 +20,7 @@ import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.eventlistener.EventListenerModule;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.warnings.WarningCollectorModule;
+import com.facebook.presto.features.config.FeatureToggleConfigurationManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.security.AccessControlManager;
@@ -222,6 +223,7 @@ public class PrestoSparkInjectorFactory
                     injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
                 }
             }
+            injector.getInstance(FeatureToggleConfigurationManager.class).loadConfigurationSources();
             bootstrapTimer.endDriverModulesLoading();
         }
         catch (Exception e) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -61,6 +61,8 @@ import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.features.config.FeatureToggleConfig;
+import com.facebook.presto.features.config.FeatureToggleModule;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
@@ -219,6 +221,7 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.airlift.json.smile.SmileCodecBinder.smileCodecBinder;
+import static com.facebook.presto.features.binder.FeatureToggleBinder.featureToggleBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static java.util.Objects.requireNonNull;
@@ -532,6 +535,11 @@ public class PrestoSparkModule
         binder.bind(PrestoSparkBroadcastTableCacheManager.class).in(Scopes.SINGLETON);
         newSetBinder(binder, PrestoSparkServiceWaitTimeMetrics.class);
         newOptionalBinder(binder, ErrorClassifier.class);
+
+        // Feature Toggle
+        configBinder(binder).bindConfig(FeatureToggleConfig.class);
+        install(new FeatureToggleModule());
+        featureToggleBinder(binder).init();
 
         // extra credentials and authenticator for Presto-on-Spark
         newSetBinder(binder, PrestoSparkCredentialsProvider.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.facebook.presto.spi.features.ConfigurationSourceFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
@@ -133,6 +134,11 @@ public interface Plugin
     }
 
     default Iterable<NodeStatusNotificationProviderFactory> getNodeStatusNotificationProviderFactory()
+    {
+        return emptyList();
+    }
+
+    default Iterable<ConfigurationSourceFactory> getConfigurationSourceFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/features/ConfigurationSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/features/ConfigurationSource.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.features;
+
+public interface ConfigurationSource
+{
+    FeatureToggleConfiguration getConfiguration();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/features/ConfigurationSourceFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/features/ConfigurationSourceFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.features;
+
+import java.util.Map;
+
+public interface ConfigurationSourceFactory
+{
+    String getName();
+
+    ConfigurationSource create(Map<String, String> config);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureConfiguration.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureConfiguration.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.features;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FeatureConfiguration
+{
+    private String featureId;
+    private boolean enabled;
+    private String featureClass;
+    private boolean hotReloadable;
+    private List<String> featureInstances;
+    private String currentInstance;
+    private String defaultInstance;
+    private FeatureToggleStrategyConfig featureToggleStrategyConfig;
+
+    @JsonCreator
+    public FeatureConfiguration(
+            @JsonProperty String featureId,
+            @JsonProperty boolean enabled,
+            @JsonProperty boolean hotReloadable,
+            @JsonProperty String featureClass,
+            @JsonProperty List<String> featureInstances,
+            @JsonProperty String currentInstance,
+            @JsonProperty String defaultInstance,
+            @JsonProperty FeatureToggleStrategyConfig featureToggleStrategyConfig)
+    {
+        this.featureId = featureId;
+        this.featureClass = featureClass;
+        this.enabled = enabled;
+        this.hotReloadable = hotReloadable;
+        this.featureInstances = featureInstances;
+        this.currentInstance = currentInstance;
+        this.defaultInstance = defaultInstance;
+        this.featureToggleStrategyConfig = featureToggleStrategyConfig;
+    }
+
+    public static FeatureConfigurationBuilder builder()
+    {
+        return new FeatureConfigurationBuilder();
+    }
+
+    @JsonProperty
+    public String getFeatureId()
+    {
+        return featureId;
+    }
+
+    public void setFeatureId(String featureId)
+    {
+        this.featureId = featureId;
+    }
+
+    @JsonProperty
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+
+    @JsonProperty
+    public String getFeatureClass()
+    {
+        return featureClass;
+    }
+
+    public void setFeatureClass(String featureClass)
+    {
+        this.featureClass = featureClass;
+    }
+
+    @JsonProperty
+    public List<String> getFeatureInstances()
+    {
+        return featureInstances;
+    }
+
+    public void setFeatureInstances(List<String> featureInstances)
+    {
+        this.featureInstances = featureInstances;
+    }
+
+    @JsonProperty
+    public String getCurrentInstance()
+    {
+        return currentInstance;
+    }
+
+    public void setCurrentInstance(String currentInstance)
+    {
+        this.currentInstance = currentInstance;
+    }
+
+    @JsonProperty
+    public String getDefaultInstance()
+    {
+        return defaultInstance;
+    }
+
+    public void setDefaultInstance(String defaultInstance)
+    {
+        this.defaultInstance = defaultInstance;
+    }
+
+    @JsonProperty
+    public Optional<FeatureToggleStrategyConfig> getFeatureToggleStrategyConfig()
+    {
+        return Optional.ofNullable(featureToggleStrategyConfig);
+    }
+
+    public void setFeatureToggleStrategyConfig(FeatureToggleStrategyConfig featureToggleStrategyConfig)
+    {
+        this.featureToggleStrategyConfig = featureToggleStrategyConfig;
+    }
+
+    public boolean getHotReloadable()
+    {
+        return hotReloadable;
+    }
+
+    public void setHotReloadable(boolean hotReloadable)
+    {
+        this.hotReloadable = hotReloadable;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FeatureConfiguration that = (FeatureConfiguration) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (!Objects.equals(featureId, that.featureId)) {
+            return false;
+        }
+        if (!Objects.equals(featureClass, that.featureClass)) {
+            return false;
+        }
+        if (!Objects.equals(featureInstances, that.featureInstances)) {
+            return false;
+        }
+        return Objects.equals(currentInstance, that.currentInstance);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = featureId != null ? featureId.hashCode() : 0;
+        result = 31 * result + (enabled ? 1 : 0);
+        result = 31 * result + (featureClass != null ? featureClass.hashCode() : 0);
+        result = 31 * result + (featureInstances != null ? featureInstances.hashCode() : 0);
+        result = 31 * result + (currentInstance != null ? currentInstance.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "FeatureConfiguration{" +
+                "featureId='" + featureId + '\'' +
+                ", enabled=" + enabled +
+                ", featureClass='" + featureClass + '\'' +
+                ", featureInstances=" + featureInstances +
+                ", currentInstance='" + currentInstance + '\'' +
+                '}';
+    }
+
+    public static class FeatureConfigurationBuilder
+    {
+        private String featureId;
+        private boolean enabled = true;
+        private String featureClass;
+        private boolean hotReloadable;
+        private List<String> featureInstances = new ArrayList<>();
+        private String currentInstance;
+        private String defaultInstance;
+        private FeatureToggleStrategyConfig featureToggleStrategyConfig;
+
+        FeatureConfigurationBuilder()
+        {
+        }
+
+        public FeatureConfigurationBuilder featureId(String featureId)
+        {
+            this.featureId = featureId;
+            return this;
+        }
+
+        public FeatureConfigurationBuilder enabled(boolean enabled)
+        {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public FeatureConfigurationBuilder featureClass(Class<?> featureClass)
+        {
+            this.featureClass = featureClass == null ? null : featureClass.getName();
+            return this;
+        }
+
+        public FeatureConfigurationBuilder hotReloadable(boolean hotReloadable)
+        {
+            this.hotReloadable = hotReloadable;
+            return this;
+        }
+
+        public FeatureConfigurationBuilder featureInstances(List<Class<?>> featureInstances)
+        {
+            this.featureInstances = featureInstances.stream().map(Class::getName).collect(Collectors.toList());
+            return this;
+        }
+
+        public FeatureConfigurationBuilder currentInstance(Class<?> currentInstance)
+        {
+            this.currentInstance = currentInstance == null ? null : currentInstance.getName();
+            return this;
+        }
+
+        public FeatureConfigurationBuilder defaultInstance(Class<?> defaultInstance)
+        {
+            this.defaultInstance = defaultInstance == null ? null : defaultInstance.getName();
+            return this;
+        }
+
+        public FeatureConfigurationBuilder featureToggleStrategyConfig(FeatureToggleStrategyConfig featureToggleStrategyConfig)
+        {
+            this.featureToggleStrategyConfig = featureToggleStrategyConfig;
+            return this;
+        }
+
+        public FeatureConfiguration build()
+        {
+            return new FeatureConfiguration(featureId, enabled, hotReloadable, featureClass, featureInstances, currentInstance, defaultInstance, featureToggleStrategyConfig);
+        }
+
+        public String toString()
+        {
+            return "FeatureConfiguration.FeatureConfigurationBuilder(featureId=" + this.featureId + ", enabled=" + this.enabled + ", featureClass=" + this.featureClass + ", hotReloadable=" + this.hotReloadable + ", featureInstances=" + this.featureInstances + ", currentInstance=" + this.currentInstance + ", defaultInstance=" + this.defaultInstance + ", featureToggleStrategyConfig=" + this.featureToggleStrategyConfig + ")";
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureToggleConfiguration.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureToggleConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.features;
+
+public interface FeatureToggleConfiguration
+{
+    FeatureConfiguration getFeatureConfiguration(String featureId);
+
+    String getCurrentInstance(String featureId);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureToggleStrategyConfig.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/features/FeatureToggleStrategyConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.features;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FeatureToggleStrategyConfig
+{
+    private static final String ACTIVE = "active";
+
+    private final Map<String, String> configurationMap;
+    private final String strategyName;
+
+    public FeatureToggleStrategyConfig(
+            String strategyName,
+            Map<String, String> configurationMap)
+    {
+        this.strategyName = strategyName;
+        this.configurationMap = configurationMap;
+    }
+
+    public boolean active()
+    {
+        if (configurationMap.containsKey(ACTIVE)) {
+            return Boolean.parseBoolean(configurationMap.get(ACTIVE));
+        }
+        return true;
+    }
+
+    public String getToggleStrategyName()
+    {
+        return strategyName;
+    }
+
+    public Map<String, String> getConfigurationMap()
+    {
+        List<String> properties = Arrays.asList(ACTIVE, "");
+        return configurationMap.entrySet().stream()
+                .filter(e -> !properties.contains(e.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Optional<String> get(String key)
+    {
+        return Optional.ofNullable(configurationMap.get(key));
+    }
+}


### PR DESCRIPTION
Feature Toggles should allow teams to modify system behavior without changing code. Feature Toggles are configured using google guice. Basic definition of toggles are crated using FeatureToggleBinder. FeatureToggleBinder creates FeatureToggle and additional configuration can be done using feature configuration.
In current stage Feature Toggles supports:
- if / else based feature toggles
- Dependency Injection based Hot reloading implementation without restart require code refactoring to add an interface when injecting the new implementation/class
- using various toggle strategies along with simple on / off toggles

configuration:

to allow feature toggle configuration four lines are needed in config.properties file
```
features.config-source-type=file
features.refresh-period=30s
```

`configuration-source-type` is source type for Feature Toggles configuration `features.config-source` is a source (file) of the configuration `features.config-type` format in which configuration is stored (json or properties) `features.refresh-period` configuration refresh period

Defining Feature Toggles

Feature toggle definition is done in google guice module using `FeatureToggleBinder`

simple feature toggle definition
```
    featureToggleBinder(binder)
                        .featureId("featureXX")
                        .bind()
```
This example creates bindings for @Inject
```
    @Inject
    public Runner(@FeatureToggle("featureXX") Supplier<Boolean> isFeatureXXEnabled)
    {
        this.isFeatureXXEnabled = isFeatureXXEnabled;
    }
```
`isFeatureXXEnabled` can be used to test if feature is enabled or disabled:
```
    boolean testFeatureXXEnabled()
    {
        return isFeatureXXEnabled.get();
    }
```

hot reloadable feature toggle definition
```
featureToggleBinder(binder, Feature01.class)
                        .featureId("feature01")
                        .baseClass(Feature01.class)
                        .defaultClass(Feature01Impl01.class)
                        .allOf(Feature01Impl01.class, Feature01Impl02.class)
                        .bind()
```
adding Feature Toggle switching strategy
```
featureToggleBinder(binder)
                        .featureId("feature04")
                        .toggleStrategy("AllowAll")
                        .toggleStrategyConfig(ImmutableMap.of("key", "value", "key2", "value2"))
```

feature-config.properties file example
```
# feature query-logger
feature.query-logger.enabled=true
feature.query-logger.strategy=OsToggle
feature.query-logger.strategy.os_name=.*Linux.*

#feature.query-rate-limiter
feature.query-rate-limiter.currentInstance=com.facebook.presto.server.protocol.QueryBlockingRateLimiter

# feature.query-cancel
feature.query-cancel.strategy=AllowList
feature.query-cancel.strategy.allow-list-source=.*IDEA.*
feature.query-cancel.strategy.allow-list-user=.*prestodb
```
in this example for first feature `query-logger`
changing value of feature.query-logger.enabled to `false` will 'disable' this feature. Changes will be effective within refresh period.

Test plan - Unit Tests
```
== RELEASE NOTES ==

General Changes
 * Add support for Feature Toggles.
