### PR TITLE
Replace sun.reflect...NotImplementedException with UnsupportedOperationException

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.testng.annotations.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.List;
 import java.util.Optional;
@@ -199,19 +198,19 @@ public class TestHiveMetadata
         @Override
         public Column toColumn(FieldSchema fieldSchema)
         {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public FieldSchema fromColumn(Column column)
         {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Optional<String> getTypeMetadata(HiveType hiveType, TypeSignature typeSignature)
         {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
Replace sun.reflect.generics.reflectiveObjects.NotImplementedException with UnsupportedOperationException in presto-hive TestHiveMetadata to avoid having a dependency on internal oracle class.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
