### PR TITLE
[Native] Fix race condition that throws "Output buffers not found"

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -64,6 +64,16 @@ class TaskManager {
           std::unordered_map<std::string, std::string>>&&
           connectorConfigStrings);
 
+  // Iterates through a map of resultRequests and fetches data from
+  // buffer manager. This method uses the getData() global call to fetch
+  // data for each resultRequest bufferManager. If the output buffer for task
+  // is not found, prepares the Result object with completed flags set to false
+  // and notifies the future.
+  // Note: This method is made public for unit testing purpose only.
+  void getDataForResultRequests(
+      const std::unordered_map<int64_t, std::shared_ptr<ResultRequest>>&
+          resultRequests);
+
   std::unique_ptr<protocol::TaskInfo> deleteTask(
       const protocol::TaskId& taskId,
       bool abort);


### PR DESCRIPTION
The race condition occurs when task is terminated and its PartitionedOutputBuffer is cleared out by downstream driver.
The task manager tries to access this buffer.

Depends on this change: https://github.com/facebookincubator/velox/pull/3502.

== Testing ==
Simulate a scenario where TaskManager processes result requests for a Task and the buffer is unavailable. Ensure that no exception is thrown and the future associated with the result request is invoked.

== RELEASE NOTES ==

Native Worker
--------------

* Fix race condition that may cause the query to fail with unhelpful "Output buffers not found" error. See :issues:`3009` for details.
