### PR TITLE
[native] Refactor shuffle interface

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -475,7 +475,7 @@ std::vector<std::string> PrestoServer::registerConnectors(
 
 void PrestoServer::registerShuffleInterfaceFactories() {
   operators::ShuffleInterfaceFactory::registerFactory(
-      operators::LocalPersistentShuffle::kShuffleName.toString(),
+      operators::LocalPersistentShuffleFactory::kShuffleName.toString(),
       std::make_unique<operators::LocalPersistentShuffleFactory>());
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -158,7 +158,7 @@ void LocalPersistentShuffle::noMoreData(bool success) {
   readyToRead->close();
 }
 
-bool LocalPersistentShuffle::hasNext(int32_t partition) const {
+bool LocalPersistentShuffle::hasNext(int32_t partition) {
   while (!readyForRead()) {
     // This sleep is only for testing purposes.
     // For the test cases in which the shuffle reader tasks run before shuffle

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -48,8 +48,6 @@ struct LocalShuffleInfo {
 /// this class (pointing to the same root path) to read and write shuffle data.
 class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
  public:
-  static constexpr folly::StringPiece kShuffleName{"local"};
-
   LocalPersistentShuffle(
       const std::string& rootPath,
       uint32_t numPartitions,
@@ -103,6 +101,7 @@ class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
 
 class LocalPersistentShuffleFactory : public ShuffleInterfaceFactory {
  public:
+  static constexpr folly::StringPiece kShuffleName{"local"};
   std::shared_ptr<ShuffleReader> createReader(
       const std::string& serializedStr,
       velox::memory::MemoryPool* FOLLY_NONNULL pool) override;

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -60,7 +60,7 @@ class LocalPersistentShuffle : public ShuffleReader, public ShuffleWriter {
 
   void noMoreData(bool success) override;
 
-  bool hasNext(int32_t partition) const override;
+  bool hasNext(int32_t partition) override;
 
   velox::BufferPtr next(int32_t partition, bool success) override;
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -36,7 +36,7 @@ class ShuffleReader {
 
   /// Check by the reader to see if more blocks are available for this
   /// partition.
-  virtual bool hasNext(int32_t partition) const = 0;
+  virtual bool hasNext(int32_t partition) = 0;
 
   /// Read the next block of data for this partition.
   /// @param success set to false to indicate aborted client.

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -115,7 +115,7 @@ class TestShuffle : public ShuffleReader, public ShuffleWriter {
     }
   }
 
-  bool hasNext(int32_t partition) const {
+  bool hasNext(int32_t partition) {
     return !readyPartitions_[partition].empty();
   }
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -50,8 +50,6 @@ struct TestShuffleInfo {
 
 class TestShuffle : public ShuffleReader, public ShuffleWriter {
  public:
-  static constexpr std::string_view kShuffleName = "test-shuffle";
-
   TestShuffle(
       memory::MemoryPool* pool,
       uint32_t numPartitions,
@@ -171,6 +169,8 @@ class TestShuffle : public ShuffleReader, public ShuffleWriter {
 
 class TestShuffleFactory : public ShuffleInterfaceFactory {
  public:
+  static constexpr std::string_view kShuffleName = "test-shuffle";
+
   std::shared_ptr<ShuffleReader> createReader(
       const std::string& serializedShuffleInfo,
       velox::memory::MemoryPool* FOLLY_NONNULL pool) override {
@@ -252,10 +252,10 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
   void registerVectorSerde() override {
     serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
     ShuffleInterfaceFactory::registerFactory(
-        std::string(TestShuffle::kShuffleName),
+        std::string(TestShuffleFactory::kShuffleName),
         std::make_unique<TestShuffleFactory>());
     ShuffleInterfaceFactory::registerFactory(
-        std::string(LocalPersistentShuffle::kShuffleName),
+        std::string(LocalPersistentShuffleFactory::kShuffleName),
         std::make_unique<LocalPersistentShuffleFactory>());
   }
 
@@ -440,7 +440,7 @@ TEST_F(UnsafeRowShuffleTest, operators) {
                   .addNode(addPartitionAndSerializeNode(4))
                   .localPartition({})
                   .addNode(addShuffleWriteNode(
-                      std::string(TestShuffle::kShuffleName), info))
+                      std::string(TestShuffleFactory::kShuffleName), info))
                   .planNode();
 
   exec::test::CursorParameters params;
@@ -469,7 +469,7 @@ TEST_F(UnsafeRowShuffleTest, endToEnd) {
   TestShuffle::create(shuffleInfo, pool());
   registerExchangeSource(TestShuffle::getInstance());
   runShuffleTest(
-      std::string(TestShuffle::kShuffleName),
+      std::string(TestShuffleFactory::kShuffleName),
       shuffleInfo,
       numPartitions,
       numMapDrivers,
@@ -537,7 +537,7 @@ TEST_F(UnsafeRowShuffleTest, persistentShuffle) {
       rootPath, numPartitions, 1 << 20 /* 1MB */, pool());
   registerExchangeSource(localShuffle);
   runShuffleTest(
-      std::string(LocalPersistentShuffle::kShuffleName),
+      std::string(LocalPersistentShuffleFactory::kShuffleName),
       shuffleInfo,
       numPartitions,
       numMapDrivers,
@@ -611,7 +611,7 @@ TEST_F(UnsafeRowShuffleTest, persistentShuffleFuzz) {
         rootPath, numPartitions, 1 << 15, pool());
     registerExchangeSource(localShuffle);
     runShuffleTest(
-        std::string(LocalPersistentShuffle::kShuffleName),
+        std::string(LocalPersistentShuffleFactory::kShuffleName),
         shuffleInfo,
         numPartitions,
         numMapDrivers,
@@ -658,7 +658,7 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
                   .addNode(addPartitionAndSerializeNode(4))
                   .localPartition({})
                   .addNode(addShuffleWriteNode(
-                      std::string(TestShuffle::kShuffleName),
+                      std::string(TestShuffleFactory::kShuffleName),
                       fmt::format(kTestShuffleInfoFormat, 10, 10)))
                   .planNode();
 

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -136,7 +136,7 @@ TEST_F(PlanConverterTest, scanAggBatch) {
   filesystems::registerLocalFileSystem();
   auto root = assertToBatchVeloxQueryPlan(
       "ScanAggBatch.json",
-      std::string(operators::LocalPersistentShuffle::kShuffleName),
+      std::string(operators::LocalPersistentShuffleFactory::kShuffleName),
       std::make_shared<std::string>(fmt::format(
           "{{\n"
           "  \"rootPath\": \"{}\",\n"


### PR DESCRIPTION
Some implementations might use iterators for iterating through shuffled data. hasNext() call needs to move iterator forward in order to tell if there is more data. Removing const specifier allows hasNext() modify possible internal iterators.

```
== NO RELEASE NOTE ==
```
