### PR TITLE
Use per-query cache for HBO stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -28,6 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class HistoryBasedPlanStatisticsManager
 {
     private final SessionPropertyManager sessionPropertyManager;
+    private final HistoryBasedStatisticsCacheManager historyBasedStatisticsCacheManager;
     private final PlanCanonicalInfoProvider planCanonicalInfoProvider;
     private final HistoryBasedOptimizationConfig config;
 
@@ -39,8 +40,9 @@ public class HistoryBasedPlanStatisticsManager
     {
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+        this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
         ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-        this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(newObjectMapper, metadata);
+        this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
     }
 
@@ -55,12 +57,12 @@ public class HistoryBasedPlanStatisticsManager
 
     public HistoryBasedPlanStatisticsCalculator getHistoryBasedPlanStatisticsCalculator(StatsCalculator delegate)
     {
-        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, delegate, planCanonicalInfoProvider, config);
+        return new HistoryBasedPlanStatisticsCalculator(() -> historyBasedPlanStatisticsProvider, historyBasedStatisticsCacheManager, delegate, planCanonicalInfoProvider, config);
     }
 
     public HistoryBasedPlanStatisticsTracker getHistoryBasedPlanStatisticsTracker()
     {
-        return new HistoryBasedPlanStatisticsTracker(() -> historyBasedPlanStatisticsProvider, sessionPropertyManager, config);
+        return new HistoryBasedPlanStatisticsTracker(() -> historyBasedPlanStatisticsProvider, historyBasedStatisticsCacheManager, sessionPropertyManager, config);
     }
 
     public PlanCanonicalInfoProvider getPlanCanonicalInfoProvider()

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -62,15 +62,18 @@ public class HistoryBasedPlanStatisticsTracker
     private static final Set<QueryType> ALLOWED_QUERY_TYPES = ImmutableSet.of(SELECT, INSERT);
 
     private final Supplier<HistoryBasedPlanStatisticsProvider> historyBasedPlanStatisticsProvider;
+    private final HistoryBasedStatisticsCacheManager historyBasedStatisticsCacheManager;
     private final SessionPropertyManager sessionPropertyManager;
     private final HistoryBasedOptimizationConfig config;
 
     public HistoryBasedPlanStatisticsTracker(
             Supplier<HistoryBasedPlanStatisticsProvider> historyBasedPlanStatisticsProvider,
+            HistoryBasedStatisticsCacheManager historyBasedStatisticsCacheManager,
             SessionPropertyManager sessionPropertyManager,
             HistoryBasedOptimizationConfig config)
     {
         this.historyBasedPlanStatisticsProvider = requireNonNull(historyBasedPlanStatisticsProvider, "historyBasedPlanStatisticsProvider is null");
+        this.historyBasedStatisticsCacheManager = requireNonNull(historyBasedStatisticsCacheManager, "historyBasedStatisticsCacheManager is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.config = requireNonNull(config, "config is null");
     }
@@ -203,9 +206,9 @@ public class HistoryBasedPlanStatisticsTracker
                                     config);
                         }));
 
-        if (newPlanStatistics.isEmpty()) {
-            return;
+        if (!newPlanStatistics.isEmpty()) {
+            historyBasedPlanStatisticsProvider.get().putStats(ImmutableMap.copyOf(newPlanStatistics));
         }
-        historyBasedPlanStatisticsProvider.get().putStats(ImmutableMap.copyOf(newPlanStatistics));
+        historyBasedStatisticsCacheManager.invalidate(queryInfo.getQueryId());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNodeWithHash;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
+import com.facebook.presto.sql.planner.PlanNodeCanonicalInfo;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public class HistoryBasedStatisticsCacheManager
+{
+    // Cache historical statistics of plan node.
+    private final Map<QueryId, LoadingCache<PlanNodeWithHash, HistoricalPlanStatistics>> statisticsCache = new ConcurrentHashMap<>();
+
+    // Cache hashes of plan node.
+    private final Map<QueryId, Map<CachingPlanCanonicalInfoProvider.CacheKey, PlanNodeCanonicalInfo>> canonicalInfoCache = new ConcurrentHashMap<>();
+
+    public HistoryBasedStatisticsCacheManager() {}
+
+    public LoadingCache<PlanNodeWithHash, HistoricalPlanStatistics> getStatisticsCache(QueryId queryId, Supplier<HistoryBasedPlanStatisticsProvider> historyBasedPlanStatisticsProvider)
+    {
+        return statisticsCache.computeIfAbsent(queryId, ignored -> CacheBuilder.newBuilder()
+                .build(new CacheLoader<PlanNodeWithHash, HistoricalPlanStatistics>()
+                {
+                    @Override
+                    public HistoricalPlanStatistics load(PlanNodeWithHash key)
+                    {
+                        return loadAll(Collections.singleton(key)).values().stream().findAny().orElseGet(HistoricalPlanStatistics::empty);
+                    }
+
+                    @Override
+                    public Map<PlanNodeWithHash, HistoricalPlanStatistics> loadAll(Iterable<? extends PlanNodeWithHash> keys)
+                    {
+                        Map<PlanNodeWithHash, HistoricalPlanStatistics> statistics = new HashMap<>(historyBasedPlanStatisticsProvider.get().getStats(ImmutableList.copyOf(keys)));
+                        // loadAll excepts all keys to be written
+                        for (PlanNodeWithHash key : keys) {
+                            statistics.putIfAbsent(key, HistoricalPlanStatistics.empty());
+                        }
+                        return ImmutableMap.copyOf(statistics);
+                    }
+                }));
+    }
+
+    public Map<CachingPlanCanonicalInfoProvider.CacheKey, PlanNodeCanonicalInfo> getCanonicalInfoCache(QueryId queryId)
+    {
+        return canonicalInfoCache.computeIfAbsent(queryId, ignored -> new ConcurrentHashMap());
+    }
+
+    public void invalidate(QueryId queryId)
+    {
+        statisticsCache.remove(queryId);
+        canonicalInfoCache.remove(queryId);
+    }
+
+    @VisibleForTesting
+    public Map<QueryId, Map<CachingPlanCanonicalInfoProvider.CacheKey, PlanNodeCanonicalInfo>> getCanonicalInfoCache()
+    {
+        return canonicalInfoCache;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCachingPlanCanonicalInfoProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCachingPlanCanonicalInfoProvider.java
@@ -50,6 +50,8 @@ public class TestCachingPlanCanonicalInfoProvider
         });
         // Assert that size of cache remains same, meaning all needed hashes were already cached.
         assertEquals(planCanonicalInfoProvider.getCacheSize(), 5L * historyBasedPlanCanonicalizationStrategyList().size());
+        planCanonicalInfoProvider.getHistoryBasedStatisticsCacheManager().invalidate(session.getQueryId());
+        assertEquals(planCanonicalInfoProvider.getCacheSize(), 0);
     }
 
     private Session createSession()

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.HistoryBasedPlanStatisticsCalculator;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
@@ -73,8 +72,6 @@ public class TestHistoryBasedStatsTracking
     @BeforeMethod(alwaysRun = true)
     public void setUp()
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
-        ((HistoryBasedPlanStatisticsCalculator) queryRunner.getStatsCalculator()).invalidateCache();
         getHistoryProvider().clearCache();
     }
 


### PR DESCRIPTION
Previously, we used caches to store hashes and stats for plan nodes in HBO framework. These are global caches shared by all queries, and entries expire in 5 mins. This is a bit hacky

This PR modifies it to store a cache per query, and evicts all entries related to a query once a query finishes. `historyBasedStatisticsCacheManager` class manages the cache and eviction

```
== NO RELEASE NOTE ==
```
