### PR TITLE
Fix bug in CombineApproxPercentileFunctions with duplicate aggregation expressions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCombineApproxPercentileFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCombineApproxPercentileFunctions.java
@@ -232,4 +232,19 @@ public class TestCombineApproxPercentileFunctions
                     }
                 })).doesNotFire();
     }
+
+    @Test
+    public void testWithDuplicate()
+    {
+        tester().assertThat(new CombineApproxPercentileFunctions(getMetadata().getFunctionAndTypeManager()))
+                .on(p -> p.aggregation(af -> {
+                    p.variable("col", BIGINT);
+                    af.globalGrouping()
+                            .addAggregation(p.variable("approx_percentile_1"), p.rowExpression("approx_percentile(col, 0.1)", ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE))
+                            .addAggregation(p.variable("approx_percentile_2"), p.rowExpression("approx_percentile(col, 0.1)", ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE))
+                            .addAggregation(p.variable("approx_percentile_3"), p.rowExpression("approx_percentile(col, 0.2)", ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE))
+                            .addAggregation(p.variable("approx_percentile_4"), p.rowExpression("approx_percentile(col, 0.2)", ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE))
+                            .source(p.values(p.variable("col")));
+                })).doesNotFire();
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6156,7 +6156,9 @@ public abstract class AbstractTestQueries
                 "   approx_percentile(totalprice, 2, 0.5)," +
                 "   approx_percentile(totalprice, 2, 0.8)," +
                 "   approx_percentile(totalprice, 2, 0.4, 0.001)," +
-                "   approx_percentile(totalprice, 2, 0.7, 0.001)\n" +
+                "   approx_percentile(totalprice, 2, 0.7, 0.001)," +
+                "   approx_percentile(orderkey, 0.9)," +
+                "   approx_percentile(orderkey, 0.8+0.1)\n" +
                 "FROM orders\n" +
                 "GROUP BY orderstatus");
 
@@ -6172,6 +6174,8 @@ public abstract class AbstractTestQueries
             Double totalPrice08Weighted = (Double) row.getField(8);
             Double totalPrice04WeightedAccuracy = (Double) row.getField(9);
             Double totalPrice07WeightedAccuracy = (Double) row.getField(10);
+            Long orderKey09v1 = ((Number) row.getField(11)).longValue();
+            Long orderKey09v2 = ((Number) row.getField(12)).longValue();
 
             List<Long> orderKeys = Ordering.natural().sortedCopy(orderKeyByStatus.get(status));
             List<Double> totalPrices = Ordering.natural().sortedCopy(totalPriceByStatus.get(status));
@@ -6206,6 +6210,12 @@ public abstract class AbstractTestQueries
 
             assertTrue(totalPrice07WeightedAccuracy >= totalPrices.get((int) (0.69 * totalPrices.size())));
             assertTrue(totalPrice07WeightedAccuracy <= totalPrices.get((int) (0.71 * totalPrices.size())));
+
+            assertTrue(orderKey09v1 >= orderKeys.get((int) (0.89 * orderKeys.size())));
+            assertTrue(orderKey09v1 <= orderKeys.get((int) (0.91 * orderKeys.size())));
+
+            assertTrue(orderKey09v2 >= orderKeys.get((int) (0.89 * orderKeys.size())));
+            assertTrue(orderKey09v2 <= orderKeys.get((int) (0.91 * orderKeys.size())));
         }
     }
 


### PR DESCRIPTION
The current implementation assumes that there are no duplicate aggregation expressions, which does not hold in some cases. To solve this problem, I need to either 1) fix the code to take care of the duplicates or 2) filter these aggregations which have duplicates. Since approach 1 will complicate the code and it's not a common case, I decided to take approach 2 to filter out these aggregations to fix the bug.

Test plan - (Please fill in how you tested your changes)

Add unit tests.

```
== RELEASE NOTES ==

General Changes
* Fix bug in CombineApproxPercentileFunctions optimization. 
   It fix the bug where the CombineApproxPercentileFunctions optimization rule fails when there are duplicate aggregation expressions to be optimized.

