### PR TITLE
Add an optimizer for AQE for swapping join sides

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.SortExpressionContext;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -174,7 +175,8 @@ public class JoinNode
                 ImmutableMap.of()); // dynamicFilters are invalid after flipping children
     }
 
-    private static Type flipType(Type type)
+    @VisibleForTesting
+    public static Type flipType(Type type)
     {
         switch (type) {
             case INNER:

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -82,7 +83,12 @@ public class RuleTester
 
     public RuleTester(List<Plugin> plugins, Map<String, String> sessionProperties, Optional<Integer> nodeCountForStats, ConnectorFactory connectorFactory)
     {
-        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+        this(plugins, sessionProperties, new SessionPropertyManager(), nodeCountForStats, connectorFactory);
+    }
+
+    public RuleTester(List<Plugin> plugins, Map<String, String> sessionProperties, SessionPropertyManager sessionPropertyManager, Optional<Integer> nodeCountForStats, ConnectorFactory connectorFactory)
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder(sessionPropertyManager)
                 .setCatalog(CATALOG_ID)
                 .setSchema("tiny")
                 .setSystemProperty("task_concurrency", "1"); // these tests don't handle exchanges from local parallel

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -73,6 +73,16 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-expressions</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory-context</artifactId>
         </dependency>
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -63,6 +63,8 @@ public class PrestoSparkConfig
     private int minHashPartitionCount = 1024;
     private boolean isResourceAllocationStrategyEnabled;
 
+    private boolean adaptiveJoinSideSwitchingEnabled;
+
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
         return sparkPartitionCountAutoTuneEnabled;
@@ -419,6 +421,19 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setHashPartitionCountScalingFactorOnOutOfMemory(double hashPartitionCountScalingFactorOnOutOfMemory)
     {
         this.hashPartitionCountScalingFactorOnOutOfMemory = hashPartitionCountScalingFactorOnOutOfMemory;
+        return this;
+    }
+
+    public boolean isAdaptiveJoinSideSwitchingEnabled()
+    {
+        return adaptiveJoinSideSwitchingEnabled;
+    }
+
+    @Config("optimizer.adaptive-join-side-switching-enabled")
+    @ConfigDescription("Enables the adaptive optimization to choose build and probe sides of a join")
+    public PrestoSparkConfig setAdaptiveJoinSideSwitchingEnabled(boolean adaptiveJoinSideSwitchingEnabled)
+    {
+        this.adaptiveJoinSideSwitchingEnabled = adaptiveJoinSideSwitchingEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -60,8 +60,14 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED = "spark_resource_allocation_strategy_enabled";
     public static final String SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED = "spark_retry_on_out_of_memory_higher_hash_partition_count_enabled";
     public static final String SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY = "spark_hash_partition_count_scaling_factor_on_out_of_memory";
+    public static final String ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED = "adaptive_join_side_switching_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
+
+    public PrestoSparkSessionProperties()
+    {
+        this(new PrestoSparkConfig());
+    }
 
     @Inject
     public PrestoSparkSessionProperties(PrestoSparkConfig prestoSparkConfig)
@@ -159,7 +165,7 @@ public class PrestoSparkSessionProperties
                         SPARK_AVERAGE_INPUT_DATA_SIZE_PER_EXECUTOR,
                         "Average input data size per executor",
                         prestoSparkConfig.getAverageInputDataSizePerExecutor(),
-                       false),
+                        false),
                 integerProperty(
                         SPARK_MAX_EXECUTOR_COUNT,
                         "Maximum count of executors to run a query",
@@ -199,6 +205,11 @@ public class PrestoSparkSessionProperties
                         SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY,
                         "Scaling factor for hash partition count when a query fails with out of memory error due to low hash partition count",
                         prestoSparkConfig.getHashPartitionCountScalingFactorOnOutOfMemory(),
+                        false),
+                booleanProperty(
+                        ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED,
+                        "Enables the adaptive optimizer to switch the build and probe sides of a join",
+                        prestoSparkConfig.isAdaptiveJoinSideSwitchingEnabled(),
                         false));
     }
 
@@ -311,6 +322,7 @@ public class PrestoSparkSessionProperties
     {
         return session.getSystemProperty(SPARK_MAX_HASH_PARTITION_COUNT, Integer.class);
     }
+
     public static int getMinHashPartitionCount(Session session)
     {
         return session.getSystemProperty(SPARK_MIN_HASH_PARTITION_COUNT, Integer.class);
@@ -329,5 +341,10 @@ public class PrestoSparkSessionProperties
     public static double getHashPartitionCountScalingFactorOnOutOfMemory(Session session)
     {
         return session.getSystemProperty(SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY, Double.class);
+    }
+
+    public static boolean isAdaptiveJoinSideSwitchingEnabled(Session session)
+    {
+        return session.getSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, Boolean.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spark.planner.optimizers;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+
+import static com.facebook.presto.SystemSessionProperties.isSizeBasedJoinDistributionTypeEnabled;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isAdaptiveJoinSideSwitchingEnabled;
+import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isBelowBroadcastLimit;
+import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isSmallerThanThreshold;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+
+/**
+ * This optimizer chooses the build and probe side of the join based on the size of the
+ * join inputs, putting the smaller table on the right side/ build side of the join.
+ * <p>
+ * for example, consider a join with two children, nodeA and nodeB
+ * if  nodeA is smaller than nodeB, we will convert
+ * <pre>
+ *     JOIN                     JOIN
+ *    /    \        = >        /    \
+ * nodeA   nodeB            nodeB   nodeA
+ * </pre>
+ */
+public class PickJoinSides
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join().matching(joinNode ->
+            joinNode.getDistributionType().isPresent()
+                    && joinNode.getDistributionType().get() == PARTITIONED
+                    // Flipping right/left non-equality joins is only supported when
+                    // changing the distribution type too
+                    && !(joinNode.getCriteria().isEmpty() && (joinNode.getType() == LEFT || joinNode.getType() == RIGHT)));
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isAdaptiveJoinSideSwitchingEnabled(session);
+    }
+
+    @Override
+    public Result apply(JoinNode joinNode, Captures captures, Context context)
+    {
+        StatsProvider statsProvider = context.getStatsProvider();
+        double leftSize = statsProvider.getStats(joinNode.getLeft()).getOutputSizeInBytes();
+        double rightSize = statsProvider.getStats(joinNode.getRight()).getOutputSizeInBytes();
+
+        if (rightSize > leftSize) {
+            return Result.ofPlanNode(joinNode.flipChildren());
+        }
+
+        // if we don't have exact costs for the join, but based on source tables we think the left side
+        // is very small or much smaller than the right, then flip the join.
+        if (isSizeBasedJoinDistributionTypeEnabled(context.getSession()) && (Double.isNaN(leftSize) || Double.isNaN(rightSize)) && isLeftSideSmall(joinNode, context)) {
+            return Result.ofPlanNode(joinNode.flipChildren());
+        }
+
+        return Result.empty();
+    }
+
+    // This logic is based on DetermineJoinDistributionType.getSizeBasedJoin(),
+    // but does not include switching the join distribution type.
+    private boolean isLeftSideSmall(JoinNode joinNode, Context context)
+    {
+        // the source table of the left side of the join is below the broadcast limit
+        boolean isRightSideSmall = isBelowBroadcastLimit(joinNode.getRight(), context);
+        boolean isLeftSideSmall = isBelowBroadcastLimit(joinNode.getLeft(), context);
+        if (isLeftSideSmall && !isRightSideSmall) {
+            return true;
+        }
+
+        // the last estimatable stats on the left are much smaller than those on the right.
+        return isSmallerThanThreshold(joinNode.getLeft(), joinNode.getRight(), context);
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -58,7 +58,8 @@ public class TestPrestoSparkConfig
                 .setMinHashPartitionCount(1024)
                 .setSparkResourceAllocationStrategyEnabled(false)
                 .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(false)
-                .setHashPartitionCountScalingFactorOnOutOfMemory(2.0));
+                .setHashPartitionCountScalingFactorOnOutOfMemory(2.0)
+                .setAdaptiveJoinSideSwitchingEnabled(false));
     }
 
     @Test
@@ -92,6 +93,7 @@ public class TestPrestoSparkConfig
                 .put("spark.resource-allocation-strategy-enabled", "true")
                 .put("spark.retry-on-out-of-memory-higher-hash-partition-count-enabled", "true")
                 .put("spark.hash-partition-count-scaling-factor-on-out-of-memory", "5.6")
+                .put("optimizer.adaptive-join-side-switching-enabled", "true")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -120,7 +122,8 @@ public class TestPrestoSparkConfig
                 .setMinHashPartitionCount(30)
                 .setSparkResourceAllocationStrategyEnabled(true)
                 .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(true)
-                .setHashPartitionCountScalingFactorOnOutOfMemory(5.6);
+                .setHashPartitionCountScalingFactorOnOutOfMemory(5.6)
+                .setAdaptiveJoinSideSwitchingEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.planner.optimizers;
+
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.VariableStatsEstimate;
+import com.facebook.presto.spark.PrestoSparkSessionProperties;
+import com.facebook.presto.spark.PrestoSparkSessionPropertyManagerProvider;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.flipType;
+import static com.facebook.presto.testing.TestngUtils.toDataProvider;
+
+@Test(singleThreaded = true)
+public class TestPickJoinSides
+{
+    private static final int NODES_COUNT = 4;
+
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester(
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                new PrestoSparkSessionPropertyManagerProvider(new SystemSessionProperties(), new PrestoSparkSessionProperties()).get(),
+                Optional.of(NODES_COUNT),
+                new TpchConnectorFactory(1));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        tester.close();
+        tester = null;
+    }
+
+    @DataProvider(name = "joinTypes")
+    public static Object[][] joinTypes()
+    {
+        return Arrays.stream(JoinNode.Type.values())
+                .collect(toDataProvider());
+    }
+
+    @Test(dataProvider = "joinTypes")
+    public void testFlipsWhenProbeSmaller(JoinNode.Type joinType)
+    {
+        int aSize = 100;
+        int bSize = 10_000;
+        assertPickJoinSides()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(aSize)
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(bSize)
+                        .build())
+                .on(p ->
+                        p.join(
+                                joinType,
+                                p.values(
+                                        new PlanNodeId("valuesA"),
+                                        ImmutableList.of(p.variable("A1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 10L), constantExpressions(BIGINT, 11L))),
+                                p.values(
+                                        new PlanNodeId("valuesB"),
+                                        ImmutableList.of(p.variable("B1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                ImmutableMap.of()))
+                .matches(join(
+                        flipType(joinType),
+                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("B1", 0)),
+                        values(ImmutableMap.of("A1", 0))));
+    }
+
+    @Test(dataProvider = "joinTypes")
+    public void testDoesNotFireWhenTablesSameSize(JoinNode.Type joinType)
+    {
+        int aSize = 100;
+        int bSize = 100;
+        assertPickJoinSides()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(aSize)
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(bSize)
+                        .build())
+                .on(p ->
+                        p.join(
+                                joinType,
+                                p.values(
+                                        ImmutableList.of(p.variable("A1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 10L), constantExpressions(BIGINT, 11L))),
+                                p.values(
+                                        ImmutableList.of(p.variable("B1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                ImmutableMap.of()))
+                .doesNotFire();
+    }
+
+    @Test(dataProvider = "joinTypes")
+    public void testFlipWhenOneTableMuchSmallerAndJoinCardinalityUnknown(JoinNode.Type joinType)
+    {
+        int aRows = 100;
+        int bRows = 10_000;
+        assertPickJoinSides()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        // set symbol stats to unknown, so the join cardinality cannot be estimated
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "A1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        // set symbol stats to unknown, so the join cardinality cannot be estimated
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "B1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.join(
+                                joinType,
+                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                ImmutableMap.of()))
+                .matches(join(
+                        flipType(joinType),
+                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("B1", 0)),
+                        values(ImmutableMap.of("A1", 0))));
+    }
+
+    @Test
+    public void testFlipsWhenSourceIsSmall()
+    {
+        VarcharType variableType = createUnboundedVarcharType(); // variable width so that average row size is respected
+        int aRows = 10_000;
+        int bRows = 10;
+
+        // output size does not exceed JOIN_MAX_BROADCAST_TABLE_SIZE limit
+        PlanNodeStatsEstimate bSourceStatsEstimate = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(bRows)
+                .addVariableStatistics(ImmutableMap.of(
+                        new VariableReferenceExpression(Optional.empty(), "B1", variableType),
+                        new VariableStatsEstimate(0, 100, 0, 64, 10)))
+                .build();
+
+        // only probe side (with small tables) source stats are available, join sides should be flipped
+        assertPickJoinSides()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.unknown())
+                .overrideStats("filterB", PlanNodeStatsEstimate.unknown())
+                .overrideStats("valuesB", bSourceStatsEstimate)
+                .on(p -> {
+                    VariableReferenceExpression a1 = p.variable("A1", variableType);
+                    VariableReferenceExpression b1 = p.variable("B1", variableType);
+                    return p.join(
+                            LEFT,
+                            p.filter(new PlanNodeId("filterB"), TRUE_CONSTANT, p.values(new PlanNodeId("valuesB"), bRows, b1)),
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            ImmutableList.of(new JoinNode.EquiJoinClause(b1, a1)),
+                            ImmutableList.of(b1, a1),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of(PARTITIONED),
+                            ImmutableMap.of());
+                })
+                .matches(join(
+                        RIGHT,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("A1", 0)),
+                        filter("true", values(ImmutableMap.of("B1", 0)))));
+    }
+
+    @Test
+    public void testFlipWhenSizeDifferenceLarge()
+    {
+        VarcharType variableType = createUnboundedVarcharType(); // variable width so that average row size is respected
+        int aRows = 10_000;
+        int bRows = 1_000;
+
+        // output size exceeds JOIN_MAX_BROADCAST_TABLE_SIZE limit
+        PlanNodeStatsEstimate aStatsEstimate = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(aRows)
+                .setTotalSize(aRows)
+                .addVariableStatistics(ImmutableMap.of(
+                        new VariableReferenceExpression(Optional.empty(), "A1", variableType),
+                        new VariableStatsEstimate(0, 100, 0, 640000d * 10000, 10)))
+                .build();
+        // output size exceeds JOIN_MAX_BROADCAST_TABLE_SIZE limit
+        PlanNodeStatsEstimate bStatsEstimate = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(bRows)
+                .setTotalSize(bRows)
+                .addVariableStatistics(ImmutableMap.of(
+                        new VariableReferenceExpression(Optional.empty(), "B1", variableType),
+                        new VariableStatsEstimate(0, 100, 0, 640000d * 10000, 10)))
+                .build();
+
+        // source tables size exceeds JOIN_MAX_BROADCAST_TABLE_SIZE limit but one side is significantly bigger than the other
+        // therefore we keep the smaller side to the build
+        assertPickJoinSides()
+                .overrideStats("valuesA", aStatsEstimate)
+                .overrideStats("valuesB", bStatsEstimate)
+                .overrideStats("filterB", PlanNodeStatsEstimate.unknown()) // unestimated term to trigger size based join ordering
+                .on(p -> {
+                    VariableReferenceExpression a1 = p.variable("A1", variableType);
+                    VariableReferenceExpression b1 = p.variable("B1", variableType);
+                    return p.join(
+                            INNER,
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            p.filter(
+                                    new PlanNodeId("filterB"),
+                                    TRUE_CONSTANT,
+                                    p.values(new PlanNodeId("valuesB"), bRows, b1)),
+                            ImmutableList.of(new JoinNode.EquiJoinClause(a1, b1)),
+                            ImmutableList.of(a1, b1),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of(PARTITIONED),
+                            ImmutableMap.of());
+                })
+                .doesNotFire();
+
+        // same but with join sides reversed
+        assertPickJoinSides()
+                .overrideStats("valuesA", aStatsEstimate)
+                .overrideStats("valuesB", bStatsEstimate)
+                .overrideStats("filterB", PlanNodeStatsEstimate.unknown()) // unestimated term to trigger size based join ordering
+                .on(p -> {
+                    VariableReferenceExpression a1 = p.variable("A1", variableType);
+                    VariableReferenceExpression b1 = p.variable("B1", variableType);
+                    return p.join(
+                            INNER,
+                            p.filter(
+                                    new PlanNodeId("filterB"),
+                                    TRUE_CONSTANT,
+                                    p.values(new PlanNodeId("valuesB"), bRows, b1)),
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            ImmutableList.of(new JoinNode.EquiJoinClause(b1, a1)),
+                            ImmutableList.of(b1, a1),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of(PARTITIONED),
+                            ImmutableMap.of());
+                })
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("A1", 0)),
+                        filter("true", values(ImmutableMap.of("B1", 0)))));
+
+        // Don't flip sides when both are similar in size
+        bStatsEstimate = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(aRows)
+                .addVariableStatistics(ImmutableMap.of(
+                        new VariableReferenceExpression(Optional.empty(), "B1", variableType),
+                        new VariableStatsEstimate(0, 100, 0, 640000d * 10000, 10)))
+                .build();
+        assertPickJoinSides()
+                .overrideStats("valuesA", aStatsEstimate)
+                .overrideStats("valuesB", bStatsEstimate)
+                .overrideStats("filterB", PlanNodeStatsEstimate.unknown()) // unestimated term to trigger size based join ordering
+                .on(p -> {
+                    VariableReferenceExpression a1 = p.variable("A1", variableType);
+                    VariableReferenceExpression b1 = p.variable("B1", variableType);
+                    return p.join(
+                            INNER,
+                            p.filter(
+                                    new PlanNodeId("filterB"),
+                                    TRUE_CONSTANT,
+                                    p.values(new PlanNodeId("valuesB"), aRows, b1)),
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            ImmutableList.of(new JoinNode.EquiJoinClause(b1, a1)),
+                            ImmutableList.of(b1, a1),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of(PARTITIONED),
+                            ImmutableMap.of());
+                })
+                .doesNotFire();
+    }
+
+    public void testDoesNotFireWhenDisabled()
+    {
+        int aSize = 100;
+        int bSize = 10_000;
+        tester.assertThat(new PickJoinSides())
+                .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "false")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(aSize)
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(bSize)
+                        .build())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(
+                                        ImmutableList.of(p.variable("A1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 10L), constantExpressions(BIGINT, 11L))),
+                                p.values(
+                                        ImmutableList.of(p.variable("B1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                ImmutableMap.of()))
+                .doesNotFire();
+    }
+
+    public void testDoesNotFireForReplicatedJoin()
+    {
+        int aSize = 100;
+        int bSize = 10_000;
+        assertPickJoinSides()
+                .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "false")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(aSize)
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(bSize)
+                        .build())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(
+                                        ImmutableList.of(p.variable("A1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 10L), constantExpressions(BIGINT, 11L))),
+                                p.values(
+                                        ImmutableList.of(p.variable("B1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED),
+                                ImmutableMap.of()))
+                .doesNotFire();
+    }
+
+    public void testDoesNotFireForRightCrossJoin()
+    {
+        int aSize = 100;
+        int bSize = 10_000;
+        assertPickJoinSides()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(aSize)
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setTotalSize(bSize)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "B1", BIGINT), new VariableStatsEstimate(0, 100, 0, 640000, 100)))
+                        .build())
+                .on(p ->
+                        p.join(
+                                RIGHT,
+                                p.values(
+                                        ImmutableList.of(p.variable("A1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 10L), constantExpressions(BIGINT, 11L))),
+                                p.values(
+                                        ImmutableList.of(p.variable("B1")),
+                                        ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
+                                ImmutableList.of(),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                ImmutableMap.of()))
+                .doesNotFire();
+    }
+
+    private RuleAssert assertPickJoinSides()
+    {
+        return tester.assertThat(new PickJoinSides())
+                .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "100MB")
+                .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "true");
+    }
+}


### PR DESCRIPTION
Add PickJoinSides optimizer to be used for choosing the build and probe side of join at runtime for AQE.  We mostly could not reuse code from DetermineJoinDistributionType in the main optimization phase because the choice of build/probe side there is very interconnected with choosing broadcast vs.partitioned join and could not be easily separated.

Test plan - unit tests


```
== NO RELEASE NOTE ==
```
