### PR TITLE
[native] Adding partial support for EquatableValueSet filter.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -614,8 +614,15 @@ std::unique_ptr<common::Filter> toFilter(
       auto equatableValueSet =
           std::dynamic_pointer_cast<protocol::EquatableValueSet>(
               domain.values)) {
+    if (equatableValueSet->entries.empty()) {
+      if (nullAllowed) {
+        return std::make_unique<common::IsNull>();
+      } else {
+        return std::make_unique<common::IsNotNull>();
+      }
+    }
     VELOX_UNSUPPORTED(
-        "EquatableValueSet to Velox filter conversion is not supported yet.");
+        "EquatableValueSet (with non-empty entries) to Velox filter conversion is not supported yet.");
   } else if (
       auto allOrNoneValueSet =
           std::dynamic_pointer_cast<protocol::AllOrNoneValueSet>(

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
@@ -596,6 +596,10 @@ abstract class TestHiveQueries
     {
         assertQuery("SELECT count(*) FROM orders where clerk is not null");
         assertQuery("SELECT count(*) FROM orders where clerk is null");
+        assertQuery("select count(*) from orders_ex where quantities is null");
+        assertQuery("select count(*) from orders_ex where quantities is not null");
+        assertQuery("select count(*) from orders_ex where quantity_by_linenumber is null");
+        assertQuery("select count(*) from orders_ex where quantity_by_linenumber is not null");
     }
 
     @Test


### PR DESCRIPTION
Adding support for EquatableValueSet when entries list is empty. Will add full support once we figure out how to use non-empty entries list and whitelist flag.