### PR TITLE
[native]Deprecate kQueryMaxTotalMemoryPerNode config

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -83,13 +83,12 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
         {entry.first, std::make_shared<core::MemConfig>(entry.second)});
   }
 
-  const int64_t maxTotalMemoryPerNode = getMaxMemoryPerNode(
-      kQueryMaxTotalMemoryPerNode, kDefaultMaxMemoryPerNode);
-
+  const int64_t maxQueryMemoryPerNode =
+      getMaxMemoryPerNode(kQueryMaxMemoryPerNode, kDefaultMaxMemoryPerNode);
   auto pool =
       memory::getProcessDefaultMemoryManager().getRoot().addChild("query_root");
   pool->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(maxTotalMemoryPerNode));
+      velox::memory::MemoryUsageTracker::create(maxQueryMemoryPerNode));
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       executor().get(),

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -127,8 +127,6 @@ class QueryContextManager {
 
   static constexpr const char* kQueryMaxMemoryPerNode =
       "query.max-memory-per-node";
-  static constexpr const char* kQueryMaxTotalMemoryPerNode =
-      "query.max-total-memory-per-node";
   static constexpr int64_t kDefaultMaxMemoryPerNode =
       std::numeric_limits<int64_t>::max();
 


### PR DESCRIPTION
Deprecate kQueryMaxTotalMemoryPerNode as Velox doesn't
differentiate user and system memory. Also improve the test
check logic to ease error debug

```
== NO RELEASE NOTE ==
```
