### PR TITLE
Introduce PrestoSparkProperties for PrestoSparkRunner

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -26,6 +26,7 @@ import com.google.inject.Module;
 
 import java.util.List;
 
+import static com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration.METADATA_STORAGE_TYPE_LOCAL;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class PrestoSparkServiceFactory
@@ -60,7 +61,7 @@ public class PrestoSparkServiceFactory
 
     protected List<Module> getAdditionalModules(PrestoSparkConfiguration configuration)
     {
-        checkArgument("LOCAL".equals(configuration.getMetadataStorageType().toUpperCase()), "only local metadata storage is supported");
+        checkArgument(METADATA_STORAGE_TYPE_LOCAL.equalsIgnoreCase(configuration.getMetadataStorageType()), "only local metadata storage is supported");
         return ImmutableList.of(new PrestoSparkLocalMetadataStorageModule());
     }
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -23,10 +23,13 @@ import static java.util.stream.Collectors.toMap;
 
 public class PrestoSparkConfiguration
 {
+    public static final String METADATA_STORAGE_TYPE_KEY = "metadata_storage_type";
+    public static final String METADATA_STORAGE_TYPE_LOCAL = "LOCAL";
+
     private final Map<String, String> configProperties;
     private final String pluginsDirectoryPath;
     private final Map<String, Map<String, String>> catalogProperties;
-    private final String metadataStorageType;
+    private final Map<String, String> prestoSparkProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
@@ -37,7 +40,7 @@ public class PrestoSparkConfiguration
             Map<String, String> configProperties,
             String pluginsDirectoryPath,
             Map<String, Map<String, String>> catalogProperties,
-            String metadataStorageType,
+            Map<String, String> prestoSparkProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -48,7 +51,8 @@ public class PrestoSparkConfiguration
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
         this.catalogProperties = unmodifiableMap(requireNonNull(catalogProperties, "catalogProperties is null").entrySet().stream()
                 .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
-        this.metadataStorageType = requireNonNull(metadataStorageType, "metadataStorageType is null");
+        this.prestoSparkProperties = unmodifiableMap(new HashMap<>(requireNonNull(prestoSparkProperties, "prestoSparkProperties is null")));
+        requireNonNull(prestoSparkProperties.get(METADATA_STORAGE_TYPE_KEY), "prestoSparkProperties must contain " + METADATA_STORAGE_TYPE_KEY);
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
@@ -78,9 +82,14 @@ public class PrestoSparkConfiguration
         return catalogProperties;
     }
 
+    public Map<String, String> getPrestoSparkProperties()
+    {
+        return prestoSparkProperties;
+    }
+
     public String getMetadataStorageType()
     {
-        return metadataStorageType;
+        return prestoSparkProperties.get(METADATA_STORAGE_TYPE_KEY);
     }
 
     public Optional<Map<String, String>> getEventListenerProperties()

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration.METADATA_STORAGE_TYPE_KEY;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
@@ -31,13 +32,14 @@ public class PrestoSparkDistribution
     private final PackageSupplier packageSupplier;
     private final Map<String, String> configProperties;
     private final Map<String, Map<String, String>> catalogProperties;
-    private final String metadataStorageType;
+    private final Map<String, String> prestoSparkProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
     private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
 
+    @Deprecated
     public PrestoSparkDistribution(
             SparkContext sparkContext,
             PackageSupplier packageSupplier,
@@ -50,12 +52,37 @@ public class PrestoSparkDistribution
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties)
     {
+        this(
+                sparkContext,
+                packageSupplier,
+                configProperties,
+                catalogProperties,
+                ImmutableMap.of(METADATA_STORAGE_TYPE_KEY, metadataStorageType),
+                eventListenerProperties,
+                accessControlProperties,
+                sessionPropertyConfigurationProperties,
+                functionNamespaceProperties,
+                tempStorageProperties);
+    }
+
+    public PrestoSparkDistribution(
+            SparkContext sparkContext,
+            PackageSupplier packageSupplier,
+            Map<String, String> configProperties,
+            Map<String, Map<String, String>> catalogProperties,
+            Map<String, String> prestoSparkProperties,
+            Optional<Map<String, String>> eventListenerProperties,
+            Optional<Map<String, String>> accessControlProperties,
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties,
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
+            Optional<Map<String, Map<String, String>>> tempStorageProperties)
+    {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
         this.configProperties = ImmutableMap.copyOf(requireNonNull(configProperties, "configProperties is null"));
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null").entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
-        this.metadataStorageType = requireNonNull(metadataStorageType, "metadataStorageType is null");
+        this.prestoSparkProperties = ImmutableMap.copyOf(requireNonNull(prestoSparkProperties, "prestoSparkProperties is null"));
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
@@ -90,9 +117,9 @@ public class PrestoSparkDistribution
         return catalogProperties;
     }
 
-    public String getMetadataStorageType()
+    public Map<String, String> getPrestoSparkProperties()
     {
-        return metadataStorageType;
+        return prestoSparkProperties;
     }
 
     public Optional<Map<String, String>> getEventListenerProperties()

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration.METADATA_STORAGE_TYPE_KEY;
+import static com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration.METADATA_STORAGE_TYPE_LOCAL;
 import static com.facebook.presto.spark.launcher.LauncherUtils.checkFile;
 import static com.facebook.presto.spark.launcher.LauncherUtils.loadCatalogProperties;
 import static com.facebook.presto.spark.launcher.LauncherUtils.loadProperties;
@@ -65,7 +67,7 @@ public class PrestoSparkLauncherCommand
                 packageSupplier,
                 loadProperties(checkFile(new File(clientOptions.config))),
                 loadCatalogProperties(new File(clientOptions.catalogs)),
-                "LOCAL",
+                ImmutableMap.of(METADATA_STORAGE_TYPE_KEY, METADATA_STORAGE_TYPE_LOCAL),
                 Optional.empty(),
                 Optional.empty(),
                 sessionPropertyConfigurationProperties,

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -59,7 +59,7 @@ public class PrestoSparkRunner
                 distribution.getPackageSupplier(),
                 distribution.getConfigProperties(),
                 distribution.getCatalogProperties(),
-                distribution.getMetadataStorageType(),
+                distribution.getPrestoSparkProperties(),
                 distribution.getEventListenerProperties(),
                 distribution.getAccessControlProperties(),
                 distribution.getSessionPropertyConfigurationProperties(),
@@ -198,7 +198,7 @@ public class PrestoSparkRunner
             PackageSupplier packageSupplier,
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
-            String metadataStorageType,
+            Map<String, String> prestoSparkProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -211,7 +211,7 @@ public class PrestoSparkRunner
                 configProperties,
                 pluginsDirectory.getAbsolutePath(),
                 catalogProperties,
-                metadataStorageType,
+                prestoSparkProperties,
                 eventListenerProperties,
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
@@ -230,9 +230,9 @@ public class PrestoSparkRunner
             implements PrestoSparkTaskExecutorFactoryProvider
     {
         private final PackageSupplier packageSupplier;
-        private final String metadataStorageType;
         private final Map<String, String> configProperties;
         private final Map<String, Map<String, String>> catalogProperties;
+        private final Map<String, String> prestoSparkProperties;
         private final Map<String, String> eventListenerProperties;
         private final Map<String, String> accessControlProperties;
         private final Map<String, String> sessionPropertyConfigurationProperties;
@@ -243,9 +243,9 @@ public class PrestoSparkRunner
         {
             requireNonNull(distribution, "distribution is null");
             this.packageSupplier = distribution.getPackageSupplier();
-            this.metadataStorageType = distribution.getMetadataStorageType();
             this.configProperties = distribution.getConfigProperties();
             this.catalogProperties = distribution.getCatalogProperties();
+            this.prestoSparkProperties = distribution.getPrestoSparkProperties();
             // Optional is not Serializable
             this.eventListenerProperties = distribution.getEventListenerProperties().orElse(null);
             this.accessControlProperties = distribution.getAccessControlProperties().orElse(null);
@@ -264,9 +264,9 @@ public class PrestoSparkRunner
 
         private static IPrestoSparkService service;
         private static String currentPackagePath;
-        private static String currentMetadataStorageType;
         private static Map<String, String> currentConfigProperties;
         private static Map<String, Map<String, String>> currentCatalogProperties;
+        private static Map<String, String> currentPrestoSparkProperties;
         private static Map<String, String> currentEventListenerProperties;
         private static Map<String, String> currentAccessControlProperties;
         private static Map<String, String> currentSessionPropertyConfigurationProperties;
@@ -282,17 +282,17 @@ public class PrestoSparkRunner
                             packageSupplier,
                             configProperties,
                             catalogProperties,
-                            metadataStorageType,
+                            prestoSparkProperties,
                             Optional.ofNullable(eventListenerProperties),
                             Optional.ofNullable(accessControlProperties),
                             Optional.ofNullable(sessionPropertyConfigurationProperties),
                             Optional.ofNullable(functionNamespaceProperties),
                             Optional.ofNullable(tempStorageProperties));
 
-                    currentMetadataStorageType = metadataStorageType;
                     currentPackagePath = getPackagePath(packageSupplier);
                     currentConfigProperties = configProperties;
                     currentCatalogProperties = catalogProperties;
+                    currentPrestoSparkProperties = prestoSparkProperties;
                     currentEventListenerProperties = eventListenerProperties;
                     currentAccessControlProperties = accessControlProperties;
                     currentSessionPropertyConfigurationProperties = sessionPropertyConfigurationProperties;
@@ -301,9 +301,9 @@ public class PrestoSparkRunner
                 }
                 else {
                     checkEquals("packagePath", currentPackagePath, getPackagePath(packageSupplier));
-                    checkEquals("metadataStorageType", currentMetadataStorageType, metadataStorageType);
                     checkEquals("configProperties", currentConfigProperties, configProperties);
                     checkEquals("catalogProperties", currentCatalogProperties, catalogProperties);
+                    checkEquals("prestoSparkProperties", currentPrestoSparkProperties, prestoSparkProperties);
                     checkEquals("eventListenerProperties", currentEventListenerProperties, eventListenerProperties);
                     checkEquals("accessControlProperties", currentAccessControlProperties, accessControlProperties);
                     checkEquals("sessionPropertyConfigurationProperties",


### PR DESCRIPTION
# Issue

The goal is to generalize Presto on Spark properties that are being used to initialize PoS jobs. Currently, there is only a specific property `metadataStorageType`, but introducing a Map structure allows passing more properties without modifying the code for every single new property.

Interfaces remain backwards compatible, it's just refactoring.

# Test plan 

UT + ran a PoS query manually

```
== NO RELEASE NOTE ==
```
