### PR TITLE
Fix BatchTaskUpdateRequest failures

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -112,18 +112,20 @@ void TaskResource::registerUris(http::HttpServer& server) {
         return acknowledgeResults(message, pathMatch);
       });
 
-  server.registerPost(
-      R"(/v1/task/(.+))",
-      [&](proxygen::HTTPMessage* message,
-          const std::vector<std::string>& pathMatch) {
-        return createOrUpdateTask(message, pathMatch);
-      });
-
+  // task/(.+)/batch must come before the /v1/task/(.+) as it's more specific
+  // otherwise all requests will be matched with /v1/task/(.+)
   server.registerPost(
       R"(/v1/task/(.+)/batch)",
       [&](proxygen::HTTPMessage* message,
           const std::vector<std::string>& pathMatch) {
         return createOrUpdateBatchTask(message, pathMatch);
+      });
+
+  server.registerPost(
+      R"(/v1/task/(.+))",
+      [&](proxygen::HTTPMessage* message,
+          const std::vector<std::string>& pathMatch) {
+        return createOrUpdateTask(message, pathMatch);
       });
 
   server.registerDelete(


### PR DESCRIPTION
Fixed two issues:
1. Since `BatchTaskUpdateRequest` request has more specific URI pattern than the `TaskUpdateRequest` (`/task/(.*)+/batch` vs `/task/(.*)+`), we need to match batch request first otherwise all requests will be matched with normal `TaskUpdateRequest`.

2.  whether the last node of the plan is PartitionedOutputNode can't guarantee the query has shuffle stage, for example a plan with TableWriteNode can also have a PartitionedOutputNode to distribute the metadata to coordinator. Changed the check to see if `serializedShuffleWriteInfo` is null to tell whether it's a shuffle query or not.