### PR TITLE
Bump Nessie from 0.43.0 to 0.44.0

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.iceberg.version>1.0.0</dep.iceberg.version>
-        <dep.nessie.version>0.43.0</dep.nessie.version>
+        <dep.nessie.version>0.44.0</dep.nessie.version>
     </properties>
 
     <dependencies>

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -27,7 +27,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.43.0";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.44.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 


### PR DESCRIPTION
Test plan - CI

```
== RELEASE NOTES ==

Iceberg Changes
* Bump Nessie from 0.43.0 to 0.44.0
```


Major Nessie improvements/changes:
Nessie GC: Command line tool is added.

More details:
https://github.com/projectnessie/nessie/blob/main/site/docs/try/releases.md#0440-release-october-18-2022
