### PR TITLE
Fix Disagg Coordinator task limit enforcement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.QueryTracker;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.resourcemanager.ClusterQueryTrackerService;
 import com.facebook.presto.resourcemanager.ClusterStatusSender;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.server.BasicQueryInfo;
@@ -127,7 +128,8 @@ public class DispatchManager
             QueryManagerConfig queryManagerConfig,
             DispatchExecutor dispatchExecutor,
             ClusterStatusSender clusterStatusSender,
-            SecurityConfig securityConfig)
+            SecurityConfig securityConfig,
+            Optional<ClusterQueryTrackerService> clusterQueryTrackerService)
     {
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
         this.analyzerProvider = requireNonNull(analyzerProvider, "analyzerClient is null");
@@ -147,7 +149,7 @@ public class DispatchManager
 
         this.clusterStatusSender = requireNonNull(clusterStatusSender, "clusterStatusSender is null");
 
-        this.queryTracker = new QueryTracker<>(queryManagerConfig, dispatchExecutor.getScheduledExecutor());
+        this.queryTracker = new QueryTracker<>(queryManagerConfig, dispatchExecutor.getScheduledExecutor(), clusterQueryTrackerService);
 
         this.securityConfig = requireNonNull(securityConfig, "securityConfig is null");
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.QueryTracker.TrackedQuery;
+import com.facebook.presto.resourcemanager.ClusterQueryTrackerService;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
@@ -81,7 +82,9 @@ public class QueryTracker<T extends TrackedQuery>
     @GuardedBy("this")
     private ScheduledFuture<?> backgroundTask;
 
-    public QueryTracker(QueryManagerConfig queryManagerConfig, ScheduledExecutorService queryManagementExecutor)
+    private final Optional<ClusterQueryTrackerService> clusterQueryTrackerService;
+
+    public QueryTracker(QueryManagerConfig queryManagerConfig, ScheduledExecutorService queryManagementExecutor, Optional<ClusterQueryTrackerService> clusterQueryTrackerService)
     {
         requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.minQueryExpireAge = queryManagerConfig.getMinQueryExpireAge();
@@ -91,6 +94,7 @@ public class QueryTracker<T extends TrackedQuery>
         this.maxQueryRunningTaskCount = queryManagerConfig.getMaxQueryRunningTaskCount();
 
         this.queryManagementExecutor = requireNonNull(queryManagementExecutor, "queryManagementExecutor is null");
+        this.clusterQueryTrackerService = clusterQueryTrackerService;
     }
 
     public synchronized void start()
@@ -278,6 +282,10 @@ public class QueryTracker<T extends TrackedQuery>
             if (runningTaskCount > maxQueryRunningTaskCount) {
                 taskCountQueue.add(new QueryAndTaskCount(query, runningTaskCount));
             }
+        }
+
+        if (clusterQueryTrackerService.isPresent()) {
+            totalRunningTaskCount = clusterQueryTrackerService.get().getRunningTaskCount();
         }
 
         runningTaskCount.set(totalRunningTaskCount);

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ClusterQueryTrackerService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ClusterQueryTrackerService.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.util.PeriodicTaskExecutor;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClusterQueryTrackerService
+{
+    private final DriftClient<ResourceManagerClient> resourceManagerClient;
+    private final ScheduledExecutorService executorService;
+    private final long runningTaskCountFetchIntervalMillis;
+    private AtomicInteger runningTaskCount;
+    private final PeriodicTaskExecutor runningTaskCountUpdater;
+
+    @Inject
+    public ClusterQueryTrackerService(
+            @ForResourceManager DriftClient<ResourceManagerClient> resourceManagerClient,
+            @ForResourceManager ScheduledExecutorService executorService,
+            ResourceManagerConfig resourceManagerConfig)
+    {
+        this.resourceManagerClient = requireNonNull(resourceManagerClient, "resourceManagerClient is null");
+        this.executorService = requireNonNull(executorService, "executorService is null");
+        this.runningTaskCountFetchIntervalMillis = requireNonNull(resourceManagerConfig, "resourceManagerConfig is null").getRunningTaskCountFetchInterval().toMillis();
+        this.runningTaskCount = new AtomicInteger(0);
+        this.runningTaskCountUpdater = new PeriodicTaskExecutor(runningTaskCountFetchIntervalMillis, executorService, () -> updateRunningTaskCount());
+    }
+
+    @PostConstruct
+    public void init()
+    {
+        runningTaskCountUpdater.start();
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        runningTaskCountUpdater.stop();
+    }
+
+    public int getRunningTaskCount()
+    {
+        return runningTaskCount.get();
+    }
+
+    private void updateRunningTaskCount()
+    {
+        this.runningTaskCount.set(resourceManagerClient.get().getRunningTaskCount());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClient.java
@@ -42,4 +42,7 @@ public interface ResourceManagerClient
 
     @ThriftMethod
     void resourceGroupRuntimeHeartbeat(String node, List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfo);
+
+    @ThriftMethod
+    int getRunningTaskCount();
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
@@ -44,6 +44,8 @@ public class ResourceManagerConfig
     private Duration resourceGroupServiceCacheExpireInterval = new Duration(10, SECONDS);
     private Duration resourceGroupServiceCacheRefreshInterval = new Duration(1, SECONDS);
 
+    private Duration runningTaskCountFetchInterval = new Duration(1, SECONDS);
+
     @MinDuration("1ms")
     public Duration getQueryExpirationTimeout()
     {
@@ -249,6 +251,17 @@ public class ResourceManagerConfig
     public ResourceManagerConfig setResourceGroupServiceCacheRefreshInterval(Duration resourceGroupServiceCacheRefreshInterval)
     {
         this.resourceGroupServiceCacheRefreshInterval = resourceGroupServiceCacheRefreshInterval;
+        return this;
+    }
+
+    public Duration getRunningTaskCountFetchInterval()
+    {
+        return runningTaskCountFetchInterval;
+    }
+    @Config("resource-manager.running-task-count-fetch-interval")
+    public ResourceManagerConfig setRunningTaskCountFetchInterval(Duration runningTaskCountFetchInterval)
+    {
+        this.runningTaskCountFetchInterval = runningTaskCountFetchInterval;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
@@ -87,4 +87,10 @@ public class ResourceManagerServer
     {
         executor.execute(() -> clusterStateProvider.registerResourceGroupRuntimeHeartbeat(node, resourceGroupRuntimeInfos));
     }
+
+    @ThriftMethod
+    public ListenableFuture<Integer> getRunningTaskCount()
+    {
+        return executor.submit(clusterStateProvider::getRunningTaskCount);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -121,6 +121,7 @@ import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.resourcemanager.ClusterMemoryManagerService;
+import com.facebook.presto.resourcemanager.ClusterQueryTrackerService;
 import com.facebook.presto.resourcemanager.ClusterStatusSender;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.NoopResourceGroupService;
@@ -401,6 +402,7 @@ public class ServerMainModule
                         addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(RandomCatalogServerAddressSelector.class));
 
         newOptionalBinder(binder, ClusterMemoryManagerService.class);
+        newOptionalBinder(binder, ClusterQueryTrackerService.class);
         install(installModuleIf(
                 ServerConfig.class,
                 ServerConfig::isResourceManagerEnabled,
@@ -413,6 +415,7 @@ public class ServerMainModule
                         moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
                         if (serverConfig.isCoordinator()) {
                             moduleBinder.bind(ClusterMemoryManagerService.class).in(Scopes.SINGLETON);
+                            moduleBinder.bind(ClusterQueryTrackerService.class).in(Scopes.SINGLETON);
                             moduleBinder.bind(ResourceGroupService.class).to(ResourceManagerResourceGroupService.class).in(Scopes.SINGLETON);
                         }
                     }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
@@ -47,7 +47,8 @@ public class TestResourceManagerConfig
                 .setResourceGroupServiceCacheEnabled(false)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(10, SECONDS))
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(1, SECONDS))
-                .setResourceGroupRuntimeHeartbeatInterval(new Duration(1, SECONDS)));
+                .setResourceGroupRuntimeHeartbeatInterval(new Duration(1, SECONDS))
+                .setRunningTaskCountFetchInterval(new Duration(1, SECONDS)));
     }
 
     @Test
@@ -70,6 +71,7 @@ public class TestResourceManagerConfig
                 .put("resource-manager.resource-group-service-cache-expire-interval", "1m")
                 .put("resource-manager.resource-group-service-cache-refresh-interval", "10m")
                 .put("resource-manager.resource-group-runtimeinfo-heartbeat-interval", "6m")
+                .put("resource-manager.running-task-count-fetch-interval", "1m")
                 .build();
 
         ResourceManagerConfig expected = new ResourceManagerConfig()
@@ -88,7 +90,8 @@ public class TestResourceManagerConfig
                 .setResourceGroupServiceCacheEnabled(true)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(1, MINUTES))
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(10, MINUTES))
-                .setResourceGroupRuntimeHeartbeatInterval(new Duration(6, MINUTES));
+                .setResourceGroupRuntimeHeartbeatInterval(new Duration(6, MINUTES))
+                .setRunningTaskCountFetchInterval(new Duration(1, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingClusterQueryTrackerService.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingClusterQueryTrackerService.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.drift.client.DriftClient;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public class TestingClusterQueryTrackerService
+        extends ClusterQueryTrackerService
+{
+    DriftClient<ResourceManagerClient> resourceManagerClient;
+    int runningTaskCount;
+
+    public TestingClusterQueryTrackerService(DriftClient<ResourceManagerClient> resourceManagerClient, ScheduledExecutorService executorService, ResourceManagerConfig resourceManagerConfig, int runningTaskCount)
+    {
+        super(resourceManagerClient, executorService, resourceManagerConfig);
+        this.runningTaskCount = runningTaskCount;
+    }
+
+    @Override
+    public int getRunningTaskCount()
+    {
+        return runningTaskCount;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class TestingResourceManagerClient
+public class TestingResourceManagerClient
         implements ResourceManagerClient
 {
     private final AtomicInteger queryHeartbeats = new AtomicInteger();
@@ -35,6 +35,8 @@ class TestingResourceManagerClient
     private final Map<String, Integer> resourceGroupInfoCalls = new ConcurrentHashMap<>();
 
     private volatile List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = ImmutableList.of();
+
+    private int runningTaskCount;
 
     @Override
     public void queryHeartbeat(String internalNode, BasicQueryInfo basicQueryInfo, long sequenceId)
@@ -53,6 +55,11 @@ class TestingResourceManagerClient
     public void setResourceGroupRuntimeInfos(List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos)
     {
         this.resourceGroupRuntimeInfos = ImmutableList.copyOf(resourceGroupRuntimeInfos);
+    }
+
+    public void setRunningTaskCount(int runningTaskCount)
+    {
+        this.runningTaskCount = runningTaskCount;
     }
 
     @Override
@@ -91,5 +98,10 @@ class TestingResourceManagerClient
     public int getResourceGroupRuntimeHeartbeats()
     {
         return resourceGroupRuntimeHeartbeats.get();
+    }
+
+    public int getRunningTaskCount()
+    {
+        return runningTaskCount;
     }
 }


### PR DESCRIPTION
For Disagg Coodinator, each coordinator is doing it's own task limit enforcement and ended up runnig lot more tasks on the cluster than configured. With this change, fixing the behavior so each coordinator get global running task count and then enforce the limit and kill queries which using tasks larger that configured limit.

Test plan - unit tests

```
== RELEASE NOTES ==

General Changes
* Fix disagg coordinator task limit enforcement
```