### PR TITLE
Add support for calculating remote source stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FragmentStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FragmentStatsProvider.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
+
+/**
+ * Provides stats for completed plan fragments.
+ */
+public class FragmentStatsProvider
+{
+    private static final DataSize CACHE_SIZE = new DataSize(10, DataSize.Unit.MEGABYTE);
+
+    private final Cache<QueryFragmentIdentifier, PlanNodeStatsEstimate> fragmentStatsMap = CacheBuilder.newBuilder()
+            .maximumSize(CACHE_SIZE.toBytes())
+            .expireAfterWrite(1, DAYS)
+            .build();
+
+    @Inject
+    public FragmentStatsProvider() {}
+
+    public void putStats(QueryId queryId, PlanFragmentId fragmentId, PlanNodeStatsEstimate planNodeStatsEstimate)
+    {
+        fragmentStatsMap.put(new QueryFragmentIdentifier(queryId, fragmentId), planNodeStatsEstimate);
+    }
+
+    public void invalidateStats(QueryId queryId, int maxFragmentId)
+    {
+        IntStream.rangeClosed(0, maxFragmentId)
+                .forEach(fragmentId -> fragmentStatsMap.invalidate(new QueryFragmentIdentifier(queryId, new PlanFragmentId(fragmentId))));
+    }
+
+    public PlanNodeStatsEstimate getStats(QueryId queryId, PlanFragmentId fragmentId)
+    {
+        PlanNodeStatsEstimate estimate = fragmentStatsMap.getIfPresent(new QueryFragmentIdentifier(queryId, fragmentId));
+        return estimate == null ? PlanNodeStatsEstimate.unknown() : estimate;
+    }
+
+    public static class QueryFragmentIdentifier
+    {
+        private final QueryId queryId;
+        private final PlanFragmentId planFragmentId;
+
+        public QueryFragmentIdentifier(QueryId queryId, PlanFragmentId planFragmentId)
+        {
+            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.planFragmentId = requireNonNull(planFragmentId, "planFragmentId is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            QueryFragmentIdentifier that = (QueryFragmentIdentifier) o;
+            return queryId.equals(that.queryId) && planFragmentId.equals(that.planFragmentId);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(queryId, planFragmentId);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -210,6 +210,11 @@ public class PlanNodeStatsEstimate
         return isNaN(outputRowCount);
     }
 
+    public boolean isTotalSizeUnknown()
+    {
+        return isNaN(totalSize);
+    }
+
     public PlanNodeStatsEstimate combineStats(PlanStatistics planStatistics, SourceInfo statsSourceInfo)
     {
         if (planStatistics.getConfidence() > 0) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/RemoteSourceStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/RemoteSourceStatsRule.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.Patterns.remoteSource;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteSourceStatsRule
+        extends SimpleStatsRule<RemoteSourceNode>
+{
+    private static final Pattern<RemoteSourceNode> PATTERN = remoteSource();
+
+    private final FragmentStatsProvider fragmentStatsProvider;
+
+    public RemoteSourceStatsRule(FragmentStatsProvider fragmentStatsProvider, StatsNormalizer normalizer)
+    {
+        super(normalizer);
+        this.fragmentStatsProvider = requireNonNull(fragmentStatsProvider, "metadata is null");
+    }
+
+    @Override
+    public Pattern<RemoteSourceNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<PlanNodeStatsEstimate> doCalculate(RemoteSourceNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    {
+        QueryId queryId = session.getQueryId();
+        return node.getSourceFragmentIds().stream()
+                .map(fragmentId -> fragmentStatsProvider.getStats(queryId, fragmentId))
+                .reduce(PlanNodeStatsEstimateMath::addStatsAndCollapseDistinctValues);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
@@ -52,7 +52,7 @@ public class StatsNormalizer
 
     private PlanNodeStatsEstimate normalize(PlanNodeStatsEstimate stats, Optional<Collection<VariableReferenceExpression>> outputVariables)
     {
-        if (stats.isOutputRowCountUnknown()) {
+        if (stats.isOutputRowCountUnknown() && stats.isTotalSizeUnknown()) {
             return PlanNodeStatsEstimate.unknown();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OptimizerStatsRecorder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OptimizerStatsRecorder.java
@@ -51,7 +51,7 @@ public class OptimizerStatsRecorder
         optimizerStats.recordFailure();
     }
 
-    void export(MBeanExporter exporter)
+    public void export(MBeanExporter exporter)
     {
         for (Map.Entry<Class<?>, OptimizerStats> entry : stats.entrySet()) {
             verify(!entry.getKey().getSimpleName().isEmpty());
@@ -64,7 +64,7 @@ public class OptimizerStatsRecorder
         }
     }
 
-    void unexport(MBeanExporter exporter)
+    public void unexport(MBeanExporter exporter)
     {
         for (Class<?> rule : stats.keySet()) {
             exporter.unexport(getName(rule));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RuleStatsRecorder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RuleStatsRecorder.java
@@ -49,7 +49,7 @@ public class RuleStatsRecorder
         stats.get(rule.getClass()).recordFailure();
     }
 
-    void export(MBeanExporter exporter)
+    public void export(MBeanExporter exporter)
     {
         for (Map.Entry<Class<?>, RuleStats> entry : stats.entrySet()) {
             verify(!entry.getKey().getSimpleName().isEmpty());
@@ -66,7 +66,7 @@ public class RuleStatsRecorder
         }
     }
 
-    void unexport(MBeanExporter exporter)
+    public void unexport(MBeanExporter exporter)
     {
         for (Class<?> rule : stats.keySet()) {
             String name = ObjectNames.builder(IterativeOptimizer.class)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -125,6 +125,11 @@ public class Patterns
         return typeOf(ProjectNode.class);
     }
 
+    public static Pattern<RemoteSourceNode> remoteSource()
+    {
+        return typeOf(RemoteSourceNode.class);
+    }
+
     public static Pattern<SampleNode> sample()
     {
         return typeOf(SampleNode.class);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -38,6 +38,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.FragmentStatsProvider;
 import com.facebook.presto.cost.HistoryBasedOptimizationConfig;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.cost.ScalarStatsCalculator;
@@ -318,6 +319,7 @@ public class LocalQueryRunner
     private final boolean alwaysRevokeMemory;
     private final NodeSpillConfig nodeSpillConfig;
     private final NodeSchedulerConfig nodeSchedulerConfig;
+    private final FragmentStatsProvider fragmentStatsProvider;
     private boolean printPlan;
 
     private final PlanChecker distributedPlanChecker;
@@ -419,7 +421,8 @@ public class LocalQueryRunner
         this.scalarStatsCalculator = new ScalarStatsCalculator(metadata);
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, new SessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig());
-        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager);
+        this.fragmentStatsProvider = new FragmentStatsProvider();
+        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
         this.costCalculator = new CostCalculatorUsingExchanges(taskCountEstimator);
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator);
@@ -616,6 +619,11 @@ public class LocalQueryRunner
     public SplitManager getSplitManager()
     {
         return splitManager;
+    }
+
+    public FragmentStatsProvider getFragmentStatsProvider()
+    {
+        return fragmentStatsProvider;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
@@ -63,6 +63,12 @@ public class PlanNodeStatsAssertion
         return this;
     }
 
+    public PlanNodeStatsAssertion totalSizeUnknown()
+    {
+        assertTrue(Double.isNaN(actual.getTotalSize()), "expected unknown totalSize but got " + actual.getTotalSize());
+        return this;
+    }
+
     public PlanNodeStatsAssertion variableStats(VariableReferenceExpression variable, Consumer<VariableStatsAssertion> columnAssertionConsumer)
     {
         VariableStatsAssertion columnAssertion = VariableStatsAssertion.assertThat(actual.getVariableStatistics(variable));

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
@@ -49,6 +49,11 @@ public class StatsCalculatorTester
         return metadata;
     }
 
+    public FragmentStatsProvider getFragmentStatsProvider()
+    {
+        return queryRunner.getFragmentStatsProvider();
+    }
+
     private StatsCalculatorTester(LocalQueryRunner queryRunner)
     {
         this.statsCalculator = queryRunner.getStatsCalculator();

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFragmentStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFragmentStatsProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static java.lang.Double.NaN;
+import static org.testng.Assert.assertEquals;
+
+public class TestFragmentStatsProvider
+{
+    @Test
+    public void testFragmentStatsProvider()
+    {
+        FragmentStatsProvider fragmentStatsProvider = new FragmentStatsProvider();
+        QueryId queryId1 = new QueryId("queryid1");
+        QueryId queryId2 = new QueryId("queryid2");
+        PlanFragmentId planFragmentId1 = new PlanFragmentId(1);
+        PlanFragmentId planFragmentId2 = new PlanFragmentId(2);
+        PlanNodeStatsEstimate planNodeStatsEstimate1 = new PlanNodeStatsEstimate(NaN, 10, true, ImmutableMap.of());
+        PlanNodeStatsEstimate planNodeStatsEstimate2 = new PlanNodeStatsEstimate(NaN, 100, true, ImmutableMap.of());
+
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId1), PlanNodeStatsEstimate.unknown());
+
+        fragmentStatsProvider.putStats(queryId1, planFragmentId1, planNodeStatsEstimate1);
+        // queryId1, fragmentId1 stats are available, other stats are unknown
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId1), planNodeStatsEstimate1);
+        assertEquals(fragmentStatsProvider.getStats(queryId2, planFragmentId1), PlanNodeStatsEstimate.unknown());
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId2), PlanNodeStatsEstimate.unknown());
+
+        // queryid1, fragmentid2 stats are available
+        fragmentStatsProvider.putStats(queryId1, planFragmentId2, planNodeStatsEstimate2);
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId2), planNodeStatsEstimate2);
+
+        // queryId2, fragmentId1 stats are available
+        fragmentStatsProvider.putStats(queryId2, planFragmentId1, planNodeStatsEstimate1);
+        assertEquals(fragmentStatsProvider.getStats(queryId2, planFragmentId1), planNodeStatsEstimate1);
+
+        // invalidate query1, query1 stats are no longer available, query 2 stats are still available
+        fragmentStatsProvider.invalidateStats(queryId1, 2);
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId1), PlanNodeStatsEstimate.unknown());
+        assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId2), PlanNodeStatsEstimate.unknown());
+        assertEquals(fragmentStatsProvider.getStats(queryId2, planFragmentId1), planNodeStatsEstimate1);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestPlanNodeStatsEstimateMath.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestPlanNodeStatsEstimateMath.java
@@ -36,9 +36,9 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testAddRowCount()
     {
-        PlanNodeStatsEstimate unknownStats = statistics(NaN, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate second = statistics(20, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate unknownStats = statistics(NaN, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate second = statistics(20, NaN, NaN, NaN, StatisticRange.empty());
 
         assertEquals(addStatsAndSumDistinctValues(unknownStats, unknownStats), PlanNodeStatsEstimate.unknown());
         assertEquals(addStatsAndSumDistinctValues(first, unknownStats), PlanNodeStatsEstimate.unknown());
@@ -47,14 +47,27 @@ public class TestPlanNodeStatsEstimateMath
     }
 
     @Test
+    public void testAddTotalSize()
+    {
+        PlanNodeStatsEstimate unknownStats = statistics(NaN, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate first = statistics(NaN, 10, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate second = statistics(NaN, 20, NaN, NaN, StatisticRange.empty());
+
+        assertEquals(addStatsAndSumDistinctValues(unknownStats, unknownStats), PlanNodeStatsEstimate.unknown());
+        assertEquals(addStatsAndSumDistinctValues(first, unknownStats), PlanNodeStatsEstimate.unknown());
+        assertEquals(addStatsAndSumDistinctValues(unknownStats, second), PlanNodeStatsEstimate.unknown());
+        assertEquals(addStatsAndSumDistinctValues(first, second).getTotalSize(), 30.0);
+    }
+
+    @Test
     public void testAddNullsFraction()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(10, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(20, 0.2, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.1, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, 0.3, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(10, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(20, NaN, 0.2, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.1, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, NaN, 0.3, NaN, NON_EMPTY_RANGE);
 
         assertAddNullsFraction(unknownRowCount, unknownRowCount, NaN);
         assertAddNullsFraction(unknownNullsFraction, unknownNullsFraction, NaN);
@@ -73,13 +86,13 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testAddAverageRowSize()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, 0.1, 10, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, 10, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownAverageRowSize = statistics(10, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(10, 0.1, 15, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(20, 0.2, 20, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.1, 0.1, 0.3, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, 0.3, 0.4, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, 0.1, 10, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, 10, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownAverageRowSize = statistics(10, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(10, NaN, 0.1, 15, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(20, NaN, 0.2, 20, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.1, NaN, 0.1, 0.3, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, NaN, 0.3, 0.4, NON_EMPTY_RANGE);
 
         assertAddAverageRowSize(unknownRowCount, unknownRowCount, NaN);
         assertAddAverageRowSize(unknownNullsFraction, unknownNullsFraction, NaN);
@@ -99,11 +112,11 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testSumNumberOfDistinctValues()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, openRange(NaN));
-        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, openRange(2));
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, openRange(3));
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, NaN, openRange(NaN));
+        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, NaN, openRange(2));
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, openRange(3));
 
         assertSumNumberOfDistinctValues(unknownRowCount, unknownRowCount, NaN);
         assertSumNumberOfDistinctValues(unknownRowCount, second, NaN);
@@ -120,11 +133,11 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testMaxNumberOfDistinctValues()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, openRange(NaN));
-        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, openRange(2));
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, openRange(3));
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, NaN, openRange(NaN));
+        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, NaN, openRange(2));
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, openRange(3));
 
         assertMaxNumberOfDistinctValues(unknownRowCount, unknownRowCount, NaN);
         assertMaxNumberOfDistinctValues(unknownRowCount, second, NaN);
@@ -141,11 +154,11 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testAddRange()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, openRange(NaN));
-        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, new StatisticRange(12, 100, 2));
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, new StatisticRange(101, 200, 3));
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate unknownRange = statistics(10, NaN, NaN, NaN, openRange(NaN));
+        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, NaN, new StatisticRange(12, 100, 2));
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, new StatisticRange(101, 200, 3));
 
         assertAddRange(unknownRange, unknownRange, NEGATIVE_INFINITY, POSITIVE_INFINITY);
         assertAddRange(unknownRowCount, second, NEGATIVE_INFINITY, POSITIVE_INFINITY);
@@ -164,9 +177,9 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testSubtractRowCount()
     {
-        PlanNodeStatsEstimate unknownStats = statistics(NaN, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate first = statistics(40, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate unknownStats = statistics(NaN, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate first = statistics(40, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
 
         assertEquals(subtractSubsetStats(unknownStats, unknownStats), PlanNodeStatsEstimate.unknown());
         assertEquals(subtractSubsetStats(first, unknownStats), PlanNodeStatsEstimate.unknown());
@@ -177,12 +190,12 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testSubtractNullsFraction()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(50, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(20, 0.2, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.7, 0.1, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, 0.3, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(50, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(20, NaN, 0.2, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountFirst = statistics(0.7, NaN, 0.1, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate fractionalRowCountSecond = statistics(0.2, NaN, 0.3, NaN, NON_EMPTY_RANGE);
 
         assertSubtractNullsFraction(unknownRowCount, unknownRowCount, NaN);
         assertSubtractNullsFraction(unknownRowCount, unknownNullsFraction, NaN);
@@ -200,12 +213,12 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testSubtractNumberOfDistinctValues()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownDistinctValues = statistics(100, 0.1, NaN, openRange(NaN));
-        PlanNodeStatsEstimate zero = statistics(0, 0.1, NaN, openRange(0));
-        PlanNodeStatsEstimate first = statistics(30, 0.1, NaN, openRange(10));
-        PlanNodeStatsEstimate second = statistics(20, 0.1, NaN, openRange(5));
-        PlanNodeStatsEstimate third = statistics(10, 0.1, NaN, openRange(3));
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownDistinctValues = statistics(100, NaN, 0.1, NaN, openRange(NaN));
+        PlanNodeStatsEstimate zero = statistics(0, NaN, 0.1, NaN, openRange(0));
+        PlanNodeStatsEstimate first = statistics(30, NaN, 0.1, NaN, openRange(10));
+        PlanNodeStatsEstimate second = statistics(20, NaN, 0.1, NaN, openRange(5));
+        PlanNodeStatsEstimate third = statistics(10, NaN, 0.1, NaN, openRange(3));
 
         assertSubtractNumberOfDistinctValues(unknownRowCount, unknownRowCount, NaN);
         assertSubtractNumberOfDistinctValues(unknownRowCount, second, NaN);
@@ -235,8 +248,8 @@ public class TestPlanNodeStatsEstimateMath
 
     private static void assertSubtractRange(double supersetLow, double supersetHigh, double subsetLow, double subsetHigh, double expectedLow, double expectedHigh)
     {
-        PlanNodeStatsEstimate first = statistics(30, NaN, NaN, new StatisticRange(supersetLow, supersetHigh, 10));
-        PlanNodeStatsEstimate second = statistics(20, NaN, NaN, new StatisticRange(subsetLow, subsetHigh, 5));
+        PlanNodeStatsEstimate first = statistics(30, NaN, NaN, NaN, new StatisticRange(supersetLow, supersetHigh, 10));
+        PlanNodeStatsEstimate second = statistics(20, NaN, NaN, NaN, new StatisticRange(subsetLow, subsetHigh, 5));
         VariableStatsEstimate statistics = subtractSubsetStats(first, second).getVariableStatistics(VARIABLE);
         assertEquals(statistics.getLowValue(), expectedLow);
         assertEquals(statistics.getHighValue(), expectedHigh);
@@ -245,9 +258,9 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testCapRowCount()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(20, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(20, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, NON_EMPTY_RANGE);
 
         assertEquals(capStats(unknownRowCount, unknownRowCount).getOutputRowCount(), NaN);
         assertEquals(capStats(first, unknownRowCount).getOutputRowCount(), NaN);
@@ -259,10 +272,10 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testCapAverageRowSize()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownAverageRowSize = statistics(20, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(20, NaN, 10, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(10, NaN, 5, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownAverageRowSize = statistics(20, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(20, NaN, NaN, 10, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, 5, NON_EMPTY_RANGE);
 
         assertCapAverageRowSize(unknownRowCount, unknownRowCount, NaN);
         assertCapAverageRowSize(unknownAverageRowSize, unknownAverageRowSize, NaN);
@@ -281,10 +294,10 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testCapNumberOfDistinctValues()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownNumberOfDistinctValues = statistics(20, NaN, NaN, openRange(NaN));
-        PlanNodeStatsEstimate first = statistics(20, NaN, NaN, openRange(10));
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, openRange(5));
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownNumberOfDistinctValues = statistics(20, NaN, NaN, NaN, openRange(NaN));
+        PlanNodeStatsEstimate first = statistics(20, NaN, NaN, NaN, openRange(10));
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, openRange(5));
 
         assertCapNumberOfDistinctValues(unknownRowCount, unknownRowCount, NaN);
         assertCapNumberOfDistinctValues(unknownNumberOfDistinctValues, unknownNumberOfDistinctValues, NaN);
@@ -301,10 +314,10 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testCapRange()
     {
-        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, StatisticRange.empty());
-        PlanNodeStatsEstimate openRange = statistics(10, NaN, NaN, openRange(NaN));
-        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, new StatisticRange(12, 100, NaN));
-        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, new StatisticRange(13, 99, NaN));
+        PlanNodeStatsEstimate emptyRange = statistics(10, NaN, NaN, NaN, StatisticRange.empty());
+        PlanNodeStatsEstimate openRange = statistics(10, NaN, NaN, NaN, openRange(NaN));
+        PlanNodeStatsEstimate first = statistics(10, NaN, NaN, NaN, new StatisticRange(12, 100, NaN));
+        PlanNodeStatsEstimate second = statistics(10, NaN, NaN, NaN, new StatisticRange(13, 99, NaN));
 
         assertCapRange(emptyRange, emptyRange, NaN, NaN);
         assertCapRange(emptyRange, openRange, NaN, NaN);
@@ -324,11 +337,11 @@ public class TestPlanNodeStatsEstimateMath
     @Test
     public void testCapNullsFraction()
     {
-        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate first = statistics(20, 0.25, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate second = statistics(10, 0.6, NaN, NON_EMPTY_RANGE);
-        PlanNodeStatsEstimate third = statistics(0, 0.6, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownRowCount = statistics(NaN, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate unknownNullsFraction = statistics(10, NaN, NaN, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate first = statistics(20, NaN, 0.25, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate second = statistics(10, NaN, 0.6, NaN, NON_EMPTY_RANGE);
+        PlanNodeStatsEstimate third = statistics(0, NaN, 0.6, NaN, NON_EMPTY_RANGE);
 
         assertCapNullsFraction(unknownRowCount, unknownRowCount, NaN);
         assertCapNullsFraction(unknownNullsFraction, unknownNullsFraction, NaN);
@@ -343,10 +356,11 @@ public class TestPlanNodeStatsEstimateMath
         assertEquals(capStats(stats, cap).getVariableStatistics(VARIABLE).getNullsFraction(), expected);
     }
 
-    private static PlanNodeStatsEstimate statistics(double rowCount, double nullsFraction, double averageRowSize, StatisticRange range)
+    private static PlanNodeStatsEstimate statistics(double rowCount, double totalSize, double nullsFraction, double averageRowSize, StatisticRange range)
     {
         return PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(rowCount)
+                .setTotalSize(totalSize)
                 .addVariableStatistics(VARIABLE, VariableStatsEstimate.builder()
                         .setNullsFraction(nullsFraction)
                         .setAverageRowSize(averageRowSize)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestRemoteSourceStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestRemoteSourceStatsRule.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.Double.NaN;
+
+public class TestRemoteSourceStatsRule
+        extends BaseStatsCalculatorTest
+{
+    @Test
+    public void testRemoteSourceStatsRule()
+    {
+        QueryId queryId = new QueryId("testqueryid");
+        Session session = testSessionBuilder()
+                .setQueryId(queryId)
+                .build();
+        StatsCalculatorTester tester = new StatsCalculatorTester(session);
+
+        tester.getFragmentStatsProvider().putStats(queryId, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        tester.getFragmentStatsProvider().putStats(queryId, new PlanFragmentId(2), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        tester
+                .assertStatsFor(planBuilder -> planBuilder.remoteSource(ImmutableList.of(new PlanFragmentId(1), new PlanFragmentId(2))))
+                .check(check -> check.totalSize(2000)
+                        .outputRowsCountUnknown());
+        tester.close();
+    }
+
+    @Test
+    public void testRemoteSourceStatsUnknown()
+    {
+        tester()
+                .assertStatsFor(planBuilder -> planBuilder.remoteSource(ImmutableList.of(new PlanFragmentId(1), new PlanFragmentId(2))))
+                .check(check -> check.outputRowsCountUnknown()
+                        .totalSizeUnknown());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestStatsNormalizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestStatsNormalizer.java
@@ -149,6 +149,19 @@ public class TestStatsNormalizer
                 .variableStats(variable, variableAssert -> variableAssert.distinctValuesCount(expectedNormalizedNdv));
     }
 
+    @Test
+    public void testTotalSizeOnlyMaintainsTotalSize()
+    {
+        PlanNodeStatsEstimate estimate = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(NaN)
+                .setTotalSize(120)
+                .build();
+
+        assertNormalized(estimate)
+                .outputRowsCountUnknown()
+                .totalSize(120);
+    }
+
     private PlanNodeStatsAssertion assertNormalized(PlanNodeStatsEstimate estimate)
     {
         PlanNodeStatsEstimate normalized = normalizer.normalize(estimate, estimate.getVariablesWithKnownStatistics());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -72,6 +72,8 @@ import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.OffsetNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
@@ -117,6 +119,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HAS
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.optimizations.ApplyNodeUtil.verifySubquerySupported;
 import static com.facebook.presto.sql.planner.optimizations.SetOperationNodeUtils.fromListMultimap;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
@@ -331,6 +334,11 @@ public class PlanBuilder
         AggregationBuilder aggregationBuilder = new AggregationBuilder(getTypes());
         aggregationBuilderConsumer.accept(aggregationBuilder);
         return aggregationBuilder.build();
+    }
+
+    public RemoteSourceNode remoteSource(List<PlanFragmentId> sourceFragmentIds)
+    {
+        return new RemoteSourceNode(Optional.empty(), idAllocator.getNextId(), sourceFragmentIds, ImmutableList.of(), false, Optional.empty(), REPARTITION);
     }
 
     public CallExpression binaryOperation(OperatorType operatorType, RowExpression left, RowExpression right)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -125,6 +125,7 @@ import com.facebook.presto.spark.node.PrestoSparkTaskManager;
 import com.facebook.presto.spark.planner.PrestoSparkPlanFragmenter;
 import com.facebook.presto.spark.planner.PrestoSparkQueryPlanner;
 import com.facebook.presto.spark.planner.PrestoSparkRddFactory;
+import com.facebook.presto.spark.planner.optimizers.AdaptivePlanOptimizers;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorTypeSerde;
 import com.facebook.presto.spi.PageIndexerFactory;
@@ -407,6 +408,7 @@ public class PrestoSparkModule
         // planner
         binder.bind(PlanFragmenter.class).in(Scopes.SINGLETON);
         binder.bind(PlanOptimizers.class).in(Scopes.SINGLETON);
+        binder.bind(AdaptivePlanOptimizers.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPlanOptimizerManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FileFragmentResultCacheConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spark.planner.optimizers;
+
+import com.facebook.presto.cost.CostCalculator;
+import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.sql.planner.OptimizerStatsRecorder;
+import com.facebook.presto.sql.planner.RuleStatsRecorder;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.weakref.jmx.MBeanExporter;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.List;
+
+/**
+ * Provides the set of PlanOptimizers for use during
+ * adaptive query replanning for presto-on-spark.
+ */
+public class AdaptivePlanOptimizers
+{
+    private final List<PlanOptimizer> adaptiveOptimizers;
+    private final RuleStatsRecorder ruleStats = new RuleStatsRecorder();
+    private final OptimizerStatsRecorder optimizerStats = new OptimizerStatsRecorder();
+    private final MBeanExporter exporter;
+
+    @Inject
+    public AdaptivePlanOptimizers(
+            MBeanExporter exporter,
+            StatsCalculator statsCalculator,
+            CostCalculator costCalculator)
+    {
+        this.exporter = exporter;
+        this.adaptiveOptimizers = ImmutableList.of(new IterativeOptimizer(ruleStats, statsCalculator, costCalculator, ImmutableSet.of(new PickJoinSides())));
+    }
+
+    @PostConstruct
+    public void initialize()
+    {
+        ruleStats.export(exporter);
+        optimizerStats.export(exporter);
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        ruleStats.unexport(exporter);
+        optimizerStats.unexport(exporter);
+    }
+
+    public List<PlanOptimizer> getAdaptiveOptimizers()
+    {
+        return adaptiveOptimizers;
+    }
+}


### PR DESCRIPTION
Adds support for computing stats for remote source nodes based on stats of completed fragments provided through the FragmentStatsProvider.  Also adds better support for PlanNodeStatsEstimates that only contain totalSize stats since that's what we expect from AQE and introduces the AdaptivePlanOptimizers class.

The next PR will integrate the RemoteSourceNode stats with HBO, so that we will use HBO stats if the remote source node stats don't differ too much from HBO stats (Similar to how HBO handles tablescan stats).

Test plan - unit tests

```
== NO RELEASE NOTE ==
```
