### PR TITLE
Add DDL support for Alpha format

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
@@ -58,6 +58,11 @@ public enum HiveStorageFormat
             com.facebook.hive.orc.OrcInputFormat.class.getName(),
             com.facebook.hive.orc.OrcOutputFormat.class.getName(),
             new DataSize(256, Unit.MEGABYTE)),
+    ALPHA(
+            "com.facebook.alpha.AlphaSerde",
+            "com.facebook.alpha.AlphaInputFormat",
+            "com.facebook.alpha.AlphaOutputFormat",
+            new DataSize(256, Unit.MEGABYTE)),
     PARQUET(
             ParquetHiveSerDe.class.getName(),
             MapredParquetInputFormat.class.getName(),
@@ -161,7 +166,7 @@ public enum HiveStorageFormat
                 return false;
             }
             SerdeAndInputFormat that = (SerdeAndInputFormat) o;
-            return serDe.equals(that.serDe) && inputFormat.equals(that.inputFormat);
+            return Objects.equals(serDe, that.serDe) && Objects.equals(inputFormat, that.inputFormat);
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -225,6 +225,7 @@ import static com.facebook.presto.hive.HiveMetadata.convertToPredicate;
 import static com.facebook.presto.hive.HiveQueryRunner.METASTORE_CONTEXT;
 import static com.facebook.presto.hive.HiveSessionProperties.OFFLINE_DATA_DEBUG_MODE_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.SORTED_WRITE_TO_TEMP_PATH_ENABLED;
+import static com.facebook.presto.hive.HiveStorageFormat.ALPHA;
 import static com.facebook.presto.hive.HiveStorageFormat.AVRO;
 import static com.facebook.presto.hive.HiveStorageFormat.CSV;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
@@ -576,7 +577,8 @@ public abstract class AbstractTestHiveClient
     protected Set<HiveStorageFormat> createTableFormats = difference(
             ImmutableSet.copyOf(HiveStorageFormat.values()),
             // exclude formats that change table schema with serde
-            ImmutableSet.of(AVRO, CSV));
+            // exclude ALPHA because it does not support DML yet
+            ImmutableSet.of(AVRO, CSV, ALPHA));
 
     private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig());
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -390,6 +390,10 @@ public abstract class AbstractTestHiveFileSystem
                 // CSV supports only unbounded VARCHAR type
                 continue;
             }
+            if (storageFormat == HiveStorageFormat.ALPHA) {
+                // Alpha read/write is not supported yet
+                continue;
+            }
             createTable(METASTORE_CONTEXT, temporaryCreateTable, storageFormat);
             dropTable(temporaryCreateTable);
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -121,6 +121,11 @@ public class TestHivePageSink
                     // CSV supports only unbounded VARCHAR type, which is not provided by lineitem
                     continue;
                 }
+                if (format == HiveStorageFormat.ALPHA) {
+                    // Alpha read/write is not supported yet
+                    continue;
+                }
+
                 config.setHiveStorageFormat(format);
                 config.setCompressionCodec(NONE);
                 long uncompressedLength = writeTestFile(config, metastoreClientConfig, metastore, makeFileName(tempDir, config));


### PR DESCRIPTION
Add DDL support for Alpha file format

This a first PR adding support for Alpha file format. This change allows to create or modify
tables with Alpha file format using Presto Interactive via DaiQuery or from Data Swarm.
DataSwarm uses Presto to create tables.

Test plan:
- added integration tests
- created a table with Alpha storage format using a verifier cluster and 
   verified input format, output format and serde in the Metastore  

```
presto:local_pnb1dw1> CREATE TABLE test_alpha (m MAP(INT, INT), ds VARCHAR) WITH (format = 'ALPHA', oncall='dwios', partitioned_by = ARRAY['ds']);
.....

$ xldb_table_info -p local_pnb1dw1.test_alpha
------------------------------------------------------------------------
TABLE TABLE TABLE TABLE TABLE TABLE TABLE TABLE TABLE TABLE TABLE
------------------------------------------------------------------------
Namespace: local_pnb1dw1
Name: test_alpha
Created: Wed Dec 14 14:49:00 PST 2022
Owner: sdruzkin
Table Type: MANAGED_TABLE
Input Format: com.facebook.alpha.AlphaInputFormat
Output Format: com.facebook.alpha.AlphaOutputFormat
SerDe: SerDeInfo{name=test_alpha, serializationLib=com.facebook.alpha.AlphaSerde, parameters={}}
```

```
== NO RELEASE NOTE ==
```
