### PR TITLE
Avoid unnecessary dictionary block in Compact

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -531,7 +531,7 @@ public class DictionaryBlock
         return uniqueIds == dictionary.getPositionCount();
     }
 
-    public DictionaryBlock compact()
+    public Block compact()
     {
         if (isCompact()) {
             return this;
@@ -558,6 +558,19 @@ public class DictionaryBlock
             return this;
         }
 
+        Block compactDictionary;
+        try {
+            compactDictionary = dictionary.copyPositions(dictionaryPositionsToCopy.elements(), 0, dictionaryPositionsToCopy.size());
+        }
+        catch (UnsupportedOperationException e) {
+            // ignore if copy positions is not supported for the dictionary block
+            return this;
+        }
+
+        if (positionCount == compactDictionary.getPositionCount()) {
+            return compactDictionary;
+        }
+
         // compact the dictionary
         int[] newIds = new int[positionCount];
         for (int i = 0; i < positionCount; i++) {
@@ -567,14 +580,8 @@ public class DictionaryBlock
             }
             newIds[i] = newId;
         }
-        try {
-            Block compactDictionary = dictionary.copyPositions(dictionaryPositionsToCopy.elements(), 0, dictionaryPositionsToCopy.size());
-            return new DictionaryBlock(positionCount, compactDictionary, newIds, true);
-        }
-        catch (UnsupportedOperationException e) {
-            // ignore if copy positions is not supported for the dictionary block
-            return this;
-        }
+
+        return new DictionaryBlock(positionCount, compactDictionary, newIds, true);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlockEncoding.java
@@ -17,6 +17,8 @@ import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
+import java.util.Optional;
+
 public class DictionaryBlockEncoding
         implements BlockEncoding
 {
@@ -33,8 +35,6 @@ public class DictionaryBlockEncoding
     {
         // The down casts here are safe because it is the block itself the provides this encoding implementation.
         DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
-
-        dictionaryBlock = dictionaryBlock.compact();
 
         // positionCount
         int positionCount = dictionaryBlock.getPositionCount();
@@ -75,5 +75,17 @@ public class DictionaryBlockEncoding
         // As a result, setting dictionaryIsCompacted to true is not appropriate here.
         // TODO: fix DictionaryBlock so that dictionaryIsCompacted can be set to true when the underlying block over-retains memory.
         return new DictionaryBlock(positionCount, dictionaryBlock, ids, false, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
+    }
+
+    @Override
+    public Optional<Block> replacementBlockForWrite(Block block)
+    {
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
+
+        if (dictionaryBlock.isCompact()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(dictionaryBlock.compact());
     }
 }


### PR DESCRIPTION
Dictionary.compact returns another dictionary.
On a memory profile I was investigating, all the
Dictionary block has a 1:1 mapping on the underlying
block and they came out of shuffle.

This PR when there is no reduction in terms of dictionary
drops the dictionary wrapper and sends the underlying
block. Though this generally improves perf, it can regress
in some cases.

Duplicating dictionary blocks are just doubling the indices.
But duplicating the underlying block (say String block)
will be more expensive.

```
== NO RELEASE NOTE ==
```
