### PR TITLE
Add Data cache support for Delta Connector

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaConnectorFactory.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaConnectorFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.delta;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.cache.CachingModule;
 import com.facebook.presto.hive.authentication.HiveAuthenticationModule;
 import com.facebook.presto.hive.gcs.HiveGcsModule;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
@@ -56,6 +57,7 @@ public class DeltaConnectorFactory
                     new JsonModule(),
                     new DeltaModule(catalogName, context.getTypeManager()),
                     new HiveS3Module(catalogName),
+                    new CachingModule(),
                     new HiveGcsModule(),
                     new HiveAuthenticationModule(),
                     new HiveMetastoreModule(catalogName, Optional.empty()),

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
@@ -15,10 +15,8 @@ package com.facebook.presto.delta;
 
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.cache.CacheFactory;
-import com.facebook.presto.cache.CacheManager;
 import com.facebook.presto.cache.CacheStats;
 import com.facebook.presto.cache.ForCachingFileSystem;
-import com.facebook.presto.cache.NoOpCacheManager;
 import com.facebook.presto.cache.filemerge.FileMergeCacheConfig;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -141,13 +139,6 @@ public class DeltaModule
         {
             return typeManager.getType(parseTypeSignature(value));
         }
-    }
-
-    @Singleton
-    @Provides
-    public CacheManager createCacheManager(CacheConfig cacheConfig, FileMergeCacheConfig fileMergeCacheConfig, CacheStats cacheStats)
-    {
-        return new NoOpCacheManager();
     }
 
     @ForCachingHiveMetastore

--- a/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaSplit.java
+++ b/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaSplit.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.delta;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -37,7 +38,8 @@ public class TestDeltaSplit
                 0,
                 200,
                 500,
-                ImmutableMap.of("part1", "part1Val"));
+                ImmutableMap.of("part1", "part1Val"),
+                NodeSelectionStrategy.NO_PREFERENCE);
 
         String json = codec.toJson(expected);
         DeltaSplit actual = codec.fromJson(json);


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Using the delta catalog access the delta table with the following delta.properties.

```
connector.name=delta
hive.metastore.uri=thrift://localhost:9083
cache.enabled=true
cache.type=ALLUXIO
cache.base-directory=file:///tmp/alluxio
cache.alluxio.max-cache-size=1GB
hive.node-selection-strategy=SOFT_AFFINITY
```

Cache hit rate metrics to check -
```
SELECT * from jmx.current."com.facebook.alluxio:name=client.cachehitrate.presto,type=gauges";
```

== RELEASE NOTES ==

Delta Changes
* Add Data cache support for Delta Connector