### PR TITLE
Completes the plumbing of shuffle information passing from Spark to native execution

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -67,7 +67,16 @@ public class TestPrestoSparkNativeExecution
                 .setCatalogSessionProperty("hive", PUSHDOWN_FILTER_ENABLED, "true")
                 .build();
 
-        assertQuerySucceeds(session, "SELECT * FROM test_order");
+        // Reset the spark context to register the native execution shuffle manager. We want to let the query runner use the default spark shuffle
+        // manager to generate the test tables and only test the new native execution shuffle manager on the test below test cases.
+        PrestoSparkQueryRunner queryRunner = (PrestoSparkQueryRunner) getQueryRunner();
+        queryRunner.resetSparkContext(getNativeExecutionShuffleConfigs());
+        try {
+            assertQuerySucceeds(session, "SELECT * FROM test_order");
+        }
+        finally {
+            queryRunner.resetSparkContext();
+        }
     }
 
     // TODO: re-enable the test once the shuffle integration is ready.

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -107,6 +107,7 @@ import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.facebook.presto.spark.execution.BatchTaskUpdateRequest;
 import com.facebook.presto.spark.execution.ForNativeExecutionTask;
 import com.facebook.presto.spark.execution.NativeExecutionProcessFactory;
 import com.facebook.presto.spark.execution.NativeExecutionTaskFactory;
@@ -282,6 +283,7 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(ServerInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkLocalShuffleReadInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkLocalShuffleWriteInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(BatchTaskUpdateRequest.class);
 
         // smile codecs
         smileCodecBinder(binder).bindSmileCodec(TaskSource.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/BatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/BatchTaskUpdateRequest.java
@@ -25,12 +25,12 @@ import static java.util.Objects.requireNonNull;
 public class BatchTaskUpdateRequest
 {
     private final TaskUpdateRequest taskUpdateRequest;
-    private final Optional<byte[]> shuffleWriteInfo;
+    private final Optional<String> shuffleWriteInfo;
 
     @JsonCreator
     public BatchTaskUpdateRequest(
             @JsonProperty("taskUpdateRequest") TaskUpdateRequest taskUpdateRequest,
-            @JsonProperty("shuffleWriteInfo") Optional<byte[]> shuffleWriteInfo)
+            @JsonProperty("shuffleWriteInfo") Optional<String> shuffleWriteInfo)
     {
         this.taskUpdateRequest = requireNonNull(taskUpdateRequest, "taskUpdateRequest is null");
         this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
@@ -43,7 +43,7 @@ public class BatchTaskUpdateRequest
     }
 
     @JsonProperty
-    public Optional<byte[]> getShuffleWriteInfo()
+    public Optional<String> getShuffleWriteInfo()
     {
         return shuffleWriteInfo;
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
@@ -23,7 +23,6 @@ import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
-import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spi.page.SerializedPage;
@@ -63,6 +62,7 @@ public class NativeExecutionTask
     private final OutputBuffers outputBuffers;
     private final PrestoSparkHttpTaskClient workerClient;
     private final TableWriteInfo tableWriteInfo;
+    private final Optional<String> shuffleWriteInfo;
     private final List<TaskSource> sources;
     private final Executor executor;
     private final HttpNativeExecutionTaskInfoFetcher taskInfoFetcher;
@@ -76,16 +76,18 @@ public class NativeExecutionTask
             List<TaskSource> sources,
             HttpClient httpClient,
             TableWriteInfo tableWriteInfo,
+            Optional<String> shuffleWriteInfo,
             Executor executor,
             ScheduledExecutorService updateScheduledExecutor,
             JsonCodec<TaskInfo> taskInfoCodec,
             JsonCodec<PlanFragment> planFragmentCodec,
-            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec,
+            JsonCodec<BatchTaskUpdateRequest> taskUpdateRequestCodec,
             TaskManagerConfig taskManagerConfig)
     {
         this.session = requireNonNull(session, "session is null");
         this.planFragment = requireNonNull(planFragment, "planFragment is null");
         this.tableWriteInfo = requireNonNull(tableWriteInfo, "tableWriteInfo is null");
+        this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
         this.sources = requireNonNull(sources, "sources is null");
         this.executor = requireNonNull(executor, "executor is null");
         this.outputBuffers = createInitialEmptyOutputBuffers(PARTITIONED);
@@ -167,6 +169,7 @@ public class NativeExecutionTask
                         sources,
                         planFragment,
                         tableWriteInfo,
+                        shuffleWriteInfo,
                         session,
                         outputBuffers),
                 new UpdateResponseHandler(future),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTaskFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTaskFactory.java
@@ -22,7 +22,6 @@ import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
-import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.sql.planner.PlanFragment;
 
 import javax.annotation.PreDestroy;
@@ -30,6 +29,7 @@ import javax.inject.Inject;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,7 +47,7 @@ public class NativeExecutionTaskFactory
     private final ScheduledExecutorService updateScheduledExecutor;
     private final JsonCodec<TaskInfo> taskInfoCodec;
     private final JsonCodec<PlanFragment> planFragmentCodec;
-    private final JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec;
+    private final JsonCodec<BatchTaskUpdateRequest> taskUpdateRequestCodec;
     private final TaskManagerConfig taskManagerConfig;
 
     @Inject
@@ -57,7 +57,7 @@ public class NativeExecutionTaskFactory
             ScheduledExecutorService updateScheduledExecutor,
             JsonCodec<TaskInfo> taskInfoCodec,
             JsonCodec<PlanFragment> planFragmentCodec,
-            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec,
+            JsonCodec<BatchTaskUpdateRequest> taskUpdateRequestCodec,
             TaskManagerConfig taskManagerConfig)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
@@ -76,7 +76,8 @@ public class NativeExecutionTaskFactory
             TaskId taskId,
             PlanFragment fragment,
             List<TaskSource> sources,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            Optional<String> shuffleWriteInfo)
     {
         return new NativeExecutionTask(
                 session,
@@ -86,6 +87,7 @@ public class NativeExecutionTaskFactory
                 sources,
                 httpClient,
                 tableWriteInfo,
+                shuffleWriteInfo,
                 executor,
                 updateScheduledExecutor,
                 taskInfoCodec,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
@@ -34,10 +34,10 @@ import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.RddAndMore;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkJavaExecutionTaskInputs;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskInputs;
 import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.SerializedTaskInfo;
 import com.facebook.presto.spark.planner.PrestoSparkPlanFragmenter;
@@ -237,7 +237,7 @@ public class PrestoSparkStaticQueryExecution
                     0,
                     serializedTaskDescriptor,
                     emptyScalaIterator(),
-                    new PrestoSparkTaskInputs(ImmutableMap.of(), ImmutableMap.of(), inputs.build()),
+                    new PrestoSparkJavaExecutionTaskInputs(ImmutableMap.of(), ImmutableMap.of(), inputs.build()),
                     taskInfoCollector,
                     shuffleStatsCollector,
                     PrestoSparkSerializedPage.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -595,7 +595,8 @@ public class PrestoSparkTaskExecutorFactory
                         fragment,
                         blockEncodingSerde,
                         processFactory,
-                        taskFactory)));
+                        taskFactory,
+                        shuffleWriteInfo.map(shuffleInfoTranslator::createSerializedWriteInfo))));
 
         taskStateMachine.addStateChangeListener(state -> {
             if (state.isDone()) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -23,6 +23,8 @@ import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.io.DataOutput;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.Location;
 import com.facebook.presto.execution.MemoryRevokingSchedulerUtils;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.StageExecutionId;
@@ -43,7 +45,9 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.TraversingQueryContextVisitor;
 import com.facebook.presto.memory.VoidTraversingQueryContextVisitor;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.RemoteTransactionHandle;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.TaskContext;
@@ -55,8 +59,11 @@ import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkJavaExecutionTaskInputs;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeTaskInputs;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleReadDescriptor;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskInputs;
@@ -69,9 +76,11 @@ import com.facebook.presto.spark.execution.PrestoSparkRowBatch.RowTupleSupplier;
 import com.facebook.presto.spark.execution.PrestoSparkRowOutputOperator.PreDeterminedPartitionFunction;
 import com.facebook.presto.spark.execution.PrestoSparkRowOutputOperator.PrestoSparkRowOutputFactory;
 import com.facebook.presto.spark.execution.operator.NativeExecutionOperator;
+import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.page.PageDataOutput;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.security.TokenAuthenticator;
 import com.facebook.presto.spi.storage.TempDataOperationContext;
@@ -80,12 +89,15 @@ import com.facebook.presto.spi.storage.TempStorage;
 import com.facebook.presto.spi.storage.TempStorageHandle;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.spiller.SpillSpaceTracker;
+import com.facebook.presto.split.RemoteSplit;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.OutputPartitioning;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.storage.TempStorageManager;
 import com.google.common.collect.ImmutableList;
@@ -108,6 +120,7 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -120,6 +133,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalTotalMemoryLimit;
@@ -130,12 +144,14 @@ import static com.facebook.presto.SystemSessionProperties.getQueryMaxMemoryPerNo
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxRevocableMemoryPerNode;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxTotalMemoryPerNode;
 import static com.facebook.presto.SystemSessionProperties.isHeapDumpOnExceededMemoryLimitEnabled;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.SystemSessionProperties.isVerboseExceededMemoryLimitErrorsEnabled;
 import static com.facebook.presto.execution.TaskState.FAILED;
 import static com.facebook.presto.execution.TaskStatus.STARTING_VERSION;
 import static com.facebook.presto.execution.buffer.BufferState.FINISHED;
 import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
+import static com.facebook.presto.operator.ExchangeOperator.REMOTE_CONNECTOR_ID;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingTarget;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingThreshold;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getShuffleOutputTargetAverageRowSize;
@@ -148,6 +164,7 @@ import static com.facebook.presto.spark.util.PrestoSparkUtils.serializeZstdCompr
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
 import static com.facebook.presto.spi.ErrorCause.UNKNOWN;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.util.Failures.toFailures;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -204,6 +221,7 @@ public class PrestoSparkTaskExecutorFactory
     private final BlockEncodingSerde blockEncodingSerde;
     private final NativeExecutionProcessFactory processFactory;
     private final NativeExecutionTaskFactory taskFactory;
+    private final PrestoSparkShuffleInfoTranslator shuffleInfoTranslator;
 
     @Inject
     public PrestoSparkTaskExecutorFactory(
@@ -231,7 +249,8 @@ public class PrestoSparkTaskExecutorFactory
             PrestoSparkConfig prestoSparkConfig,
             BlockEncodingSerde blockEncodingSerde,
             NativeExecutionProcessFactory processFactory,
-            NativeExecutionTaskFactory taskFactory)
+            NativeExecutionTaskFactory taskFactory,
+            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator)
     {
         this(
                 sessionPropertyManager,
@@ -262,7 +281,8 @@ public class PrestoSparkTaskExecutorFactory
                 prestoSparkBroadcastTableCacheManager,
                 blockEncodingSerde,
                 processFactory,
-                taskFactory);
+                taskFactory,
+                shuffleInfoTranslator);
     }
 
     public PrestoSparkTaskExecutorFactory(
@@ -294,7 +314,8 @@ public class PrestoSparkTaskExecutorFactory
             PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager,
             BlockEncodingSerde blockEncodingSerde,
             NativeExecutionProcessFactory processFactory,
-            NativeExecutionTaskFactory taskFactory)
+            NativeExecutionTaskFactory taskFactory,
+            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator)
     {
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
@@ -326,6 +347,7 @@ public class PrestoSparkTaskExecutorFactory
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.processFactory = requireNonNull(processFactory, "processFactory is null");
         this.taskFactory = requireNonNull(taskFactory, "taskFactory is null");
+        this.shuffleInfoTranslator = requireNonNull(shuffleInfoTranslator, "shuffleInfoFactory is null");
     }
 
     @Override
@@ -382,19 +404,6 @@ public class PrestoSparkTaskExecutorFactory
 
         // TODO: include attemptId in taskId
         TaskId taskId = new TaskId(new StageExecutionId(stageId, 0), partitionId);
-
-        List<TaskSource> taskSources = getTaskSources(serializedTaskSources);
-
-        log.info("Task [%s] received %d splits.",
-                taskId,
-                taskSources.stream()
-                        .mapToInt(taskSource -> taskSource.getSplits().size())
-                        .sum());
-
-        OptionalLong totalSplitSize = computeAllSplitsSize(taskSources);
-        if (totalSplitSize.isPresent()) {
-            log.info("Total split size: %s bytes.", totalSplitSize.getAsLong());
-        }
 
         // TODO: Remove this once we can display the plan on Spark UI.
 
@@ -505,49 +514,28 @@ public class PrestoSparkTaskExecutorFactory
         ImmutableMap.Builder<PlanNodeId, List<PrestoSparkShuffleInput>> shuffleInputs = ImmutableMap.builder();
         ImmutableMap.Builder<PlanNodeId, List<java.util.Iterator<PrestoSparkSerializedPage>>> pageInputs = ImmutableMap.builder();
         ImmutableMap.Builder<PlanNodeId, List<?>> broadcastInputs = ImmutableMap.builder();
-        for (RemoteSourceNode remoteSource : fragment.getRemoteSourceNodes()) {
-            List<PrestoSparkShuffleInput> remoteSourceRowInputs = new ArrayList<>();
-            List<java.util.Iterator<PrestoSparkSerializedPage>> remoteSourcePageInputs = new ArrayList<>();
-            List<List<?>> broadcastInputsList = new ArrayList<>();
-            for (PlanFragmentId sourceFragmentId : remoteSource.getSourceFragmentIds()) {
-                Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> shuffleInput = inputs.getShuffleInputs().get(sourceFragmentId.toString());
-                Broadcast<?> broadcastInput = inputs.getBroadcastInputs().get(sourceFragmentId.toString());
-                List<PrestoSparkSerializedPage> inMemoryInput = inputs.getInMemoryInputs().get(sourceFragmentId.toString());
+        ImmutableMap.Builder<PlanNodeId, PrestoSparkShuffleReadInfo> shuffleReadInfos = ImmutableMap.builder();
 
-                if (shuffleInput != null) {
-                    checkArgument(broadcastInput == null, "single remote source is not expected to accept different kind of inputs");
-                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
-                    remoteSourceRowInputs.add(new PrestoSparkShuffleInput(sourceFragmentId.getId(), shuffleInput));
-                    continue;
-                }
+        List<TaskSource> taskSources;
+        Optional<PrestoSparkShuffleWriteInfo> shuffleWriteInfo = Optional.empty();
 
-                if (broadcastInput != null) {
-                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
-                    // TODO: Enable NullifyingIterator once migrated to one task per JVM model
-                    // NullifyingIterator removes element from the list upon return
-                    // This allows GC to gradually reclaim memory
-                    // remoteSourcePageInputs.add(getNullifyingIterator(broadcastInput.value()));
-                    broadcastInputsList.add((List<?>) broadcastInput.value());
-                    continue;
-                }
-
-                if (inMemoryInput != null) {
-                    // for in-memory inputs pages can be released incrementally to save memory
-                    remoteSourcePageInputs.add(getNullifyingIterator(inMemoryInput));
-                    continue;
-                }
-
-                throw new IllegalArgumentException("Input not found for sourceFragmentId: " + sourceFragmentId);
-            }
-            if (!remoteSourceRowInputs.isEmpty()) {
-                shuffleInputs.put(remoteSource.getId(), remoteSourceRowInputs);
-            }
-            if (!remoteSourcePageInputs.isEmpty()) {
-                pageInputs.put(remoteSource.getId(), remoteSourcePageInputs);
-            }
-            if (!broadcastInputsList.isEmpty()) {
-                broadcastInputs.put(remoteSource.getId(), broadcastInputsList);
-            }
+        if (isNativeExecutionEnabled(session) && fragment.getRoot() instanceof NativeExecutionNode) {
+            checkArgument(
+                    inputs instanceof PrestoSparkNativeTaskInputs,
+                    format("PrestoSparkNativeTaskInputs is required for native execution, but %s is provided", inputs.getClass().getName()));
+            PrestoSparkNativeTaskInputs nativeInputs = (PrestoSparkNativeTaskInputs) inputs;
+            fillNativeExecutionTaskInputs(fragment, nativeInputs, shuffleReadInfos);
+            shuffleWriteInfo = nativeInputs.getShuffleWriteDescriptor().isPresent() && !findTableWriteNode(fragment.getRoot()).isPresent() ?
+                    Optional.of(shuffleInfoTranslator.createShuffleWriteInfo(nativeInputs.getShuffleWriteDescriptor().get())) : Optional.empty();
+            taskSources = getNativeExecutionShuffleSources(session, taskId, fragment, shuffleReadInfos.build(), getTaskSources(serializedTaskSources));
+        }
+        else {
+            checkArgument(
+                    inputs instanceof PrestoSparkJavaExecutionTaskInputs,
+                    format("PrestoSparkJavaExecutionTaskInputs is required for java execution, but %s is provided", inputs.getClass().getName()));
+            PrestoSparkJavaExecutionTaskInputs taskInputs = (PrestoSparkJavaExecutionTaskInputs) inputs;
+            fillJavaExecutionTaskInputs(fragment, taskInputs, shuffleInputs, pageInputs, broadcastInputs);
+            taskSources = getTaskSources(serializedTaskSources);
         }
 
         OutputBufferMemoryManager memoryManager = new OutputBufferMemoryManager(
@@ -602,7 +590,12 @@ public class PrestoSparkTaskExecutorFactory
                         stageId),
                 taskDescriptor.getTableWriteInfo(),
                 true,
-                ImmutableList.of(new NativeExecutionOperator.NativeExecutionOperatorTranslator(session, fragment, blockEncodingSerde, processFactory, taskFactory)));
+                ImmutableList.of(new NativeExecutionOperator.NativeExecutionOperatorTranslator(
+                        session,
+                        fragment,
+                        blockEncodingSerde,
+                        processFactory,
+                        taskFactory)));
 
         taskStateMachine.addStateChangeListener(state -> {
             if (state.isDone()) {
@@ -619,6 +612,16 @@ public class PrestoSparkTaskExecutorFactory
                 notificationExecutor,
                 memoryUpdateExecutor);
 
+        log.info("Task [%s] received %d splits.",
+                taskId,
+                taskSources.stream()
+                        .mapToInt(taskSource -> taskSource.getSplits().size())
+                        .sum());
+
+        OptionalLong totalSplitSize = computeAllSplitsSize(taskSources);
+        if (totalSplitSize.isPresent()) {
+            log.info("Total split size: %s bytes.", totalSplitSize.getAsLong());
+        }
         taskExecution.start(taskSources);
 
         return new PrestoSparkTaskExecutor<>(
@@ -673,6 +676,77 @@ public class PrestoSparkTaskExecutorFactory
         return OptionalLong.of(sum);
     }
 
+    private void fillNativeExecutionTaskInputs(
+            PlanFragment fragment,
+            PrestoSparkNativeTaskInputs inputs,
+            ImmutableMap.Builder<PlanNodeId, PrestoSparkShuffleReadInfo> shuffleReadInfos)
+    {
+        for (RemoteSourceNode remoteSource : fragment.getRemoteSourceNodes()) {
+            for (PlanFragmentId sourceFragmentId : remoteSource.getSourceFragmentIds()) {
+                PrestoSparkShuffleReadDescriptor shuffleReadDescriptor = inputs.getShuffleReadDescriptors().get(sourceFragmentId.toString());
+                if (shuffleReadDescriptor != null) {
+                    shuffleReadInfos.put(remoteSource.getId(), shuffleInfoTranslator.createShuffleReadInfo(shuffleReadDescriptor));
+                }
+            }
+        }
+    }
+
+    private void fillJavaExecutionTaskInputs(
+            PlanFragment fragment,
+            PrestoSparkJavaExecutionTaskInputs inputs,
+            ImmutableMap.Builder<PlanNodeId, List<PrestoSparkShuffleInput>> shuffleInputs,
+            ImmutableMap.Builder<PlanNodeId, List<java.util.Iterator<PrestoSparkSerializedPage>>> pageInputs,
+            ImmutableMap.Builder<PlanNodeId, List<?>> broadcastInputs)
+    {
+        for (RemoteSourceNode remoteSource : fragment.getRemoteSourceNodes()) {
+            ImmutableList.Builder<PrestoSparkShuffleInput> remoteSourceRowInputsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<java.util.Iterator<PrestoSparkSerializedPage>> remoteSourcePageInputsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<List<?>> broadcastInputsListBuilder = ImmutableList.builder();
+            for (PlanFragmentId sourceFragmentId : remoteSource.getSourceFragmentIds()) {
+                Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> shuffleInput = inputs.getShuffleInputs().get(sourceFragmentId.toString());
+                Broadcast<?> broadcastInput = inputs.getBroadcastInputs().get(sourceFragmentId.toString());
+                List<PrestoSparkSerializedPage> inMemoryInput = inputs.getInMemoryInputs().get(sourceFragmentId.toString());
+
+                if (shuffleInput != null) {
+                    checkArgument(broadcastInput == null, "single remote source is not expected to accept different kind of inputs");
+                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
+                    remoteSourceRowInputsBuilder.add(new PrestoSparkShuffleInput(sourceFragmentId.getId(), shuffleInput));
+                    continue;
+                }
+
+                if (broadcastInput != null) {
+                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
+                    // TODO: Enable NullifyingIterator once migrated to one task per JVM model
+                    // NullifyingIterator removes element from the list upon return
+                    // This allows GC to gradually reclaim memory
+                    // remoteSourcePageInputs.add(getNullifyingIterator(broadcastInput.value()));
+                    broadcastInputsListBuilder.add((List<?>) broadcastInput.value());
+                    continue;
+                }
+
+                if (inMemoryInput != null) {
+                    // for in-memory inputs pages can be released incrementally to save memory
+                    remoteSourcePageInputsBuilder.add(getNullifyingIterator(inMemoryInput));
+                    continue;
+                }
+
+                throw new IllegalStateException("Input not found for sourceFragmentId: " + sourceFragmentId);
+            }
+            List<PrestoSparkShuffleInput> remoteSourceRowInputs = remoteSourceRowInputsBuilder.build();
+            List<java.util.Iterator<PrestoSparkSerializedPage>> remoteSourcePageInputs = remoteSourcePageInputsBuilder.build();
+            List<List<?>> broadcastInputsList = broadcastInputsListBuilder.build();
+            if (!remoteSourceRowInputs.isEmpty()) {
+                shuffleInputs.put(remoteSource.getId(), remoteSourceRowInputs);
+            }
+            if (!remoteSourcePageInputs.isEmpty()) {
+                pageInputs.put(remoteSource.getId(), remoteSourcePageInputs);
+            }
+            if (!broadcastInputsList.isEmpty()) {
+                broadcastInputs.put(remoteSource.getId(), broadcastInputsList);
+            }
+        }
+    }
+
     private List<TaskSource> getTaskSources(Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources)
     {
         long totalSerializedSizeInBytes = 0;
@@ -684,6 +758,43 @@ public class PrestoSparkTaskExecutorFactory
         }
         log.info("Total serialized size of all task sources: %s", succinctBytes(totalSerializedSizeInBytes));
         return result.build();
+    }
+
+    private List<TaskSource> getNativeExecutionShuffleSources(
+            Session session, TaskId taskId, PlanFragment fragment, Map<PlanNodeId, PrestoSparkShuffleReadInfo> shuffleReadInfos, List<TaskSource> taskSources)
+    {
+        ImmutableSet.Builder<ScheduledSplit> result = ImmutableSet.builder();
+        PlanNode root = fragment.getRoot();
+        AtomicLong nextSplitId = new AtomicLong();
+        shuffleReadInfos.forEach((planNodeId, info) ->
+                result.add(new ScheduledSplit(nextSplitId.getAndIncrement(), planNodeId, new Split(REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(
+                        new Location(format("batch://%s?shuffleInfo=%s", taskId, shuffleInfoTranslator.createSerializedReadInfo(info))),
+                        taskId)))));
+
+        List<TaskSource> nativeExecutionSources = taskSources.stream().filter(taskSource -> taskSource.getPlanNodeId().equals(root)).collect(Collectors.toList());
+        checkState(nativeExecutionSources.size() <= 1, "At most 1 taskSource is expected for NativeExecutionNode but got %s", nativeExecutionSources.size());
+        if (!nativeExecutionSources.isEmpty()) {
+            // Append the shuffle splits with original splits
+            TaskSource nativeExecutionSource = nativeExecutionSources.get(0);
+            result.addAll(nativeExecutionSource.getSplits());
+        }
+
+        TaskSource newTaskSource = new TaskSource(root.getId(), result.build(), ImmutableSet.of(Lifespan.taskWide()), true);
+        ImmutableList.Builder<TaskSource> newTaskSources = ImmutableList.builder();
+        // Combine the shuffle read taskSource and original sources
+        newTaskSources.add(newTaskSource)
+                .addAll(taskSources.stream()
+                        .filter(taskSource -> !taskSource.getPlanNodeId().equals(root))
+                        .collect(Collectors.toList()));
+        return newTaskSources.build();
+    }
+
+    private Optional<TableWriterNode> findTableWriteNode(PlanNode node)
+    {
+        PlanNode root = node instanceof NativeExecutionNode ? ((NativeExecutionNode) node).getSubPlan() : node;
+        return searchFrom(root)
+                .where(TableWriterNode.class::isInstance)
+                .findFirst();
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
@@ -86,6 +86,7 @@ public class NativeExecutionOperator
     private final LocalMemoryContext systemMemoryContext;
     private final PlanFragment planFragment;
     private final TableWriteInfo tableWriteInfo;
+    private final Optional<String> shuffleWriteInfo;
     private final PagesSerde serde;
     private final NativeExecutionProcessFactory processFactory;
     private final NativeExecutionTaskFactory taskFactory;
@@ -103,13 +104,15 @@ public class NativeExecutionOperator
             TableWriteInfo tableWriteInfo,
             PagesSerde serde,
             NativeExecutionProcessFactory processFactory,
-            NativeExecutionTaskFactory taskFactory)
+            NativeExecutionTaskFactory taskFactory,
+            Optional<String> shuffleWriteInfo)
     {
         this.sourceId = requireNonNull(sourceId, "sourceId is null");
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.systemMemoryContext = operatorContext.localSystemMemoryContext();
         this.planFragment = requireNonNull(planFragment, "planFragment is null");
         this.tableWriteInfo = requireNonNull(tableWriteInfo, "tableWriteInfo is null");
+        this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
         this.serde = requireNonNull(serde, "serde is null");
         this.processFactory = requireNonNull(processFactory, "processFactory is null");
         this.taskFactory = requireNonNull(taskFactory, "taskFactory is null");
@@ -205,7 +208,8 @@ public class NativeExecutionOperator
                 operatorContext.getDriverContext().getTaskId(),
                 planFragment,
                 ImmutableList.of(taskSource),
-                tableWriteInfo);
+                tableWriteInfo,
+                shuffleWriteInfo);
     }
 
     private Page processResult(SerializedPage page)
@@ -284,6 +288,7 @@ public class NativeExecutionOperator
         private final PlanNodeId planNodeId;
         private final PlanFragment planFragment;
         private final TableWriteInfo tableWriteInfo;
+        private final Optional<String> shuffleWriteInfo;
         private final PagesSerdeFactory serdeFactory;
         private final NativeExecutionProcessFactory processFactory;
         private final NativeExecutionTaskFactory taskFactory;
@@ -296,12 +301,14 @@ public class NativeExecutionOperator
                 TableWriteInfo tableWriteInfo,
                 PagesSerdeFactory serdeFactory,
                 NativeExecutionProcessFactory processFactory,
-                NativeExecutionTaskFactory taskFactory)
+                NativeExecutionTaskFactory taskFactory,
+                Optional<String> shuffleWriteInfo)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.planFragment = requireNonNull(planFragment, "planFragment is null");
             this.tableWriteInfo = requireNonNull(tableWriteInfo, "tableWriteInfo is null");
+            this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
             this.serdeFactory = requireNonNull(serdeFactory, "serdeFactory is null");
             this.processFactory = requireNonNull(processFactory, "processFactory is null");
             this.taskFactory = requireNonNull(taskFactory, "taskFactory is null");
@@ -325,7 +332,8 @@ public class NativeExecutionOperator
                     tableWriteInfo,
                     serdeFactory.createPagesSerde(),
                     processFactory,
-                    taskFactory);
+                    taskFactory,
+                    shuffleWriteInfo);
         }
 
         @Override
@@ -345,14 +353,22 @@ public class NativeExecutionOperator
     {
         private final PlanFragment fragment;
         private final Session session;
+        private final Optional<String> shuffleWriteInfo;
         private final BlockEncodingSerde blockEncodingSerde;
         private final NativeExecutionProcessFactory processFactory;
         private final NativeExecutionTaskFactory taskFactory;
 
-        public NativeExecutionOperatorTranslator(Session session, PlanFragment fragment, BlockEncodingSerde blockEncodingSerde, NativeExecutionProcessFactory processFactory, NativeExecutionTaskFactory taskFactory)
+        public NativeExecutionOperatorTranslator(
+                Session session,
+                PlanFragment fragment,
+                BlockEncodingSerde blockEncodingSerde,
+                NativeExecutionProcessFactory processFactory,
+                NativeExecutionTaskFactory taskFactory,
+                Optional<String> shuffleWriteInfo)
         {
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.session = requireNonNull(session, "session is null");
+            this.shuffleWriteInfo = requireNonNull(shuffleWriteInfo, "shuffleWriteInfo is null");
             this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
             this.processFactory = requireNonNull(processFactory, "processFactory is null");
             this.taskFactory = requireNonNull(taskFactory, "taskFactory is null");
@@ -372,7 +388,8 @@ public class NativeExecutionOperator
                         context.getTableWriteInfo(),
                         new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session), isExchangeChecksumEnabled(session)),
                         processFactory,
-                        taskFactory);
+                        taskFactory,
+                        shuffleWriteInfo);
                 return Optional.of(
                         new LocalExecutionPlanner.PhysicalOperation(operatorFactory, makeLayout(node), context, UNGROUPED_EXECUTION));
             }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -23,6 +23,7 @@ import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeTaskRdd;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
@@ -71,6 +72,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.classTag;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.serializeZstdCompressed;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -251,10 +253,26 @@ public class PrestoSparkRddFactory
             taskSourceRdd = Optional.empty();
         }
 
-        return JavaPairRDD.fromRDD(
-                PrestoSparkTaskRdd.create(sparkContext.sc(), taskSourceRdd, shuffleInputRddMap, taskProcessor).setName(getRDDName(fragment.getId().getId())),
-                classTag(MutablePartitionId.class),
-                classTag(outputType));
+        if (isNativeExecutionEnabled(session)) {
+            return JavaPairRDD.fromRDD(
+                    PrestoSparkNativeTaskRdd.create(
+                            sparkContext.sc(),
+                            taskSourceRdd,
+                            shuffleInputRddMap,
+                            taskProcessor).setName(getRDDName(fragment.getId().getId())),
+                    classTag(MutablePartitionId.class),
+                    classTag(outputType));
+        }
+        else {
+            return JavaPairRDD.fromRDD(
+                    PrestoSparkTaskRdd.create(
+                            sparkContext.sc(),
+                            taskSourceRdd,
+                            shuffleInputRddMap,
+                            taskProcessor).setName(getRDDName(fragment.getId().getId())),
+                    classTag(MutablePartitionId.class),
+                    classTag(outputType));
+        }
     }
 
     private PrestoSparkTaskSourceRdd createTaskSourcesRdd(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
@@ -98,7 +98,7 @@ public class TestBatchTaskUpdateRequest
                 createInitialEmptyOutputBuffers(PARTITIONED),
                 Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
         String shuffleWriteInfo = "dummy-shuffle-write-info";
-        BatchTaskUpdateRequest batchUpdateRequest = new BatchTaskUpdateRequest(updateRequest, Optional.of(shuffleWriteInfo.getBytes()));
+        BatchTaskUpdateRequest batchUpdateRequest = new BatchTaskUpdateRequest(updateRequest, Optional.of(shuffleWriteInfo));
         JsonCodec<BatchTaskUpdateRequest> batchTaskUpdateRequestJsonCodec = getJsonCodec();
         byte[] batchUpdateRequestJson = batchTaskUpdateRequestJsonCodec.toBytes(batchUpdateRequest);
         BatchTaskUpdateRequest recoveredBatchUpdateRequest = batchTaskUpdateRequestJsonCodec.fromBytes(batchUpdateRequestJson);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -31,8 +31,8 @@ import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.operator.PageBufferClient;
 import com.facebook.presto.operator.PageTransportErrorException;
 import com.facebook.presto.operator.TaskStats;
-import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.server.smile.BaseResponse;
+import com.facebook.presto.spark.execution.BatchTaskUpdateRequest;
 import com.facebook.presto.spark.execution.HttpNativeExecutionTaskInfoFetcher;
 import com.facebook.presto.spark.execution.HttpNativeExecutionTaskResultFetcher;
 import com.facebook.presto.spark.execution.NativeExecutionProcess;
@@ -117,7 +117,7 @@ public class TestPrestoSparkHttpClient
     private static final Duration NO_DURATION = new Duration(0, TimeUnit.MILLISECONDS);
     private static final JsonCodec<TaskInfo> TASK_INFO_JSON_CODEC = JsonCodec.jsonCodec(TaskInfo.class);
     private static final JsonCodec<PlanFragment> PLAN_FRAGMENT_JSON_CODEC = JsonCodec.jsonCodec(PlanFragment.class);
-    private static final JsonCodec<TaskUpdateRequest> TASK_UPDATE_REQUEST_JSON_CODEC = JsonCodec.jsonCodec(TaskUpdateRequest.class);
+    private static final JsonCodec<BatchTaskUpdateRequest> TASK_UPDATE_REQUEST_JSON_CODEC = JsonCodec.jsonCodec(BatchTaskUpdateRequest.class);
     private static final JsonCodec<ServerInfo> SERVER_INFO_JSON_CODEC = JsonCodec.jsonCodec(ServerInfo.class);
     private static final ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
     private static final ScheduledExecutorService updateScheduledExecutor = newScheduledThreadPool(4);
@@ -238,6 +238,7 @@ public class TestPrestoSparkHttpClient
                 sources,
                 createPlanFragment(),
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                Optional.empty(),
                 TestingSession.testSessionBuilder().build(),
                 createInitialEmptyOutputBuffers(PARTITIONED));
 
@@ -701,7 +702,8 @@ public class TestPrestoSparkHttpClient
                     taskId,
                     createPlanFragment(),
                     sources,
-                    new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                    new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                    Optional.empty());
             assertNotNull(task);
             assertFalse(task.getTaskInfo().isPresent());
             assertFalse(task.pollResult().isPresent());
@@ -878,8 +880,8 @@ public class TestPrestoSparkHttpClient
                             }
                         }
                         else if (method.equalsIgnoreCase("POST")) {
-                            // POST /v1/task/{taskId}
-                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\z").matcher(path).find()) {
+                            // POST /v1/task/{taskId}/batch
+                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\/batch\\z").matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createTaskInfoResponse(HttpStatus.OK)));
                                 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkJavaExecutionTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkJavaExecutionTaskInputs.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.spark.broadcast.Broadcast;
+import scala.Tuple2;
+import scala.collection.Iterator;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+// TODO: This is a temporary implementation intending to have a cleaner commit split. The next commit will move impl from PrestoSparkTaskInputs here.
+public class PrestoSparkJavaExecutionTaskInputs
+        implements PrestoSparkTaskInputs
+{
+    // fragmentId -> Iterator<[partitionId, page]>
+    private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs;
+    private final Map<String, Broadcast<?>> broadcastInputs;
+    // For the COORDINATOR_ONLY fragment we first collect the inputs on the Driver
+    private final Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs;
+
+    public PrestoSparkJavaExecutionTaskInputs(
+            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs,
+            Map<String, Broadcast<?>> broadcastInputs,
+            Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs)
+    {
+        this.shuffleInputs = ImmutableMap.copyOf(requireNonNull(shuffleInputs, "shuffleInputs is null"));
+        this.broadcastInputs = ImmutableMap.copyOf(requireNonNull(broadcastInputs, "broadcastInputs is null"));
+        this.inMemoryInputs = ImmutableMap.copyOf(requireNonNull(inMemoryInputs, "inMemoryInputs is null"));
+    }
+
+    public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> getShuffleInputs()
+    {
+        return shuffleInputs;
+    }
+
+    public Map<String, Broadcast<?>> getBroadcastInputs()
+    {
+        return broadcastInputs;
+    }
+
+    public Map<String, List<PrestoSparkSerializedPage>> getInMemoryInputs()
+    {
+        return inMemoryInputs;
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeExecutionShuffleManager.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeExecutionShuffleManager.java
@@ -19,6 +19,7 @@ import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
 import org.apache.spark.scheduler.MapStatus;
 import org.apache.spark.scheduler.MapStatus$;
+import org.apache.spark.shuffle.BaseShuffleHandle;
 import org.apache.spark.shuffle.ShuffleBlockResolver;
 import org.apache.spark.shuffle.ShuffleHandle;
 import org.apache.spark.shuffle.ShuffleManager;
@@ -31,12 +32,15 @@ import scala.collection.Iterator;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /*
  * {@link PrestoSparkNativeExecutionShuffleManager} is the shuffle manager implementing the Spark shuffle manager interface specifically for native execution. The reasons we have this
@@ -50,8 +54,8 @@ import static java.lang.String.format;
 public class PrestoSparkNativeExecutionShuffleManager
         implements ShuffleManager
 {
-    private final Map<Integer, ShuffleHandle> shuffleDependencyMap = new ConcurrentHashMap<>();
-    private final Map<Integer, Integer> shuffleNumMaps = new ConcurrentHashMap<>();
+    private final Map<Integer, ShuffleHandle> partitionIdToShuffleHandle = new ConcurrentHashMap<>();
+    private final Map<Integer, BaseShuffleHandle<?, ?, ?>> shuffleIdToBaseShuffleHandle = new ConcurrentHashMap<>();
     private final ShuffleManager fallbackShuffleManager;
     private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
 
@@ -71,19 +75,27 @@ public class PrestoSparkNativeExecutionShuffleManager
         }
     }
 
+    protected void registerShuffleHandle(BaseShuffleHandle handle, int mapId)
+    {
+        partitionIdToShuffleHandle.put(mapId, handle);
+        shuffleIdToBaseShuffleHandle.put(handle.shuffleId(), handle);
+    }
+
     @Override
     public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency)
     {
-        shuffleNumMaps.put(shuffleId, numMaps);
         return fallbackShuffleManager.registerShuffle(shuffleId, numMaps, dependency);
     }
 
     @Override
     public <K, V> ShuffleWriter<K, V> getWriter(ShuffleHandle handle, int mapId, TaskContext context)
     {
-        shuffleDependencyMap.put(mapId, handle);
-        int shuffleId = handle.shuffleId();
-        return new EmptyShuffleWriter<>(getNumOfPartitions(shuffleId));
+        checkState(
+                requireNonNull(handle, "handle is null") instanceof BaseShuffleHandle,
+                "class %s is not instance of BaseShuffleHandle", handle.getClass().getName());
+        BaseShuffleHandle<?, ?, ?> baseShuffleHandle = (BaseShuffleHandle<?, ?, ?>) handle;
+        registerShuffleHandle(baseShuffleHandle, mapId);
+        return new EmptyShuffleWriter<>(baseShuffleHandle.dependency().partitioner().numPartitions());
     }
 
     @Override
@@ -118,15 +130,15 @@ public class PrestoSparkNativeExecutionShuffleManager
      */
     public Optional<ShuffleHandle> getShuffleHandle(int partitionId)
     {
-        return Optional.ofNullable(shuffleDependencyMap.getOrDefault(partitionId, null));
+        return Optional.ofNullable(partitionIdToShuffleHandle.getOrDefault(partitionId, null));
     }
 
     public int getNumOfPartitions(int shuffleId)
     {
-        if (!shuffleNumMaps.containsKey(shuffleId)) {
+        if (!shuffleIdToBaseShuffleHandle.containsKey(shuffleId)) {
             throw new RuntimeException(format("shuffleId=[%s] is not registered", shuffleId));
         }
-        return shuffleNumMaps.get(shuffleId);
+        return shuffleIdToBaseShuffleHandle.get(shuffleId).dependency().partitioner().numPartitions();
     }
 
     static class EmptyShuffleReader<K, V>
@@ -143,10 +155,12 @@ public class PrestoSparkNativeExecutionShuffleManager
             extends ShuffleWriter<K, V>
     {
         private final long[] mapStatus;
+        private static final long DEFAULT_MAP_STATUS = 1L;
 
         public EmptyShuffleWriter(int totalMapStages)
         {
             this.mapStatus = new long[totalMapStages];
+            Arrays.fill(mapStatus, DEFAULT_MAP_STATUS);
         }
 
         @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskInputs.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkNativeTaskInputs
+        implements PrestoSparkTaskInputs
+{
+    // fragmentId -> PrestoSparkShuffleReadDescriptor for native execution
+    private final Map<String, PrestoSparkShuffleReadDescriptor> shuffleReadDescriptors;
+    private final Optional<PrestoSparkShuffleWriteDescriptor> shuffleWriteDescriptor;
+
+    public PrestoSparkNativeTaskInputs(
+            Map<String, PrestoSparkShuffleReadDescriptor> shuffleReadDescriptors,
+            Optional<PrestoSparkShuffleWriteDescriptor> shuffleWriteDescriptor)
+    {
+        this.shuffleReadDescriptors = ImmutableMap.copyOf(requireNonNull(shuffleReadDescriptors, "shuffleReadDescriptors is null"));
+        this.shuffleWriteDescriptor = requireNonNull(shuffleWriteDescriptor, "shuffleWriteDescriptor is null");
+    }
+
+    public Map<String, PrestoSparkShuffleReadDescriptor> getShuffleReadDescriptors()
+    {
+        return shuffleReadDescriptors;
+    }
+
+    public Optional<PrestoSparkShuffleWriteDescriptor> getShuffleWriteDescriptor()
+    {
+        return shuffleWriteDescriptor;
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskRdd.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.spark.MapOutputTracker;
+import org.apache.spark.Partition;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkContext;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.TaskContext;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.rdd.ShuffledRDD;
+import org.apache.spark.rdd.ShuffledRDDPartition;
+import org.apache.spark.rdd.ZippedPartitionsPartition;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.storage.BlockId;
+import org.apache.spark.storage.BlockManagerId;
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.collection.Seq;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static scala.collection.JavaConversions.asJavaCollection;
+import static scala.collection.JavaConversions.seqAsJavaList;
+
+/**
+ * PrestoSparkTaskRdd represents execution of Presto stage, it contains:
+ * - A list of shuffleInputRdds, each of the corresponding to a child stage.
+ * - An optional taskSourceRdd, which represents ALL table scan inputs in this stage.
+ * <p>
+ * Table scan is present when joining a bucketed table with an unbucketed table, for example:
+ * Join
+ * /  \
+ * Scan  Remote Source
+ * <p>
+ * In this case, bucket to Spark partition mapping has to be consistent with the Spark shuffle partition.
+ * <p>
+ * When the stage partitioning is SINGLE_DISTRIBUTION and the shuffleInputRdds is empty,
+ * the taskSourceRdd is expected to be present and contain exactly one empty partition.
+ * <p>
+ * The broadcast inputs are encapsulated in taskProcessor.
+ */
+public class PrestoSparkNativeTaskRdd<T extends PrestoSparkTaskOutput>
+        extends PrestoSparkTaskRdd<T>
+{
+    public static <T extends PrestoSparkTaskOutput> PrestoSparkNativeTaskRdd<T> create(
+            SparkContext context,
+            Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
+            // fragmentId -> RDD
+            Map<String, RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRddMap,
+            PrestoSparkTaskProcessor<T> taskProcessor)
+    {
+        requireNonNull(context, "context is null");
+        requireNonNull(taskSourceRdd, "taskSourceRdd is null");
+        requireNonNull(shuffleInputRddMap, "shuffleInputRddMap is null");
+        requireNonNull(taskProcessor, "taskProcessor is null");
+        ImmutableList.Builder<String> shuffleInputFragmentIds = ImmutableList.builder();
+        ImmutableList.Builder<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds = ImmutableList.builder();
+        for (Map.Entry<String, RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> entry : shuffleInputRddMap.entrySet()) {
+            shuffleInputFragmentIds.add(entry.getKey());
+            shuffleInputRdds.add(entry.getValue());
+        }
+        return new PrestoSparkNativeTaskRdd<>(context, taskSourceRdd, shuffleInputFragmentIds.build(), shuffleInputRdds.build(), taskProcessor);
+    }
+
+    @Override
+    public Iterator<Tuple2<MutablePartitionId, T>> compute(Partition split, TaskContext context)
+    {
+        PrestoSparkTaskSourceRdd taskSourceRdd = getTaskSourceRdd();
+        List<Partition> partitions = seqAsJavaList(((ZippedPartitionsPartition) split).partitions());
+        int expectedPartitionsSize = (taskSourceRdd != null ? 1 : 0) + getShuffleInputRdds().size();
+        checkState(partitions.size() == expectedPartitionsSize,
+                format("Unexpected partitions size. Expected: %s. Actual: %s.", expectedPartitionsSize, partitions.size()));
+
+        Iterator<SerializedPrestoSparkTaskSource> taskSourceIterator;
+        if (taskSourceRdd != null) {
+            taskSourceIterator = taskSourceRdd.iterator(partitions.get(partitions.size() - 1), context);
+        }
+        else {
+            taskSourceIterator = emptyScalaIterator();
+        }
+
+        return getTaskProcessor().process(
+                taskSourceIterator,
+                getShuffleReadDescriptors(partitions),
+                getShuffleWriteDescriptor(split));
+    }
+
+    private PrestoSparkNativeTaskRdd(
+            SparkContext context,
+            Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
+            List<String> shuffleInputFragmentIds,
+            List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds,
+            PrestoSparkTaskProcessor<T> taskProcessor)
+    {
+        super(context, taskSourceRdd, shuffleInputFragmentIds, shuffleInputRdds, taskProcessor);
+    }
+
+    private Map<String, PrestoSparkShuffleReadDescriptor> getShuffleReadDescriptors(List<Partition> partitions)
+    {
+        //The classloader_interface package tries to have minimal external dependencies (except the spark-core), so we use HashMap instead of Guava's ImmutableMap
+        ImmutableMap.Builder<String, PrestoSparkShuffleReadDescriptor> shuffleReadDescriptors = ImmutableMap.builder();
+
+        // Get shuffle information from ShuffledRdds for shuffle read
+        int numPartitions = partitions.size();
+        List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds = getShuffleInputRdds();
+        List<String> shuffleInputFragmentIds = getShuffleInputFragmentIds();
+        checkState(
+                numPartitions >= shuffleInputRdds.size() && numPartitions >= shuffleInputFragmentIds.size(),
+                format(
+                        "Size of shuffleInputRdds %d or shuffleInputFragmentIds %d is not equal to number of partitions %d",
+                        shuffleInputRdds.size(),
+                        shuffleInputFragmentIds.size(),
+                        numPartitions));
+        for (int i = 0; i < shuffleInputRdds.size(); i++) {
+            Partition partition = partitions.get(i);
+            checkState(partition != null);
+            checkState(partition instanceof ShuffledRDDPartition,
+                    "partition is required to be ShuffledRddPartition, but got: %s", partition.getClass().getName());
+
+            RDD<?> shuffleRdd = shuffleInputRdds.get(i);
+            checkState(shuffleRdd != null);
+            checkState(shuffleRdd instanceof ShuffledRDD, "ShuffledRdd is required but got: %s", shuffleRdd.getClass().getName());
+
+            ShuffleHandle handle = ((ShuffleDependency<?, ?, ?>) shuffleRdd.dependencies().head()).shuffleHandle();
+            shuffleReadDescriptors.put(
+                    shuffleInputFragmentIds.get(i),
+                    new PrestoSparkShuffleReadDescriptor(
+                            partition,
+                            handle,
+                            shuffleRdd.getNumPartitions(),
+                            getBlockIds(((ShuffledRDDPartition) partition), handle),
+                            getPartitionSize(((ShuffledRDDPartition) partition), handle)));
+        }
+        return shuffleReadDescriptors.build();
+    }
+
+    private Optional<PrestoSparkShuffleWriteDescriptor> getShuffleWriteDescriptor(Partition split)
+    {
+        // Get shuffle information from Spark shuffle manager for shuffle write
+        checkState(
+                SparkEnv.get().shuffleManager() instanceof PrestoSparkNativeExecutionShuffleManager,
+                "Native execution requires to use PrestoSparkNativeExecutionShuffleManager. But got: %s", SparkEnv.get().shuffleManager().getClass().getName());
+        PrestoSparkNativeExecutionShuffleManager shuffleManager = (PrestoSparkNativeExecutionShuffleManager) SparkEnv.get().shuffleManager();
+        Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(split.index());
+
+        return shuffleHandle.map(handle -> new PrestoSparkShuffleWriteDescriptor(handle, shuffleManager.getNumOfPartitions(handle.shuffleId())));
+    }
+
+    private List<String> getBlockIds(ShuffledRDDPartition partition, ShuffleHandle shuffleHandle)
+    {
+        MapOutputTracker mapOutputTracker = SparkEnv.get().mapOutputTracker();
+        Collection<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapSizes = asJavaCollection(mapOutputTracker.getMapSizesByExecutorId(
+                shuffleHandle.shuffleId(), partition.idx(), partition.idx() + 1));
+        return mapSizes.stream().map(item -> item._1.executorId()).collect(Collectors.toList());
+    }
+
+    private List<Long> getPartitionSize(ShuffledRDDPartition partition, ShuffleHandle shuffleHandle)
+    {
+        MapOutputTracker mapOutputTracker = SparkEnv.get().mapOutputTracker();
+        Collection<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapSizes = asJavaCollection(mapOutputTracker.getMapSizesByExecutorId(
+                shuffleHandle.shuffleId(), partition.idx(), partition.idx() + 1));
+        //Each partition/BlockManagerId can contain multiple blocks (with BlockId), here sums up all the blocks from each BlockManagerId/Partition
+        return mapSizes.stream()
+                .map(
+                        item -> seqAsJavaList(item._2)
+                                .stream()
+                                .map(item2 -> ((Long) item2._2))
+                                .reduce(0L, Long::sum))
+                .collect(Collectors.toList());
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -13,47 +13,6 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-import org.apache.spark.broadcast.Broadcast;
-import scala.Tuple2;
-import scala.collection.Iterator;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.Collections.unmodifiableMap;
-import static java.util.Objects.requireNonNull;
-
-public class PrestoSparkTaskInputs
+public interface PrestoSparkTaskInputs
 {
-    // fragmentId -> Iterator<[partitionId, page]>
-    private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs;
-    private final Map<String, Broadcast<?>> broadcastInputs;
-    // For the COORDINATOR_ONLY fragment we first collect the inputs on the Driver
-    private final Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs;
-
-    public PrestoSparkTaskInputs(
-            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs,
-            Map<String, Broadcast<?>> broadcastInputs,
-            Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs)
-    {
-        this.shuffleInputs = unmodifiableMap(new HashMap<>(requireNonNull(shuffleInputs, "shuffleInputs is null")));
-        this.broadcastInputs = unmodifiableMap(new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null")));
-        this.inMemoryInputs = unmodifiableMap(new HashMap<>(requireNonNull(inMemoryInputs, "inMemoryInputs is null")));
-    }
-
-    public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> getShuffleInputs()
-    {
-        return shuffleInputs;
-    }
-
-    public Map<String, Broadcast<?>> getBroadcastInputs()
-    {
-        return broadcastInputs;
-    }
-
-    public Map<String, List<PrestoSparkSerializedPage>> getInMemoryInputs()
-    {
-        return inMemoryInputs;
-    }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
@@ -57,8 +57,8 @@ import static scala.collection.JavaConversions.seqAsJavaList;
 public class PrestoSparkTaskRdd<T extends PrestoSparkTaskOutput>
         extends ZippedPartitionsBaseRDD<Tuple2<MutablePartitionId, T>>
 {
-    private List<String> shuffleInputFragmentIds;
     private List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds;
+    private List<String> shuffleInputFragmentIds;
     private PrestoSparkTaskSourceRdd taskSourceRdd;
     private PrestoSparkTaskProcessor<T> taskProcessor;
 
@@ -82,7 +82,7 @@ public class PrestoSparkTaskRdd<T extends PrestoSparkTaskOutput>
         return new PrestoSparkTaskRdd<>(context, taskSourceRdd, shuffleInputFragmentIds, shuffleInputRdds, taskProcessor);
     }
 
-    private PrestoSparkTaskRdd(
+    protected PrestoSparkTaskRdd(
             SparkContext context,
             Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
             List<String> shuffleInputFragmentIds,
@@ -159,5 +159,10 @@ public class PrestoSparkTaskRdd<T extends PrestoSparkTaskOutput>
     public List<String> getShuffleInputFragmentIds()
     {
         return shuffleInputFragmentIds;
+    }
+
+    public PrestoSparkTaskProcessor<T> getTaskProcessor()
+    {
+        return taskProcessor;
     }
 }


### PR DESCRIPTION
* Add PrestoSparkNativeTaskRdd for native execution
  * Add required entities to connect the shuffle information passing on the Spark side.
* Inject shuffle write info to native execution entities and switch to BatchTaskUpdateRequest
  * Completes the shuffle information passing from Spark to native execution. Additionally it switches the the calling of task update from original interactive API (TaskUpdateRequest) to batch API (BatchTaskUpdateRequest).
* Fix ShuffleManager for getting the shuffleHandle

```
== NO RELEASE NOTE ==
```
