### PR TITLE
(v2) Fix ROUND() returning incorrect results for edge cases

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRoundBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRoundBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlRoundBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlRoundBenchmark(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "sql_round", 3, 5,
+                "SELECT TRANSFORM(SEQUENCE(1, 1000), i -> ROUND(totalprice + i, 1000)) FROM orders");
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlRoundBenchmark(createLocalQueryRunner()).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -746,6 +746,8 @@ public class TestMathFunctions
         assertFunction("round(DOUBLE '" + GREATEST_DOUBLE_LESS_THAN_HALF + "')", DOUBLE, 0.0);
         assertFunction("round(DOUBLE '-" + 0x1p-1 + "')", DOUBLE, -1.0); // -0.5
         assertFunction("round(DOUBLE '-" + GREATEST_DOUBLE_LESS_THAN_HALF + "')", DOUBLE, -0.0);
+        assertFunction("round(DOUBLE '5.0', 20)", DOUBLE, 5.0);
+        assertFunction("round(DOUBLE '1e100', 0)", DOUBLE, 1e100d);
 
         assertFunction("round(TINYINT '3', TINYINT '0')", TINYINT, (byte) 3);
         assertFunction("round(TINYINT '3', 0)", TINYINT, (byte) 3);
@@ -808,6 +810,8 @@ public class TestMathFunctions
         assertFunction("round(REAL '-3.5', 1)", REAL, -3.5f);
         assertFunction("round(REAL '-3.5001', 1)", REAL, -3.5f);
         assertFunction("round(REAL '-3.99', 1)", REAL, -4.0f);
+        assertFunction("round(REAL '5.0', 20)", REAL, 5.0f);
+        assertFunction("round(REAL '1e30', 0)", REAL, 1e30f);
 
         // ROUND short DECIMAL -> short DECIMAL
         assertFunction("round(DECIMAL '0')", createDecimalType(1, 0), SqlDecimal.of("0"));


### PR DESCRIPTION
This achieves the same as #18451, which was reverted (#18768) because of a performance regression (see [comment](https://github.com/prestodb/presto/pull/18451#issuecomment-1338902054)).
Instead of systematically using BigDecimal in round(), we call it only when we detect that we are on an edge case scenario of num*factor overflowing a long.

Test plan -
Unit test: `mvn -Dtest="TestMathFunctions" test`
Performance: [SqlRoundBenchmark.java](https://gist.github.com/sviscaino/945ca6c1b63762bdd082bf512a184787) (did not commit it):
- [result](https://gist.github.com/sviscaino/a6b3d4ffd9c4f99d1e0f14480c367142) for the original round() (that is wrong for edge cases)
- [result](https://gist.github.com/sviscaino/657a9c1fe6374d9692abdda47da79119) for the version that systematically uses BigDecimal (performance regression)
- [result](https://gist.github.com/sviscaino/130e38bb41629b6daa5ca211daec181c) for this PR's version (no performance regression)


```
== NO RELEASE NOTE ==
```
