### PR TITLE
Add canonicalization for TopNNode, DistinctLimitNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -44,7 +45,7 @@ import static java.util.Objects.requireNonNull;
 public class StatsEquivalentPlanNodeWithLimit
         extends InternalPlanNode
 {
-    private static final Set<Class<?>> LIMITING_NODES = ImmutableSet.of(LimitNode.class, TopNNode.class, TopNRowNumberNode.class);
+    private static final Set<Class<?>> LIMITING_NODES = ImmutableSet.of(LimitNode.class, TopNNode.class, TopNRowNumberNode.class, DistinctLimitNode.class);
 
     // TODO: We are storing duplicated information at multiple levels. Look into if we can optimize it.
     private final PlanNode plan;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsEquivalentPlanNodeWithLimit.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.InternalPlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 public class StatsEquivalentPlanNodeWithLimit
         extends InternalPlanNode
 {
-    private static final Set<Class<?>> LIMITING_NODES = ImmutableSet.of(LimitNode.class, TopNNode.class);
+    private static final Set<Class<?>> LIMITING_NODES = ImmutableSet.of(LimitNode.class, TopNNode.class, TopNRowNumberNode.class);
 
     // TODO: We are storing duplicated information at multiple levels. Look into if we can optimize it.
     private final PlanNode plan;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.StatsEquivalentPlanNodeWithLimit;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -97,6 +98,17 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         @Override
         public PlanNode visitLimit(LimitNode node, RewriteContext<Context> context)
         {
+            return visitLimitingNode(node, context);
+        }
+
+        @Override
+        public PlanNode visitTopN(TopNNode node, RewriteContext<Context> context)
+        {
+            return visitLimitingNode(node, context);
+        }
+
+        private PlanNode visitLimitingNode(PlanNode node, RewriteContext<Context> context)
+        {
             context.get().getLimits().addLast(node);
             PlanNode result = visitPlan(node, context);
             context.get().getLimits().removeLast();
@@ -106,9 +118,9 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
 
     private static class Context
     {
-        private final Deque<LimitNode> limits = new ArrayDeque<>();
+        private final Deque<PlanNode> limits = new ArrayDeque<>();
 
-        public Deque<LimitNode> getLimits()
+        public Deque<PlanNode> getLimits()
         {
             return limits;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.StatsEquivalentPlanNodeWithLimit;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -103,6 +104,12 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
 
         @Override
         public PlanNode visitTopN(TopNNode node, RewriteContext<Context> context)
+        {
+            return visitLimitingNode(node, context);
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Context> context)
         {
             return visitLimitingNode(node, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -110,6 +111,12 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
 
         @Override
         public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Context> context)
+        {
+            return visitLimitingNode(node, context);
+        }
+
+        @Override
+        public PlanNode visitDistinctLimit(DistinctLimitNode node, RewriteContext<Context> context)
         {
             return visitLimitingNode(node, context);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -301,6 +301,16 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testTopNRowNumber()
+            throws Exception
+    {
+        String query1 = "SELECT orderstatus FROM (SELECT orderstatus, row_number() OVER (PARTITION BY orderstatus ORDER BY custkey) n FROM orders) WHERE n = 1";
+        String query2 = "SELECT orderstatus FROM (SELECT orderstatus, row_number() OVER (PARTITION BY orderstatus ORDER BY custkey) n FROM orders) WHERE n <= 2";
+        assertSamePlanHash(query1, query1, CONNECTOR);
+        assertDifferentPlanHash(query1, query2, CONNECTOR);
+    }
+
+    @Test
     public void testInsert()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -272,6 +272,16 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testRowNumber()
+            throws Exception
+    {
+        String query1 = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY regionkey) from nation";
+        String query2 = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY name) from nation";
+        assertSamePlanHash(query1, query1, CONNECTOR);
+        assertDifferentPlanHash(query1, query2, CONNECTOR);
+    }
+
+    @Test
     public void testLimit()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -292,6 +292,15 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testTopN()
+            throws Exception
+    {
+        String query = "SELECT orderkey FROM orders GROUP BY 1 ORDER BY 1 DESC LIMIT 1";
+        assertSamePlanHash(query, query, CONNECTOR);
+        assertDifferentPlanHash(query, "SELECT orderkey FROM orders GROUP BY 1 ORDER BY 1 DESC LIMIT 2", CONNECTOR);
+    }
+
+    @Test
     public void testInsert()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -263,6 +263,15 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testSemiJoin()
+            throws Exception
+    {
+        String query = "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 2))";
+        assertSamePlanHash(query, query, CONNECTOR);
+        assertDifferentPlanHash(query, "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 1))", CONNECTOR);
+    }
+
+    @Test
     public void testLimit()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanHashes.java
@@ -311,6 +311,16 @@ public class TestCanonicalPlanHashes
     }
 
     @Test
+    public void testDistinctLimit()
+            throws Exception
+    {
+        String query1 = "SELECT distinct regionkey from nation limit 2";
+        String query2 = "SELECT distinct regionkey from nation limit 3";
+        assertSamePlanHash(query1, query1, CONNECTOR);
+        assertDifferentPlanHash(query1, query2, CONNECTOR);
+    }
+
+    @Test
     public void testInsert()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -199,6 +200,16 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.longBitsToDouble(4616202753553671564L))));
         executeAndTrackHistory(query);
         assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testRowNumber()
+    {
+        String query = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY regionkey) from nation where substr(name, 1, 1) = 'A'";
+
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(2)));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -306,6 +307,15 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
         executeAndTrackHistory(query);
         assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(3)));
+    }
+
+    @Test
+    public void testDistinctLimit()
+    {
+        String query = "SELECT distinct regionkey from nation limit 2";
+        assertPlan(query, anyTree(node(DistinctLimitNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(DistinctLimitNode.class, anyTree(any())).withOutputRowCount(2)));
     }
 
     private void executeAndTrackHistory(String sql)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -296,6 +297,15 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, anyTree(node(TopNNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(Double.NaN)));
         executeAndTrackHistory(query);
         assertPlan(query, anyTree(node(TopNNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(255)));
+    }
+
+    @Test
+    public void testTopNRowNumber()
+    {
+        String query = "SELECT orderstatus FROM (SELECT orderstatus, row_number() OVER (PARTITION BY orderstatus ORDER BY custkey) n FROM orders) WHERE n = 1";
+        assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(3)));
     }
 
     private void executeAndTrackHistory(String sql)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.testing.QueryRunner;
@@ -188,6 +189,16 @@ public class TestHistoryBasedStatsTracking
         assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(Double.NaN));
         executeAndTrackHistory(query);
         assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(25));
+    }
+
+    @Test
+    public void testSemiJoin()
+    {
+        String query = "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 2))";
+
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.longBitsToDouble(4616202753553671564L))));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
     }
 
     @Test


### PR DESCRIPTION
Depends on https://github.com/prestodb/presto/pull/18823

Add support to canonicalize and hash following plan nodes in HBO:

TopNNode
TopNRowNumberNode
DistinctLimitNode


```
== NO RELEASE NOTE ==
```
