### PR TITLE
Add release notes for 0.279

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.279
     release/release-0.278.1
     release/release-0.278
     release/release-0.277

--- a/presto-docs/src/main/sphinx/release/release-0.279.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.279.rst
@@ -1,0 +1,67 @@
+=============
+Release 0.279
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug in ``CombineApproxPercentileFunctions`` optimization that caused query failures when there were duplicate aggregation expressions.
+* Fix disaggregated coordinator task limit enforcement.
+* Fix weighted fair scheduling in disaggregated coordinator.
+* Fix max(x, n) and min(x, n) returning NULL on window aggregations.
+* Add an optimization that removes redundant distinct if the output is already distinct after a group by operation. The optimization is controlled by session property ``remove_redundant_distinct_aggregation`` which is default to false.
+* Add function :func:`array_sort_desc` to sort an array in the descending order.
+* Add function :func:`map_remove_null_values` to remove all the entries where the value is null from a given map.
+* Add function :func:`map_top_n_keys` to returns an array of the top N keys of the provided map. An optional lambda comparator can also be passed to perform a custom comparison of the keys. Returns all the keys if the value N is greater than or equal to size of the map. For N < 0, the function returns keys in the reverse order. For N = 0, the function returns empty array.
+* Add function :func:`map_top_n_values` to return top N values of the provided map. An optional lambda comparator can also be passed as parameter for custom sorting of the values.
+* Add function :func:`map_top_n` to truncate map items, keeping only the top N elements by value.
+* Add function :func:`remove_nulls` to remove null elements from an array.
+* Add functions :func:`array_min_by`, :func:`array_max_by`, to find the smallest or largest element of an array when applying a custom measuring function.
+* Extend functions :func:`array_frequency`, :func:`array_duplicates`, :func:`array_has_duplicates`, :func:`array_intersect(array(array(E))` to accept any type as input instead of only varchar/double.
+* Add ``CONTROL`` as a new ``QueryType``. The ``CONTROL`` queryType represents statements of session control and transaction control types.
+* Remove two unused session parameters - ``hash_based_distinct_limit_enabled`` and ``hash_based_distinct_limit_threshold`` and the corresponding implementation in favor of the ``quick_distinct_limit_enabled`` feature.
+
+Elasticsearch Connector Changes
+_______________________________
+* Add support for Elasticsearch user and password authentication. :issue:`15909`.
+
+Hive Connector Changes
+______________________
+* Fix a bug when ``optimize_metadata_queries`` is set to true where queries with aggregations on partition columns and filters on row subfields could return wrong results.
+* Disable S3 Select pushdown when the query does not have a predicate or projection.
+
+Iceberg Connector Changes
+_________________________
+* Update Iceberg from 0.14.1 to 1.0.0.
+
+Pinot Connector Changes
+_______________________
+* Add pushdown support for function :func:`STRPOS`.
+
+PostgreSQL Connector Changes
+____________________________
+* Add support for PostgreSQL UUID Data type.
+
+Delta Lake Changes
+__________________
+* Upgrade Delta Standalone to 0.6.0.
+
+Spark Changes
+__________________
+* Add property ``spark_executor_allocation_strategy_enabled`` to auto-tune spark max executor count (``spark.dynamicAllocation.maxExecutors``)  based on input data. Only required if ``spark_resource_allocation_strategy_enabled`` is not already enabled.
+* Add property ``spark_hash_partition_count_allocation_strategy_enabled`` to auto-tune hash partition count (``hash_partition_count``) based on input data. Only required if ``spark_SPI_allocation_strategy_enabled`` is not already enabled.
+
+Open Telemetry Changes
+______________________
+* Introduce a new Open Telemetry tracer implementation. The legacy tracer module can be replaced by the new plugin for loading customized tracing infrastructure. Users are able to enable the tracer by installing the ``presto-open-telemetry`` plugin and updating the application configuration (``config.properties``). Open Telemetry tracer can take in propagated context (only B3 specification currently supported) and baggage (W3C specification) headers, if provided, and inject into new traces / spans. Traces can be exported to any specified backend with the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
+
+SPI Changes
+___________
+* Rename ``ConnectorMaterializedViewDefinition`` to  ``MaterializedViewDefinition``.
+
+**Credits**
+===========
+
+Aditi Pandit, Alex Chen, Amit Dutta, Anant Aneja, Arjun Gupta, Arunachalam Thirupathi, Asjad Syed, Avinash Jain, Beinan, Christopher Graves, Deepak Majeti, Devesh Agrawal, Eduard Tudenhoefner, Feilong Liu, Ge Gao, George Wang, Guy Moore, Hope Wang, James Petty, James Sun, Jaromir Vanek, Jingmei Huang, Jon Janzen, Josh Soref, JoshuaTang, Karteek Murthy Samba Murthy, Krishna Pai, Linkiewicz, Milosz, Linsong Wang, Lyublena Antova, MJ Deng, Masha Basmanova, Michael Shang, Nizar Hejazi, Pramod, Pranjal Shankhdhar, Pratyaksh Sharma, Pratyush Verma, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Sacha Viscaino, Sergey Pershin, Sergii Druzkin, Sreeni Viswanadha, Swapnil Tailor, Timothy Meehan, Vivek, Ying, Zac, Zhenxiao Luo, abhiseksaikia, ajantha-bhat, dnnanuti, dnskr, pen4, singcha, suheng, tanjialiang, v-jizhang, wangd, xiaoxmeng


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/18904 [native] Advance velox version. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18841 [native] Adding partial support for EquatableValueSet filter. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18839 [native] Import native and hashjoin related changes. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18830 [native] Better error message when filter conversion is not supported. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18760 [native] Minor changes in PrestoTask. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18751 [native] Fix crash in Taskmanager getResults. (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/18725 [native] Minor cosmetic change in prestotask. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18641 [native] Use velox exception instead of std exception. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/18562 [native] Allow overriding file system registration. (Merged by: Amit Dutta)

## Avinash Jain
- [ ] https://github.com/prestodb/presto/pull/18625 Adding support of MAP_TOP_N_KEYS to Presto (Merged by: Sreeni Viswanadha)

## Eduard Tudenhoefner
- [ ] https://github.com/prestodb/presto/pull/18709 Upgrade Iceberg from 1.0.0 to 1.1.0 (Merged by: Chunxu Tang)
- [ ] https://github.com/prestodb/presto/pull/18124 Re-enable Nessie namespace/table visibility tests (Merged by: Chunxu Tang)

## Ge Gao
- [ ] https://github.com/prestodb/presto/pull/18377 [native] Table writer 2: Add Presto write protocols (Merged by: Ge Gao)

## George Wang
- [ ] https://github.com/prestodb/presto/pull/18384 Improve call performance for `sync_partition_metadata` utility (Merged by: Ying)
- [ ] https://github.com/prestodb/presto/pull/18682 Enable Estimated Stats on Query Plan for Instrumentation Monitoring (Merged by: Ying)

## Guy Moore
- [ ] https://github.com/prestodb/presto/pull/18552 Prepare for next development iteration - 0.279-SNAPSHOT (Merged by: Guy ☀️ Moore)

## Jon Janzen
- [ ] https://github.com/prestodb/presto/pull/18686 [native] Fix gitattributes (Merged by: Michael Shang)

## Karteek Murthy Samba Murthy
- [ ] https://github.com/prestodb/presto/pull/18827 Advance Velox (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/18320 Decimal arithmetic and logical functions e2e tests (Merged by: Aditi Pandit)

## Linkiewicz, Milosz
- [ ] https://github.com/prestodb/presto/pull/18572 [native] PrestoCpp build from source pipeline (Merged by: Krishna Pai)

## Linsong Wang
- [ ] https://github.com/prestodb/presto/pull/18483 [18366] Create a Jenkins pipeline to build and release artifacts (Merged by: Timothy Meehan)
- [ ] 240d0b8d5b2732137a903ce5e083157b0e614fa3 Update stable release branch development version to 0.279.1-SNAPSHOT

## Lyublena Antova
- [ ] https://github.com/prestodb/presto/pull/17642 Optimize const grouping keys (Merged by: Sreeni Viswanadha)

## MJ Deng
- [ ] https://github.com/prestodb/presto/pull/18837 Fix BatchTaskUpdateRequest failures (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/18681 Add NativeExecutionProcess and facilities (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/18623 Add NativeExecutionShuffleManager for presto spark native execution (Merged by: ARUNACHALAM THIRUPATHI)

## Reetika Agrawal
- [ ] https://github.com/prestodb/presto/pull/16875 Add support for UUID in PostgreSQL connector (Merged by: Timothy Meehan)

## Vivek
- [ ] https://github.com/prestodb/presto/pull/18381 Transformations of Existential Subqueries using Early-out Joins (Merged by: Rebecca Schlussel)

## ajantha-bhat
- [ ] https://github.com/prestodb/presto/pull/18710 Bump Nessie from 0.43.0 to 0.44.0 (Merged by: Chunxu Tang)

## pen4
- [ ] https://github.com/prestodb/presto/pull/18763 fix(sec): upgrade com.google.protobuf:protobuf-java to 3.21.7 (Merged by: Rebecca Schlussel)

# Extracted Release Notes
- #16524 (Author: v-jizhang): Add support for user/password auth - Elasticsearch
  - Add support for Elasticsearch user and password authentication. :issue:`15909`.
- #18460 (Author: Sacha Viscaino): Add REMOVE_NULLS function for arrays
  - Add :func:`remove_nulls` function to remove null elements from an array.
- #18512 (Author: Feilong Liu): Remove redundant distinct over group by
  - Add an optimization which removes redundant distinct if the output is already distinct after a group by operation. The optimization is controlled by session property `remove_redundant_distinct_aggregation` which is default to false.
- #18525 (Author: Eduard Tudenhoefner): Update Iceberg from 0.14.1 to 1.0.0
  - Update Iceberg from 0.14.1 to 1.0.0.
- #18534 (Author: Alex Chen): integrate and implement open telemetry tracing
  - Introduced a new plugin type for tracing. The legacy tracer module can be replaced by the new plugin for loading customized tracing infrastructure.
  - Introduced a new Open Telemetry tracer implementation. Users are able to enable the tracer by installing the ``presto-open-telemetry`` plugin and updating the application configuration (``config.properties``). Open Telemetry tracer can take in propagated context (only B3 specification currently supported) and baggage (W3C specification) headers, if provided, and inject into new traces / spans. Traces can be exported to any specified backend with the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
- #18543 (Author: Swapnil Tailor): Fix weighted fair scheduling in disagg coordinator
  - Fix for weighted fair scheduling in disaggregated coordinator.
- #18555 (Author: Sacha Viscaino): Add ARRAY_MIN_BY, ARRAY_MAX_BY functions
  - Add functions :func:`array_min_by`, :func:`array_max_by`, to find the smallest or largest element of an array when applying a custom measuring function.
- #18561 (Author: Rohit Jain): Create QueryPreparer interface
  - Add ``CONTROL`` as a new ``QueryType``.  The CONTROL queryType represents statements of session control and transaction control types.
- #18566 (Author: Nizar Hejazi): Support STRPOS pushdown to Pinot; Fix missing configuration property pinot.query-options error
  - Add pushdown support for ``STRPOS`` function.
- #18587 (Author: Sacha Viscaino): Generalize existing SQL UDF functions to all types
  - Extend :func:`array_frequency`, :func:`array_duplicates`, :func:`array_has_duplicates`, :func:`array_intersect(array(array(E))` to accept any type as input instead of only varchar/double.
- #18595 (Author: Swapnil Tailor): Fix Disaggregated Coordinator Weighted Scheduling
  - Fix weighted scheduling for disaggregated coordinator.
- #18607 (Author: Avinash Jain): Adding support of map_top_n_values to Presto
  - Add :func:`map_top_n_values` to return top N values of the provided map. An optional lambda comparator can also be passed as parameter for custom sorting of the values.
- #18615 (Author: Sacha Viscaino): Fix MIN(x, n) and MAX(x, n) returning NULL on window aggregations
  - Fix max(x, n) and min(x, n) returning NULL on window aggregations.
- #18660 (Author: Avinash Jain): Adding support for ARRAY_SORT_DESC to Presto
  - Add :func:`array_sort_desc` function to sort an array in the descending order.
- #18675 (Author: Avinash Jain): Adding support of MAP_REMOVE_NULL_VALUES for Presto
  - Add :func:`map_remove_null_values` to remove all the entries where the value is null from the given map.
- #18680 (Author: Rohit Jain): Move ViewDefinition to presto-analyzer
  - Rename ``ConnectorMaterializedViewDefinition`` to  ``MaterializedViewDefinition``.
- #18698 (Author: Avinash Jain): Adding support of MAP_TOP_N for Presto
  - Add :func:`map_top_n` to truncates map items. Keeps only the top N elements by value.
- #18704 (Author: Rebecca Schlussel): Fix wrong results in MetadataQueryOptimizer with subfield filters
  - Fix a bug when ``optimize_metadata_queries`` was set to true where queries with aggregations on partition columns and filters on row subfields could return wrong results.
- #18716 (Author: Pratyush Verma): Add auto-tuning of max executor and hash partition
  - Add property ``spark_executor_allocation_strategy_enabled`` to auto-tune spark max executor count (``spark.dynamicAllocation.maxExecutors``)  based on input data. Only required if ``spark_resource_allocation_strategy_enabled`` is not already enabled.
  - Add property ``spark_hash_partition_count_allocation_strategy_enabled`` to auto-tune hash partition count (``hash_partition_count``) based on input data. Only required if ``spark_resource_allocation_strategy_enabled`` is not already enabled.
- #18732 (Author: Swapnil Tailor): Fix Disagg Coordinator task limit enforcement
  - Fix disagg coordinator task limit enforcement.
- #18749 (Author: Sreeni Viswanadha): Remove unused code
  - Removed two unused session params - `hash_based_distinct_limit_enabled` and `hash_based_distinct_limit_threshold` and the corresponding implementation in favor of the `quick_distinct_limit_enabled` feature.
- #18773 (Author: dnskr): Upgrade Delta Standalone to 0.6.0
  - Upgrade Delta Standalone to 0.6.0.
- #18778 (Author: dnnanuti): Disable S3 Select pushdown when the query does not filter data
  - Disable S3 Select pushdown when the query does not have a predicate or projection.
- #18889 (Author: Feilong Liu): Fix bug in CombineApproxPercentileFunctions with duplicate aggregation expressions
  - Fix bug in CombineApproxPercentileFunctions optimization. It fix the bug where the CombineApproxPercentileFunctions optimization rule fails when there are duplicate aggregation expressions to be optimized.

# All Commits
- 240d0b8d5b2732137a903ce5e083157b0e614fa3 Update stable release branch development version to 0.279.1-SNAPSHOT (Linsong Wang)
- 820b4eb314c6eefc7d3eb2a36363a87c9b89dea7 Add test dependency on presto-common to presto-benchto-benchmarks (Vivek)
- 2a7dd51de52b92bf180ae59741ce65f58f45ee30 Add Hive S3 tests for comma and pipe delimited CSVs (dnnanuti)
- 8ab844c974040fbef8292d602574c6df3fffa177 Fix bug in TypedSet.addAndGetPosition when adding a new element (Sreeni Viswanadha)
- 0bc762b37f4171645ee9294502560044c2468ebb [native] Advance velox version. (Amit Dutta)
- 4fdd16e169106e68d87f1ec6427ef83dc27d3fad Add a metastore interface to control add partition commit batch size (George Wang)
- bb88317f2992111293b744e25ca1cf0dbb10c8b0 Bypass file path check for sync partition (George Wang)
- 13109edc183d3515ad8c6507cb5309dc83811a88 Use correct API to get partition names in batch for sync partition call (George Wang)
- 3cfe62f009e1aab634aa148410f4859baf18bd0d Adding support of MAP_TOP_N for Presto (Avinash Jain)
- e7be56a1130fd259e7496e98c861007365150d8e Document public methods of SqlQueryExecution (Anant Aneja)
- a1a9299e054173ed380e1e6704310ff9c9b8e0a0 Add AdaptivePlanOptimizers class (Rebecca Schlussel)
- ab3bdf103cb7ef600ba8c3fbdf363a4460cb86c8 Add support for calculating RemoteSourceNode stats (Rebecca Schlussel)
- 48c1dbf63ace32a6f83d09c2fc05b4c1b6e8750c Better support stats that only contain total size (Rebecca Schlussel)
- 791ff32cd325a0e11e6868f69afac81e1bb271ee Remove crux analyzer artifacts (Rohit Jain)
- ad8660b9ee067616fa3f9650ae73914f7510c658 Add analyzer provider plugin (Rohit Jain)
- 001dbd525f935c6d2f178c6eb84638efc9d53b79 Remove ParsingOptions from AnalyzerOptions (Rohit Jain)
- f92c65fd068ac3d5cfd5f7a9ca78b9e59a29bc00 Cancel previous workflow runs for github actions (Josh Soref)
- e349c4ad846f9e6a241a2b7eb3bc333f6f8037b7 Fix bug in CombineApproxPercentileFunctions (Feilong Liu)
- 974bbba732d18632081cdc7e18ab7db0b484d1f3 Refactor S3 tests (dnnanuti)
- e0f637fe9c362734bb4bc3c235825ff689781a8a [native] Refactor shuffle reader to deal with only 1 partition (tanjialiang)
- 1c3e7c84324645f6efa682f23047254fa6ff1fbe Advance Velox version (xiaoxmeng)
- 94c1d72ff5353fa0d2ba60588f06eb2b104a658e Add Graphviz query plan monitoring for instrumentation (George Wang)
- a67150e1c8f1ea6c037b53a92a879bf328c18183 Add estimates to json format of the plan (George Wang)
- f817946cfe102070cd3d1f35f47bab288016c727 Add estimates to graphviz of the plan (George Wang)
- 4250b5cbe4472de78f73014d786954032dce119a Add units for Alluxio metrics (Zac)
- 78f7a7c98b425d5b836c22978b09b5bedecce67a [native] Adding partial support for EquatableValueSet filter. (Amit Dutta)
- 62945aa53239455edc26d66048fc14cfed25b385 [native]Deprecate total memory query limit as velox doesn't differentiate user and system memory (xiaoxmeng)
- cc5c323cecf69c8d40bf78e19880c4cc3a1638a0 [native] Import native and hashjoin related changes. (Amit Dutta)
- 1b2f463c8ff9e3124a17dbd5d7bec2c907e90291 Fix batch query plan convertor for non shuffle plan (MJ Deng)
- 72b8852106c580bdb50cff34b1012a942df7b331 Fix BatchTaskUpdate request URI matching order (MJ Deng)
- f00d078d5369a0f046cae10f22dd802a32a8d848 Add sdruzkin as CODEOWNER for presto-orc (Rebecca Schlussel)
- 181ec81d770dedfbc45c3db00979725b12dd1d94 Replace sun.reflect...NotImplementedException with UnsupportedOperationException (Sergii Druzkin)
- 3839ee08cc6b6d5ad99d94b2bdc5a80dfd1ef313 [native] Move shuffle name to shuffle factory (tanjialiang)
- e258434b94bb227d2a409273c006a3e3dfc4bf84 [native] Remove const specifier from hasNext in ShuffleReader (tanjialiang)
- bb3794d72ba2b807cc455861ddc6c181ead01af3 Fix storage descriptor test cases (Pratyaksh Sharma)
- db015ec95133d62fa27f7f9b5e75a6e18223a65a [native] Update code that sets up the task spill directory. (Sergey Pershin)
- 017d65c08eb782b50e1ece3b659e343ace661341 Fix leaked query count reporting in the disagg coordinators codepath (Devesh Agrawal)
- 15788ac24c87a20ae731b4c92df20860f6890e12 Fix bug in CBO stats (Pranjal Shankhdhar)
- c4401f62bd01c39580806fac37e36224b0a3c4d5 [native] Better error message when filter conversion is not supported. (Amit Dutta)
- cd41eb1235b7a0e101b3c518ba4b9c8aa210bce9 Advance Velox (Karteek Murthy Samba Murthy)
- 1c4822c00bb9ae298bc920ce71b1bed1e6c361c1 Add support for user/password auth (v-jizhang)
- cb569f1abc579277ba3d7c3da6ed193593ab511c Use assertj for query assertions (v-jizhang)
- f6a0a03b087d7d5c80dab72fba1000eceb6e5f61 Add a constructor to QueryAssertions (v-jizhang)
- 13ca62fc6ee66b4893e424046ee325b34cb44c61 Add instructions on how to start Elasticsearch (v-jizhang)
- 881a6160fcb6c19b50f892edf02d248cb898310b Migrate Elasticsearch tests to testcontainers (v-jizhang)
- 03938b401755f38affa30f400a5281684c311be8 Add support for UUID in PostgreSQL connector (Reetika Agrawal)
- f0e39cba74c29080280d22228ee447490dbd987e Fix catalog config resource lost on hudi mor read (suheng)
- 05688c7592fa9b6eb42d3a2c6020e0f5bef93c4e update com.google.protobuf:protobuf-java 3.19.2 to 3.21.7 (pen4)
- ddca5d1f922034a01a53056d230d23f8a8fee931 Add auto-tuning of max executor and hash partition (Pratyush Verma)
- 3b05e3285febc8ee26103a5adf6c79615ef184cd [velox] Generate Task spilling directory. (Sergey Pershin)
- 760a0ea027ebe2934b8a39d217b472a64e372761 Remove negative test cases (Karteek Murthy Samba Murthy)
- d572b09e019ef9df4cc8544011afe00210e98b7d Decimal arithmetic and logical functions e2e tests (Karteek Murthy Samba Murthy)
- 755567697356f562044cc0e9606c951d37afeeeb Add an optimizer for AQE for swapping join sides (Rebecca Schlussel)
- 1582da049c8ea052aab68ea34941e61efa8c4bf3 Upgrade Delta Standalone to 0.6.0 (dnskr)
- a7f066651fb19d0a1aa0070d37aed61a2ef8cef0 Advance velox version with memory back out (xiaoxmeng)
- 2d8839b71dd77ebb4bb10c9831e3862973587eb5 Add a session property enabling DWRF flat map writer (Sergii Druzkin)
- 5a7e3256819f7cb7bf531447c83b53040c589d5e Add DDL support for Alpha format (Sergii Druzkin)
- 07b00d20d80b38f322defb8ebf1b790cee96caef Fix bug in test TestCursorProcessorCompiler (wangd)
- 39841469aa1d5dd8b153d315f5aa1fc2f67521d8 Table writer 3: Adapt to renaming of FileSink (Ge Gao)
- 28ca22bf984ee4fb349941d251aca886239ae294 Remove unused classes (Vivek)
- 367cf032fa0b031229f263f1ec56aef209492528 [native] Advance Velox version. (Sergey Pershin)
- dd5ae3bd7a572f1c66d25b303af49fb3c2ab0802 Introduce PrestoSparkProperties for PrestoSparkRunner (Jaromir Vanek)
- 9c5970dc5fda0a9197f225aaead149194541bdc0 Adding support of MAP_REMOVE_NULL_VALUES for Presto (Avinash Jain)
- 6af6af692e8f4405247b3fee511d635764667a5c Abstract the NativeExecutionProcessFactory to be a pluggable interface (MJ Deng)
- d1a0bce2262c1c65cfaaf6d0c55c7d5ebc824e63 Add TypedSet.addAndGetPosition for use in MultiMapFromEntries (Sreeni Viswanadha)
- 57a32524d9f54e9c6ef53d87b4155bedfd2e934c [native] Temporarily disable the spilling test in TaskManagerTest (Sergey Pershin)
- da9f26081a08774f34dfc9528636c00b2c458a14 Disable S3 Select pushdown when the query does not filter data (dnnanuti)
- 40d84a406553fae46e1fed53f89ff0956855e678 Optimize plan hashing in case of union/join nodes (Pranjal Shankhdhar)
- 5a31a49da30084f44cf297f53d2030ea585d19a0 [native] Update Velox version (tanjialiang)
- 800baa5fbd66f9b4e31e979fd23cb077435dae92 [native] Add virtual destructor for ShuffleInterfaceFactory (tanjialiang)
- 95cc942a3d7ef4ed5f6c9197f1510fac17f305a4 [native] Remove readyForRead() as it is not used (tanjialiang)
- 0725d5bbd7ffcfe30a708430ddf705c429a22086 Resolve "Unknown file extension" license-maven-plugin warnings (dnskr)
- 17acbebd71af53d88008adf8ba94c1d2842ad479 [native] Split ShuffleInterface to ShuffleReadInterface and ShuffleWriteInterface (tanjialiang)
- 9e010a7070bdf76ccf9f81ef57e6a2c251f1ad55 Optimize mapToMapCast for common cases (Sreeni Viswanadha)
- 717f74bce5daeca0edb8b28b387b0ae9c308bf0e Optimize TypeSet contains/add pattern (Arunachalam Thirupathi)
- 313b7a0c90c7a561671a8d06e2e83d99c2058787 [native] Fix shuffle code for buck build and cleanup (tanjialiang)
- 2744f0ee04fc17189ecf644258b29f36b7c6e7fa Fix Disagg Coordinator task limit enforcement (Swapnil Tailor)
- 8ba44bec2c887b469fe8dbae11a406dc831b9b04 Minify the router UI (JoshuaTang)
- d17e99ed560339d60eff2c6fe41581f44b9c23e0 Add shangxinli as CODEOWNER for Parquet (Timothy Meehan)
- b3d7cf47b50747922b06dbfd2c266a3ba5eee557 [native] Update velox version (tanjialiang)
- f760a0a5717bf416944048fb06e277b1fac9abaa [native] Move construction of ShuffleInterface for write in operator (tanjialiang)
- 1abb2fc064378624fd578e55118131cd7ddd99b1 [native] Add batch task update http endpoint (tanjialiang)
- b111eaa587c7dde7eea8a352a0b8bd91d551f977 [native] Add batch read exchange source creation (tanjialiang)
- 7d22bc0e5beae0926fa3ae43de6d0a5168c9ba5b [native] Add batch task creation logic for shuffle write (tanjialiang)
- 0dabcc7d0202d5097dd7e2bcd10558d0d1a48ad5 [native] Add shuffle write path plan conversion in PrestoToVeloxQueryPlan (tanjialiang)
- 670ae5b10aaac3041dc5f493a8add721524784d6 [native] Shuffle related entities should have shared ownership to ShuffleInterface (tanjialiang)
- 51c51c4294bce8ac80f77cd01b0cebfa1b38f832 [native] Change PartitionAndSerialize to have pass in partition function (tanjialiang)
- 73ad442d000808e8b1f6a41b25202371879b0238 [native] Add LocalShuffleDeserializer (tanjialiang)
- 0271efdbb4fecd13cc7e584846d54762307ed820 [native] Add shuffle interface registration framework (tanjialiang)
- 3d2ac5aa501063c482c3d7be9f27a20f43eeb00f [native] Minor refactor on TestingPersistentShuffle (tanjialiang)
- ad30c8f37ae10e8d1e715b5287fa8626f848207d Revert "Fix ROUND() returning incorrect results for edge cases" (Jingmei Huang)
- cf349fbf3363beccd7897debc030ccfc5c26412a Remove duplicate MISSING_TABLE errorcode (Rohit Jain)
- 524df392b5806c1163c3e49c2cd73a47a9c2169e [native] Use "experimental.spiller-spill-path" config property. (Sergey Pershin)
- 9b74150360bfae5265bb9c25f3c0d637b7b550d1 Create s3select package for presto-hive (dnnanuti)
- 2d046446e5bc7610f4842e26a8f7e889033fcc95 Adding Glue catalog configuration in Iceberg document (Reetika Agrawal)
- b8357f4f7552a98de14f03d395751d5c1d42a308 [native] Fix 'spilling' Runtime Metrics. (Sergey Pershin)
- 128df8312e086ae007d519e6f2c72a17b99b5133 Add types method in metadataResolver (Rohit Jain)
- a586c9064d2171ef72e7ef3f99ec2fe18893c80f [native] Minor changes in PrestoTask. (Amit Dutta)
- b12080ed31da999f13f3eb8ae2cf77e3b0eddff9 Optimize copyPositions method in DictionaryBlock (Arunachalam Thirupathi)
- 1cb5fff934b6b1a0d5f7f80c886dc27212ea66ee Add dummy crux analyzer (Rohit Jain)
- b80831f06a0416af7386b95b093df7f986db115e [native] Fix crash in Taskmanager getResults. (Amit Dutta)
- c9482cd82c2fa60624f7f8e971ac4180b8825845 Upgrade Iceberg from 1.0.0 to 1.1.0 (Eduard Tudenhoefner)
- bc3f6ec8bf9210c6de105cd1d60606c9d039ec10 Address bug in flushing broadcast table to temp storage (Arjun Gupta)
- d68a7ee739a116fcfb835b12211062b64ad25af6 [native] Advance velox version and update memory usage (xiaoxmeng)
- a032115d57df0e3cd9997c92feda6eeb85b4fe28 [native] some trivial  code cleanup (xiaoxmeng)
- 48a7d5f477d7d1c462a0a95e5a174c63d9bb623b Update the BatchTaskUpdateRequest structure to remove the ShuffleReadInfo field (MJ Deng)
- 97a6e44f867a5d4542f3701862858afeaf67136d Fix a typo in a json_parse example (Zac)
- 8860ea491370b451c951831776b0998ab07ebfd9 Integrate native process with NativeExecutionOperator (MJ Deng)
- 2c1d4023c88694ddf082b744f96d99f8fb38b7cc implement open telemetry tracing plugin (Alex Chen)
- d9c2c0abd4c82a3d86f0850760c6c83b6446fd87 Remove unused code. (Sreeni Viswanadha)
- a39e7c9b13927a3903952e3fbcc5962c4e70a5d1 Implement fragmented execution (singcha)
- ef401448c3488bbd5d131b2e78a221e665292bb1 [native] Fix gitattributes (Jon Janzen)
- 2ad80f01674be890bdd7fb79a3776ac35d38d01a Update with velox memory management (xiaoxmeng)
- 35aa790c1de84501ac82e78f266c0fa2c052720d Refactor json file based function manager (Feilong Liu)
- 43e52ae4e0f597817eee4b3fc5dc4de331c8073a Bump Nessie from 0.43.0 to 0.44.0 (ajantha-bhat)
- 1fedf48a2920b305201733ea1c0fb2acf22d29b7 Add MetadataResolver interface (Rohit Jain)
- fc9769035a2d220b32ff41e83e52677e1e1a2f9b Support HBO for presto on spark (Pranjal Shankhdhar)
- 7f5f2192f0da2bc95889ce38e320b16ba1d753c6 Use exact size when using history based statistics (Pranjal Shankhdhar)
- 20c06c36670015ed6d963157dfc7be05d1cb3366 Log when MetadataPlanOptimizer triggers (Rebecca Schlussel)
- 82441f5ef3d6f38dc61428db20039d9dc95dae1f Fix wrong results in MetadataQueryOptimizer with subfield filters (Rebecca Schlussel)
- bffedbb54dd16b104e6b51fe1dd9420883261adb Bash common.sh memory_gb_preflight_check() added (Linkiewicz, Milosz)
- 225471d20d99aeb7318663d9395b5fa80013ca54 Folly build from source fix. (Linkiewicz, Milosz)
- 88b0d494f2724bef83c14ff996e281cfac25abf6 entrypoint.sh - defaults all required runtime parameters when no commandline flags provided nor config file mounted. (Linkiewicz, Milosz)
- bffd8c6a9e36c474c4d8b1e05be0e5182e9373bc [native] PrestoCpp build from source pipeline (Linkiewicz, Milosz)
- eeb5a7daef064b0343d2783b69b2c5fe349750d2 Add NativeExecutionProcess and facilities (MJ Deng)
- 558677e54cbf2272a4df4a0c7570eedb9be6c8c3 Re-enable Nessie namespace/table visibility tests (Eduard Tudenhoefner)
- b50a353cfb9de65dfd25741f838688d23ab9696c [native] Minor cosmetic change in prestotask. (Amit Dutta)
- 7aa8e2fc736a683444e4dcc80c576c4588061fc0 [native] Add new query runtime metrics (spilling & # of drivers). (Sergey Pershin)
- fd4ad2a66603a1fced28c40890627d636ba0fb31 Upgrade alluxio to 2.9.0 (Hope Wang)
- bcf306058df2d9f6ac299d72baef1ad2f3601c8c Add name for prestor executors (xiaoxmeng)
- 20e6b25e90828dd6db49ef89e7750bc9dc75d743 Rename ConnectorMaterializedViewDefinition (Rohit Jain)
- bc898d164477bfd7ffc8c71142e607424f3feaee Move ViewDefinition to presto-analyzer (Rohit Jain)
- 5a7e10d46823ce04cf768c9d97beb14aa94efa06 Add NativeExecutionShuffleManager for presto spark native execution (MJ Deng)
- f806a0e7250bcc82e4a756f36a5f0087c26b869b Fix last scheduling cycle run time metric (Swapnil Tailor)
- 3deb0b4eccaa1969368928d6bf8a8c7ef3a84629 [native] Rename two Presto operators in operator stats. (Sergey Pershin)
- ac3e41e09050fce14190394135c0706ab2a9f067 Add support for retrieving table by TableHandle (Arunachalam Thirupathi)
- c4cf3fadac59bd60307222df28b55c61769743a4 Move HiveTableHandle from presto-hive to presto-hive-metastore (Arunachalam Thirupathi)
- 2d0e5bcb775adeac619e71b69603ce05d913f2c4 Add HiveTableHandle to HiveTableLayoutHandle (Arunachalam Thirupathi)
- a1175e3662dedcd590da719ffef4e8a439273a8a Optimize slice function (Sreeni Viswanadha)
- 71b391111e888cd6242807ada11ac24f92f367fb Avoid footer stats when not reliable (abhiseksaikia)
- 3fc62731e0e955036160eba8ab16d3386802d139 [native] Fix license headers (tanjialiang)
- 31bb7b890c8e2a474b8b41c73aa65536d1377ea2 [native] Add comments to shuffle related codebase (tanjialiang)
- 374c7768d7c8af916642a0411d70b253f5907671 Log rules triggered per query in iterative optimizer (Feilong Liu)
- d391a05b065ef59d8c95d77eecd5a4d2489cc7d5 Fix Hudi queries from S3 table when using hive connector (Pratyaksh Sharma)
- 7c1c9a4349e6749b4fb41f79046efb1662e59282 Update DROP Table example in Delta document (Reetika Agrawal)
- e126d8dc220e22aa24a865e4528dc30d6fc20448 Fix a typo in CBO doc (v-jizhang)
- ba08fac130c03a5e78d08175b72cd561954d1983 Adding support of MAP_TOP_N_VALUES to Presto (Avinash Jain)
- 6309d418f581a65bf182e623c0d645fefdd6aa4d Add IterativePlanFragmenter (Rebecca Schlussel)
- 4ab31747b30dcb3e0a27f03e31caf1b73ec0fcc4 Add equals/hashcode for StatsAndCost and StageExecutionDescriptor (Rebecca Schlussel)
- ce413c84ba1fb9970362ce8e274a97a1bfb9ce08 Move common plan fragmenting code to common classes (Rebecca Schlussel)
- 88076b399cc32657356addd5e256f4d35e84161e Extract public methods/classes for plan fragmenting (Rebecca Schlussel)
- 00e721ac4d78c5901f293b34c646ac4c87c33baa Extract GroupedExecutionTagger to a top level class (Rebecca Schlussel)
- 093b3b4112b9af2354601018de3634d7a89ea423 Refactor HiveTableLayoutHandle (Arunachalam Thirupathi)
- 02fec80f204e92ea83b6c50d5072f86916d72828 [native] Change PrestoExchangeSourceTest::waitForDeleteResults to wait longer (tanjialiang)
- e6d644540ed0abc44e268265ef998c822018945a Add Json file based function namespace manager (Feilong Liu)
- a90bc6ee25b4badcefa9eb81c52d30e2dd0f37f0 Add CPP UDF type (Feilong Liu)
- fc13d26983688ed9d4c91e239bb442cc9ab778de [native] Fix presto_protocol README headers (Deepak Majeti)
- 0fd614ba75ffc35ad06cd2077ae3937c8a2aaac6 [native] Include FBTHRIFT system path in CMakeList.txt (Ge Gao)
- ac56a5acd037d6082639e3cba823262011e5487f [native] Improve presto_protocol README (Deepak Majeti)
- 05072ca09aa25b5ba68d124bb5c4db3a4330abae Advance velox version and use consolidated memory pool (xiaoxmeng)
- 7d5fa52accb6605219adce7f060ea74001becdd5 [native] Add BatchTaskUpdateRequest to native execution protocol (tanjialiang)
- 5b1f2ddef7d03568941fab44daeb9c4cc7cfaaf9 Transformations of Existential Subqueries using Early-out Joins (Vivek)
- d21bbc2f91662bbccd191ede4c6a3f83ab8512c7 Add LogicalProperty canBeHomogenized that determines whether one set of intermediate plan expressions can be realized using another set (Vivek)
- c78a75a4983fdd0dc265e5cd3b2d2da5a9bdaf89 Add information about Presto native and Velox (Krishna Pai)
- c329c3838e423d3f0653a9274228eb3adfd1a616 [native] Add Presto write protocols (Ge Gao)
- 19a9bb8a516ced26c8528f50b5d3f4cfa9d245a1 Adding support of ARRAY_SORT_DESC for Presto (Avinash Jain)
- 43a5fa03c656c80373cc1a7934f7c71b45e1325c Add revocable memory info in GCStatusMonitor logs (Swapnil Tailor)
- c9ebcd336ee76040fb1cd92044329b0c2207d859 [native] Add support for TPC-H Connector Protocol Bindings (Deepak Majeti)
- 2f14947e94271b2ecd60da90ccc0f79c0f5ba5ae Fix PullConstantsAboveGroupBy for empty input (Rebecca Schlussel)
- 9bcf89d0443f846790b3480e22fecb29ff4e0f1f [native] Add more semi- and anti-join e2e tests (Masha Basmanova)
- 8b9bc1a8ab2d5e241272febc9a9cfd35787fe296 [native] Update Velox (Masha Basmanova)
- 13900cb858270b08bba6bc4d1d53d93e3cbc7657 Update velox version (tanjialiang)
- 30ed727f35d93f5157bd8224529e2fcd287eeed4 Support HiveFileSplit in presto_cpp (Arunachalam Thirupathi)
- 4ab6b4bf9359b661ba6b4477248556ae04be26b2 Refactor HiveFileSplit to its own class (Arunachalam Thirupathi)
- 4fd6506790a667546638d5c8fe32651d1589a540 Update with new QueryCtx interface and advance Velox version (xiaoxmeng)
- d60aae2b9e8ae8197bbc14a0d2886dde831bc0f5 [native] Replace JoinType::kLeftSemi with kLeftSemiFilter (Ge Gao)
- 919ce85e64cd15ad255a244c69a105d34f6696e8 [native] Bring generated protocol code up-to-date with PrestoDB (tanjialiang)
- 28c738876dfc4ea7393449bfe4b2d9eaacf7e110 Add local shuffle implementation for shuffle read/write info (tanjialiang)
- 5a95ff6a814f3e834ea56b74b97345c1c6bcba84 Add BatchTaskUpdateRequest class for native execution (tanjialiang)
- 25522006348be2edfeedc6d2f5014bbae841f7b7 Add shuffle info interfaces for native execution mode (tanjialiang)
- 05fcfbf2756979bb1660ca7f535959725fa9c442 Adding support of MAP_TOP_N_KEYS to Presto (Avinash Jain)
- 87c43b2b9a5e726200bf85d46931bc58e1787577 Fix incorrectly set wall time (Anant Aneja)
- 352c8a27b8957ef7f5827d040d7fb3bc454f3bd6 [native] Use velox exception instead of std exception. (Amit Dutta)
- 79b2d04a46e1be56800a9c64eaec8296d21a8124 [native] Use Release configuration instead of Debug for native-test. (Sergey Pershin)
- 339d1d7c45e1be5cd21e99a3b9e538182f1d340f Add window ranking function tests (Pramod)
- 63804c7e36651ff0190c1a7cfc5aba3109d919c6 Add ARRAY_MIN_BY, ARRAY_MAX_BY functions (Sacha Viscaino)
- 8e6665670e28bbdd1a3bc48f18414a47a9896ada [native] Pass LocationHandle to HiveInsertTableHandle (Ge Gao)
- 4053ddccf171df4aba222243dc2e43a792a9385e Fix MIN(x, n) and MAX(x, n) on window functions (Sacha Viscaino)
- 6ad58d80a792645510de5ab7a5d85ecd197cd737 Move constant grouping keys above the group by (Lyublena Antova)
- fb0c4dc0b4c7b1b570501ad6054113b5d538f79e Add native execution related properties to config classes (tanjialiang)
- 99d8b63c4a3676e621f60008429f5b4d51f7d2a2 [native] Fix test native failure (Deepak Majeti)
- 47173acadb3d875bc6bd3e30c27258ccca630a2e Add logging for IterativeOptimizer (Feilong Liu)
- e2f5ad57fef87dd67412cc53181a5e1ab97fc429 Add optimizer information collector for optimizer logging (Feilong Liu)
- c32f1b8a355fdfa3cf0656e471caf07c574ddc26 Change $0 to $BASH_SOURCE[0] (Miłosz Linkiewicz)
- f7d9d6d41c1582794e88e1c30cbd149a63708b75 Fix to sourcing (Miłosz Linkiewicz)
- 10ee47234e72aad522baad3588b9cffd11065ff1 Source velox helper functions (Miłosz Linkiewicz)
- ccd432453dfd9703c818080090b8c134fc53b8db Use cmake_install from velox (Miłosz Linkiewicz)
- 9841ab8a21f14de78a805047973ec97620b93c1f Build shared libs (Miłosz Linkiewicz)
- 7a6b423def1d159ea39d5fe10c653ed6d92f9ae0 [native] Centos unified build and install process (Milosz Linkiewicz)
- 0e1fa6fb02a20354fa7c95d5813401509654c62e [native] Add folly install job for script to work correctly (Milosz Linkiewicz)
- bad783d4162c3a41221855f6798b2b1d8874d49e Fix bug in test TestFilteredAggregations (Feilong Liu)
- f6b45656e2deae817a77b37a7ff1036c74574c8f Put type translator back (James Sun)
- 40421f35baa6795c521bd0804e156fb5f329e435 Add property builder and populator (tanjialiang)
- 208b60e909d60fb6baf5faae875849180d1928b4 Fix Disaggregated Coordinator Weighted Scheduling (Swapnil Tailor)
- ea8ea14a2c0c7ea0c8b6b4e7b3be746cafdc368c Support multi-coordinator while serving task info (Asjad Syed)
- 6f57e42f2b9c03d2e66b70168bb971db13908230 Add javadoc for query dispatch management (George Wang)
- 55e2523ca3ba7ecf126b8fcfc0bc59e516ac0560 Fix CI for next snapshot iteration PRs (Guy Moore)
- 96180d8fdce426691c0cdadd7359d1cbc7047888 Expose Filter push down support (Arunachalam Thirupathi)
- cb986f6c2b62ab45cb03df7f2573b053dde33751 Add retryExecutionStrategy in client tags (Arjun Gupta)
- a62173e8317f5d7069ddbabc0aeeb55648050455 Fetcher timeout should be at http level (tanjialiang)
- 456d5cfbd49b528222de28568af3b7101019d490 Support Domain Expressions for GlueHiveMetastore (Vivek)
- e52a7f1450cbcdd63d92de45c19f0dbeffe87a15 Generalize existing SQL UDF functions to all types (Sacha Viscaino)
- 816187a2802a43ca08c22803148c0a18d6cee79b Support STRPOS pushdown to Pinot; Fix missing configuration property pinot.query-options error (Nizar Hejazi)
- 6edfac9f9f4ed74a0cc0757206f50c75e96e31f9 Add javadoc for Presto query submission protocol (Vivek)
- e7a5eea2808a3f53a78294b9618002de8c9e6701 Add TypeParameters to SqlInvokedFunction (Sacha Viscaino)
- b84bfcc8405184ae5dfc88b5034192d8a986f1f7 Use map sorting json config in FRC (Pranjal Shankhdhar)
- e97afc8e3bdb765938ee77858490037260f50520 Add QueryPreparer interface (Rohit Jain)
- bc873b879841c7e054a213d40f6a149cdc2718e4 Rename QueryPreparer to BuiltInQueryPreparer (Rohit Jain)
- dc7ccb44d559350d428e3be2c33fa33b020f51cd Use querytype as key in QueryExecutionFactory map (Rohit Jain)
- bf0a94c7b449c66e32970d8a57bb6b34a2e244af Order map entries during HBO Canonicalization (Pranjal Shankhdhar)
- 1c9de99de7cb65b97f0bb304c3e58fb4caf02dac Fix CI for next snapshot iteration PRs (Guy Moore)
- 50b0e4413c88c5d71f700dc2e8e05d65cee63905 Add custom plan translation in LocalExecutionPlanner (MJ Deng)
- 21a3bbe59ccb2b0d8c72003d47771b7106be810c Canonicalize domain predicate in TableScanNode (Pranjal Shankhdhar)
- ba9ec306d453f968f711e437ab2d60b91dc6b700 Add more tests to TestPrestoSparkHttpWorkerClient.java (tanjialiang)
- e1552e52b48f0a376db228a05426ddb713f8cda9 Refactor TestingResponse to extract logic to be customizable by users (tanjialiang)
- a7f08511de686b18e48f9d3887f43d8e72ed2505 [native] Allow overriding file system registration. (Amit Dutta)
- 4e96f4df4670204bc703b936cad5172758349171 Create REMOVE_NULLS function (Sacha Viscaino)
- 5adc7c00aec765ecba85a4923cbfa1d791195db9 Update Iceberg to 1.0.0 (Eduard Tudenhoefner)
- 0628c0dda676c8545569fff0900d5d7886d45e66 Fix weighted fair scheduling in disagg coordinator (Swapnil Tailor)
- d1b99ee0d46f8699116094d9bc55ed7cba4921e8 Updated assert aggregation to include approximate equals (Christopher Graves)
- ccec1844b6a7b5b6086c0db6991ffaf44390500b update to build tar and docker image (Linsong Wang)
- 6091b4ea575430b01d5abf97ddcb3610a9075c68 add init Jenkinsfile (Linsong Wang)
- 87f543ae101db9872ca3549ec533e417559e78a2 Remove redundant distinct over group by (Feilong Liu)
- c6f6262c00c170d3a3c48ab406eac50f60bcaa93 Improve HBO overhead with LIMIT (Pranjal Shankhdhar)
- 50e3bcfb033e1f7b3d4e5e2eaec03322bdea68e9 Fix flaky HBO tests (Pranjal Shankhdhar)
- c1f4254fe1f390460a8543aefc3e1d690af76531 [native] Temporarily disable HttpTest.outstandingRequests. (Sergey Pershin)
- 310e15d21a53544be1a64f7a8e640f5c285320bd [native] Add two spill_memory_threshold session propertiess. (Sergey Pershin)