### PR TITLE
[Native][Issue-3593] Handle Task::updateBroadcastOutputBuffer failure gracefully with error log message

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -333,11 +333,10 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
 
   getDataForResultRequests(resultRequests);
 
-  // TODO Handle possible race condition. Refer:
-  // https://github.com/facebookincubator/velox/issues/3593
-  if (outputBuffers.type == protocol::BufferType::BROADCAST) {
-    execTask->updateBroadcastOutputBuffers(
-        outputBuffers.buffers.size(), outputBuffers.noMoreBufferIds);
+  if (outputBuffers.type == protocol::BufferType::BROADCAST &&
+      !execTask->updateBroadcastOutputBuffers(
+          outputBuffers.buffers.size(), outputBuffers.noMoreBufferIds)) {
+    LOG(INFO) << "Failed to update broadcast buffers for task: " << taskId;
   }
 
   for (const auto& source : sources) {


### PR DESCRIPTION
The TaskManager may enter a race condition on Task::updateBrodacastBuffers() leading to an exception:"Output buffers not found" if the PartitionedOutputBuffers for that task are previously deleted by a downstream driver.

This PR handles this path gracefully by checking the error condition in a new `PartitionedOutputBuffersManager::getBufferIfExists()` API instead of `getBuffer()` call (which throws that exception).  An error message is also logged in this case.