### PR TITLE
Fix TableSample for Decimal Type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1593,7 +1593,7 @@ class StatementAnalyzer
             if (convertibleToDoubleWithCast(samplePercentageType)) {
                 InterpretedFunctionInvoker functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionAndTypeManager());
                 FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, samplePercentageType, DoubleType.DOUBLE);
-                samplePercentageObject =  functionInvoker.invoke(cast, session.getSqlFunctionProperties(), singletonList(samplePercentageObject));
+                samplePercentageObject = functionInvoker.invoke(cast, session.getSqlFunctionProperties(), singletonList(samplePercentageObject));
             }
 
             double samplePercentageValue = ((Number) samplePercentageObject).doubleValue();

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestFractionalTableSample.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestFractionalTableSample.java
@@ -1,0 +1,30 @@
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+
+public class TestFractionalTableSample extends AbstractTestQueryFramework
+{
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        LocalQueryRunner queryRunner = new LocalQueryRunner(TEST_SESSION);
+        queryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @org.testng.annotations.Test
+    public void testTableSampleWIthF()
+    {
+        assertQuerySucceeds("SELECT count(*) FROM tpch.tiny.orders TABLESAMPLE BERNOULLI (0.000000000000000000001)");
+        assertQuerySucceeds("SELECT count(*) FROM tpch.tiny.orders TABLESAMPLE BERNOULLI (0.02)");
+    }
+
+
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestFractionalTableSample.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestFractionalTableSample.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.tests;
 
 import com.facebook.presto.testing.LocalQueryRunner;
@@ -7,9 +20,9 @@ import com.google.common.collect.ImmutableMap;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 
-public class TestFractionalTableSample extends AbstractTestQueryFramework
+public class TestFractionalTableSample
+        extends AbstractTestQueryFramework
 {
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -25,6 +38,4 @@ public class TestFractionalTableSample extends AbstractTestQueryFramework
         assertQuerySucceeds("SELECT count(*) FROM tpch.tiny.orders TABLESAMPLE BERNOULLI (0.000000000000000000001)");
         assertQuerySucceeds("SELECT count(*) FROM tpch.tiny.orders TABLESAMPLE BERNOULLI (0.02)");
     }
-
-
 }


### PR DESCRIPTION
Fixes [issue](https://github.com/prestodb/presto/issues/18923) #18923
Test plan -
Unit test + Tested on TPCH
Query
`
SELECT * FROM tpch.sf1.customer TABLESAMPLE BERNOULLI(0.23150292229611358) 
`
== RELEASE NOTES ==
General Changes
Fixed an issue with TableSample where the scale and precision of decimal values were not being taken into account, resulting in incorrect interpretation of fractions and potential inaccuracies in the final results