### PR TITLE
Add canonicalization for more plan nodes in HBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -428,18 +428,18 @@ public class CanonicalPlanGenerator
     private Aggregation getCanonicalAggregation(Aggregation aggregation, Map<VariableReferenceExpression, VariableReferenceExpression> context)
     {
         return new Aggregation(
-                (CallExpression) inlineAndCanonicalize(context, aggregation.getCall()),
+                inlineAndCanonicalize(context, aggregation.getCall()),
                 aggregation.getFilter().map(filter -> inlineAndCanonicalize(context, filter)),
                 aggregation.getOrderBy().map(orderBy -> getCanonicalOrderingScheme(orderBy, context)),
                 aggregation.isDistinct(),
-                aggregation.getMask().map(context::get));
+                aggregation.getMask().map(mask -> inlineAndCanonicalize(context, mask)));
     }
 
     private static OrderingScheme getCanonicalOrderingScheme(OrderingScheme orderingScheme, Map<VariableReferenceExpression, VariableReferenceExpression> context)
     {
         return new OrderingScheme(
                 orderingScheme.getOrderBy().stream()
-                        .map(orderBy -> new Ordering(context.get(orderBy.getVariable()), orderBy.getSortOrder()))
+                        .map(orderBy -> new Ordering(inlineAndCanonicalize(context, orderBy.getVariable()), orderBy.getSortOrder()))
                         .collect(toImmutableList()));
     }
 
@@ -447,7 +447,7 @@ public class CanonicalPlanGenerator
     {
         return new GroupingSetDescriptor(
                 groupingSetDescriptor.getGroupingKeys().stream()
-                        .map(context::get)
+                        .map(key -> inlineAndCanonicalize(context, key))
                         .collect(toImmutableList()),
                 groupingSetDescriptor.getGroupingSetCount(),
                 groupingSetDescriptor.getGlobalGroupingSets());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -204,6 +204,30 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testMarkDistinct()
+            throws Exception
+    {
+        String query = "SELECT count(*), count(distinct orderstatus) FROM (SELECT * FROM orders WHERE orderstatus = 'F')";
+        assertSamePlanHash(query, query, CONNECTOR);
+    }
+
+    @Test
+    public void testAssignUniqueId()
+            throws Exception
+    {
+        String query = "SELECT name, (SELECT name FROM region WHERE regionkey = nation.regionkey) FROM nation";
+        assertSamePlanHash(query, query, CONNECTOR);
+    }
+
+    @Test
+    public void testEnforceSingleRow()
+            throws Exception
+    {
+        String query = "SELECT (SELECT regionkey FROM nation WHERE name = 'nosuchvalue') AS sub";
+        assertSamePlanHash(query, query, CONNECTOR);
+    }
+
+    @Test
     public void testJoin()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -32,6 +32,8 @@ import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.REMOV
 import static com.facebook.presto.sql.planner.CanonicalPlanGenerator.generateCanonicalPlan;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.graph.Traverser.forTree;
+import static com.google.common.hash.Hashing.sha256;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
@@ -165,6 +167,20 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testWindow()
+            throws Exception
+    {
+        String query1 = "SELECT orderkey, SUM(custkey) OVER (PARTITION BY orderstatus ORDER BY totalprice) FROM orders where orderkey < 1000";
+        String query2 = "SELECT orderkey, SUM(custkey) OVER (PARTITION BY orderstatus ORDER BY totalprice) FROM orders where orderkey < 2000";
+
+        assertSamePlanHash(query1 + " UNION ALL " + query2, query2 + " UNION ALL " + query1, CONNECTOR);
+
+        assertDifferentPlanHash(query1,
+                "SELECT orderkey, SUM(custkey) OVER (PARTITION BY totalprice ORDER BY totalprice) FROM orders where orderkey < 1000",
+                CONNECTOR);
+    }
+
+    @Test
     public void testJoin()
             throws Exception
     {
@@ -231,16 +247,16 @@ public class TestCanonicalPlanHashes
     private void assertSamePlanHash(String sql1, String sql2, PlanCanonicalizationStrategy strategy)
             throws Exception
     {
-        String hashes1 = getPlanHash(sql1, strategy);
-        String hashes2 = getPlanHash(sql2, strategy);
+        String hashes1 = sha256().hashString(getPlanHash(sql1, strategy), UTF_8).toString();
+        String hashes2 = sha256().hashString(getPlanHash(sql2, strategy), UTF_8).toString();
         assertEquals(hashes1, hashes2);
     }
 
     private void assertDifferentPlanHash(String sql1, String sql2, PlanCanonicalizationStrategy strategy)
             throws Exception
     {
-        String hashes1 = getPlanHash(sql1, strategy);
-        String hashes2 = getPlanHash(sql2, strategy);
+        String hashes1 = sha256().hashString(getPlanHash(sql1, strategy), UTF_8).toString();
+        String hashes2 = sha256().hashString(getPlanHash(sql2, strategy), UTF_8).toString();
         assertNotEquals(hashes1, hashes2);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -193,6 +193,17 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testSort()
+            throws Exception
+    {
+        String query1 = "SELECT * FROM nation where substr(name, 1, 1) = 'A' ORDER BY regionkey";
+        String query2 = "SELECT * FROM nation where substr(name, 1, 1) = 'A' ORDER BY nationkey";
+
+        assertSamePlanHash(query1, query1, CONNECTOR);
+        assertDifferentPlanHash(query1, query2, CONNECTOR);
+    }
+
+    @Test
     public void testJoin()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -181,6 +181,18 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testValues()
+            throws Exception
+    {
+        String query1 = "SELECT * FROM ( VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)";
+        String query2 = "SELECT * FROM ( VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(idd, name)";
+        String query3 = "SELECT * FROM ( VALUES (1, 'a'), (3, 'b'), (2, 'c')) AS t(id, name)";
+
+        assertSamePlanHash(query1, query2, CONNECTOR);
+        assertDifferentPlanHash(query1, query3, CONNECTOR);
+    }
+
+    @Test
     public void testJoin()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -147,6 +147,16 @@ public class TestHistoryBasedStatsTracking
     }
 
     @Test
+    public void testValues()
+    {
+        String query = "SELECT * FROM (SELECT * FROM ( VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)) T1 JOIN (SELECT nationkey FROM nation WHERE substr(name, 1, 1) = 'A') T2 ON T2.nationkey = T1.id";
+
+        assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
     public void testUnionMultiple()
     {
         assertPlan(

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.planner.assertions.Matcher;
 import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -154,6 +155,16 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
         executeAndTrackHistory(query);
         assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testSort()
+    {
+        String query = "SELECT * FROM nation where substr(name, 1, 1) = 'A' ORDER BY regionkey";
+
+        assertPlan(query, anyTree(node(SortNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(SortNode.class, anyTree(any())).withOutputRowCount(2)));
     }
 
     @Test


### PR DESCRIPTION
Depends on https://github.com/prestodb/presto/pull/18821

Add support to canonicalize and hash following plan nodes in HBO:

* ValuesNode
* SortNode
* MarkDistinctNode
* AssignUniqueIdNode
* EnforceSingleRowNode

```
== NO RELEASE NOTE ==
```
