### PR TITLE
Fix bug in CBO stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -127,7 +127,7 @@ public class PlanNodeStatsEstimate
     {
         requireNonNull(planNode, "planNode is null");
 
-        if (sourceInfo.isConfident() && !isNaN(totalSize)) {
+        if (!sourceInfo.estimateSizeUsingVariables() && !isNaN(totalSize)) {
             return totalSize;
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
@@ -49,4 +49,10 @@ public class CostBasedSourceInfo
     {
         return confident;
     }
+
+    @Override
+    public boolean estimateSizeUsingVariables()
+    {
+        return true;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
@@ -20,4 +20,13 @@ package com.facebook.presto.spi.statistics;
 public abstract class SourceInfo
 {
     public abstract boolean isConfident();
+
+    /**
+     * Whether to estimate size of plan output using variable statistics.
+     * If false, we will use estimated size in plan statistics itself.
+     */
+    public boolean estimateSizeUsingVariables()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
This PR slightly changed the behaviour of CBO: https://github.com/prestodb/presto/pull/18584

CBO computes plan stats(rows, size), but doesn't use size field. It uses variable sizes and rows to compute size.

HBO however should use size directly.

Previous PR checked whether do it by isConfident() function, but that's not the right way as some CBO stats can be confident. So we change this behaviour back, so for CBO we only estimate size using variable sizes.

Identified issue when one of the queries(~ 0.01%) failed during shadow runs

```
== NO RELEASE NOTE ==
```
