### PR TITLE
Upgrade Delta Standalone to 0.6.0

### DIFF
--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone_2.12</artifactId>
-            <version>0.5.0</version>
+            <version>0.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
This PR upgrades Delta Standalone dependency to 0.6.0 for Delta Lake Connector.


Signed-off-by: dnskr <dnskrv88@gmail.com>

Test plan - Existing tests

```
== RELEASE NOTES ==

Delta Lake Connector Changes
* Upgrade Delta Standalone to 0.6.0
```
