### PR TITLE
Optimize TypeSet contains/add pattern

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -121,6 +121,9 @@ public class TypedSet
 
         // containsNullElement flag is maintained so contains() method can have shortcut for null value
         if (block.isNull(position)) {
+            if (containNullElements) {
+                return false;
+            }
             containNullElements = true;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/multimapagg/MultimapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/multimapagg/MultimapAggregationFunction.java
@@ -149,8 +149,7 @@ public class MultimapAggregationFunction
 
             state.forEach((key, value, keyValueIndex) -> {
                 // Merge values of the same key into an array
-                if (!keySet.contains(key, keyValueIndex)) {
-                    keySet.add(key, keyValueIndex);
+                if (keySet.add(key, keyValueIndex)) {
                     keyType.appendTo(key, keyValueIndex, distinctKeyBlockBuilder);
                     BlockBuilder valueArrayBuilder = valueType.createBlockBuilder(null, 10, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
                     valueArrayBlockBuilders.set(keySet.positionOf(key, keyValueIndex), valueArrayBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -152,7 +152,7 @@ public final class MapConstructor
             }
 
             if (keyType.getJavaType() == Block.class) {
-                // If it's nto primitive or string, we need to look for nulls in the block.
+                // If it's not primitive or string, we need to look for nulls in the block.
                 Object keyObject = readNativeValue(mapType.getKeyType(), keyBlock, i);
                 try {
                     if ((boolean) keyIndeterminate.invoke(keyObject, false)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
@@ -230,8 +230,7 @@ public final class MapToMapCast
         BlockBuilder mapBlockBuilder = toMapType.createBlockBuilder(null, 1);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
         for (int i = 0; i < fromMap.getPositionCount(); i += 2) {
-            if (!typedSet.contains(keyBlock, i / 2)) {
-                typedSet.add(keyBlock, i / 2);
+            if (typedSet.add(keyBlock, i / 2)) {
                 toKeyType.appendTo(keyBlock, i / 2, blockBuilder);
                 if (fromMap.isNull(i + 1)) {
                     blockBuilder.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MultimapFromEntriesFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MultimapFromEntriesFunction.java
@@ -70,11 +70,10 @@ public final class MultimapFromEntriesFunction
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
             }
 
-            if (keySet.contains(rowBlock, 0)) {
+            if (!keySet.add(rowBlock, 0)) {
                 entryIndicesList[keySet.positionOf(rowBlock, 0)].add(i);
             }
             else {
-                keySet.add(rowBlock, 0);
                 entryIndicesList[keySet.size() - 1].add(i);
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
@@ -208,11 +208,13 @@ public class TestTypedSet
         assertEquals(typedSet.isContainNullElements(), false);
         for (int i = 0; i < elementCount; i++) {
             BIGINT.writeLong(blockBuilder, i);
-            typedSet.add(blockBuilder, i);
+            assertTrue(typedSet.add(blockBuilder, i), "First add should return true");
+            assertFalse(typedSet.add(blockBuilder, i), "Adding an repeat element should return false");
         }
         assertEquals(typedSet.isContainNullElements(), false);
         blockBuilder.appendNull();
-        typedSet.add(blockBuilder, blockBuilder.getPositionCount() - 1);
+        assertTrue(typedSet.add(blockBuilder, blockBuilder.getPositionCount() - 1), "Original null");
+        assertFalse(typedSet.add(blockBuilder, blockBuilder.getPositionCount() - 1), "repeat null");
         assertEquals(typedSet.isContainNullElements(), true);
     }
 


### PR DESCRIPTION
Many callers of TypedSet checks if the key exists before adding the 
key. This change is similar to replacing containsKey/put pattern with
putIfAbsent and using the return result to do the conditional processing.

Test plan - 
Enhanced existing tests.

```
== NO RELEASE NOTE ==
```
