### PR TITLE
Table writer 3: Adapt to renaming of FileSink

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -199,7 +199,7 @@ class TaskManagerTest : public testing::Test {
     dwrf::WriterOptions options;
     options.config = std::make_shared<facebook::velox::dwrf::Config>();
     options.schema = rowType_;
-    auto sink = std::make_unique<dwio::common::FileSink>(
+    auto sink = std::make_unique<dwio::common::LocalFileSink>(
         filePath, dwio::common::MetricsLog::voidLog());
     dwrf::Writer writer{options, std::move(sink), *pool_};
 


### PR DESCRIPTION
FileSink has been renamed to LocalFileSink, to be accurate. It is implementation of dwrf DataSink specifically writing to local files.

```
== NO RELEASE NOTE ==
```
