### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.21.7

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.19.2</version>
+            <version>3.21.7</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.19.2</version>
+            <version>3.21.7</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.19.2
- [CVE-2022-3171](https://www.oscs1024.com/hd/CVE-2022-3171)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.19.2 to 3.21.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>