### PR TITLE
Add S3 Select pushdown for JSON files

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectDataType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectDataType.java
@@ -15,5 +15,6 @@ package com.facebook.presto.hive.s3select;
 
 public enum S3SelectDataType
 {
-    CSV
+    CSV,
+    JSON;
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectJsonRecordReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectJsonRecordReader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3select;
+
+import com.amazonaws.services.s3.model.InputSerialization;
+import com.amazonaws.services.s3.model.JSONInput;
+import com.amazonaws.services.s3.model.JSONOutput;
+import com.amazonaws.services.s3.model.JSONType;
+import com.amazonaws.services.s3.model.OutputSerialization;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.util.Properties;
+
+public class S3SelectJsonRecordReader
+        extends S3SelectLineRecordReader
+{
+    public S3SelectJsonRecordReader(Configuration configuration,
+            HiveClientConfig clientConfig,
+            Path path,
+            long start,
+            long length,
+            Properties schema,
+            String ionSqlQuery,
+            PrestoS3ClientFactory s3ClientFactory)
+    {
+        super(configuration, clientConfig, path, start, length, schema, ionSqlQuery, s3ClientFactory);
+    }
+
+    @Override
+    protected InputSerialization buildInputSerialization()
+    {
+        // JSONType.LINES is the only JSON format supported by the Hive JsonSerDe.
+        JSONInput selectObjectJSONInputSerialization = new JSONInput();
+        selectObjectJSONInputSerialization.setType(JSONType.LINES);
+
+        InputSerialization selectObjectInputSerialization = new InputSerialization();
+        selectObjectInputSerialization.setCompressionType(getCompressionType());
+        selectObjectInputSerialization.setJson(selectObjectJSONInputSerialization);
+
+        return selectObjectInputSerialization;
+    }
+
+    @Override
+    protected OutputSerialization buildOutputSerialization()
+    {
+        OutputSerialization selectObjectOutputSerialization = new OutputSerialization();
+        JSONOutput selectObjectJSONOutputSerialization = new JSONOutput();
+        selectObjectOutputSerialization.setJson(selectObjectJSONOutputSerialization);
+
+        return selectObjectOutputSerialization;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectLineRecordReaderProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectLineRecordReaderProvider.java
@@ -39,6 +39,8 @@ public class S3SelectLineRecordReaderProvider
         switch (dataType) {
             case CSV:
                 return Optional.of(new S3SelectCsvRecordReader(configuration, clientConfig, path, start, length, schema, ionSqlQuery, s3ClientFactory));
+            case JSON:
+                return Optional.of(new S3SelectJsonRecordReader(configuration, clientConfig, path, start, length, schema, ionSqlQuery, s3ClientFactory));
             default:
                 // return empty if data type is not returned by the serDeMapper or unrecognizable by the LineRecordReader
                 return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectRecordCursorProvider.java
@@ -98,7 +98,7 @@ public class S3SelectRecordCursorProvider
         if (s3SelectDataTypeOptional.isPresent()) {
             S3SelectDataType s3SelectDataType = s3SelectDataTypeOptional.get();
 
-            IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
+            IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager, s3SelectDataType);
             String ionSqlQuery = queryBuilder.buildSql(columns, effectivePredicate);
             Optional<S3SelectLineRecordReader> recordReader = S3SelectLineRecordReaderProvider.get(configuration, clientConfig, path, fileSplit.getStart(), fileSplit.getLength(), schema, ionSqlQuery, s3ClientFactory, s3SelectDataType);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectSerDeDataTypeMapper.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectSerDeDataTypeMapper.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.s3select;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.apache.hive.hcatalog.data.JsonSerDe;
 
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +25,8 @@ public class S3SelectSerDeDataTypeMapper
     // Contains mapping of SerDe class name to corresponding data type.
     // Multiple SerDe classes can be mapped to the same data type.
     private static final Map<String, S3SelectDataType> SERDE_TO_DATA_TYPE_MAPPING = ImmutableMap.of(
-            LazySimpleSerDe.class.getName(), S3SelectDataType.CSV);
+            LazySimpleSerDe.class.getName(), S3SelectDataType.CSV,
+            JsonSerDe.class.getName(), S3SelectDataType.JSON);
 
     private S3SelectSerDeDataTypeMapper() {}
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestIonSqlQueryBuilder.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestIonSqlQueryBuilder.java
@@ -46,6 +46,8 @@ import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.HIVE_TIMESTAMP;
+import static com.facebook.presto.hive.s3select.S3SelectDataType.CSV;
+import static com.facebook.presto.hive.s3select.S3SelectDataType.JSON;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static org.testng.Assert.assertEquals;
 
@@ -54,32 +56,45 @@ public class TestIonSqlQueryBuilder
     @Test
     public void testBuildSQL()
     {
-        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager());
         List<HiveColumnHandle> columns = ImmutableList.of(
                 new HiveColumnHandle("n_nationkey", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty(), Optional.empty()),
                 new HiveColumnHandle("n_name", HIVE_STRING, parseTypeSignature(VARCHAR), 1, REGULAR, Optional.empty(), Optional.empty()),
                 new HiveColumnHandle("n_regionkey", HIVE_INT, parseTypeSignature(INTEGER), 2, REGULAR, Optional.empty(), Optional.empty()));
 
+        // CSV
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), CSV);
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s",
                 queryBuilder.buildSql(columns, TupleDomain.all()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 columns.get(2), Domain.create(SortedRangeSet.copyOf(BIGINT, ImmutableList.of(Range.equal(BIGINT, 3L))), false)));
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE (case s._3 when '' then null else CAST(s._3 AS INT) end = 3)",
                 queryBuilder.buildSql(columns, tupleDomain));
+
+        // JSON
+        queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), JSON);
+        assertEquals(queryBuilder.buildSql(columns, TupleDomain.all()),
+                "SELECT s.n_nationkey, s.n_name, s.n_regionkey FROM S3Object s");
+        assertEquals(queryBuilder.buildSql(columns, tupleDomain),
+                "SELECT s.n_nationkey, s.n_name, s.n_regionkey FROM S3Object s " +
+                        "WHERE (case s.n_regionkey when '' then null else CAST(s.n_regionkey AS INT) end = 3)");
     }
 
     @Test
     public void testEmptyColumns()
     {
-        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager());
+        // CSV
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), CSV);
         assertEquals("SELECT ' ' FROM S3Object s", queryBuilder.buildSql(ImmutableList.of(), TupleDomain.all()));
+
+        // JSON
+        queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), JSON);
+        assertEquals(queryBuilder.buildSql(ImmutableList.of(), TupleDomain.all()), "SELECT ' ' FROM S3Object s");
     }
 
     @Test
     public void testDecimalColumns()
     {
         TypeManager typeManager = createTestFunctionAndTypeManager();
-        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
                 new HiveColumnHandle("quantity", HiveType.valueOf("decimal(20,0)"), parseTypeSignature(DECIMAL), 0, REGULAR, Optional.empty(), Optional.empty()),
                 new HiveColumnHandle("extendedprice", HiveType.valueOf("decimal(20,2)"), parseTypeSignature(DECIMAL), 1, REGULAR, Optional.empty(), Optional.empty()),
@@ -90,29 +105,44 @@ public class TestIonSqlQueryBuilder
                         columns.get(0), Domain.create(ofRanges(Range.lessThan(DecimalType.createDecimalType(20, 0), longDecimal("50"))), false),
                         columns.get(1), Domain.create(ofRanges(Range.equal(HiveType.valueOf("decimal(20,2)").getType(typeManager), longDecimal("0.05"))), false),
                         columns.get(2), Domain.create(ofRanges(Range.range(decimalType, shortDecimal("0.0"), true, shortDecimal("0.02"), true)), false)));
+
+        // CSV
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager, CSV);
+
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE ((case s._1 when '' then null else CAST(s._1 AS DECIMAL(20,0)) end < 50)) AND " +
                         "(case s._2 when '' then null else CAST(s._2 AS DECIMAL(20,2)) end = 0.05) AND ((case s._3 when '' then null else CAST(s._3 AS DECIMAL(10,2)) " +
                         "end >= 0.00 AND case s._3 when '' then null else CAST(s._3 AS DECIMAL(10,2)) end <= 0.02))",
                 queryBuilder.buildSql(columns, tupleDomain));
+
+        // JSON
+        queryBuilder = new IonSqlQueryBuilder(typeManager, JSON);
+        assertEquals(queryBuilder.buildSql(columns, tupleDomain),
+                "SELECT s.quantity, s.extendedprice, s.discount FROM S3Object s WHERE ((case s.quantity when '' then null else CAST(s.quantity AS DECIMAL(20,0)) end < 50)) AND " +
+                        "(case s.extendedprice when '' then null else CAST(s.extendedprice AS DECIMAL(20,2)) end = 0.05) AND ((case s.discount when '' then null else CAST(s.discount AS DECIMAL(10,2)) " +
+                        "end >= 0.00 AND case s.discount when '' then null else CAST(s.discount AS DECIMAL(10,2)) end <= 0.02))");
     }
 
     @Test
     public void testDateColumn()
     {
-        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager());
         List<HiveColumnHandle> columns = ImmutableList.of(
                 new HiveColumnHandle("t1", HIVE_TIMESTAMP, parseTypeSignature(TIMESTAMP), 0, REGULAR, Optional.empty(), Optional.empty()),
                 new HiveColumnHandle("t2", HIVE_DATE, parseTypeSignature(StandardTypes.DATE), 1, REGULAR, Optional.empty(), Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 columns.get(1), Domain.create(SortedRangeSet.copyOf(DATE, ImmutableList.of(Range.equal(DATE, (long) DateTimeUtils.parseDate("2001-08-22")))), false)));
 
+        // CSV
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), CSV);
         assertEquals("SELECT s._1, s._2 FROM S3Object s WHERE (case s._2 when '' then null else CAST(s._2 AS TIMESTAMP) end = `2001-08-22`)", queryBuilder.buildSql(columns, tupleDomain));
+
+        // JSON
+        queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), JSON);
+        assertEquals(queryBuilder.buildSql(columns, tupleDomain), "SELECT s.t1, s.t2 FROM S3Object s WHERE (case s.t2 when '' then null else CAST(s.t2 AS TIMESTAMP) end = `2001-08-22`)");
     }
 
     @Test
     public void testNotPushDoublePredicates()
     {
-        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager());
         List<HiveColumnHandle> columns = ImmutableList.of(
                 new HiveColumnHandle("quantity", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty(), Optional.empty()),
                 new HiveColumnHandle("extendedprice", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 1, REGULAR, Optional.empty(), Optional.empty()),
@@ -122,7 +152,14 @@ public class TestIonSqlQueryBuilder
                         columns.get(0), Domain.create(ofRanges(Range.lessThan(BIGINT, 50L)), false),
                         columns.get(1), Domain.create(ofRanges(Range.equal(DOUBLE, 0.05)), false),
                         columns.get(2), Domain.create(ofRanges(Range.range(DOUBLE, 0.0, true, 0.02, true)), false)));
+
+        // CSV
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), CSV);
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE ((case s._1 when '' then null else CAST(s._1 AS INT) end < 50))",
                 queryBuilder.buildSql(columns, tupleDomain));
+
+        // JSON
+        queryBuilder = new IonSqlQueryBuilder(createTestFunctionAndTypeManager(), JSON);
+        assertEquals(queryBuilder.buildSql(columns, tupleDomain), "SELECT s.quantity, s.extendedprice, s.discount FROM S3Object s WHERE ((case s.quantity when '' then null else CAST(s.quantity AS INT) end < 50))");
     }
 }


### PR DESCRIPTION
**Closing this PR and merging it with related tests PR: https://github.com/prestodb/presto/pull/18902**

Add JSON support for Hive connector with S3 Select pushdown

Similarly to CSV, enable S3 Select pushdown for Hive tables relying on JSON files stored in S3 and serialized/deserialized with `org.apache.hive.hcatalog.data.JsonSerDe`.
Small refactoring for IonSqlQueryBuilder needed to support query generation for JSON.
The pushdown logic works for base columns, aligned with CSV implementation.

The tests for JSON support are in a separate PR, as they require more changes: https://github.com/prestodb/presto/pull/18902

```
== RELEASE NOTES ==

Hive Changes
* Add Amazon S3 Select pushdown for JSON files.
```

