### PR TITLE
Update with velox memory management and fix a buffer double free issue in UnsafeRowExchangeSource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -56,8 +56,7 @@ class PeriodicTaskManager {
   folly::CPUThreadPoolExecutor* driverCPUExecutor_;
   folly::IOThreadPoolExecutor* httpExecutor_;
   TaskManager* taskManager_;
-  velox::memory::MemoryManager<velox::memory::MmapMemoryAllocator>&
-      memoryManager_;
+  velox::memory::MemoryManager<>& memoryManager_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -157,12 +157,12 @@ void PrestoExchangeSource::processDataResponse(
     page = std::make_unique<exec::SerializedPage>(
         std::move(singleChain),
         pool_,
-        [mappedMemory = response->mappedMemory()](folly::IOBuf& iobuf) {
-          // Free the backed memory from MappedMemory on page dtor
+        [allocator = response->allocator()](folly::IOBuf& iobuf) {
+          // Free the backed memory from MemoryAllocator on page dtor.
           folly::IOBuf* start = &iobuf;
           auto curr = start;
           do {
-            mappedMemory->freeBytes(curr->writableData(), curr->length());
+            allocator->freeBytes(curr->writableData(), curr->length());
             curr = curr->next();
           } while (curr != start);
         });

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -351,12 +351,11 @@ void PrestoServer::initializeAsyncCache() {
   options.capacity = memoryBytes;
   options.useMmapArena = systemConfig->useMmapArena();
   options.mmapArenaCapacityRatio = systemConfig->mmapArenaCapacityRatio();
-  
-  auto allocator = std::make_shared<memory::MmapAllocator>(options);
-  mappedMemory_ = std::make_shared<cache::AsyncDataCache>(
-      allocator, memoryBytes, std::move(ssd));
 
-  memory::MappedMemory::setDefaultInstance(mappedMemory_.get());
+  auto allocator = std::make_shared<memory::MmapAllocator>(options);
+  cache_ = std::make_shared<cache::AsyncDataCache>(
+      allocator, memoryBytes, std::move(ssd));
+  memory::MemoryAllocator::setDefaultInstance(cache_.get());
 }
 
 void PrestoServer::stop() {
@@ -476,8 +475,7 @@ std::shared_ptr<velox::connector::Connector> PrestoServer::connectorWithCache(
     const std::string& connectorName,
     const std::string& catalogName,
     std::shared_ptr<const velox::Config> properties) {
-  VELOX_CHECK_NOT_NULL(
-      dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
+  VELOX_CHECK_NOT_NULL(cache_);
   LOG(INFO) << "STARTUP: Using AsyncDataCache";
   return facebook::velox::connector::getConnectorFactory(connectorName)
       ->newConnector(

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -19,7 +19,8 @@
 #include <velox/exec/Task.h>
 #include <velox/expression/Expr.h>
 #include "presto_cpp/main/CPUMon.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #if __has_include("filesystem")
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -112,7 +113,7 @@ class PrestoServer {
   std::unique_ptr<folly::IOThreadPoolExecutor> connectorIoExecutor_;
 
   // Instance of AsyncDataCache used for all large allocations.
-  std::shared_ptr<velox::memory::MappedMemory> mappedMemory_;
+  std::shared_ptr<velox::cache::AsyncDataCache> cache_;
 
   std::unique_ptr<http::HttpServer> httpServer_;
   std::unique_ptr<SignalHandler> signalHandler_;

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
       executor().get(),
       config,
       connectorConfigs,
-      memory::MappedMemory::getInstance(),
+      memory::MemoryAllocator::getInstance(),
       std::move(pool),
       spillExecutor(),
       queryId);

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -41,7 +41,7 @@ HttpResponse::~HttpResponse() {
   // Clear out any leftover iobufs if not consumed.
   for (auto& buf : bodyChain_) {
     if (buf) {
-      mappedMemory_->freeBytes(buf->writableData(), buf->length());
+      allocator_->freeBytes(buf->writableData(), buf->length());
     }
   }
 }
@@ -50,7 +50,7 @@ void HttpResponse::append(std::unique_ptr<folly::IOBuf>&& iobuf) {
   VELOX_CHECK(!iobuf->isChained());
   uint64_t dataLength = iobuf->length();
 
-  void* buf = mappedMemory_->allocateBytes(dataLength);
+  void* buf = allocator_->allocateBytes(dataLength);
   if (buf == nullptr) {
     VELOX_FAIL(
         "Cannot spare enough system memory to receive more HTTP response.");

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -16,7 +16,7 @@
 #include <proxygen/lib/http/HTTPConnector.h>
 #include <proxygen/lib/http/connpool/SessionPool.h>
 #include <proxygen/lib/http/session/HTTPUpstreamSession.h>
-#include <velox/common/memory/MappedMemory.h>
+#include <velox/common/memory/MemoryAllocator.h>
 #include "presto_cpp/main/http/HttpConstants.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -26,7 +26,7 @@ class HttpResponse {
  public:
   explicit HttpResponse(std::unique_ptr<proxygen::HTTPMessage> headers)
       : headers_(std::move(headers)),
-        mappedMemory_(velox::memory::MappedMemory::getInstance()) {}
+        allocator_(velox::memory::MemoryAllocator::getInstance()) {}
 
   ~HttpResponse();
 
@@ -49,15 +49,15 @@ class HttpResponse {
     return std::move(bodyChain_);
   }
 
-  velox::memory::MappedMemory* FOLLY_NONNULL mappedMemory() {
-    return mappedMemory_;
+  velox::memory::MemoryAllocator* FOLLY_NONNULL allocator() {
+    return allocator_;
   }
 
   std::string dumpBodyChain() const;
 
  private:
   const std::unique_ptr<proxygen::HTTPMessage> headers_;
-  velox::memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+  velox::memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   std::vector<std::unique_ptr<folly::IOBuf>> bodyChain_;
 };

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -77,9 +77,9 @@ std::string bodyAsString(http::HttpResponse& response) {
   auto iobufs = response.consumeBody();
   for (auto& body : iobufs) {
     oss << std::string((const char*)body->data(), body->length());
-    response.mappedMemory()->freeBytes(body->writableData(), body->length());
+    response.allocator()->freeBytes(body->writableData(), body->length());
   }
-  EXPECT_EQ(response.mappedMemory()->numAllocated(), 0);
+  EXPECT_EQ(response.allocator()->numAllocated(), 0);
   return oss.str();
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -42,7 +42,6 @@ class ShuffleWriteOperator : public Operator {
     for (auto i = 0; i < input->size(); ++i) {
       auto partition = partitions->valueAt(i);
       auto data = serializedRows->valueAt(i);
-
       shuffle_->collect(partition, std::string_view(data.data(), data.size()));
     }
   }
@@ -65,7 +64,7 @@ class ShuffleWriteOperator : public Operator {
   }
 
  private:
-  ShuffleInterface* shuffle_;
+  ShuffleInterface* const FOLLY_NONNULL shuffle_;
 };
 } // namespace
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -15,7 +15,7 @@
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
-#include <velox/common/memory/MappedMemory.h>
+#include <velox/common/memory/MemoryAllocator.h>
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/http/HttpClient.h"
 #include "presto_cpp/main/http/HttpServer.h"
@@ -295,20 +295,18 @@ class PrestoExchangeSourceTest : public testing::Test {
  public:
   void SetUp() override {
     auto& defaultManager =
-        memory::MemoryManager<memory::MemoryAllocator, memory::kNoAlignment>::
-            getProcessDefaultManager();
+        memory::MemoryManager<memory::kNoAlignment>::getInstance();
     auto& pool =
-        dynamic_cast<memory::MemoryPoolImpl<memory::MemoryAllocator, 16>&>(
-            defaultManager.getRoot());
+        dynamic_cast<memory::MemoryPoolImpl<16>&>(defaultManager.getRoot());
     pool_ = &pool;
     memory::MmapAllocatorOptions options;
     options.capacity = 1L << 30;
-    mappedMemory_ = std::make_unique<memory::MmapAllocator>(options);
-    memory::MappedMemory::setDefaultInstance(mappedMemory_.get());
+    allocator_ = std::make_unique<memory::MmapAllocator>(options);
+    memory::MemoryAllocator::setDefaultInstance(allocator_.get());
   }
 
   void TearDown() override {
-    memory::MappedMemory::setDefaultInstance(nullptr);
+    memory::MemoryAllocator::setDefaultInstance(nullptr);
   }
 
   void requestNextPage(
@@ -322,7 +320,7 @@ class PrestoExchangeSourceTest : public testing::Test {
   }
 
   memory::MemoryPool* pool_;
-  std::unique_ptr<memory::MappedMemory> mappedMemory_;
+  std::unique_ptr<memory::MemoryAllocator> allocator_;
 };
 
 TEST_F(PrestoExchangeSourceTest, basic) {

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -117,7 +117,7 @@ class Cursor {
   }
 
   memory::MemoryPool* pool_;
-  memory::MappedMemory* mappedMemory_ = memory::MappedMemory::getInstance();
+  memory::MemoryAllocator* allocator_ = memory::MemoryAllocator::getInstance();
   TaskManager* taskManager_;
   const protocol::TaskId taskId_;
   RowTypePtr rowType_;


### PR DESCRIPTION
Advanced Velox version and update the presto cpp side
memory management access code.

This PR also fixes a buffer double free issue in
UnsafeRowExchangeSource.

```
== NO RELEASE NOTE ==
```
