### PR TITLE
Abstract the WorkerProperty to be a pluggable interface

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -116,6 +116,8 @@ import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.node.PrestoSparkInternalNodeManager;
 import com.facebook.presto.spark.node.PrestoSparkNodePartitioningManager;
 import com.facebook.presto.spark.node.PrestoSparkQueryManager;
@@ -486,6 +488,8 @@ public class PrestoSparkModule
         binder.bind(RemoteTaskStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RemoteTaskStats.class).withGeneratedName();
         binder.bind(NativeExecutionProcessFactory.class).in(Scopes.SINGLETON);
+        binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
         binder.bind(NativeExecutionTaskFactory.class).in(Scopes.SINGLETON);
         httpClientBinder(binder).bindHttpClient("nativeExecution", ForNativeExecutionTask.class)
                 .withConfigDefaults(config -> {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
@@ -18,9 +18,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
-import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
-import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
-import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spi.PrestoException;
 import io.airlift.units.Duration;
 
@@ -48,9 +46,7 @@ public class NativeExecutionProcessFactory
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final TaskManagerConfig taskManagerConfig;
-    private final NativeExecutionSystemConfig systemConfig;
-    private final NativeExecutionNodeConfig nodeConfig;
-    private final NativeExecutionConnectorConfig connectorConfig;
+    private final WorkerProperty<?, ?, ?> workerProperty;
 
     @Inject
     public NativeExecutionProcessFactory(
@@ -59,24 +55,20 @@ public class NativeExecutionProcessFactory
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             TaskManagerConfig taskManagerConfig,
-            NativeExecutionSystemConfig systemConfig,
-            NativeExecutionNodeConfig nodeConfig,
-            NativeExecutionConnectorConfig connectorConfig)
+            WorkerProperty<?, ?, ?> workerProperty)
+
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.coreExecutor = requireNonNull(coreExecutor, "coreExecutor is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
         this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
-        this.systemConfig = requireNonNull(systemConfig, "systemConfig is null");
-        this.nodeConfig = requireNonNull(nodeConfig, "nodeConfig is null");
-        this.connectorConfig = requireNonNull(connectorConfig, "connectorConfig is null");
+        this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
     }
 
     public NativeExecutionProcess createNativeExecutionProcess(
             Session session,
             URI location)
-            throws IOException
     {
         return createNativeExecutionProcess(session, location, MAX_ERROR_DURATION);
     }
@@ -95,9 +87,7 @@ public class NativeExecutionProcessFactory
                     serverInfoCodec,
                     maxErrorDuration,
                     taskManagerConfig,
-                    systemConfig,
-                    nodeConfig,
-                    connectorConfig);
+                    workerProperty);
         }
         catch (IOException e) {
             throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start native process: %s", e.getMessage()), e);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.google.inject.Inject;
+
+/**
+ * A utility class that helps with properties and its materialization.
+ */
+public class PrestoSparkWorkerProperty
+        extends WorkerProperty<NativeExecutionConnectorConfig, NativeExecutionNodeConfig, NativeExecutionSystemConfig>
+{
+    @Inject
+    public PrestoSparkWorkerProperty(
+            NativeExecutionSystemConfig systemConfig,
+            NativeExecutionConnectorConfig connectorConfig,
+            NativeExecutionNodeConfig nodeConfig)
+    {
+        super(connectorConfig, nodeConfig, systemConfig);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
@@ -22,17 +22,87 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /**
- * A utility class that helps with properties and its materialization.
+ * The implementor of any new WorkerProperty is expected to provide three configuration classes (or their variants) as minimal requirements to run the native process.
+ * The variants of the new configuration classes need to extend these three as base class to provide any new configs or override existing configs. For example:
+ * <p>
+ * // new configuration variance
+ * public class InternalNativeExecutionNodeConfig
+ * extends NativeExecutionNodeConfig
+ * {
+ * private static final String SMC_SERVICE_INVENTORY_TIER = "smc-service-inventory.tier";
+ * <p>
+ * private String smcServiceInventoryTier = "dummy.tier";
+ *
+ * @Override public Map<String, String> getAllProperties()
+ * {
+ * ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+ * return builder.putAll(super.getAllProperties())
+ * .put(SMC_SERVICE_INVENTORY_TIER, smcServiceInventoryTier)
+ * .build();
+ * }
+ * @Config(SMC_SERVICE_INVENTORY_TIER) public PrestoFacebookSparkNativeExecutionNodeConfig setSmcServiceInventoryTier(String smcServiceInventoryTier)
+ * {
+ * this.smcServiceInventoryTier = smcServiceInventoryTier;
+ * return this;
+ * }
+ * }
+ * <p>
+ * // New WorkerProperty with new InternalNativeExecutionNodeConfig
+ * public class InternalWorkerProperty
+ * extends WorkerProperty<NativeExecutionConnectorConfig, InternalNativeExecutionNodeConfig, NativeExecutionSystemConfig>
+ * {
+ * @Inject public InternalWorkerProperty(
+ * NativeExecutionSystemConfig systemConfig,
+ * NativeExecutionConnectorConfig connectorConfig,
+ * InternalNativeExecutionNodeConfig nodeConfig)
+ * {
+ * super(connectorConfig, nodeConfig, systemConfig);
+ * }
+ * }
  */
-public class WorkerProperty
+public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extends NativeExecutionNodeConfig, T3 extends NativeExecutionSystemConfig>
 {
-    private WorkerProperty()
+    private final T1 connectorConfig;
+    private final T2 nodeConfig;
+    private final T3 systemConfig;
+
+    public WorkerProperty(
+            T1 connectorConfig,
+            T2 nodeConfig,
+            T3 systemConfig)
     {
+        this.systemConfig = requireNonNull(systemConfig, "systemConfig is null");
+        this.nodeConfig = requireNonNull(nodeConfig, "nodeConfig is null");
+        this.connectorConfig = requireNonNull(connectorConfig, "connectorConfig is null");
     }
 
-    public static void populateProperty(Map<String, String> properties, Path path)
+    public T1 getConnectorConfig()
+    {
+        return connectorConfig;
+    }
+
+    public T2 getNodeConfig()
+    {
+        return nodeConfig;
+    }
+
+    public T3 getSystemConfig()
+    {
+        return systemConfig;
+    }
+
+    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path connectorConfigPath)
+            throws IOException
+    {
+        populateProperty(systemConfig.getAllProperties(), systemConfigPath);
+        populateProperty(nodeConfig.getAllProperties(), nodeConfigPath);
+        populateProperty(connectorConfig.getAllProperties(), connectorConfigPath);
+    }
+
+    private void populateProperty(Map<String, String> properties, Path path)
             throws IOException
     {
         File file = new File(path.toString());

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spark.execution.NativeExecutionTaskFactory;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.PageCodecMarker;
@@ -755,15 +756,17 @@ public class TestPrestoSparkHttpClient
             TaskManagerConfig config)
     {
         ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
+        PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
+                new NativeExecutionSystemConfig(),
+                new NativeExecutionConnectorConfig(),
+                new NativeExecutionNodeConfig());
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
                 new TestingHttpClient(responseManager),
                 newSingleThreadExecutor(),
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,
                 config,
-                new NativeExecutionSystemConfig(),
-                new NativeExecutionNodeConfig(),
-                new NativeExecutionConnectorConfig());
+                workerProperty);
         List<TaskSource> sources = new ArrayList<>();
         return factory.createNativeExecutionProcess(
                 testSessionBuilder().build(),


### PR DESCRIPTION
In this PR, we created an abstract class `WorkerProperty` to be a base class for different implementation which will take different worker property classes (e.g NativeExecutionSystemConfigs).

The reason is that the Guice framework doesn't allow to bind different version of the config classes (e.g NativeExecutionSystemConfigs etc) in different environments which we have to have for OSS and internal environment.  To solve this issue, we choose to bind different versions of the `WorkerProperty ` where OSS implementation will take the default config classes (e.g NativeExecutionSystemConfigs) and our internal version can take another (say FacebookNativeExecutionSystemConfigs).

```
== NO RELEASE NOTE ==
```