### PR TITLE
Add auto-tuning of max executor and hash partition

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -61,9 +61,10 @@ public class PrestoSparkConfig
     private DataSize averageInputDataSizePerPartition = new DataSize(2, GIGABYTE);
     private int maxHashPartitionCount = 4096;
     private int minHashPartitionCount = 1024;
-    private boolean isResourceAllocationStrategyEnabled;
-
     private boolean adaptiveJoinSideSwitchingEnabled;
+    private boolean resourceAllocationStrategyEnabled;
+    private boolean executorAllocationStrategyEnabled;
+    private boolean hashPartitionCountAllocationStrategyEnabled;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -385,14 +386,14 @@ public class PrestoSparkConfig
 
     public boolean isSparkResourceAllocationStrategyEnabled()
     {
-        return isResourceAllocationStrategyEnabled;
+        return resourceAllocationStrategyEnabled;
     }
 
     @Config("spark.resource-allocation-strategy-enabled")
     @ConfigDescription("Determines whether the resource allocation strategy for executor and partition count is enabled")
-    public PrestoSparkConfig setSparkResourceAllocationStrategyEnabled(boolean isResourceAllocationStrategyEnabled)
+    public PrestoSparkConfig setSparkResourceAllocationStrategyEnabled(boolean resourceAllocationStrategyEnabled)
     {
-        this.isResourceAllocationStrategyEnabled = isResourceAllocationStrategyEnabled;
+        this.resourceAllocationStrategyEnabled = resourceAllocationStrategyEnabled;
         return this;
     }
 
@@ -434,6 +435,32 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setAdaptiveJoinSideSwitchingEnabled(boolean adaptiveJoinSideSwitchingEnabled)
     {
         this.adaptiveJoinSideSwitchingEnabled = adaptiveJoinSideSwitchingEnabled;
+        return this;
+    }
+
+    public boolean isExecutorAllocationStrategyEnabled()
+    {
+        return executorAllocationStrategyEnabled;
+    }
+
+    @Config("spark.executor-allocation-strategy-enabled")
+    @ConfigDescription("Determines whether the executor allocation strategy is enabled. This will be suppressed if used alongside spark.dynamicAllocation.maxExecutors")
+    public PrestoSparkConfig setExecutorAllocationStrategyEnabled(boolean executorAllocationStrategyEnabled)
+    {
+        this.executorAllocationStrategyEnabled = executorAllocationStrategyEnabled;
+        return this;
+    }
+
+    public boolean isHashPartitionCountAllocationStrategyEnabled()
+    {
+        return hashPartitionCountAllocationStrategyEnabled;
+    }
+
+    @Config("spark.hash-partition-count-allocation-strategy-enabled")
+    @ConfigDescription("Determines whether the hash partition count strategy is enabled. This will be suppressed if used alongside hash_partition_count")
+    public PrestoSparkConfig setHashPartitionCountAllocationStrategyEnabled(boolean hashPartitionCountAllocationStrategyEnabled)
+    {
+        this.hashPartitionCountAllocationStrategyEnabled = hashPartitionCountAllocationStrategyEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -58,6 +58,8 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_MAX_HASH_PARTITION_COUNT = "spark_max_hash_partition_count";
     public static final String SPARK_MIN_HASH_PARTITION_COUNT = "spark_min_hash_partition_count";
     public static final String SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED = "spark_resource_allocation_strategy_enabled";
+    public static final String SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED = "spark_executor_allocation_strategy_enabled";
+    public static final String SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED = "spark_hash_partition_count_allocation_strategy_enabled";
     public static final String SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED = "spark_retry_on_out_of_memory_higher_hash_partition_count_enabled";
     public static final String SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY = "spark_hash_partition_count_scaling_factor_on_out_of_memory";
     public static final String ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED = "adaptive_join_side_switching_enabled";
@@ -197,6 +199,16 @@ public class PrestoSparkSessionProperties
                         prestoSparkConfig.isSparkResourceAllocationStrategyEnabled(),
                         false),
                 booleanProperty(
+                        SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED,
+                        "Flag to enable optimized executor allocation strategy",
+                        prestoSparkConfig.isExecutorAllocationStrategyEnabled(),
+                        false),
+                booleanProperty(
+                        SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED,
+                        "Flag to enable optimized hash partition count allocation strategy",
+                        prestoSparkConfig.isHashPartitionCountAllocationStrategyEnabled(),
+                        false),
+                booleanProperty(
                         SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED,
                         "Increases hash partition count by scaling factor specified by spark.hash-partition-count-scaling-factor-on-out-of-memory if query fails due to low hash partition count",
                         prestoSparkConfig.isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(),
@@ -331,6 +343,16 @@ public class PrestoSparkSessionProperties
     public static boolean isSparkResourceAllocationStrategyEnabled(Session session)
     {
         return session.getSystemProperty(SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED, Boolean.class);
+    }
+
+    public static boolean isSparkExecutorAllocationStrategyEnabled(Session session)
+    {
+        return session.getSystemProperty(SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED, Boolean.class);
+    }
+
+    public static boolean isSparkHashPartitionCountAllocationStrategyEnabled(Session session)
+    {
+        return session.getSystemProperty(SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED, Boolean.class);
     }
 
     public static boolean isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(Session session)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spark.PhysicalResourceSettings;
 import com.facebook.presto.spark.PrestoSparkPhysicalResourceCalculator;
+import com.facebook.presto.spark.PrestoSparkSourceStatsCollector;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.sql.analyzer.Analysis;
@@ -122,7 +123,8 @@ public class PrestoSparkQueryPlanner
         Optional<Output> output = new OutputExtractor().extractOutput(plan.getRoot());
         Optional<QueryType> queryType = getQueryType(preparedQuery.getStatement().getClass());
         List<String> columnNames = ((OutputNode) plan.getRoot()).getColumnNames();
-        PhysicalResourceSettings physicalResourceSettings = new PrestoSparkPhysicalResourceCalculator().calculate(plan.getRoot(), metadata, session);
+        PhysicalResourceSettings physicalResourceSettings = new PrestoSparkPhysicalResourceCalculator()
+                .calculate(plan.getRoot(), new PrestoSparkSourceStatsCollector(metadata, session), session);
         return new PlanAndMore(
                 plan,
                 Optional.ofNullable(analysis.getUpdateType()),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -59,7 +59,9 @@ public class TestPrestoSparkConfig
                 .setSparkResourceAllocationStrategyEnabled(false)
                 .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(false)
                 .setHashPartitionCountScalingFactorOnOutOfMemory(2.0)
-                .setAdaptiveJoinSideSwitchingEnabled(false));
+                .setAdaptiveJoinSideSwitchingEnabled(false)
+                .setExecutorAllocationStrategyEnabled(false)
+                .setHashPartitionCountAllocationStrategyEnabled(false));
     }
 
     @Test
@@ -94,6 +96,8 @@ public class TestPrestoSparkConfig
                 .put("spark.retry-on-out-of-memory-higher-hash-partition-count-enabled", "true")
                 .put("spark.hash-partition-count-scaling-factor-on-out-of-memory", "5.6")
                 .put("optimizer.adaptive-join-side-switching-enabled", "true")
+                .put("spark.executor-allocation-strategy-enabled", "true")
+                .put("spark.hash-partition-count-allocation-strategy-enabled", "true")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -123,7 +127,9 @@ public class TestPrestoSparkConfig
                 .setSparkResourceAllocationStrategyEnabled(true)
                 .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(true)
                 .setHashPartitionCountScalingFactorOnOutOfMemory(5.6)
-                .setAdaptiveJoinSideSwitchingEnabled(true);
+                .setAdaptiveJoinSideSwitchingEnabled(true)
+                .setHashPartitionCountAllocationStrategyEnabled(true)
+                .setExecutorAllocationStrategyEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkPhysicalResourceAllocationStrategy.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkPhysicalResourceAllocationStrategy.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.planner;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.AbstractMockMetadata;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spark.PhysicalResourceSettings;
+import com.facebook.presto.spark.PrestoSparkPhysicalResourceCalculator;
+import com.facebook.presto.spark.PrestoSparkSourceStatsCollector;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.TestingMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_MAX_EXECUTOR_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_MAX_HASH_PARTITION_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_MIN_EXECUTOR_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_MIN_HASH_PARTITION_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestPrestoSparkPhysicalResourceAllocationStrategy
+{
+    // mocked metadata with table statistics generating random estimate count for the purpose of testing
+    // no other method is stubbed so will likely throw UnsupportedOperationException
+    private static class MockedMetadata
+            extends AbstractMockMetadata
+    {
+        @Override
+        public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+        {
+            return TableStatistics.builder().setRowCount(Estimate.of(100)).setTotalSize(Estimate.of(1000)).build();
+        }
+    }
+
+    // default properties passed as part of system property
+    private static final PropertyMetadata<?>[] defaultPropertyMetadata = new PropertyMetadata[] {
+            PropertyMetadata.integerProperty(SPARK_MIN_EXECUTOR_COUNT, "SPARK_MIN_EXECUTOR_COUNT", 10, false),
+            PropertyMetadata.integerProperty(SPARK_MAX_EXECUTOR_COUNT, "SPARK_MAX_EXECUTOR_COUNT", 1000, false),
+            PropertyMetadata.integerProperty(SPARK_MIN_HASH_PARTITION_COUNT, "SPARK_MIN_HASH_PARTITION_COUNT", 10, false),
+            PropertyMetadata.integerProperty(SPARK_MAX_HASH_PARTITION_COUNT, "SPARK_MAX_HASH_PARTITION_COUNT", 1000, false),
+            PropertyMetadata.dataSizeProperty(SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR, "SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR", new DataSize(200, DataSize.Unit.BYTE), false),
+            PropertyMetadata.dataSizeProperty(SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION, "SPARK_AVERAGE_INPUT_DATA_SIZE_PER_PARTITION", new DataSize(100, DataSize.Unit.BYTE), false),
+            PropertyMetadata.integerProperty(HASH_PARTITION_COUNT, "HASH_PARTITION_COUNT", 150, false)
+    };
+    // system property with allocation based tuning enabled
+    private static final Session testSessionWithAllocation = testSessionBuilder(new SessionPropertyManager(
+            new ImmutableList.Builder<PropertyMetadata<?>>().add(defaultPropertyMetadata).add(
+                    PropertyMetadata.booleanProperty(SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED, "SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED", true, false)
+            ).build())).build();
+    // system property with allocation based tuning disabled
+    private static final Session testSessionWithoutAllocation = testSessionBuilder(new SessionPropertyManager(
+            new ImmutableList.Builder<PropertyMetadata<?>>().add(defaultPropertyMetadata).add(
+                    PropertyMetadata.booleanProperty(SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED, "SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED", false, false),
+                    PropertyMetadata.booleanProperty(SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED, "SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED", false, false),
+                    PropertyMetadata.booleanProperty(SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED, "SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED", false, false)
+            ).build())).build();
+    private static final Metadata mockedMetadata = new MockedMetadata();
+
+    /**
+     * Return any plan node, the node does not even need to be "correct",
+     * only used for the purpose of traversing and estimating the source stats
+     */
+    private PlanNode getPlanToTest(Session session, Metadata metadata)
+    {
+        PlanBuilder planBuilder = new PlanBuilder(session, new PlanNodeIdAllocator(), metadata);
+        VariableReferenceExpression sourceJoin = planBuilder.variable("sourceJoin");
+
+        TableScanNode a = planBuilder.tableScan(ImmutableList.of(sourceJoin), ImmutableMap.of(sourceJoin, new TestingMetadata.TestingColumnHandle("sourceJoin")));
+        VariableReferenceExpression filteringSource = planBuilder.variable("filteringSource");
+        TableScanNode b = planBuilder.tableScan(ImmutableList.of(filteringSource), ImmutableMap.of(filteringSource, new TestingMetadata.TestingColumnHandle("filteringSource")));
+
+        return planBuilder.join(JoinNode.Type.LEFT, a, b);
+    }
+
+    @Test
+    public void testHashPartitionCountAllocationStrategy()
+    {
+        PrestoSparkSourceStatsCollector prestoSparkSourceStatsCollector = new PrestoSparkSourceStatsCollector(mockedMetadata, testSessionWithAllocation);
+        PlanNode nodeToTest = getPlanToTest(testSessionWithAllocation, mockedMetadata);
+
+        PhysicalResourceSettings settingsHolder = new PrestoSparkPhysicalResourceCalculator()
+                .calculate(nodeToTest, prestoSparkSourceStatsCollector, testSessionWithAllocation);
+        assertEquals(settingsHolder.getHashPartitionCount(), 20);
+        assertEquals(settingsHolder.getMaxExecutorCount().getAsInt(), 10);
+    }
+
+    @Test
+    public void testHashPartitionCountWithoutAllocationStrategy()
+    {
+        PrestoSparkSourceStatsCollector prestoSparkSourceStatsCollector = new PrestoSparkSourceStatsCollector(mockedMetadata, testSessionWithoutAllocation);
+        PlanNode nodeToTest = getPlanToTest(testSessionWithoutAllocation, mockedMetadata);
+
+        PhysicalResourceSettings settingsHolder = new PrestoSparkPhysicalResourceCalculator()
+                .calculate(nodeToTest, prestoSparkSourceStatsCollector, testSessionWithoutAllocation);
+        assertEquals(settingsHolder.getHashPartitionCount(), 150);
+        assertFalse(settingsHolder.getMaxExecutorCount().isPresent());
+    }
+}


### PR DESCRIPTION
## Test Plan
Added unit test to the classes modified.
Ran presto server on local and submitted queries on "customers" table to confirm correct hash_partition_count is used.


## Summary
Added 2 configuration options (`spark_executor_allocation_strategy_enabled`, `spark_hash_partition_count_allocation_strategy_enabled`) to auto-tune, `spark.dynamicAllocation.maxExecutors` and `hash_partition_count` based on the input table stats, respectively.

The auto tune configuration option take precedence over explicitly provided values for `spark.dynamicAllocation.maxExecutors` and `hash_partition_count`. 

If `spark_resource_allocation_strategy_enabled` is enabled, both executor and hash partition are considered to be auto-tune enabled. This configuration option could be removed in subsequent revision, as it is redundant.


```
== RELEASE NOTES ==

General Changes
* Add property ``spark_executor_allocation_strategy_enabled`` to auto-tune spark max executor count (``spark.dynamicAllocation.maxExecutors``)  based on input data. Only required if ``spark_resource_allocation_strategy_enabled`` is not already enabled.
* Add property ``spark_hash_partition_count_allocation_strategy_enabled`` to auto-tune hash partition count (``hash_partition_count``) based on input data. Only required if ``spark_resource_allocation_strategy_enabled`` is not already enabled.

```