### PR TITLE
[native] Fix 'spilling' Runtime Metrics.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -205,6 +205,10 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
 
   const velox::exec::TaskStats taskStats = task->taskStats();
   protocol::TaskStats& prestoTaskStats = info.stats;
+  // Clear the old runtime metrics as not all of them would be overwritten by
+  // the new ones.
+  prestoTaskStats.runtimeStats.clear();
+
   prestoTaskStats.totalScheduledTimeInNanos = {};
   prestoTaskStats.totalCpuTimeInNanos = {};
   prestoTaskStats.totalBlockedTimeInNanos = {};
@@ -472,7 +476,6 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
         it.second);
   }
 
-  prestoTaskStats.runtimeStats.clear();
   for (const auto& stat : taskRuntimeStats) {
     prestoTaskStats.runtimeStats[stat.first] =
         toRuntimeMetric(stat.first, stat.second);


### PR DESCRIPTION
Test plan - Build and run in the test cluster.

We were cleaning up the old runtime metrics in the end of PrestoTask::updateInfoLocked(), while adding metrics
on spilling before that. As the result spilling metrics never got out.
Moved the cleaning to the very beginning of the function.

```
== NO RELEASE NOTE ==
```
