### PR TITLE
Address bug in flushing broadcast table to temp storage

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -1101,7 +1101,7 @@ public class PrestoSparkTaskExecutorFactory
                     PageDataOutput pageDataOutput = new PageDataOutput(page.getSerializedPage());
                     long writtenSize = pageDataOutput.size();
 
-                    if ((writeBufferSizeInBytes - bufferedBytes) < writtenSize) {
+                    if ((writeBufferSizeInBytes - bufferedBytes) < writtenSize && !bufferedPages.isEmpty()) {
                         tempDataSink.write(bufferedPages);
                         bufferedPages.clear();
                         bufferedBytes = 0;


### PR DESCRIPTION
When page size is bigger than `storage_based_broadcast_join_write_buffer_size`, 
then we enter the code flow where we try to flush empty buffer. This PR adds the 
check to skip flushing if buffer is empty.

```
== NO RELEASE NOTE ==
```
