### PR TITLE
[native] Return the original type for null RLE block

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
@@ -262,28 +262,7 @@ velox::VectorPtr readRleBlock(
     throw std::runtime_error("Unexpected RLE block. Expected single null.");
   }
 
-  if (type->kind() == velox::TypeKind::SHORT_DECIMAL ||
-      type->kind() == velox::TypeKind::LONG_DECIMAL) {
-    return velox::BaseVector::createNullConstant(type, positionCount, pool);
-  }
-
-  velox::TypeKind typeKind;
-  if (encoding == kByteArray) {
-    typeKind = velox::TypeKind::UNKNOWN;
-  } else if (encoding == kLongArray) {
-    typeKind = velox::TypeKind::BIGINT;
-  } else if (encoding == kIntArray) {
-    typeKind = velox::TypeKind::INTEGER;
-  } else if (encoding == kShortArray) {
-    typeKind = velox::TypeKind::SMALLINT;
-  } else if (encoding == kVariableWidth) {
-    typeKind = velox::TypeKind::VARCHAR;
-  } else {
-    VELOX_FAIL("Unexpected RLE block encoding: {}", encoding);
-  }
-
-  return velox::BaseVector::createConstant(
-      velox::variant(typeKind), positionCount, pool);
+  return velox::BaseVector::createNullConstant(type, positionCount, pool);
 }
 
 void unpackTimestampWithTimeZone(

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
@@ -100,7 +100,7 @@ TEST_F(Base64Test, singleNull) {
 
   auto vector = readBlock(BIGINT(), data, pool_.get());
 
-  ASSERT_EQ(TypeKind::UNKNOWN, vector->typeKind());
+  ASSERT_EQ(TypeKind::BIGINT, vector->typeKind());
   ASSERT_EQ(1, vector->size());
   ASSERT_TRUE(vector->isNullAt(0));
 }
@@ -114,7 +114,7 @@ TEST_F(Base64Test, arrayOfNulls) {
   ASSERT_EQ(1, vector->size());
 
   auto arrayVector = vector->as<ArrayVector>();
-  ASSERT_EQ(TypeKind::UNKNOWN, arrayVector->elements()->typeKind());
+  ASSERT_EQ(TypeKind::BIGINT, arrayVector->elements()->typeKind());
 
   auto elementsVector = arrayVector->elements();
   ASSERT_EQ(4, elementsVector->size());

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
@@ -154,6 +154,9 @@ abstract class TestHiveQueries
         // Double and float inequality filter
         assertQuery("SELECT SUM(discount) FROM lineitem WHERE discount != 0.04");
         assertQuery("SELECT SUM(discount_as_real) FROM lineitem WHERE discount_as_real != cast(0.1 as REAL)");
+
+        // When else clause is a null constant with Map type.
+        assertQuery("SELECT if(orderkey % 2 = 0, quantity_by_linenumber) FROM orders_ex");
     }
 
     @Test


### PR DESCRIPTION
Consider the following query: 
```
SELECT
  IF((col_str = 'foo'), col_map, null)
FROM
  (
    VALUES
        ('foo', MAP(ARRAY['bar'], ARRAY[123.456]))
) AS t(col_str, col_map)
```

The `null` inside `IF` is a ConstantExpression with type `MAP(VARCHAR, DOUBLE)`. When the CPP worker converts it to Velox expression, it refers to the map's keys/values block to get their types. In this case, the value is a RleBlock which is somehow encoded as LONG_ARRAY. So instead of using the right type DOUBLE, the type BIGINT is assigned to the expression after conversion, causing the query failure.

To fix the bug, it is needed to give the original type when reading the RLE block.

```
== NO RELEASE NOTE ==
```
