### PR TITLE
[native] Remove readyForRead() as it is not used

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -64,8 +64,6 @@ class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
 
   velox::BufferPtr next(int32_t partition, bool success) override;
 
-  bool readyForRead() const override;
-
  private:
   // Finds and creates the next file for writing the next block of the
   // given 'partition'.
@@ -79,6 +77,8 @@ class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
 
   // Writes the in-progress block to the given partition.
   void storePartitionBlock(int32_t partition);
+
+  bool readyForRead() const;
 
   // Deletes all the files in the root directory.
   void cleanup();

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -28,11 +28,6 @@ class ShuffleWriter {
   /// Tell the shuffle system the writer is done.
   /// @param success set to false to indicate aborted client.
   virtual void noMoreData(bool success) = 0;
-
-  /// Return true if all the data is finished writing and is ready to
-  /// to be read while noMoreData signals the shuffle service that there
-  /// is no more data to be writen.
-  virtual bool readyForRead() const = 0;
 };
 
 class ShuffleReader {

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -113,7 +113,6 @@ class TestShuffle : public ShuffleReader, public ShuffleWriter {
         inProgressPartitions_[i].reset();
       }
     }
-    readyForRead_ = true;
   }
 
   bool hasNext(int32_t partition) const {
@@ -127,10 +126,6 @@ class TestShuffle : public ShuffleReader, public ShuffleWriter {
     auto buffer = readyPartitions_[partition].back();
     readyPartitions_[partition].pop_back();
     return buffer;
-  }
-
-  bool readyForRead() const {
-    return readyForRead_;
   }
 
   static void reset() {
@@ -160,7 +155,6 @@ class TestShuffle : public ShuffleReader, public ShuffleWriter {
 
  private:
   memory::MemoryPool* pool_{nullptr};
-  bool readyForRead_ = false;
   const uint32_t numPartitions_;
   const uint32_t maxBytesPerPartition_;
 


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
