### PR TITLE
Fix TableSample for Decimal Type

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -388,6 +388,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testTableSampleWithFraction()
+    {
+        assertQuerySucceeds("SELECT count(*) FROM orders TABLESAMPLE BERNOULLI (0.000000000000000000001)");
+        assertQuerySucceeds("SELECT count(*) FROM orders TABLESAMPLE BERNOULLI (0.02)");
+    }
+
+    @Test
     public void testRowSubscript()
     {
         // Subscript on Row with unnamed fields


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/18923 
Test plan -
Unit test + Tested on TPCH
Query
`SELECT * FROM tpch.sf1.customer TABLESAMPLE BERNOULLI(0.23150292229611358) 
`

== RELEASE NOTES ==
General Changes
Fixed an issue with TableSample where the scale and precision of decimal values were not being taken into account, resulting in incorrect interpretation of fractions and potential inaccuracies in the final results