### PR TITLE
[native] nits refactorings

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -149,6 +149,7 @@ void PrestoServer::run() {
   registerFileSystems();
   registerOptionalHiveStorageAdapters();
   registerShuffleInterfaceFactories();
+  registerCustomOperators();
   protocol::registerHiveConnectors();
   protocol::registerTpchConnector();
 
@@ -234,9 +235,7 @@ void PrestoServer::run() {
   velox::functions::prestosql::registerAllScalarFunctions();
   velox::aggregate::prestosql::registerAllAggregateFunctions();
   velox::window::prestosql::registerAllWindowFunctions();
-  if (!velox::isRegisteredVectorSerde()) {
-    velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
-  }
+  registerVectorSerdes();
 
   facebook::velox::exec::ExchangeSource::registerFactory(
       PrestoExchangeSource::createExchangeSource);
@@ -474,6 +473,12 @@ void PrestoServer::registerShuffleInterfaceFactories() {
   operators::ShuffleInterfaceFactory::registerFactory(
       operators::LocalPersistentShuffleFactory::kShuffleName.toString(),
       std::make_unique<operators::LocalPersistentShuffleFactory>());
+}
+
+void PrestoServer::registerVectorSerdes() {
+  if (!velox::isRegisteredVectorSerde()) {
+    velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  }
 }
 
 void PrestoServer::registerFileSystems() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -88,6 +88,10 @@ class PrestoServer {
 
   virtual void registerShuffleInterfaceFactories();
 
+  virtual void registerCustomOperators(){};
+
+  virtual void registerVectorSerdes();
+
   virtual void registerFileSystems();
 
   void initializeAsyncCache();

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -44,7 +44,6 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
         velox::ROW(
             {"partition", "data"}, {velox::INTEGER(), velox::VARBINARY()})
             ->equivalent(*outputType_));
-    VELOX_USER_CHECK(!keys_.empty(), "Empty partition keys");
     VELOX_USER_CHECK_NOT_NULL(
         partitionFunctionFactory_,
         "Partition function factory cannot be null.");

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2226,7 +2226,14 @@ velox::core::PlanFragment VeloxQueryPlanConverter::toBatchVeloxQueryPlan(
       std::move(*serializedShuffleWriteInfo),
       std::move(localPartitionNode));
 
-  planFragment.planNode = shuffleWriteNode;
+  // For presto_cpp, the last node must be the PartitionedOutputNode in order to
+  // get the output (e.g actual data or metadata) and send back to coordinator.
+  auto finalPartitionedOutputNode = core::PartitionedOutputNode::single(
+      "final-partitioned-output",
+      shuffleWriteNode->outputType(),
+      {shuffleWriteNode});
+  planFragment.planNode = finalPartitionedOutputNode;
+  LOG(INFO) << planFragment.planNode->toString(true, true);
   return planFragment;
 }
 

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -145,8 +145,14 @@ TEST_F(PlanConverterTest, scanAggBatch) {
           exec::test::TempDirectoryPath::create()->path,
           10)));
 
+  auto partitionedOutput =
+      std::dynamic_pointer_cast<const core::PartitionedOutputNode>(root);
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->sources().size(), 1);
+
   auto shuffleWrite =
-      std::dynamic_pointer_cast<const operators::ShuffleWriteNode>(root);
+      std::dynamic_pointer_cast<const operators::ShuffleWriteNode>(
+          partitionedOutput->sources().back());
   ASSERT_NE(shuffleWrite, nullptr);
   ASSERT_EQ(shuffleWrite->sources().size(), 1);
 


### PR DESCRIPTION
Some minor refactorings:
* Extracted common registrations out as plugin points for different server implementations:
  * custom operators registration
  * vector serdes registration
* Added partitioned output plan node to the end for batch planning
* Bug fixes in PartitionAndSerialize.*
```
== NO RELEASE NOTE ==
```
