### PR TITLE
Make HiveTableLayoutHandle.pushdownFilterEnabled configurable.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2739,7 +2739,7 @@ public class HiveMetadata
                                 .setPartitions(hivePartitionResult.getPartitions())
                                 .setBucketHandle(hiveBucketHandle)
                                 .setBucketFilter(hivePartitionResult.getBucketFilter())
-                                .setPushdownFilterEnabled(false)
+                                .setPushdownFilterEnabled(isPushdownFilterEnabled(session, tableHandle))
                                 .setLayoutString(layoutString)
                                 .setRequestedColumns(requestedColumns)
                                 .setPartialAggregationsPushedDown(false)


### PR DESCRIPTION
There would be `hiveLayout->pushdownFilterEnabled Table scan with filter pushdown disabled is not supported` when running a query like `select * from table` on `Prestissimo` if table was stored as parquet. And this pr make `HiveTableLayoutHandle`'s `pushdownFilterEnable` configurable.

Test plan - (Please fill in how you tested your changes)

Existing tests, no new features are added.

```
== NO RELEASE NOTE ==
```
