### PR TITLE
[native] Generate Task spilling directory.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -250,13 +250,6 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                 velox::util::getTimeZoneName(session.timeZoneKey));
           }
 
-          // Copy spill path from the System Config to the Velox Query config
-          // via 'configs'.
-          const auto spillPath = SystemConfig::instance()->spillerSpillPath();
-          if (not spillPath.empty()) {
-            configs.emplace(velox::core::QueryConfig::kSpillPath, spillPath);
-          }
-
           std::unordered_map<
               std::string,
               std::unordered_map<std::string, std::string>>


### PR DESCRIPTION
Generate unique spilling directory for each task that has at least one operator
capable of spilling data and the corresponding spilling is enabled.
Also advancing Velox version.

Test plan - Updated test.

```
== NO RELEASE NOTE ==
```
