### PR TITLE
Prestissimo: Fix logic deserializing LongDecimal-typed Data Encoded in INT128_ARRAY in bytestream read

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
@@ -38,6 +38,8 @@ struct ByteStream {
 
   template <typename T>
   T read() {
+    // Directly reading int128 values is not yet supported in ByteStream.
+    static_assert(sizeof(T) <= sizeof(uint64_t));
     T value = *reinterpret_cast<const T*>(data_ + offset_);
     offset_ += sizeof(T);
     return value;
@@ -58,6 +60,16 @@ struct ByteStream {
   const char* data_;
   int32_t offset_;
 };
+
+// ByteStream::read specialization for int128_t
+template <>
+velox::int128_t ByteStream::read<velox::int128_t>() {
+  // Fetching int128_t value by reading two 64-bit blocks rather than one
+  // 128-bit block to avoid general protection exception.
+  auto low = read<int64_t>();
+  auto high = read<int64_t>();
+  return velox::buildInt128(high, low);
+}
 
 velox::BufferPtr
 readNulls(int32_t count, ByteStream& stream, velox::memory::MemoryPool* pool) {

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
@@ -82,6 +82,81 @@ TEST_F(Base64Test, singleTinyint) {
   ASSERT_EQ(1, intVector->valueAt(0));
 }
 
+TEST_F(Base64Test, simpleLongDecimal) {
+  // Note: string values of block representations in following test cases (e.g.,
+  // "data0") can be obtained by reading the actual block representations of
+  // corresponding unscaled values in running services of Prestissimo.
+
+  // Unscaled value = 0
+  const std::string data0 =
+      "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+  auto vector0 = readBlock(LONG_DECIMAL(24, 2), data0, pool_.get());
+
+  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector0->typeKind());
+  ASSERT_EQ(1, vector0->size());
+  ASSERT_FALSE(vector0->isNullAt(0));
+
+  auto decimalVector0 =
+      vector0->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
+  ASSERT_EQ(UnscaledLongDecimal(0), decimalVector0->valueAt(0));
+
+  // Unscaled value = 100
+  const std::string data1 =
+      "DAAAAElOVDEyOF9BUlJBWQEAAAAAZAAAAAAAAAAAAAAAAAAAAA==";
+  auto vector1 = readBlock(LONG_DECIMAL(24, 2), data1, pool_.get());
+
+  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector1->typeKind());
+  ASSERT_EQ(1, vector1->size());
+  ASSERT_FALSE(vector1->isNullAt(0));
+
+  auto decimalVector1 =
+      vector1->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
+  ASSERT_EQ(UnscaledLongDecimal(100), decimalVector1->valueAt(0));
+
+  // Unscaled value = -100
+  const std::string data2 =
+      "DAAAAElOVDEyOF9BUlJBWQEAAAAAZAAAAAAAAAAAAAAAAAAAgA==";
+  auto vector2 = readBlock(LONG_DECIMAL(24, 2), data2, pool_.get());
+
+  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector2->typeKind());
+  ASSERT_EQ(1, vector2->size());
+  ASSERT_FALSE(vector2->isNullAt(0));
+
+  auto decimalVector2 =
+      vector2->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
+  ASSERT_EQ(UnscaledLongDecimal(-100), decimalVector2->valueAt(0));
+
+  // Unscaled value = 10^20
+  const std::string data3 =
+      "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAQYy1ex2sFAAAAAAAAAA==";
+  auto vector3 = readBlock(LONG_DECIMAL(24, 2), data3, pool_.get());
+
+  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector3->typeKind());
+  ASSERT_EQ(1, vector3->size());
+  ASSERT_FALSE(vector3->isNullAt(0));
+
+  auto decimalVector3 =
+      vector3->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
+  ASSERT_EQ(
+      UnscaledLongDecimal(DecimalUtil::kPowersOfTen[20]),
+      decimalVector3->valueAt(0));
+
+  // Unscaled value = -10^20
+  const std::string data4 =
+      "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAQYy1ex2sFAAAAAAAAgA==";
+  auto vector4 = readBlock(LONG_DECIMAL(24, 2), data4, pool_.get());
+
+  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector4->typeKind());
+  ASSERT_EQ(1, vector4->size());
+  ASSERT_FALSE(vector4->isNullAt(0));
+
+  auto decimalVector4 =
+      vector4->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
+  ASSERT_EQ(
+      UnscaledLongDecimal(-DecimalUtil::kPowersOfTen[20]),
+      decimalVector4->valueAt(0));
+}
+
 TEST_F(Base64Test, singleString) {
   std::string data = "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAoAAAAACgAAADIwMTktMTEtMTA=";
 


### PR DESCRIPTION
== RELEASE NOTES ==

General Changes
* On the Velox side, reading int128 in Bytestream is not yet supported, and instead, it reads two 64bit integers and combine them for form an int128. However, on Prestissimo, the loophole seems to still exist. Without this fix, in the release mode, Prestissimo will crash with EXC_BAD_ACCESS error when deserializing LongDecimal data (unit tests) since it is trying to directly parse a 128-bit block.

This is the backtrace information of the core dump we encounter.
![image](https://user-images.githubusercontent.com/1387708/209240242-64f08e72-b299-4c89-8c6a-55964bf2d029.png)

Test plan
* Added multiple unit tests for deserializing base64 encoded long Decimals for Prestissimo

