### PR TITLE
Add units for Alluxio metrics

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -19,6 +19,8 @@ import alluxio.client.quota.CacheScope;
 import com.facebook.presto.hive.HiveFileContext;
 import com.google.common.collect.ImmutableMap;
 
+import static com.facebook.presto.common.RuntimeUnit.BYTE;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static java.util.Objects.requireNonNull;
 
@@ -43,6 +45,7 @@ public class PrestoCacheContext
         }
         return context;
     }
+
     private PrestoCacheContext(HiveFileContext hiveFileContext)
     {
         this.hiveFileContext = requireNonNull(hiveFileContext, "hiveFileContext is null");
@@ -51,7 +54,16 @@ public class PrestoCacheContext
     @Override
     public void incrementCounter(String name, StatsUnit unit, long value)
     {
-        hiveFileContext.incrementCounter(name, NONE, value);
+        switch (unit) {
+            case BYTE:
+                hiveFileContext.incrementCounter(name, BYTE, value);
+                break;
+            case NANO:
+                hiveFileContext.incrementCounter(name, NANO, value);
+                break;
+            default:
+                hiveFileContext.incrementCounter(name, NONE, value);
+        }
     }
 
     public HiveFileContext getHiveFileContext()


### PR DESCRIPTION
Following up on #18174, this change fixes the units for RuntimeMetrics CacheBytesReadCache/CacheBytesRequestedExternal:

![image](https://user-images.githubusercontent.com/4384058/209871140-496cff95-0cee-455f-86ad-68e006ebb528.png)
![image](https://user-images.githubusercontent.com/4384058/209871148-a71a8f3a-9aba-4dcd-9699-a63d927f10bb.png)


```
== NO RELEASE NOTE ==
```
