### PR TITLE
Fix bugs in duplicate items in UNNEST expression

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1681,4 +1681,10 @@ public class TestLogicalPlanner
                                 ImmutableMap.of("out", expression("json.f3.square(orderkey)")),
                                 tableScan("orders", ImmutableMap.of("orderkey", "orderkey")))));
     }
+
+    @Test
+    public void testDuplicateUnnestItem()
+    {
+        assertPlanSucceeded("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(array[2, 3], ARRAY[2, 3]) AS r(r1, r2)", this.getQueryRunner().getDefaultSession());
+    }
 }


### PR DESCRIPTION
### What's the change?

Current UNNEST node will fail if there are duplicate expressions in UNNEST, for example, query `SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(array[2, 3], ARRAY[2, 3]) AS r(r1, r2)`. This is because we use a map to store the mapping between expressions in UNNEST and output symbols. Duplicate expressions will produce the same key for the map.

In this PR, I skip the duplicate items in the unnest node, and add a projection node over the output of the UNNEST node for the output of the skipped items.

This basically is a rewrite from
`SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(array[2, 3], ARRAY[2, 3]) AS r(r1, r2)`
to
`SELECT *, r1 as r2 from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(array[2, 3]) AS r(r1)`

### Test plan - (Please fill in how you tested your changes)

Added unit test.

```
== RELEASE NOTES ==

General Changes
* Fix the bug where duplicate items in UNNEST leads to query compilation failure
```

