### PR TITLE
[native] Fix crash in window queries without ORDER BY clause

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1855,12 +1855,14 @@ VeloxQueryPlanConverter::toVeloxQueryPlan(
 
   std::vector<core::FieldAccessTypedExprPtr> sortFields;
   std::vector<core::SortOrder> sortOrders;
-  auto nodeSpecOrdering = node->specification.orderingScheme->orderBy;
-  sortFields.reserve(nodeSpecOrdering.size());
-  sortOrders.reserve(nodeSpecOrdering.size());
-  for (const auto& spec : nodeSpecOrdering) {
-    sortFields.emplace_back(exprConverter_.toVeloxExpr(spec.variable));
-    sortOrders.emplace_back(toVeloxSortOrder(spec.sortOrder));
+  if (node->specification.orderingScheme) {
+    auto nodeSpecOrdering = node->specification.orderingScheme->orderBy;
+    sortFields.reserve(nodeSpecOrdering.size());
+    sortOrders.reserve(nodeSpecOrdering.size());
+    for (const auto& spec : nodeSpecOrdering) {
+      sortFields.emplace_back(exprConverter_.toVeloxExpr(spec.variable));
+      sortOrders.emplace_back(toVeloxSortOrder(spec.sortOrder));
+    }
   }
 
   std::vector<std::string> windowNames;


### PR DESCRIPTION
Presto-to-Velox plan conversion logic didn't handle the case of 
window clause without ORDER BY causing a crash.