### PR TITLE
Fix bug in test TestCursorProcessorCompiler

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCursorProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCursorProcessorCompiler.java
@@ -210,7 +210,8 @@ public class TestCursorProcessorCompiler
     private void checkPageEqual(Page a, Page b)
     {
         assertEquals(a.getPositionCount(), b.getPositionCount());
-        for (int i = 0; i < a.getPositionCount(); i++) {
+        assertEquals(a.getChannelCount(), b.getChannelCount());
+        for (int i = 0; i < a.getChannelCount(); i++) {
             checkBlockEqual(a.getBlock(i), b.getBlock(i));
         }
     }


### PR DESCRIPTION
When we try to check whether two pages are equal, we should invoke getChannelCount() to get the number of Blocks in a Page.

```
== NO RELEASE NOTE ==
```
