### PR TITLE
Fix failing Timezone test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -83,6 +83,13 @@ public class TestTimeZoneUtils
                 continue;
             }
 
+            if (zoneId.equals("America/Ciudad_Juarez")) {
+                // TODO: remove Once this new Timezone is supported.
+                // This is included in 2022g release of the tz code and data.
+                // https://mm.icann.org/pipermail/tz-announce/2022-November/000076.html
+                continue;
+            }
+
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));
 


### PR DESCRIPTION
Test plan - Locally ran

Newly added tz value causes test failure. 
https://mm.icann.org/pipermail/tz-announce/2022-November/000076.html

Bypassing this until tzdata upgrade.


```
== NO RELEASE NOTE ==
```
