### PR TITLE
Add TypedSet.addAndGetPosition for use in MultiMapFromEntries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -136,6 +136,25 @@ public class TypedSet
         return false;
     }
 
+    public int addAndGetPosition(Block block, int position)
+    {
+        requireNonNull(block, "block must not be null");
+        checkArgument(position >= 0, "position must be >= 0");
+
+        // containsNullElement flag is maintained so contains() method can have shortcut for null value
+        int hashPosition = getHashPositionOfElement(block, position);
+        int currentPosition = blockPositionByHash.get(hashPosition);
+        if (currentPosition == EMPTY_SLOT) {
+            if (block.isNull(position)) {
+                containNullElements = true;
+            }
+            addNewElement(hashPosition, block, position);
+            return blockPositionByHash.getInt(hashPosition);
+        }
+
+        return currentPosition;
+    }
+
     public boolean addNonNull(Block block, int position)
     {
         requireNonNull(block, "block must not be null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MultimapFromEntriesFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MultimapFromEntriesFunction.java
@@ -70,12 +70,7 @@ public final class MultimapFromEntriesFunction
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
             }
 
-            if (!keySet.add(rowBlock, 0)) {
-                entryIndicesList[keySet.positionOf(rowBlock, 0)].add(i);
-            }
-            else {
-                entryIndicesList[keySet.size() - 1].add(i);
-            }
+            entryIndicesList[keySet.addAndGetPosition(rowBlock, 0)].add(i);
         }
 
         BlockBuilder multimapBlockBuilder = mapType.createBlockBuilder(null, keySet.size());


### PR DESCRIPTION
Since TypedSet.add already computes position, we add a method that can simply return the position (after adding if needed) and use it in optimizing the MultimapFromEntries function.

Test plan - tests exist


```
== NO RELEASE NOTE ==
```
