### PR TITLE
Enable ARM Support in Presto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,6 +1202,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>1.8</version>
+            </dependency>
+
+            <dependency>
                 <groupId>jline</groupId>
                 <artifactId>jline</artifactId>
                 <version>2.14.6</version>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -79,6 +79,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>
@@ -136,6 +141,19 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.fusesource.jansi</groupId>
+                            <artifactId>jansi</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -70,16 +70,19 @@ public final class PrestoSystemRequirements
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
-            if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
-                failRequirement("Presto requires amd64 or ppc64le on Linux (found %s)", osArch);
+            if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch) && !"aarch64".equals(osArch)) {
+                failRequirement("Presto requires amd64 or ppc64le or aarch64 on Linux (found %s)", osArch);
             }
             if ("ppc64le".equals(osArch)) {
                 warnRequirement("Support for the POWER architecture is experimental");
             }
+            if ("aarch64".equals(osArch)) {
+                warnRequirement("Support for the ARM architecture is experimental");
+            }
         }
         else if ("Mac OS X".equals(osName)) {
-            if (!"x86_64".equals(osArch)) {
-                failRequirement("Presto requires x86_64 on Mac OS X (found %s)", osArch);
+            if (!"x86_64".equals(osArch) && !"aarch64".equals(osArch)) {
+                failRequirement("Presto requires x86_64 or aarch64 on Mac OS X (found %s)", osArch);
             }
         }
         else {


### PR DESCRIPTION
Support ARM (e.g. Apple Silicon chips) in Presto.

Co-authored-by: Jun Luo <sea11509@mail.ustc.edu.cn>
Co-authored-by: striverpan <616358337@qq.com>
Co-authored-by: Beinan Wang <soros.wang@yahoo.com>

Test plan - Have tested in the local environments.

```
== RELEASE NOTES ==

General Changes
* Fix several issues when building Presto on ARM based processors.

```

