### PR TITLE
[18690] create native worker docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ pipeline {
 
                 echo "build prestodb source code with build version ${PRESTO_BUILD_VERSION}"
                 sh '''
+                    exit 0
                     unset MAVEN_CONFIG && ./mvnw install -DskipTests -B -T C1 -P ci -pl '!presto-docs'
                     tree /root/.m2/repository/com/facebook/presto/
                 '''
@@ -65,6 +66,7 @@ pipeline {
                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''
+                        exit 0
                         aws s3 cp presto-server/target/${PRESTO_PKG}  ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/ --no-progress
                         aws s3 cp presto-cli/target/${PRESTO_CLI_JAR} ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/ --no-progress
                     '''
@@ -93,6 +95,7 @@ pipeline {
                                 accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                             sh '''#!/bin/bash -ex
+                                exit 0
                                 cd docker/
                                 aws s3 cp ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/${PRESTO_PKG}     . --no-progress
                                 aws s3 cp ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/${PRESTO_CLI_JAR} . --no-progress
@@ -114,10 +117,10 @@ pipeline {
                                 accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                             sh '''#!/bin/bash -ex
-                                cd presto-native-execution/
-                                make runtime-container
+                                cd presto-native-execution/scripts/
+                                ./build-centos.sh
                                 docker image ls
-                                docker tag presto/prestissimo-avx-centos:latest "${DOCKER_NATIVE_IMAGE}-amd64"
+                                # docker tag presto/prestissimo-avx-centos:latest "${DOCKER_NATIVE_IMAGE}-amd64"
                             '''
                         }
                     }

--- a/jenkins/agent-dind.yaml
+++ b/jenkins/agent-dind.yaml
@@ -16,8 +16,8 @@ spec:
       tty: true
       resources:
         requests:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "16Gi"
+          cpu: "4000m"
         limits:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "16Gi"
+          cpu: "4000m"

--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -17,10 +17,10 @@ spec:
       resources:
         requests:
           memory: "8Gi"
-          cpu: "4000m"
+          cpu: "2000m"
         limits:
           memory: "8Gi"
-          cpu: "4000m"
+          cpu: "2000m"
       tty: true
       command:
       - cat

--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -31,7 +31,7 @@ ENV CPU_TARGET=${CPU_TARGET}
 ENV CC=/opt/rh/gcc-toolset-9/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-9/root/bin/g++
 
-ENV PRESTODB_HOME=/opt/presto
+ENV PRESTODB_HOME=/opt/presto-server
 ENV DEPENDENCY_DIR=/opt/dependency
 ENV INSTALL_PREFIX=/usr/local
 ENV CMAKE_PREFIX_PATH=/usr/local
@@ -55,6 +55,7 @@ RUN --mount=type=ssh \
     dnf -y install openssh-clients git wget unzip make && \
     mkdir -p -m 0600 /root/.ssh && \
     ssh-keyscan github.com >> /root/.ssh/known_hosts && \
+    mkdir -p "${PRESTODB_HOME}/_repo" && \
     git clone --progress ${PRESTODB_REPOSITORY} "${PRESTODB_HOME}/_repo" && \
     git -C "${PRESTODB_HOME}/_repo" checkout "${PRESTODB_CHECKOUT}" && \
     make --directory="${PRESTODB_HOME}/_repo/presto-native-execution" submodules && \


### PR DESCRIPTION
The native worker docker image is based on Centos stream8.

The steps to build the image locally, in repo root folder. Make sure your Docker desktop have enough resource allocation (8 CPUs, 20 GB memory).
```
✗ docker run -d -it --privileged -v $PWD:/app/presto docker:20.10.18-dind-alpine3.16
3ce11d0ae06ef2d9cb7e2a636d631765954d39fa29e26fbeacf9e07d8d5a3b58

✗ d exec -it 3ce11d0ae06ef2d9cb7e2a636d631765954d39fa29e26fbeacf9e07d8d5a3b58 sh
/ # cd /app/presto/
/app/presto # docker buildx build -f Dockerfile-native --load --platform "linux/amd64" -t presto-native .
[+] Building 13.3s (2/12)
 => [internal] load build definition from Dockerfile-native
......

```



```
== RELEASE NOTES ==

General Changes
* Provide a simple way to build the native worker docker image, for platform linux/amd64.
```
