### PR TITLE
Add canonicalization for SemiJoin and RowNumber plan nodes

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -272,6 +272,16 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testRowNumber()
+            throws Exception
+    {
+        String query1 = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY regionkey) from nation";
+        String query2 = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY name) from nation";
+        assertSamePlanHash(query1, query1, CONNECTOR);
+        assertDifferentPlanHash(query1, query2, CONNECTOR);
+    }
+
+    @Test
     public void testLimit()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -263,6 +263,15 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testSemiJoin()
+            throws Exception
+    {
+        String query = "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 2))";
+        assertSamePlanHash(query, query, CONNECTOR);
+        assertDifferentPlanHash(query, "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 1))", CONNECTOR);
+    }
+
+    @Test
     public void testLimit()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -199,6 +200,16 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.longBitsToDouble(4616202753553671564L))));
         executeAndTrackHistory(query);
         assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testRowNumber()
+    {
+        String query = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY regionkey) from nation where substr(name, 1, 1) = 'A'";
+
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(2)));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.testing.QueryRunner;
@@ -188,6 +189,16 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(Double.NaN));
         executeAndTrackHistory(query);
         assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(25));
+    }
+
+    @Test
+    public void testSemiJoin()
+    {
+        String query = "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 2))";
+
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.longBitsToDouble(4616202753553671564L))));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
     }
 
     @Test


### PR DESCRIPTION
Add support to canonicalize and hash following plan nodes in HBO:

* SemiJoinNode
* RowNumberNode

```
== NO RELEASE NOTE ==
```
