### PR TITLE
[native] Add new query runtime metrics (spilling & # of drivers).

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -232,7 +232,7 @@ void PrestoServer::run() {
 
   velox::functions::prestosql::registerAllScalarFunctions();
   velox::aggregate::prestosql::registerAllAggregateFunctions();
-  velox::window::registerWindowFunctions();
+  velox::window::prestosql::registerAllWindowFunctions();
   if (!velox::isRegisteredVectorSerde()) {
     velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
   }

--- a/presto-native-execution/presto_cpp/main/types/tests/TypeSignatureTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/TypeSignatureTest.cpp
@@ -395,8 +395,8 @@ TEST_F(TestTypeSignature, functionType) {
 }
 
 TEST_F(TestTypeSignature, decimalType) {
-  assertSignature("decimal(10, 5)", "SHORT_DECIMAL(10,5)");
-  assertSignature("decimal(20,10)", "LONG_DECIMAL(20,10)");
+  assertSignature("decimal(10, 5)", "DECIMAL(10,5)");
+  assertSignature("decimal(20,10)", "DECIMAL(20,10)");
   ASSERT_THROWS_CONTAINS_MESSAGE(
       parseTypeSignature("decimal");
       , VeloxUserError, "Failed to parse type [decimal]");


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Turning Velox's numbers of drivers into Presto runtime metrics.
Turning Velox's spilling counters into Presto runtime metrics.
Advancing Velox version.

```
== NO RELEASE NOTE ==
```
