### PR TITLE
[native] Use "experimental.spiller-spill-path" config property.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -23,7 +23,6 @@
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
-#include "velox/serializers/PrestoSerializer.h"
 
 DEFINE_int32(
     old_task_ms,

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "TaskResource.h"
+#include "presto_cpp/main/TaskResource.h"
 #include <presto_cpp/main/common/Exception.h>
 #include "presto_cpp/external/json/json.hpp"
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/thrift/ProtocolToThrift.h"
 #include "presto_cpp/main/thrift/ThriftIO.h"
 #include "presto_cpp/main/thrift/gen-cpp2/PrestoThrift.h"
@@ -243,6 +244,13 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTask(
             configs.emplace(
                 velox::core::QueryConfig::kSessionTimezone,
                 velox::util::getTimeZoneName(session.timeZoneKey));
+          }
+
+          // Copy spill path from the System Config to the Velox Query config
+          // via 'configs'.
+          const auto spillPath = SystemConfig::instance()->spillerSpillPath();
+          if (not spillPath.empty()) {
+            configs.emplace(velox::core::QueryConfig::kSpillPath, spillPath);
           }
 
           std::unordered_map<

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -86,6 +86,11 @@ int32_t SystemConfig::numSpillThreads() const {
   return opt.hasValue() ? opt.value() : std::thread::hardware_concurrency();
 }
 
+std::string SystemConfig::spillerSpillPath() const {
+  auto opt = optionalProperty<std::string>(std::string(kSpillerSpillPath));
+  return opt.hasValue() ? opt.value() : "";
+}
+
 int32_t SystemConfig::shutdownOnsetSec() const {
   auto opt = optionalProperty<int32_t>(std::string(kShutdownOnsetSec));
   return opt.hasValue() ? opt.value() : kShutdownOnsetSecDefault;

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -84,6 +84,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpExecThreads{"http_exec_threads"};
   static constexpr std::string_view kNumIoThreads{"num-io-threads"};
   static constexpr std::string_view kNumSpillThreads{"num-spill-threads"};
+  static constexpr std::string_view kSpillerSpillPath =
+      "experimental.spiller-spill-path";
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
   static constexpr std::string_view kSystemMemoryGb{"system-memory-gb"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
@@ -132,6 +134,8 @@ class SystemConfig : public ConfigBase {
   int32_t numIoThreads() const;
 
   int32_t numSpillThreads() const;
+
+  std::string spillerSpillPath() const;
 
   int32_t shutdownOnsetSec() const;
 


### PR DESCRIPTION
"experimental.spiller-spill-path" is the Presto config property to specify
the path to spill data. It is passed in the "config.properties" file.

Test plan - Run local setup to observe that path being picked up correctly
from the "config.properties" and passed to the Spiller Config.

```
== NO RELEASE NOTE ==
```
