### PR TITLE
[native] Split ShuffleInterface to Read and Write separately

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -474,9 +474,9 @@ std::vector<std::string> PrestoServer::registerConnectors(
 }
 
 void PrestoServer::registerShuffleInterfaceFactories() {
-  operators::ShuffleInterface::registerFactory(
+  operators::ShuffleInterfaceFactory::registerFactory(
       operators::LocalPersistentShuffle::kShuffleName.toString(),
-      operators::LocalPersistentShuffle::create);
+      std::make_unique<operators::LocalPersistentShuffleFactory>());
 }
 
 void PrestoServer::registerFileSystems() {

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -210,31 +210,26 @@ LocalShuffleInfo LocalShuffleInfo::deserialize(const std::string& info) {
   return shuffleInfo;
 }
 
-// static
-std::shared_ptr<ShuffleInterface> LocalPersistentShuffle::create(
+std::shared_ptr<ShuffleReader> LocalPersistentShuffleFactory::createReader(
     const std::string& serializedStr,
-    operators::ShuffleInterface::Type type,
     velox::memory::MemoryPool* pool) {
   static const uint64_t maxBytesPerPartition =
       SystemConfig::instance()->localShuffleMaxPartitionBytes();
-  if (type == operators::ShuffleInterface::Type::kRead) {
-    const operators::LocalShuffleInfo readInfo =
-        operators::LocalShuffleInfo::deserialize(serializedStr);
-    return std::make_shared<operators::LocalPersistentShuffle>(
-        readInfo.rootPath, readInfo.numPartitions, maxBytesPerPartition, pool);
-  } else if (type == operators::ShuffleInterface::Type::kWrite) {
-    const operators::LocalShuffleInfo writeInfo =
-        operators::LocalShuffleInfo::deserialize(serializedStr);
-    return std::make_shared<operators::LocalPersistentShuffle>(
-        writeInfo.rootPath,
-        writeInfo.numPartitions,
-        maxBytesPerPartition,
-        pool);
-  } else {
-    VELOX_FAIL(
-        "Unknown shuffle interface type '{}'.",
-        static_cast<ShuffleInterface::Type>(type));
-  }
+  const operators::LocalShuffleInfo readInfo =
+      operators::LocalShuffleInfo::deserialize(serializedStr);
+  return std::make_shared<operators::LocalPersistentShuffle>(
+      readInfo.rootPath, readInfo.numPartitions, maxBytesPerPartition, pool);
+}
+
+std::shared_ptr<ShuffleWriter> LocalPersistentShuffleFactory::createWriter(
+    const std::string& serializedStr,
+    velox::memory::MemoryPool* pool) {
+  static const uint64_t maxBytesPerPartition =
+      SystemConfig::instance()->localShuffleMaxPartitionBytes();
+  const operators::LocalShuffleInfo writeInfo =
+      operators::LocalShuffleInfo::deserialize(serializedStr);
+  return std::make_shared<operators::LocalPersistentShuffle>(
+      writeInfo.rootPath, writeInfo.numPartitions, maxBytesPerPartition, pool);
 }
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -46,7 +46,7 @@ struct LocalShuffleInfo {
 /// multi-process use scenarios as long as each producer or consumer is assigned
 /// to a distinct group of partition IDs. Each of them can create an instance of
 /// this class (pointing to the same root path) to read and write shuffle data.
-class LocalPersistentShuffle : public ShuffleInterface {
+class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
  public:
   static constexpr folly::StringPiece kShuffleName{"local"};
 
@@ -65,11 +65,6 @@ class LocalPersistentShuffle : public ShuffleInterface {
   velox::BufferPtr next(int32_t partition, bool success) override;
 
   bool readyForRead() const override;
-
-  static std::shared_ptr<ShuffleInterface> create(
-      const std::string& serializedStr,
-      operators::ShuffleInterface::Type type,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool);
 
  private:
   // Finds and creates the next file for writing the next block of the
@@ -104,6 +99,17 @@ class LocalPersistentShuffle : public ShuffleInterface {
   std::shared_ptr<velox::filesystems::FileSystem> fileSystem_;
   // Used to make sure files created by this thread have unique names.
   std::thread::id threadId_;
+};
+
+class LocalPersistentShuffleFactory : public ShuffleInterfaceFactory {
+ public:
+  std::shared_ptr<ShuffleReader> createReader(
+      const std::string& serializedStr,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  std::shared_ptr<ShuffleWriter> createWriter(
+      const std::string& serializedStr,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
 };
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -31,17 +31,15 @@ class ShuffleWriteOperator : public Operator {
             planNode->id(),
             "ShuffleWrite") {
     const auto& shuffleName = planNode->shuffleName();
-    auto shuffleFactory = ShuffleInterface::factory(shuffleName);
+    auto shuffleFactory = ShuffleInterfaceFactory::factory(shuffleName);
     VELOX_CHECK(
         shuffleFactory != nullptr,
         fmt::format(
             "Failed to create shuffle write interface: Shuffle factory "
             "with name '{}' is not registered.",
             shuffleName));
-    shuffle_ = shuffleFactory(
-        planNode->serializedShuffleWriteInfo(),
-        ShuffleInterface::Type::kWrite,
-        operatorCtx_->pool());
+    shuffle_ = shuffleFactory->createWriter(
+        planNode->serializedShuffleWriteInfo(), operatorCtx_->pool());
   }
 
   bool needsInput() const override {
@@ -76,7 +74,7 @@ class ShuffleWriteOperator : public Operator {
   }
 
  private:
-  std::shared_ptr<ShuffleInterface> shuffle_;
+  std::shared_ptr<ShuffleWriter> shuffle_;
 };
 } // namespace
 

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -66,7 +66,7 @@ UnsafeRowExchangeSource::createExchangeSource(
       !shuffleName.empty(),
       "shuffle.name is not provided in config.properties to create a shuffle "
       "interface.");
-  auto& shuffleFactory = ShuffleInterface::factory(shuffleName);
+  auto shuffleFactory = ShuffleInterfaceFactory::factory(shuffleName);
   auto uri = folly::Uri(url);
   auto serializedShuffleInfo = getSerializedShuffleInfo(uri);
   VELOX_USER_CHECK(
@@ -77,8 +77,7 @@ UnsafeRowExchangeSource::createExchangeSource(
       uri.host(),
       destination,
       std::move(queue),
-      shuffleFactory(
-          serializedShuffleInfo.value(), ShuffleInterface::Type::kRead, pool),
+      shuffleFactory->createReader(serializedShuffleInfo.value(), pool),
       pool);
 }
 }; // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.h
@@ -26,7 +26,7 @@ class UnsafeRowExchangeSource : public velox::exec::ExchangeSource {
       const std::string& taskId,
       int destination,
       std::shared_ptr<velox::exec::ExchangeQueue> queue,
-      const std::shared_ptr<ShuffleInterface>& shuffle,
+      const std::shared_ptr<ShuffleReader>& shuffle,
       velox::memory::MemoryPool* FOLLY_NONNULL pool)
       : ExchangeSource(taskId, destination, queue, pool), shuffle_(shuffle) {}
 
@@ -47,6 +47,6 @@ class UnsafeRowExchangeSource : public velox::exec::ExchangeSource {
       velox::memory::MemoryPool* FOLLY_NONNULL pool);
 
  private:
-  const std::shared_ptr<ShuffleInterface> shuffle_;
+  const std::shared_ptr<ShuffleReader> shuffle_;
 };
 } // namespace facebook::presto::operators


### PR DESCRIPTION
ShuffleInterface currently expose both read and write endpoints. We should split it to two separate interfaces each of which handles only read or write. This will make the code cleaner and easier to maintain, or extend.

```
== NO RELEASE NOTE ==
```
