### PR TITLE
[native] Fix Cast expressions on Varbinary

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -143,6 +143,10 @@ velox::variant VeloxExprConverter::getConstantValue(
       return velox::variant(
           valueVector->as<velox::SimpleVector<velox::StringView>>()->valueAt(
               0));
+    case TypeKind::VARBINARY:
+      return velox::variant::binary(
+          valueVector->as<velox::SimpleVector<velox::StringView>>()->valueAt(
+              0));
     default:
       throw std::invalid_argument(
           "Unexpected Block type: " + mapTypeKindToName(typeKind));
@@ -411,7 +415,7 @@ std::shared_ptr<const ConstantTypedExpr> VeloxExprConverter::toVeloxExpr(
     default: {
       const auto value = getConstantValue(type, pexpr->valueBlock);
 
-      return std::make_shared<ConstantTypedExpr>(value);
+      return std::make_shared<ConstantTypedExpr>(type, value);
     }
   }
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -278,6 +278,84 @@ TEST_F(RowExpressionTest, varchar3) {
   testConstantExpression(str, "VARCHAR", "\"102\"");
 }
 
+TEST_F(RowExpressionTest, varbinary1) {
+  // The result was generated from
+  // `select to_big_endian_32(1)`.
+  std::string str = R"##(
+        {
+            "@type": "constant",
+            "valueBlock": "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAQAAAAABAAAAAAAAAE=",
+            "type": "varbinary"
+        }
+    )##";
+  // The expected value is a Base64 value for 1 in big endian.
+  testConstantExpression(str, "VARBINARY", "\"AAAAAQ==\"");
+}
+
+TEST_F(RowExpressionTest, varbinary2) {
+  // The result was generated from
+  // `select cast('value' as varbinary)`.
+  std::string str = R"##(
+        {
+            "@type": "constant",
+            "valueBlock": "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAHZhbHVl",
+            "type": "varbinary"
+        }
+    )##";
+  testConstantExpression(
+      str, "VARBINARY", '"' + encoding::Base64::encode("value") + '"');
+}
+
+TEST_F(RowExpressionTest, varbinary3) {
+  // The result was generated from
+  // `select cast('SPECIAL_#@,$|%/^~?{}+-' as varbinary)`.
+  std::string str = R"##(
+        {
+            "@type": "constant",
+            "valueBlock": "DgAAAFZBUklBQkxFX1dJRFRIAQAAABYAAAAAFgAAAFNQRUNJQUxfI0AsJHwlL15+P3t9Ky0=",
+            "type": "varbinary"
+        }
+    )##";
+  testConstantExpression(
+      str,
+      "VARBINARY",
+      '"' + encoding::Base64::encode("SPECIAL_#@,$|%/^~?{}+-") + '"');
+}
+
+TEST_F(RowExpressionTest, varbinary4) {
+  // The result was generated from
+  // `select cast(null as varbinary)`.
+  std::string str = R"##(
+        {
+            "@type": "constant",
+            "valueBlock": "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAAAAAABgAAAAAA=",
+            "type": "varbinary"
+        }
+    )##";
+  testConstantExpression(str, "VARBINARY", "null");
+}
+
+TEST_F(RowExpressionTest, varbinary5) {
+  // The result was generated from
+  // `select
+  // cast('0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
+  // as varbinary)`.
+  std::string str = R"##(
+        {
+            "@type": "constant",
+            "valueBlock": "DgAAAFZBUklBQkxFX1dJRFRIAQAAAGQAAAAAZAAAADAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODk=",
+            "type": "varbinary"
+        }
+    )##";
+  testConstantExpression(
+      str,
+      "VARBINARY",
+      '"' +
+          encoding::Base64::encode(
+              "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789") +
+          '"');
+}
+
 TEST_F(RowExpressionTest, timestamp) {
   std::string str = R"(
         {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
@@ -226,6 +226,12 @@ abstract class TestHiveQueries
                 + "try_cast(linenumber AS INTEGER), try_cast(linenumber AS BIGINT), try_cast(quantity AS REAL), "
                 + "try_cast(orderkey AS DOUBLE), try_cast(orderkey AS VARCHAR) FROM lineitem");
 
+        // Casts to varbinary.
+        assertQuery("SELECT cast(null as varbinary)");
+        assertQuery("SELECT cast('' as varbinary)");
+        assertQuery("SELECT cast('string_longer_than_12_characters' as varbinary)");
+        assertQuery("SELECT cast(comment as varbinary) from orders");
+
         // Some values are too large and would trigger "Out of range for tinyint" for a regular cast.
         assertQuery("SELECT try_cast(orderkey as TINYINT) FROM lineitem");
 


### PR DESCRIPTION
Fixes query failures for 
```
select cast('' as varbinary); 
select sha256(cast('abc' as varbinary));
``` 

The error seen previously: 
```
Unexpected Block type: VARBINARY
```

Test plan:
Unit tests for Varbinary block expressions and integration tests for CAST sql queries with varbinary are added.

```
== NO RELEASE NOTE ==
```
