### PR TITLE
Optimize mapToMapCast for common cases

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapToMapCast.java
@@ -93,10 +93,10 @@ public class BenchmarkMapToMapCast
         public void setup()
         {
             MetadataManager metadata = createTestMetadataManager();
-            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, mapType(DOUBLE, BIGINT), mapType(BIGINT, DOUBLE));
+            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, mapType(BIGINT, DOUBLE), mapType(BIGINT, BIGINT));
 
             List<RowExpression> projections = ImmutableList.of(
-                    new CallExpression(CAST.name(), functionHandle, mapType(BIGINT, DOUBLE), ImmutableList.of(field(0, mapType(DOUBLE, BIGINT)))));
+                    new CallExpression(CAST.name(), functionHandle, mapType(BIGINT, DOUBLE), ImmutableList.of(field(0, mapType(BIGINT, BIGINT)))));
 
             pageProcessor = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0))
                     .compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), projections)
@@ -104,7 +104,7 @@ public class BenchmarkMapToMapCast
 
             Block keyBlock = createKeyBlock(POSITION_COUNT, MAP_SIZE);
             Block valueBlock = createValueBlock(POSITION_COUNT, MAP_SIZE);
-            Block block = createMapBlock(mapType(DOUBLE, BIGINT), POSITION_COUNT, keyBlock, valueBlock);
+            Block block = createMapBlock(mapType(BIGINT, DOUBLE), POSITION_COUNT, keyBlock, valueBlock);
             page = new Page(block);
         }
 
@@ -120,18 +120,18 @@ public class BenchmarkMapToMapCast
 
         private static Block createKeyBlock(int positionCount, int mapSize)
         {
-            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(null, positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = BIGINT.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
-                DOUBLE.writeDouble(valueBlockBuilder, ThreadLocalRandom.current().nextLong());
+                BIGINT.writeLong(valueBlockBuilder, ThreadLocalRandom.current().nextLong());
             }
             return valueBlockBuilder.build();
         }
 
         private static Block createValueBlock(int positionCount, int mapSize)
         {
-            BlockBuilder valueBlockBuilder = BIGINT.createBlockBuilder(null, positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
-                BIGINT.writeLong(valueBlockBuilder, ThreadLocalRandom.current().nextLong());
+                DOUBLE.writeDouble(valueBlockBuilder, ThreadLocalRandom.current().nextLong());
             }
             return valueBlockBuilder.build();
         }


### PR DESCRIPTION
Common case for mapToMapCast is to cast the values and it's a lot less common to cast the keys. So we rearrange the code to not cast keys when the from and to key types are same. 

Also fixed the benchmark which was testing MAP<DOUBLE, BIGINT> to more common MAP<BIGINT, DOUBLE>. Seeing about 40% gains.


Old:

Benchmark                        Mode  Cnt     Score     Error  Units
BenchmarkMapToMapCast.benchmark  avgt   30  1039.686 ± 109.385  ns/op

New:

Benchmark                        Mode  Cnt    Score    Error  Units
BenchmarkMapToMapCast.benchmark  avgt   30  591.680 ± 52.162  ns/op

Test plan -  test exist


```
== NO RELEASE NOTE ==
```
