### PR TITLE
Fix setting PartititioningHandle in IterativePlanFragmenter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -287,12 +287,7 @@ public abstract class BasePlanFragmenter
 
         PartitioningScheme partitioningScheme = exchange.getPartitioningScheme();
 
-        if (exchange.getType() == ExchangeNode.Type.GATHER) {
-            context.get().setSingleNodeDistribution();
-        }
-        else if (exchange.getType() == ExchangeNode.Type.REPARTITION) {
-            context.get().setDistribution(partitioningScheme.getPartitioning().getHandle(), metadata, session);
-        }
+        setDistributionForExchange(exchange.getType(), partitioningScheme, context);
 
         ImmutableList.Builder<SubPlan> builder = ImmutableList.builder();
         for (int sourceIndex = 0; sourceIndex < exchange.getSources().size(); sourceIndex++) {
@@ -309,6 +304,16 @@ public abstract class BasePlanFragmenter
                 .collect(toImmutableList());
 
         return new RemoteSourceNode(exchange.getSourceLocation(), exchange.getId(), childrenIds, exchange.getOutputVariables(), exchange.isEnsureSourceOrdering(), exchange.getOrderingScheme(), exchange.getType());
+    }
+
+    protected void setDistributionForExchange(ExchangeNode.Type exchangeType, PartitioningScheme partitioningScheme, RewriteContext<FragmentProperties> context)
+    {
+        if (exchangeType == ExchangeNode.Type.GATHER) {
+            context.get().setSingleNodeDistribution();
+        }
+        else if (exchangeType == ExchangeNode.Type.REPARTITION) {
+            context.get().setDistribution(partitioningScheme.getPartitioning().getHandle(), metadata, session);
+        }
     }
 
     private PlanNode createRemoteMaterializedExchange(ExchangeNode exchange, RewriteContext<FragmentProperties> context)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
@@ -265,9 +265,13 @@ public class IterativePlanFragmenter
         public PlanNode visitRemoteSource(RemoteSourceNode node, RewriteContext<FragmentProperties> context)
         {
             List<SubPlan> childSubPlans = node.getSourceFragmentIds().stream()
-                    .map(id -> subPlanByFragmentId.get(id))
+                    .map(subPlanByFragmentId::get)
                     .collect(toImmutableList());
             context.get().addChildren(childSubPlans);
+
+            // the partitioning handle should be the same as the handle from the partitioning scheme
+            // of any of the input fragments.
+            setDistributionForExchange(node.getExchangeType(), childSubPlans.get(0).getFragment().getPartitioningScheme(), context);
             return super.visitRemoteSource(node, context);
         }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
@@ -105,6 +105,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.facebook.presto.SystemSessionProperties.FORCE_SINGLE_NODE_OUTPUT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spark.planner.TestIterativePlanFragmenter.CanonicalTestFragment.toCanonicalTestFragment;
@@ -141,7 +142,10 @@ public class TestIterativePlanFragmenter
     @BeforeClass
     public void setUp()
     {
-        session = testSessionBuilder().setCatalog("tpch").build();
+        session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSystemProperty(FORCE_SINGLE_NODE_OUTPUT, "false")
+                .build();
 
         CatalogManager catalogManager = new CatalogManager();
         catalogManager.registerCatalog(createBogusTestingCatalog("tpch"));


### PR DESCRIPTION
The partitioning handle for non-leaf fragments is often based on the partitioning of the exchange. In the non-iterative plan fragmenter this is set when processing the remote exchange.  Since we lose that context in the IterativePlanFragmenter, we need to recreate it.

Test plan -  unit test and tested in the new adaptive executor code that's in progress.

```
== NO RELEASE NOTE ==
```
