### PR TITLE
Add new AddNotNullFiltersToJoinNode rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1106,8 +1106,8 @@ public final class SystemSessionProperties
                         WarningHandlingLevel::name),
                 booleanProperty(
                         OPTIMIZE_NULLS_IN_JOINS,
-                        "Filter nulls from inner side of join",
-                        featuresConfig.isOptimizeNullsInJoin(),
+                        "(DEPRECATED) Filter nulls from inner side of join. If this is set, joins_not_null_inference_strategy = 'INFER_FROM_STANDARD_OPERATORS' is assumed",
+                        false,
                         false),
                 booleanProperty(
                         OPTIMIZE_PAYLOAD_JOINS,
@@ -2299,11 +2299,6 @@ public final class SystemSessionProperties
         return session.getSystemProperty(WARNING_HANDLING, WarningHandlingLevel.class);
     }
 
-    public static boolean isOptimizeNullsInJoin(Session session)
-    {
-        return session.getSystemProperty(OPTIMIZE_NULLS_IN_JOINS, Boolean.class);
-    }
-
     public static boolean isOptimizePayloadJoins(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_PAYLOAD_JOINS, Boolean.class);
@@ -2311,6 +2306,9 @@ public final class SystemSessionProperties
 
     public static JoinNotNullInferenceStrategy getNotNullInferenceStrategy(Session session)
     {
+        if (session.getSystemProperty(OPTIMIZE_NULLS_IN_JOINS, Boolean.class)) {
+            return JoinNotNullInferenceStrategy.INFER_FROM_STANDARD_OPERATORS;
+        }
         return session.getSystemProperty(JOINS_NOT_NULL_INFERENCE_STRATEGY, JoinNotNullInferenceStrategy.class);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.properties.LogicalPropertiesProviderImpl;
 import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregations;
+import com.facebook.presto.sql.planner.iterative.rule.AddNotNullFiltersToJoinNode;
 import com.facebook.presto.sql.planner.iterative.rule.CombineApproxPercentileFunctions;
 import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
 import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithOrFilterToInnerJoin;
@@ -466,7 +467,8 @@ public class PlanOptimizers
                                 new RemoveRedundantDistinctLimit(),
                                 new RemoveRedundantAggregateDistinct(),
                                 new RemoveRedundantIdentityProjections(),
-                                new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))),
+                                new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()),
+                                new AddNotNullFiltersToJoinNode(metadata.getFunctionAndTypeManager()))),
                 inlineProjections,
                 simplifyRowExpressionOptimizer, // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
                 projectionPushDown,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -66,7 +66,6 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Intersect;
-import com.facebook.presto.sql.tree.IsNotNullPredicate;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
@@ -322,13 +321,11 @@ class RelationPlanner
                     if (firstDependencies.stream().allMatch(left::canResolve) && secondDependencies.stream().allMatch(right::canResolve)) {
                         leftComparisonExpressions.add(firstExpression);
                         rightComparisonExpressions.add(secondExpression);
-                        addNullFilters(complexJoinExpressions, node.getType(), firstExpression, secondExpression);
                         joinConditionComparisonOperators.add(comparisonOperator);
                     }
                     else if (firstDependencies.stream().allMatch(right::canResolve) && secondDependencies.stream().allMatch(left::canResolve)) {
                         leftComparisonExpressions.add(secondExpression);
                         rightComparisonExpressions.add(firstExpression);
-                        addNullFilters(complexJoinExpressions, node.getType(), secondExpression, firstExpression);
                         joinConditionComparisonOperators.add(comparisonOperator.flip());
                     }
                     else {
@@ -468,32 +465,6 @@ class RelationPlanner
         }
 
         return new RelationPlan(root, analysis.getScope(node), outputs);
-    }
-
-    private void addNullFilters(List<Expression> conditions, Join.Type joinType, Expression left, Expression right)
-    {
-        if (SystemSessionProperties.isOptimizeNullsInJoin(session)) {
-            switch (joinType) {
-                case INNER:
-                    addNullFilterIfSupported(conditions, left);
-                    addNullFilterIfSupported(conditions, right);
-                    break;
-                case LEFT:
-                    addNullFilterIfSupported(conditions, right);
-                    break;
-                case RIGHT:
-                    addNullFilterIfSupported(conditions, left);
-                    break;
-            }
-        }
-    }
-
-    private void addNullFilterIfSupported(List<Expression> conditions, Expression incoming)
-    {
-        if (!(incoming instanceof InPredicate)) {
-            // (A.x IN (1,2,3)) IS NOT NULL is not supported as a join condition as of today.
-            conditions.add(new IsNotNullPredicate(incoming));
-        }
     }
 
     private RelationPlan planJoinUsing(Join node, RelationPlan left, RelationPlan right, SqlPlannerContext context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddNotNullFiltersToJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddNotNullFiltersToJoinNode.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.IntermediateFormExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.getNotNullInferenceStrategy;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy.NONE;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.intersection;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
+
+public class AddNotNullFiltersToJoinNode
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join();
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final Logger logger = Logger.get(AddNotNullFiltersToJoinNode.class);
+    private final FunctionResolution functionResolution;
+
+    public AddNotNullFiltersToJoinNode(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return getNotNullInferenceStrategy(session) != NONE;
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(JoinNode joinNode, Captures captures, Context context)
+    {
+        Collection<VariableReferenceExpression> inferredNotNullVariables;
+        JoinNotNullInferenceStrategy notNullInferenceStrategy = getNotNullInferenceStrategy(context.getSession());
+
+        switch (joinNode.getType()) {
+            case LEFT:
+                // NOT NULL can be inferred for the right-side variables
+                inferredNotNullVariables = extractNotNullVariables(joinNode.getCriteria(), joinNode.getFilter(), joinNode.getRight().getOutputVariables(), notNullInferenceStrategy);
+                break;
+            case RIGHT:
+                // NOT NULL can be inferred for the left-side variables
+                inferredNotNullVariables = extractNotNullVariables(joinNode.getCriteria(), joinNode.getFilter(), joinNode.getLeft().getOutputVariables(), notNullInferenceStrategy);
+                break;
+            case INNER:
+                // NOT NULL can be inferred for variables from both sides of the join
+                inferredNotNullVariables = extractNotNullVariables(joinNode.getCriteria(), joinNode.getFilter(), concat(joinNode.getLeft().getOutputVariables().stream(),
+                        joinNode.getRight().getOutputVariables().stream()).collect(toImmutableList()), notNullInferenceStrategy);
+                break;
+            case FULL:
+            default:
+                // NOT NULL cannot be inferred
+                return Result.empty();
+        }
+
+        if (inferredNotNullVariables.isEmpty()) {
+            return Result.empty();
+        }
+
+        Set<VariableReferenceExpression> existingNotNullVariables = getExistingNotNullVariables(joinNode.getFilter());
+        logger.debug("NotNull filters :: Existing : %s, Inferred :%s", existingNotNullVariables, inferredNotNullVariables);
+
+        if (existingNotNullVariables.containsAll(inferredNotNullVariables)) {
+            // No new NOT NULL variables were inferred
+            return Result.empty();
+        }
+
+        RowExpression updatedJoinFilter = and(joinNode.getFilter().orElse(TRUE_CONSTANT), buildNotNullRowExpression(inferredNotNullVariables));
+        return Result.ofPlanNode(
+                new JoinNode(joinNode.getSourceLocation(),
+                        context.getIdAllocator().getNextId(),
+                        joinNode.getType(),
+                        joinNode.getLeft(),
+                        joinNode.getRight(),
+                        joinNode.getCriteria(),
+                        joinNode.getOutputVariables(),
+                        Optional.ofNullable(updatedJoinFilter),
+                        joinNode.getLeftHashVariable(),
+                        joinNode.getRightHashVariable(),
+                        joinNode.getDistributionType(),
+                        joinNode.getDynamicFilters()));
+    }
+
+    private Collection<VariableReferenceExpression> extractNotNullVariables(List<JoinNode.EquiJoinClause> joinCriteria, Optional<RowExpression> joinFilter,
+            List<VariableReferenceExpression> candidates, JoinNotNullInferenceStrategy notNullInferenceStrategy)
+    {
+        RowExpression combinedFilter = TRUE_CONSTANT;
+
+        for (JoinNode.EquiJoinClause criteria : joinCriteria) {
+            combinedFilter = and(combinedFilter, criteria.getLeft());
+            combinedFilter = and(combinedFilter, criteria.getRight());
+        }
+
+        combinedFilter = and(combinedFilter, joinFilter.orElse(TRUE_CONSTANT));
+
+        return intersection(ImmutableSet.copyOf(candidates), inferNotNullVariables(combinedFilter, notNullInferenceStrategy));
+    }
+
+    @VisibleForTesting
+    Set<VariableReferenceExpression> getExistingNotNullVariables(Optional<RowExpression> joinFilter)
+    {
+        if (!joinFilter.isPresent()) {
+            return ImmutableSet.of();
+        }
+
+        ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
+
+        DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<VariableReferenceExpression>> isNotNullExtractingVisitor =
+                new DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<VariableReferenceExpression>>()
+                {
+                    @Override
+                    public Void visitCall(CallExpression call, ImmutableSet.Builder<VariableReferenceExpression> context)
+                    {
+                        // Match a 'not(IS_NULL(VariableReferenceExpression))' call *exactly*
+                        if (functionResolution.isNotFunction(call.getFunctionHandle()) &&
+                                call.getArguments().size() == 1 &&
+                                call.getArguments().get(0) instanceof SpecialFormExpression &&
+                                ((SpecialFormExpression) call.getArguments().get(0)).getForm() == IS_NULL &&
+                                ((SpecialFormExpression) call.getArguments().get(0)).getArguments().size() == 1 &&
+                                ((SpecialFormExpression) call.getArguments().get(0)).getArguments().get(0) instanceof VariableReferenceExpression) {
+                            context.add((VariableReferenceExpression) ((SpecialFormExpression) call.getArguments().get(0)).getArguments().get(0));
+                        }
+                        return null;
+                    }
+
+                    @Override
+                    public Void visitIntermediateFormExpression(IntermediateFormExpression expression, ImmutableSet.Builder<VariableReferenceExpression> context)
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public Void visitSpecialForm(SpecialFormExpression specialForm, ImmutableSet.Builder<VariableReferenceExpression> context)
+                    {
+                        if (specialForm.getForm() == AND) {
+                            return super.visitSpecialForm(specialForm, context);
+                        }
+                        return null;
+                    }
+                };
+
+        joinFilter.get().accept(isNotNullExtractingVisitor, builder);
+        return builder.build();
+    }
+
+    private ImmutableSet<VariableReferenceExpression> inferNotNullVariables(RowExpression expression, JoinNotNullInferenceStrategy notNullInferenceStrategy)
+    {
+        ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
+        expression.accept(new ExtractInferredNotNullVariablesVisitor(functionAndTypeManager, notNullInferenceStrategy), builder);
+        return builder.build();
+    }
+
+    private RowExpression buildNotNullRowExpression(Collection<VariableReferenceExpression> expressions)
+    {
+        List<CallExpression> isNotNullExpressions = expressions.stream().map(x -> new CallExpression(
+                        x.getSourceLocation(),
+                        "not",
+                        functionResolution.notFunction(),
+                        BOOLEAN,
+                        singletonList(new SpecialFormExpression(x.getSourceLocation(), IS_NULL, BOOLEAN, x))))
+                .collect(toImmutableList());
+
+        return and(isNotNullExpressions);
+    }
+
+    @VisibleForTesting
+    public static class ExtractInferredNotNullVariablesVisitor
+            extends DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<VariableReferenceExpression>>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final JoinNotNullInferenceStrategy notNullInferenceStrategy;
+
+        public ExtractInferredNotNullVariablesVisitor(FunctionAndTypeManager functionAndTypeManager, JoinNotNullInferenceStrategy notNullInferenceStrategy)
+        {
+            this.functionAndTypeManager = functionAndTypeManager;
+            this.notNullInferenceStrategy = notNullInferenceStrategy;
+        }
+
+        @Override
+        public Void visitCall(CallExpression call, ImmutableSet.Builder<VariableReferenceExpression> context)
+        {
+            final FunctionHandle functionHandle = call.getFunctionHandle();
+            final FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(functionHandle);
+
+            switch (notNullInferenceStrategy) {
+                case INFER_FROM_STANDARD_OPERATORS:
+                    if (!functionMetadata.getOperatorType().isPresent() || functionMetadata.getOperatorType().get().isCalledOnNullInput()) {
+                        // We can't map this CallExpression to an OperatorType OR
+                        // this OperatorType can be called on NULL inputs, so we can't make NOT NULL inferences on it's arguments
+                        return null;
+                    }
+                    break;
+                case USE_FUNCTION_METADATA:
+                    if (functionMetadata.isCalledOnNullInput()) {
+                        // Since this function can operate on NULL inputs and return a valid value, we can't make NOT NULL inference on it's arguments
+                        return null;
+                    }
+                    break;
+                default:
+                    return null;
+            }
+
+            return super.visitCall(call, context);
+        }
+
+        @Override
+        public Void visitSpecialForm(SpecialFormExpression specialForm, ImmutableSet.Builder<VariableReferenceExpression> context)
+        {
+            SpecialFormExpression.Form form = specialForm.getForm();
+            if (form == AND) {
+                // All arguments of an AND expression must be NOT NULL for the expression to be true
+                // Hence, we can proceed with extracting candidates for NOT NULL inference on it's arguments
+                return super.visitSpecialForm(specialForm, context);
+            }
+            // For all other SpecialForms e.g. OR, COALESCE, IS_NULL, CASE, DEREFERENCE we abstain from making NOT NULL inferences
+            return null;
+        }
+
+        @Override
+        public Void visitIntermediateFormExpression(IntermediateFormExpression expression, ImmutableSet.Builder<VariableReferenceExpression> context)
+        {
+            // TODO : For now, we are not traversing any IntermediateFormExpression's. For some cases, such as InSubqueryExpression
+            // we may be able to do some null inference-ing
+            return null;
+        }
+
+        @Override
+        public Void visitVariableReference(VariableReferenceExpression variableReferenceExpression, ImmutableSet.Builder<VariableReferenceExpression> context)
+        {
+            context.add(variableReferenceExpression);
+            return super.visitVariableReference(variableReferenceExpression, context);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -38,6 +38,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.LEGACY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.TOP_DOWN;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy.USE_FUNCTION_METADATA;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy.PUSH_THROUGH_LOW_MEMORY_OPERATORS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILLER_SPILL_PATH;
@@ -178,6 +179,7 @@ public class TestFeaturesConfig
                 .setOptimizeCommonSubExpressions(true)
                 .setPreferDistributedUnion(true)
                 .setOptimizeNullsInJoin(false)
+                .setJoinsNotNullInferenceStrategy(FeaturesConfig.JoinNotNullInferenceStrategy.NONE)
                 .setSkipRedundantSort(true)
                 .setWarnOnNoTableLayoutFilter("")
                 .setInlineSqlFunctions(true)
@@ -356,6 +358,7 @@ public class TestFeaturesConfig
                 .put("optimize-common-sub-expressions", "false")
                 .put("prefer-distributed-union", "false")
                 .put("optimize-nulls-in-join", "true")
+                .put("optimizer.joins-not-null-inference-strategy", "USE_FUNCTION_METADATA")
                 .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .put("inline-sql-functions", "false")
                 .put("check-access-control-on-utilized-columns-only", "true")
@@ -531,6 +534,7 @@ public class TestFeaturesConfig
                 .setOptimizeCommonSubExpressions(false)
                 .setPreferDistributedUnion(false)
                 .setOptimizeNullsInJoin(true)
+                .setJoinsNotNullInferenceStrategy(USE_FUNCTION_METADATA)
                 .setSkipRedundantSort(false)
                 .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds")
                 .setInlineSqlFunctions(false)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddNotNullFiltersToJoinNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddNotNullFiltersToJoinNode.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.rule.AddNotNullFiltersToJoinNode.ExtractInferredNotNullVariablesVisitor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.JOINS_NOT_NULL_INFERENCE_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_NULLS_IN_JOINS;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy.INFER_FROM_STANDARD_OPERATORS;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy.USE_FUNCTION_METADATA;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.relational.Expressions.variable;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestAddNotNullFiltersToJoinNode
+        extends BasePlanTest
+{
+    private static final Map<String, Type> testVariableTypeMap;
+    private final TestingRowExpressionTranslator rowExpressionTranslator;
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public TestAddNotNullFiltersToJoinNode()
+    {
+        super(ImmutableMap.of(OPTIMIZE_NULLS_IN_JOINS, Boolean.toString(false),
+                JOINS_NOT_NULL_INFERENCE_STRATEGY, USE_FUNCTION_METADATA.toString()));
+
+        functionAndTypeManager = createTestFunctionAndTypeManager();
+        Metadata metadata = MetadataManager.createTestMetadataManager();
+        rowExpressionTranslator = new TestingRowExpressionTranslator(metadata);
+    }
+
+    @DataProvider
+    public static Object[][] getExistingNotNullVarsTestCases()
+    {
+        return new Object[][] {
+                {"a IS NOT NULL AND b IS NOT NULL", new String[] {"a", "b"}},
+                {"a > 10 AND b IS NOT NULL AND c is NOT NULL", new String[] {"b", "c"}},
+                {"a is NULL AND b IS NOT NULL", new String[] {"b"}},
+                {"NOT(a is NULL)", new String[] {"a"}},
+                {"NOT(a is NULL OR b is NULL)", new String[] {}},
+                {"a is NOT NULL OR b is NOT NULL", new String[] {}}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] standardOperatorTestCases()
+    {
+        return new Object[][] {
+                {"a + b > 10", new String[] {"a", "b"}},
+                {"a != 10 - b", new String[] {"a", "b"}},
+                {"a > b", new String[] {"a", "b"}},
+                {"a + NULL > b", new String[] {"a", "b"}},
+                // We can infer NOT NULL predicates on arguments of an AND expression
+                {"a > b and c = d", new String[] {"a", "b", "c", "d"}},
+                {"a IS NULL and b > c", new String[] {"b", "c"}},
+                // We cannot infer NOT NULL predicates on arguments of an OR expression
+                {"a > b OR c = d", new String[] {}},
+                // COALESCE can operate on NULL arguments, so cant infer predicates on its arguments
+                {"COALESCE(a,b)", new String[] {}},
+                // IN can operate on NULL arguments, so cant infer predicates on its arguments
+                {"a IN (b,10,NULL)", new String[] {}},
+                // arr[3] = 10 translates to EQUAL(SUBSCRIPT(arr, 3), 10). SUBSCRIPT is a standard Operator, so we can infer that 'arr' is NOT NULL
+                {"arr[3] = 10", new String[] {"arr"}},
+                // c_struct.a = 10 translates to EQUAL(DEREFERENCE(c_struct, 0), 10).
+                // We chose to not make any inferences for DEREFERENCE clauses, hence we don't add any NOT NULL clauses for 'c_struct' or 'c_struct.a'
+                {"c_struct.a = 10", new String[] {}},
+                // NULLs are only inferred from standard operators
+                {"NOT (b + 10 > c)", new String[] {}},
+                {"abs(b + c) > 10", new String[] {}},
+                {"random(b) = ceil(c)", new String[] {}},
+                {"d > e and abs(b + c) > 10", new String[] {"d", "e"}},
+        };
+    }
+
+    @DataProvider
+    public static Object[][] nonStandardOperatorTestCases()
+    {
+        return new Object[][] {
+                {"NOT (b + 10 > c)", new String[] {"b", "c"}},
+                {"abs(b + c) > 10", new String[] {"b", "c"}},
+                {"random(b) = ceil(c)", new String[] {"b", "c"}},
+        };
+    }
+
+    @Test
+    public void testNotNullPredicatesAddedForSingleEquiJoinClause()
+    {
+        String query = "select 1 from lineitem l join orders o on l.orderkey = o.orderkey";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL",
+                                                tableScan("lineitem", ImmutableMap.of("LINE_ORDER_KEY", "orderkey")))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IS NOT NULL",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))))));
+    }
+
+    @Test
+    public void testNotNullPredicatesAddedForCrossJoinReducedToInnerJoin()
+    {
+        String query = "select 1 from lineitem l, orders o where l.orderkey = o.orderkey";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL",
+                                                tableScan("lineitem", ImmutableMap.of("LINE_ORDER_KEY", "orderkey")))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IS NOT NULL",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))))));
+
+        query = "select 1 from lineitem l join orders o on l.orderkey = o.orderkey, customer c where c.custkey = o.custkey";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL",
+                                                tableScan("lineitem", ImmutableMap.of("LINE_ORDER_KEY", "orderkey")))),
+                                anyTree(join(INNER,
+                                        ImmutableList.of(equiJoinClause("ORDERS_CUSTOMER_KEY", "CUSTOMER_CUSTOMER_KEY")),
+                                        anyTree(
+                                                filter("ORDERS_CUSTOMER_KEY IS NOT NULL AND ORDERS_ORDER_KEY IS NOT NULL",
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey",
+                                                                "ORDERS_CUSTOMER_KEY", "custkey")))),
+                                        anyTree(
+                                                filter("CUSTOMER_CUSTOMER_KEY IS NOT NULL",
+                                                        tableScan("customer", ImmutableMap.of("CUSTOMER_CUSTOMER_KEY", "custkey")))))))));
+    }
+
+    @Test
+    public void testMultipleNotNullsAddedForMultipleEquiJoinClause()
+    {
+        String query = "select 1 from lineitem l join orders o on l.orderkey = o.orderkey and l.partkey = o.custkey";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY"),
+                                        equiJoinClause("partkey", "custkey")),
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL AND partkey IS NOT NULL",
+                                                tableScan("lineitem",
+                                                        ImmutableMap.of(
+                                                                "LINE_ORDER_KEY", "orderkey",
+                                                                "partkey", "partkey")))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IS NOT NULL AND custkey IS NOT NULL",
+                                                tableScan("orders",
+                                                        ImmutableMap.of(
+                                                                "ORDERS_ORDER_KEY", "orderkey",
+                                                                "custkey", "custkey")))))));
+    }
+
+    @Test
+    public void testNotNullInferredForJoinFilter()
+    {
+        String query = "select 1 from lineitem l join orders o on l.orderkey = o.orderkey and partkey + custkey > 10";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                // Only single equi join clause in this case
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                // Extra join filter is passed unchanged
+                                Optional.of("partkey + custkey > 10"),
+                                // We can infer NOT NULL filters on partkey and custkey since the ADD function cannot operate on NULL arguments
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL AND partkey IS NOT NULL",
+                                                tableScan("lineitem",
+                                                        ImmutableMap.of(
+                                                                "LINE_ORDER_KEY", "orderkey",
+                                                                "partkey", "partkey")))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IS NOT NULL AND custkey IS NOT NULL",
+                                                tableScan("orders",
+                                                        ImmutableMap.of(
+                                                                "ORDERS_ORDER_KEY", "orderkey",
+                                                                "custkey", "custkey")))))));
+    }
+
+    @Test
+    public void testNotNullPredicatesAddedOnlyForInnerSideTablesVariableReferences()
+    {
+        String query = "select 1 from lineitem l left join orders o on l.orderkey = o.orderkey and partkey - custkey > 10";
+        assertPlan(query,
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                Optional.of("partkey - custkey > 10"),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of(
+                                                "LINE_ORDER_KEY", "orderkey",
+                                                "partkey", "partkey"))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IS NOT NULL and custkey IS NOT NULL",
+                                                tableScan("orders",
+                                                        ImmutableMap.of(
+                                                                "ORDERS_ORDER_KEY", "orderkey",
+                                                                "custkey", "custkey")))))));
+
+        query = "select 1 from lineitem l right join orders o on l.orderkey = o.orderkey and custkey > partkey";
+        assertPlan(query,
+                anyTree(
+                        join(RIGHT,
+                                ImmutableList.of(equiJoinClause("LINE_ORDER_KEY", "ORDERS_ORDER_KEY")),
+                                Optional.of("custkey > partkey"),
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IS NOT NULL and partkey IS NOT NULL",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINE_ORDER_KEY", "orderkey",
+                                                        "partkey", "partkey")))),
+                                anyTree(
+                                        tableScan("orders",
+                                                ImmutableMap.of(
+                                                        "ORDERS_ORDER_KEY", "orderkey",
+                                                        "custkey", "custkey"))))));
+    }
+
+    @Test(dataProvider = "standardOperatorTestCases")
+    public void testNotNullInferenceForInferFromStandardOperatorsStrategy(String filterSql, String[] expectedInferredNotNullVariables)
+    {
+        assertInferredNotNullVariableRefsListMatch(INFER_FROM_STANDARD_OPERATORS, filterSql, buildVariableReferencesList(expectedInferredNotNullVariables));
+    }
+
+    @Test(dataProvider = "nonStandardOperatorTestCases")
+    public void testNotNullInferenceForUseFunctionMetadataStrategy(String filterSql, String[] expectedInferredNotNullVariables)
+    {
+        assertInferredNotNullVariableRefsListMatch(USE_FUNCTION_METADATA, filterSql, buildVariableReferencesList(expectedInferredNotNullVariables));
+    }
+
+    @Test(dataProvider = "getExistingNotNullVarsTestCases")
+    public void testGetExistingNotNullVars(String filterSql, String[] expectedNotNullVars)
+    {
+        Set<VariableReferenceExpression> actual = new AddNotNullFiltersToJoinNode(functionAndTypeManager).getExistingNotNullVariables(
+                Optional.of(rowExpressionTranslator.translate(filterSql, testVariableTypeMap)));
+
+        assertEquals(actual, buildVariableReferencesList(expectedNotNullVars));
+    }
+
+    private List<VariableReferenceExpression> buildVariableReferencesList(String... var)
+    {
+        return Arrays.stream(var).map(x -> variable(x, testVariableTypeMap.get(x))).collect(Collectors.toList());
+    }
+
+    private void assertInferredNotNullVariableRefsListMatch(JoinNotNullInferenceStrategy notNullInferenceStrategy,
+            String filterSql, List<VariableReferenceExpression> expectedInferredNotNullVariables)
+    {
+        ExtractInferredNotNullVariablesVisitor visitor = new ExtractInferredNotNullVariablesVisitor(functionAndTypeManager, notNullInferenceStrategy);
+
+        RowExpression rowExpression = rowExpressionTranslator.translate(filterSql, testVariableTypeMap);
+        ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
+        rowExpression.accept(visitor, builder);
+        assertEquals(builder.build(), expectedInferredNotNullVariables);
+    }
+
+    static {
+        ImmutableMap.Builder<String, Type> builder = ImmutableMap.builder();
+        builder.put("a", BIGINT);
+        builder.put("b", BIGINT);
+        builder.put("c", BIGINT);
+        builder.put("d", BIGINT);
+        builder.put("e", BIGINT);
+        builder.put("arr", new ArrayType(BIGINT));
+        builder.put("c_struct", RowType.from(ImmutableList.of(RowType.field("a", BIGINT))));
+        testVariableTypeMap = builder.build();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -89,6 +89,7 @@ import static com.google.common.base.Strings.padEnd;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.newArrayList;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
 import static io.airlift.tpch.TpchTable.LINE_ITEM;
 import static io.airlift.tpch.TpchTable.NATION;
 import static io.airlift.tpch.TpchTable.ORDERS;
@@ -180,6 +181,18 @@ public class H2QueryRunner
                 "  comment VARCHAR(23) NOT NULL\n" +
                 ")");
         insertRows(tpchMetadata, PART);
+
+        handle.execute(" CREATE TABLE customer (     \n" +
+                "    custkey BIGINT NOT NULL,         \n" +
+                "    name VARCHAR(25) NOT NULL,       \n" +
+                "    address VARCHAR(40) NOT NULL,    \n" +
+                "    nationkey BIGINT NOT NULL,       \n" +
+                "    phone VARCHAR(15) NOT NULL,      \n" +
+                "    acctbal DOUBLE NOT NULL,         \n" +
+                "    mktsegment VARCHAR(10) NOT NULL, \n" +
+                "    comment VARCHAR(117) NOT NULL    \n" +
+                " ) ");
+        insertRows(tpchMetadata, CUSTOMER);
     }
 
     private void insertRows(TpchMetadata tpchMetadata, TpchTable tpchTable)


### PR DESCRIPTION
On Join nodes, NOT NULL filters can be inferred from the equi-join clause and the join filter. These NOT NULL filters can be helpful for
- Converting outer to inner joins
- Reduce data scanned if connector supports efficient NULL filtering

This commit aims to replace similar functionality added in #14578

### Comparing existing NOT NULL inference support v. new changes in this PR 
Assume below three tables -  
|     |     |
| --- | --- |
| Table | Columns |
| t0  | b0,c0 |
| t1  | b1,c1 |
| t2  | b2,c2 |

Difference observed with below queries -

|     |     |     |     |
| --- | --- | --- | --- |
| Query | Expected NOT NULL inferred predicate cols |Existing | New |
| select 1 from t0 join t1 on b0 = b1; | b0, b1 | Added | Added |
| select 1 from t0, t1 where b0 = b1; | b0, b1 | Not added | Added |
| select 1 from t0, t1, t2 where b0 = b1 and c1=c2; | b0,b1,c1,c2 | Not added | Added |
| select 1 from t0 left join t1 on b0 = b1; | b1  | Added | Added |
| select 1 from t0 join t1 on c0=c1 and b0 > b1; | b0,c0,b1,c1 | Added | Added |
| select 1 from t0 join t1 on c0=c1 and b0 + b1 > 10; | b0,c0,b1,c1 | Not null filters only added for c0,c1 | Added |
| select 1 from t0 join t1 on c0=c1 and abs(b0 + b1) = 5; | b0,c0,b1,c1 | Not null filters only added for c0,c1 | Added |

### Test plan 
New unit tests added

```
== RELEASE NOTES ==

General Changes
* Improved null inferencing for join nodes. `optimize_nulls_in_join` session property is deprecated and we replaced with a new `joins_not_null_inference_strategy` session property to control null inferencing

```