### PR TITLE
Add a session property enabling DWRF flat map writer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -72,6 +72,7 @@ public final class HiveSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_INTEGER_DICTIONARY_ENCODING_ENABLED = "orc_optimized_writer_integer_dictionary_encoding_enabled";
     private static final String ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_ENCODING_ENABLED = "orc_optimized_writer_string_dictionary_encoding_enabled";
     private static final String ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED = "orc_optimized_writer_string_dictionary_sorting_enabled";
+    private static final String ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED = "orc_optimized_writer_flat_map_writer_enabled";
     private static final String ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL = "orc_optimized_writer_compression_level";
     private static final String PAGEFILE_WRITER_MAX_STRIPE_SIZE = "pagefile_writer_max_stripe_size";
     public static final String HIVE_STORAGE_FORMAT = "hive_storage_format";
@@ -289,6 +290,11 @@ public final class HiveSessionProperties
                         ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED,
                         "ORC: Enable string dictionary sorting",
                         orcFileWriterConfig.isStringDictionarySortingEnabled(),
+                        false),
+                booleanProperty(
+                        ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED,
+                        "ORC: Enable flat map writer",
+                        orcFileWriterConfig.isFlatMapWriterEnabled(),
                         false),
                 integerProperty(
                         ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL,
@@ -837,6 +843,11 @@ public final class HiveSessionProperties
     public static boolean isStringDictionarySortingEnabled(ConnectorSession session)
     {
         return session.getProperty(ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isFlatMapWriterEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED, Boolean.class);
     }
 
     public static OptionalInt getCompressionLevel(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -36,6 +36,7 @@ public class OrcFileWriterConfig
     }
 
     public static final int DEFAULT_COMPRESSION_LEVEL = Integer.MIN_VALUE;
+    private static final boolean DEFAULT_FLAT_MAP_WRITER_ENABLED = false;
 
     private DataSize stripeMinSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MIN_SIZE;
     private DataSize stripeMaxSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MAX_SIZE;
@@ -52,6 +53,7 @@ public class OrcFileWriterConfig
     private boolean isIntegerDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionarySortingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
+    private boolean isFlatMapWriterEnabled = DEFAULT_FLAT_MAP_WRITER_ENABLED;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
@@ -176,6 +178,18 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setStringDictionarySortingEnabled(boolean isStringDictionarySortingEnabled)
     {
         this.isStringDictionarySortingEnabled = isStringDictionarySortingEnabled;
+        return this;
+    }
+
+    public boolean isFlatMapWriterEnabled()
+    {
+        return isFlatMapWriterEnabled;
+    }
+
+    @Config("hive.orc.writer.flat-map-writer-enabled")
+    public OrcFileWriterConfig setFlatMapWriterEnabled(boolean isFlatMapWriterEnabled)
+    {
+        this.isFlatMapWriterEnabled = isFlatMapWriterEnabled;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -52,10 +53,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
@@ -72,6 +75,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferS
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStringStatisticsLimit;
 import static com.facebook.presto.hive.HiveSessionProperties.isDwrfWriterStripeCacheEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isExecutionBasedMemoryAccountingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isFlatMapWriterEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isIntegerDictionaryEncodingEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isStringDictionaryEncodingEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isStringDictionarySortingEnabled;
@@ -82,15 +86,38 @@ import static com.facebook.presto.orc.metadata.KeyProvider.CRYPTO_SERVICE;
 import static com.facebook.presto.orc.metadata.KeyProvider.UNKNOWN;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMNS;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMN_TYPES;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_NAME;
 
 public class OrcFileWriterFactory
         implements HiveFileWriterFactory
 {
+    /**
+     * A boolean value, stored in the SerDe properties as a string, indicating
+     * that the flat map writer for this table should be enabled.
+     */
+    private static final String ORC_FLAT_MAP_WRITER_ENABLED_KEY = "orc.flatten.map";
+
+    /**
+     * A comma separated list of column numbers, stored in the SerDe properties,
+     * indicating which columns should use flat map writer.
+     */
+    private static final String ORC_FLAT_MAP_COLUMN_NUMBERS_KEY = "orc.map.flat.cols";
+    private static final Splitter FLAT_MAP_COLUMN_NUMBERS_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+
+    /**
+     * A boolean value, stored in the SerDe properties as a string, indicating
+     * that the flat map writer should generate map column statistics instead of
+     * compound column statistics.
+     */
+    private static final String ORC_MAP_STATISTICS_KEY = "orc.map.statistics";
+
     private final DateTimeZone hiveStorageTimeZone;
     private final HdfsEnvironment hdfsEnvironment;
     private final DataSinkFactory dataSinkFactory;
@@ -219,6 +246,9 @@ public class OrcFileWriterFactory
 
             Optional<DwrfWriterEncryption> dwrfWriterEncryption = createDwrfEncryption(encryptionInformation, fileColumnNames, fileColumnTypes);
 
+            boolean mapStatisticsEnabled = isMapStatisticsEnabled(schema);
+            Set<Integer> flattenedColumns = getFlattenedColumns(schema, session);
+
             return Optional.of(new OrcFileWriter(
                     dataSink,
                     rollbackAction,
@@ -241,6 +271,8 @@ public class OrcFileWriterFactory
                             .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
                             .withDwrfStripeCacheEnabled(isDwrfWriterStripeCacheEnabled(session))
                             .withDwrfStripeCacheMaxSize(getDwrfWriterStripeCacheMaxSize(session))
+                            .withFlattenedColumns(flattenedColumns)
+                            .withMapStatisticsEnabled(mapStatisticsEnabled)
                             .withCompressionLevel(getCompressionLevel(session))
                             .build(),
                     fileInputColumnIndexes,
@@ -322,5 +354,34 @@ public class OrcFileWriterFactory
             throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, "Unknown " + orcEncoding + " compression type " + compressionName);
         }
         return compression;
+    }
+
+    private Set<Integer> getFlattenedColumns(Properties schema, ConnectorSession session)
+    {
+        boolean flatMapsEnabled = parseBoolean(schema.getProperty(ORC_FLAT_MAP_WRITER_ENABLED_KEY, "false"));
+        ImmutableSet.Builder<Integer> flattenedColumnsBuilder = ImmutableSet.builder();
+        if (flatMapsEnabled) {
+            String columnsValue = schema.getProperty(ORC_FLAT_MAP_COLUMN_NUMBERS_KEY, "");
+            FLAT_MAP_COLUMN_NUMBERS_SPLITTER.splitToList(columnsValue).stream()
+                    .map(Integer::valueOf)
+                    .forEach(flattenedColumnsBuilder::add);
+        }
+        Set<Integer> flattenedColumns = flattenedColumnsBuilder.build();
+
+        // fail if flat maps are enabled for the table, but flat map writer is not enabled in the session
+        boolean flatMapWriterEnabled = isFlatMapWriterEnabled(session);
+        if (!flattenedColumns.isEmpty() && !flatMapWriterEnabled) {
+            String tableName = schema.getProperty(META_TABLE_NAME);
+            throw new PrestoException(
+                    HIVE_INVALID_METADATA,
+                    format("Table '%s' is flattened, but flat map writer is not enabled for this session.", tableName));
+        }
+
+        return flattenedColumns;
+    }
+
+    private boolean isMapStatisticsEnabled(Properties schema)
+    {
+        return parseBoolean(schema.getProperty(ORC_MAP_STATISTICS_KEY, "false"));
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -63,7 +63,8 @@ public class TestOrcFileWriterConfig
                 .setCompressionLevel(Integer.MIN_VALUE)
                 .setIntegerDictionaryEncodingEnabled(false)
                 .setStringDictionaryEncodingEnabled(true)
-                .setStringDictionarySortingEnabled(true));
+                .setStringDictionarySortingEnabled(true)
+                .setFlatMapWriterEnabled(false));
     }
 
     @Test
@@ -85,6 +86,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.integer-dictionary-encoding-enabled", "true")
                 .put("hive.orc.writer.string-dictionary-encoding-enabled", "false")
                 .put("hive.orc.writer.string-dictionary-sorting-enabled", "false")
+                .put("hive.orc.writer.flat-map-writer-enabled", "true")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -102,7 +104,8 @@ public class TestOrcFileWriterConfig
                 .setCompressionLevel(5)
                 .setIntegerDictionaryEncodingEnabled(true)
                 .setStringDictionaryEncodingEnabled(false)
-                .setStringDictionarySortingEnabled(false);
+                .setStringDictionarySortingEnabled(false)
+                .setFlatMapWriterEnabled(true);
 
         assertFullMapping(properties, expected);
     }
@@ -129,6 +132,7 @@ public class TestOrcFileWriterConfig
         DataSize dwrfStripeCacheMaxSize = new DataSize(4, MEGABYTE);
         DwrfStripeCacheMode dwrfStripeCacheMode = INDEX;
         int compressionLevel = 5;
+        boolean flatMapWriterEnabled = true;
 
         OrcFileWriterConfig config = new OrcFileWriterConfig()
                 .setStripeMinSize(stripeMinSize)
@@ -142,7 +146,8 @@ public class TestOrcFileWriterConfig
                 .setDwrfStripeCacheEnabled(false)
                 .setDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
                 .setDwrfStripeCacheMode(dwrfStripeCacheMode)
-                .setCompressionLevel(5);
+                .setCompressionLevel(5)
+                .setFlatMapWriterEnabled(flatMapWriterEnabled);
 
         assertEquals(stripeMinSize, config.getStripeMinSize());
         assertEquals(stripeMaxSize, config.getStripeMaxSize());
@@ -156,6 +161,7 @@ public class TestOrcFileWriterConfig
         assertEquals(dwrfStripeCacheMaxSize, config.getDwrfStripeCacheMaxSize());
         assertEquals(dwrfStripeCacheMode, config.getDwrfStripeCacheMode());
         assertEquals(compressionLevel, config.getCompressionLevel());
+        assertEquals(flatMapWriterEnabled, config.isFlatMapWriterEnabled());
 
         assertNotSame(config.toOrcWriterOptionsBuilder(), config.toOrcWriterOptionsBuilder());
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();


### PR DESCRIPTION
This change enables DWRF flat map writer and map statistics for tables having flat map config.

### Meta info required to enable flat map writer
Flat map writer should be enabled for map columns listed in the table serde 
property `orc.map.flat.cols=0,1...` and if the table has a serde property `orc.flatten.map=true`.

Flat map writer has a capability to use map column statistics if the table serde property 
`orc.map.statistics` set to true. If flat map writer is not enabled this property has no effect.

### Feature guarding flag
This feature is guarded by the new session property `orc_optimized_writer_flat_map_writer_enabled`.
If this session property is set and the table has flat map configs then the ORC writer will use flat map writers,
but if the session property is not set then the query will fail with a message saying that the session
property should be set.

### Note on the integration of table properties
Currently Presto does not support setting required
orc.flatten.map/orc.map.flat.cols/orc.map.statistics table serde properties which limits testing.
I'll follow up on this PR and add support for these properties to HiveMetadata + add integration test.

Test plan:
- update unit tests
- did manual testing on the verifier cluster

```
== NO RELEASE NOTE ==
```
