### PR TITLE
[native] Fix shuffle code for buck build and cleanup

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -15,14 +15,8 @@ add_library(
   presto_operators PartitionAndSerialize.cpp ShuffleWrite.cpp
                    UnsafeRowExchangeSource.cpp LocalPersistentShuffle.cpp)
 
-target_link_libraries(
-  presto_operators
-  presto_common
-  velox_core
-  velox_exec
-  velox_expression
-  velox_hive_partition_function
-  velox_vector)
+target_link_libraries(presto_operators presto_common velox_core velox_exec
+                      velox_vector)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
-#include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 
 using namespace facebook::velox::exec;

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -34,6 +34,8 @@ class ShuffleInterface {
           Type type,
           velox::memory::MemoryPool* pool)>;
 
+  virtual ~ShuffleInterface() = default;
+
   /// Write to the shuffle one row at a time.
   virtual void collect(int32_t partition, std::string_view data) = 0;
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(
   presto_operators
   velox_vector_fuzzer
   velox_exec_test_lib
+  velox_hive_partition_function
   velox_vector_test_lib
   velox_type
   velox_vector

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -226,6 +226,19 @@ auto addShuffleWriteNode(
 } // namespace
 
 class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
+ public:
+  static constexpr std::string_view kTestShuffleInfoFormat =
+      "{{\n"
+      "  \"numPartitions\": {},\n"
+      "  \"maxBytesPerPartition\": {}\n"
+      "}}";
+
+  static constexpr std::string_view kLocalShuffleInfoFormat =
+      "{{\n"
+      "  \"rootPath\": \"{}\",\n"
+      "  \"numPartitions\": {}\n"
+      "}}";
+
  protected:
   void registerVectorSerde() override {
     serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
@@ -400,18 +413,6 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       fileSystem->remove(file);
     }
   }
-
-  const std::string kTestShuffleInfoFormat =
-      "{{\n"
-      "  \"numPartitions\": {},\n"
-      "  \"maxBytesPerPartition\": {}\n"
-      "}}";
-
-  const std::string kLocalShuffleInfoFormat =
-      "{{\n"
-      "  \"rootPath\": \"{}\",\n"
-      "  \"numPartitions\": {}\n"
-      "}}";
 };
 
 TEST_F(UnsafeRowShuffleTest, operators) {

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -147,18 +147,18 @@ TEST_F(PlanConverterTest, scanAggBatch) {
 
   auto shuffleWrite =
       std::dynamic_pointer_cast<const operators::ShuffleWriteNode>(root);
-  ASSERT(shuffleWrite != nullptr);
+  ASSERT_NE(shuffleWrite, nullptr);
   ASSERT_EQ(shuffleWrite->sources().size(), 1);
 
   auto localPartition =
       std::dynamic_pointer_cast<const core::LocalPartitionNode>(
           shuffleWrite->sources().back());
-  ASSERT(localPartition != nullptr);
+  ASSERT_NE(localPartition, nullptr);
   ASSERT_EQ(localPartition->sources().size(), 1);
 
   auto partitionAndSerializeNode =
       std::dynamic_pointer_cast<const operators::PartitionAndSerializeNode>(
           localPartition->sources().back());
-  ASSERT(partitionAndSerializeNode != nullptr);
+  ASSERT_NE(partitionAndSerializeNode, nullptr);
   ASSERT_EQ(partitionAndSerializeNode->numPartitions(), 3);
 }


### PR DESCRIPTION
Due to compiler differences there are some changes needed to make shuffle related codebase compile with internal clang compiler
```
== NO RELEASE NOTE ==
```
