### PR TITLE
Fix bug in TypedSet.addAndGetPosition

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -149,7 +149,7 @@ public class TypedSet
                 containNullElements = true;
             }
             addNewElement(hashPosition, block, position);
-            return blockPositionByHash.getInt(hashPosition);
+            return blockPositionByHash.getInt(getHashPositionOfElement(block, position));
         }
 
         return currentPosition;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6247,4 +6247,10 @@ public abstract class AbstractTestQueries
         assertQuery("select cardinality(map_subset(map(array[1,2,3,4], array['a', 'b', 'c', 'd']), array[10,20]))", "select 0");
         assertQuery("select cardinality(map_subset(map(), array[10,20]))", "select 0");
     }
+
+    @Test
+    public void testMultiMapFromEntriesWihTransform()
+    {
+        assertQuerySucceeds("select multimap_from_entries(x) from (select zip(array[orderkey], array[array[custkey, custkey]]) x from (select 1 orderkey, 1 custkey))");
+    }
 }


### PR DESCRIPTION
We need to recompute the hash in typed set when a new element is added.

Test plan - added test with repro

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
