### PR TITLE
Fix find_first function for NULL value

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -223,11 +223,13 @@ Array Functions
 
 .. function:: find_first(array(E), function(T,boolean)) -> E
 
-    Returns the first element of ``array`` which returns true for ``function(T,boolean)``. Returns ``NULL`` if no such element exists.
+    Returns the first element of ``array`` which returns true for ``function(T,boolean)``, throws exception if the returned element is NULL.
+    Returns ``NULL`` if no such element exists.
 
 .. function:: find_first(array(E), index, function(T,boolean)) -> E
 
-    Returns the first element of ``array`` which returns true for ``function(T,boolean)``. Returns ``NULL`` if no such element exists.
+    Returns the first element of ``array`` which returns true for ``function(T,boolean)``, throws exception if the returned element is NULL.
+    Returns ``NULL`` if no such element exists.
     If ``index`` > 0, the search for element starts at position ``index`` until the end of array.
     If ``index`` < 0, the search for element starts at position ``abs(index)`` counting from last, until the start of array. ::
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -102,7 +102,7 @@ import com.facebook.presto.operator.scalar.ArrayElementAtFunction;
 import com.facebook.presto.operator.scalar.ArrayEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayExceptFunction;
 import com.facebook.presto.operator.scalar.ArrayFilterFunction;
-import com.facebook.presto.operator.scalar.ArrayFindFirstFirstFunction;
+import com.facebook.presto.operator.scalar.ArrayFindFirstFunction;
 import com.facebook.presto.operator.scalar.ArrayFindFirstIndexFunction;
 import com.facebook.presto.operator.scalar.ArrayFindFirstIndexWithOffsetFunction;
 import com.facebook.presto.operator.scalar.ArrayFindFirstWithOffsetFunction;
@@ -810,7 +810,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(ArrayNgramsFunction.class)
                 .scalar(ArrayAllMatchFunction.class)
                 .scalar(ArrayAnyMatchFunction.class)
-                .scalar(ArrayFindFirstFirstFunction.class)
+                .scalar(ArrayFindFirstFunction.class)
                 .scalar(ArrayFindFirstWithOffsetFunction.class)
                 .scalar(ArrayFindFirstIndexFunction.class)
                 .scalar(ArrayFindFirstIndexWithOffsetFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstFunction.java
@@ -24,10 +24,10 @@ import io.airlift.slice.Slice;
 
 @Description("Return the first element which matches the given predicate, null if no match")
 @ScalarFunction(value = "find_first", deterministic = true)
-public final class ArrayFindFirstFirstFunction
+public final class ArrayFindFirstFunction
         extends ArrayFindFirstWithOffsetFunction
 {
-    private ArrayFindFirstFirstFunction() {}
+    private ArrayFindFirstFunction() {}
 
     @TypeParameter("T")
     @SqlType("T")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstWithOffsetFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstWithOffsetFunction.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.function.TypeParameter;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Math.toIntExact;
 
@@ -112,6 +113,9 @@ public class ArrayFindFirstWithOffsetFunction
             }
             Boolean match = function.apply(element);
             if (TRUE.equals(match)) {
+                if (element == null) {
+                    checkCondition(false, INVALID_FUNCTION_ARGUMENT, "FIND_FIRST finds NULL as match, which is not supported.");
+                }
                 return element;
             }
         }
@@ -136,6 +140,9 @@ public class ArrayFindFirstWithOffsetFunction
             }
             Boolean match = function.apply(element);
             if (TRUE.equals(match)) {
+                if (element == null) {
+                    checkCondition(false, INVALID_FUNCTION_ARGUMENT, "FIND_FIRST finds NULL as match, which is not supported.");
+                }
                 return element;
             }
         }
@@ -160,6 +167,9 @@ public class ArrayFindFirstWithOffsetFunction
             }
             Boolean match = function.apply(element);
             if (TRUE.equals(match)) {
+                if (element == null) {
+                    checkCondition(false, INVALID_FUNCTION_ARGUMENT, "FIND_FIRST finds NULL as match, which is not supported.");
+                }
                 return element;
             }
         }
@@ -184,6 +194,9 @@ public class ArrayFindFirstWithOffsetFunction
             }
             Boolean match = function.apply(element);
             if (TRUE.equals(match)) {
+                if (element == null) {
+                    checkCondition(false, INVALID_FUNCTION_ARGUMENT, "FIND_FIRST finds NULL as match, which is not supported.");
+                }
                 return element;
             }
         }
@@ -208,6 +221,9 @@ public class ArrayFindFirstWithOffsetFunction
             }
             Boolean match = function.apply(element);
             if (TRUE.equals(match)) {
+                if (element == null) {
+                    checkCondition(false, INVALID_FUNCTION_ARGUMENT, "FIND_FIRST finds NULL as match, which is not supported.");
+                }
                 return element;
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFindFirstFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFindFirstFunction.java
@@ -89,9 +89,9 @@ public class TestArrayFindFirstFunction
     @Test
     public void testNullArray()
     {
-        assertFunction("find_first(ARRAY [NULL], x -> x IS NULL)", UNKNOWN, null);
+        assertInvalidFunction("find_first(ARRAY [NULL], x -> x IS NULL)", "FIND_FIRST finds NULL as match, which is not supported.");
         assertFunction("find_first(ARRAY [NULL], x -> x IS NOT NULL)", UNKNOWN, null);
-        assertFunction("find_first(ARRAY [CAST (NULL AS INTEGER)], x -> x IS NULL)", INTEGER, null);
+        assertInvalidFunction("find_first(ARRAY [CAST (NULL AS INTEGER)], x -> x IS NULL)", "FIND_FIRST finds NULL as match, which is not supported.");
     }
 
     @Test


### PR DESCRIPTION
### What's the change

Fixes https://github.com/prestodb/presto/issues/18899


- Ambiguous NULL return value for find_first function.

The find_first function returns NULL if no match found. However, it cannot distinguish from the NULL returned as values.

For example, both `SELECT FIND_FIRST(ARRAY[NULL, 1], x->x is NULL);` and `SELECT FIND_FIRST(ARRAY[1], x->x is NULL);` return NULL.

In this PR, the find_first function will throw exception if the returned match value is NULL.


### Test plan - (Please fill in how you tested your changes)

Add unit tests

```
== RELEASE NOTES ==

General Changes
* Fix output of find_first function for NULL
   Now it will throw exception if the found matched value is NULL
```
