### PR TITLE
[native] Update code that sets up the task spill directory.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -118,6 +118,13 @@ class TaskManager {
   // in exec/Task.h).
   std::array<size_t, 5> getTaskNumbers(size_t& numTasks) const;
 
+  /// Build directory path for spilling for the given task.
+  /// Always returns non-empty string.
+  static std::string buildTaskSpillDirectoryPath(
+      const std::string& baseSpillPath,
+      const std::string& queryId,
+      const protocol::TaskId& taskId);
+
  public:
   static constexpr folly::StringPiece kMaxDriversPerTask{
       "max_drivers_per_task"};

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -839,4 +839,14 @@ TEST_F(TaskManagerTest, aggregationSpill) {
   }
 }
 
+TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
+  EXPECT_EQ(
+      "fs::/base/2022-12-20/presto_native/20221220-Q/Task1/",
+      TaskManager::buildTaskSpillDirectoryPath(
+          "fs::/base", "20221220-Q", "Task1"));
+  EXPECT_EQ(
+      "fsx::/root/1970-01-01/presto_native/Q100/Task22/",
+      TaskManager::buildTaskSpillDirectoryPath("fsx::/root", "Q100", "Task22"));
+}
+
 // TODO: add disk spilling test for order by and hash join later.


### PR DESCRIPTION
- Use the PlanFragment::canSpill() to determine is Task can spill.
- Add unit test for spill path generation.
- Advance Velox version and fix the build.

Test plan - New test.

```
== NO RELEASE NOTE ==
```
