### PR TITLE
Add UDF find_first_index

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -236,6 +236,23 @@ Array Functions
         SELECT find_first(ARRAY[3, 4, 5, 6], 2, x -> x < 4); -- NULL
         SELECT find_first(ARRAY[3, 4, 5, 6], -2, x -> x > 5); -- NULL
 
+.. function:: find_first_index(array(E), function(T,boolean)) -> BIGINT
+
+    Returns the index of the first element of ``array`` which returns true for ``function(T,boolean)``.
+    Returns ``NULL`` if no such element exists.
+
+.. function:: find_first_index(array(E), index, function(T,boolean)) -> BIGINT
+
+    Returns the index of the first element of ``array`` which returns true for ``function(T,boolean)``.
+    Returns ``NULL`` if no such element exists.
+    If ``index`` > 0, the search for element starts at position ``index`` until the end of array.
+    If ``index`` < 0, the search for element starts at position ``abs(index)`` counting from last, until the start of array. ::
+
+        SELECT find_first(ARRAY[3, 4, 5, 6], 2, x -> x > 0); -- 2
+        SELECT find_first(ARRAY[3, 4, 5, 6], -2, x -> x > 0); -- 3
+        SELECT find_first(ARRAY[3, 4, 5, 6], 2, x -> x < 4); -- NULL
+        SELECT find_first(ARRAY[3, 4, 5, 6], -2, x -> x > 5); -- NULL
+
 .. function:: ngrams(array(T), n) -> array(array(T))
 
     Returns ``n``-grams for the ``array``::

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -103,6 +103,8 @@ import com.facebook.presto.operator.scalar.ArrayEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayExceptFunction;
 import com.facebook.presto.operator.scalar.ArrayFilterFunction;
 import com.facebook.presto.operator.scalar.ArrayFindFirstFirstFunction;
+import com.facebook.presto.operator.scalar.ArrayFindFirstIndexFunction;
+import com.facebook.presto.operator.scalar.ArrayFindFirstIndexWithOffsetFunction;
 import com.facebook.presto.operator.scalar.ArrayFindFirstWithOffsetFunction;
 import com.facebook.presto.operator.scalar.ArrayFunctions;
 import com.facebook.presto.operator.scalar.ArrayGreaterThanOperator;
@@ -810,6 +812,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(ArrayAnyMatchFunction.class)
                 .scalar(ArrayFindFirstFirstFunction.class)
                 .scalar(ArrayFindFirstWithOffsetFunction.class)
+                .scalar(ArrayFindFirstIndexFunction.class)
+                .scalar(ArrayFindFirstIndexWithOffsetFunction.class)
                 .scalar(ArrayNoneMatchFunction.class)
                 .scalar(ArrayNormalizeFunction.class)
                 .scalar(MapDistinctFromOperator.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstIndexFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstIndexFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.TypeParameterSpecialization;
+import io.airlift.slice.Slice;
+
+@Description("Return the index of the first element which matches the given predicate, null if no match")
+@ScalarFunction(value = "find_first_index", deterministic = true)
+public final class ArrayFindFirstIndexFunction
+        extends ArrayFindFirstIndexWithOffsetFunction
+{
+    private ArrayFindFirstIndexFunction() {}
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Block.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findBlock(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") BlockToBooleanFunction function)
+    {
+        return findBlockUtil(elementType, arrayBlock, 1, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Slice.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findSlice(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") SliceToBooleanFunction function)
+    {
+        return findSliceUtil(elementType, arrayBlock, 1, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findLong(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") LongToBooleanFunction function)
+    {
+        return findLongUtil(elementType, arrayBlock, 1, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findDouble(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
+    {
+        return findDoubleUtil(elementType, arrayBlock, 1, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findBoolean(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
+    {
+        return findBooleanUtil(elementType, arrayBlock, 1, function);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstIndexWithOffsetFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFindFirstIndexWithOffsetFunction.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.TypeParameterSpecialization;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Boolean.TRUE;
+import static java.lang.Math.toIntExact;
+
+@Description("Return the index of the first element which matches the given predicate, null if no match")
+@ScalarFunction(value = "find_first_index", deterministic = true)
+public class ArrayFindFirstIndexWithOffsetFunction
+{
+    protected ArrayFindFirstIndexWithOffsetFunction() {}
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Block.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findBlockWithOffset(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType(StandardTypes.BIGINT) long offset,
+            @SqlType("function(T, boolean)") BlockToBooleanFunction function)
+    {
+        return findBlockUtil(elementType, arrayBlock, offset, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Slice.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findSliceWithOffset(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType(StandardTypes.BIGINT) long offset,
+            @SqlType("function(T, boolean)") SliceToBooleanFunction function)
+    {
+        return findSliceUtil(elementType, arrayBlock, offset, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findLongWithOffset(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType(StandardTypes.BIGINT) long offset,
+            @SqlType("function(T, boolean)") LongToBooleanFunction function)
+    {
+        return findLongUtil(elementType, arrayBlock, offset, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findDoubleWithOffset(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType(StandardTypes.BIGINT) long offset,
+            @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
+    {
+        return findDoubleUtil(elementType, arrayBlock, offset, function);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
+    @SqlType(StandardTypes.BIGINT)
+    @SqlNullable
+    public static Long findBooleanWithOffset(
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType(StandardTypes.BIGINT) long offset,
+            @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
+    {
+        return findBooleanUtil(elementType, arrayBlock, offset, function);
+    }
+
+    public static Long findBlockUtil(
+            Type elementType,
+            Block arrayBlock,
+            long offset,
+            BlockToBooleanFunction function)
+    {
+        int startPosition = checkedIndexToBlockPosition(arrayBlock, offset);
+        if (startPosition < 0) {
+            return null;
+        }
+        int increment = offset > 0 ? 1 : -1;
+        for (int i = startPosition; i < arrayBlock.getPositionCount() && i >= 0; i += increment) {
+            Block element = null;
+            if (!arrayBlock.isNull(i)) {
+                element = (Block) elementType.getObject(arrayBlock, i);
+            }
+            Boolean match = function.apply(element);
+            if (TRUE.equals(match)) {
+                return Long.valueOf(i + 1);
+            }
+        }
+        return null;
+    }
+
+    public static Long findSliceUtil(
+            Type elementType,
+            Block arrayBlock,
+            long offset,
+            SliceToBooleanFunction function)
+    {
+        int startPosition = checkedIndexToBlockPosition(arrayBlock, offset);
+        if (startPosition < 0) {
+            return null;
+        }
+        int increment = offset > 0 ? 1 : -1;
+        for (int i = startPosition; i < arrayBlock.getPositionCount() && i >= 0; i += increment) {
+            Slice element = null;
+            if (!arrayBlock.isNull(i)) {
+                element = elementType.getSlice(arrayBlock, i);
+            }
+            Boolean match = function.apply(element);
+            if (TRUE.equals(match)) {
+                return Long.valueOf(i + 1);
+            }
+        }
+        return null;
+    }
+
+    public static Long findLongUtil(
+            Type elementType,
+            Block arrayBlock,
+            long offset,
+            LongToBooleanFunction function)
+    {
+        int startPosition = checkedIndexToBlockPosition(arrayBlock, offset);
+        if (startPosition < 0) {
+            return null;
+        }
+        int increment = offset > 0 ? 1 : -1;
+        for (int i = startPosition; i < arrayBlock.getPositionCount() && i >= 0; i += increment) {
+            Long element = null;
+            if (!arrayBlock.isNull(i)) {
+                element = elementType.getLong(arrayBlock, i);
+            }
+            Boolean match = function.apply(element);
+            if (TRUE.equals(match)) {
+                return Long.valueOf(i + 1);
+            }
+        }
+        return null;
+    }
+
+    public static Long findDoubleUtil(
+            Type elementType,
+            Block arrayBlock,
+            long offset,
+            DoubleToBooleanFunction function)
+    {
+        int startPosition = checkedIndexToBlockPosition(arrayBlock, offset);
+        if (startPosition < 0) {
+            return null;
+        }
+        int increment = offset > 0 ? 1 : -1;
+        for (int i = startPosition; i < arrayBlock.getPositionCount() && i >= 0; i += increment) {
+            Double element = null;
+            if (!arrayBlock.isNull(i)) {
+                element = elementType.getDouble(arrayBlock, i);
+            }
+            Boolean match = function.apply(element);
+            if (TRUE.equals(match)) {
+                return Long.valueOf(i + 1);
+            }
+        }
+        return null;
+    }
+
+    public static Long findBooleanUtil(
+            Type elementType,
+            Block arrayBlock,
+            long offset,
+            BooleanToBooleanFunction function)
+    {
+        int startPosition = checkedIndexToBlockPosition(arrayBlock, offset);
+        if (startPosition < 0) {
+            return null;
+        }
+        int increment = offset > 0 ? 1 : -1;
+        for (int i = startPosition; i < arrayBlock.getPositionCount() && i >= 0; i += increment) {
+            Boolean element = null;
+            if (!arrayBlock.isNull(i)) {
+                element = elementType.getBoolean(arrayBlock, i);
+            }
+            Boolean match = function.apply(element);
+            if (TRUE.equals(match)) {
+                return Long.valueOf(i + 1);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return PrestoException if the index is 0, -1 if the index is out of range (to tell the calling function to return null), and the element position otherwise.
+     */
+    private static int checkedIndexToBlockPosition(Block block, long index)
+    {
+        int arrayLength = block.getPositionCount();
+        if (index == 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "SQL array indices start at 1");
+        }
+        if (Math.abs(index) > arrayLength) {
+            return -1; // -1 indicates that the element is out of range and "ELEMENT_AT" should return null
+        }
+        index = index > 0 ? index - 1 : arrayLength + index;
+        return toIntExact(index);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -77,7 +77,7 @@ public class ArraySqlFunctions
     public static String arrayDuplicates()
     {
         return "RETURN CONCAT(" +
-                "IF (cardinality(filter(input, x -> x is NULL)) > 1, array[find_first(input, x -> x IS NULL)], array[])," +
+                "IF (cardinality(filter(input, x -> x is NULL)) > 1, array[element_at(input, find_first_index(input, x -> x IS NULL))], array[])," +
                 "map_keys(map_filter(array_frequency(input), (k, v) -> v > 1)))";
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFindFirstIndexFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFindFirstIndexFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+
+public class TestArrayFindFirstIndexFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction("find_first_index(ARRAY [5, 6], x -> x = 5)", BIGINT, 1L);
+        assertFunction("find_first_index(ARRAY [BIGINT '5', BIGINT '6'], x -> x = 5)", BIGINT, 1L);
+        assertFunction("find_first_index(ARRAY [5, 6], x -> x > 5)", BIGINT, 2L);
+        assertFunction("find_first_index(ARRAY [null, false, true, false, true, false], x -> nullif(x, false))", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [null, true, false, null, true, false, null], x -> not x)", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [4.8E0, 6.2E0], x -> x > 5)", BIGINT, 2L);
+        assertFunction("find_first_index(ARRAY ['abc', 'def', 'ayz'], x -> substr(x, 1, 1) = 'a')", BIGINT, 1L);
+        assertFunction("find_first_index(ARRAY [ARRAY ['abc', null, '123'], ARRAY ['def', 'x', '456']], x -> x[2] IS NULL)", BIGINT, 1L);
+    }
+
+    @Test
+    public void testPositiveOffset()
+    {
+        assertFunction("find_first_index(ARRAY [5, 6], 2, x -> x = 5)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [5, 6], 4, x -> x > 0)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [5, 6, 7, 8], 3, x -> x > 5)", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [3, 4, 5, 6], 2, x -> x > 0)", BIGINT, 2L);
+        assertFunction("find_first_index(ARRAY [3, 4, 5, 6], 2, x -> x < 4)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [null, false, true, null, true, false], 4, x -> nullif(x, false))", BIGINT, 5L);
+        assertFunction("find_first_index(ARRAY [4.8E0, 6.2E0, 7.8E0], 3, x -> x > 5)", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY ['abc', 'def', 'ayz'], 2, x -> substr(x, 1, 1) = 'a')", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [ARRAY ['abc', null, '123'], ARRAY ['def', null, '456']], 2, x -> x[2] IS NULL)", BIGINT, 2L);
+    }
+
+    @Test
+    public void testNegativeOffset()
+    {
+        assertFunction("find_first_index(ARRAY [5, 6], -2, x -> x > 5)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [5, 6], -4, x -> x > 0)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [5, 6, 7, 8], -2, x -> x > 5)", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [9, 6, 3, 8], -2, x -> x > 5)", BIGINT, 2L);
+        assertFunction("find_first_index(ARRAY [3, 4, 5, 6], -2, x -> x > 0)", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [3, 4, 5, 6], -2, x -> x > 5)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [null, false, true, null, true, false], -3, x -> nullif(x, false))", BIGINT, 3L);
+        assertFunction("find_first_index(ARRAY [4.8E0, 6.2E0, 7.8E0], -2, x -> x > 5)", BIGINT, 2L);
+        assertFunction("find_first_index(ARRAY ['abc', 'def', 'ayz'], -2, x -> substr(x, 1, 1) = 'a')", BIGINT, 1L);
+        assertFunction("find_first_index(ARRAY [ARRAY ['abc', null, '123'], ARRAY ['def', null, '456']], -2, x -> x[2] IS NULL)", BIGINT, 1L);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("find_first_index(ARRAY [], x -> true)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [], x -> false)", BIGINT, null);
+        assertFunction("find_first_index(CAST (ARRAY [] AS ARRAY(BIGINT)), x -> true)", BIGINT, null);
+    }
+
+    @Test
+    public void testNullArray()
+    {
+        assertFunction("find_first_index(ARRAY [NULL], x -> x IS NULL)", BIGINT, 1L);
+        assertFunction("find_first_index(ARRAY [NULL], x -> x IS NOT NULL)", BIGINT, null);
+        assertFunction("find_first_index(ARRAY [CAST (NULL AS BIGINT)], x -> x IS NULL)", BIGINT, 1L);
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("find_first_index(NULL, x -> true)", BIGINT, null);
+        assertFunction("find_first_index(NULL, x -> false)", BIGINT, null);
+    }
+}


### PR DESCRIPTION
### What's the change

Fixes https://github.com/prestodb/presto/issues/18900

- Add a new UDF find_first_index

This UDF is similar to find_first, but it returns the index instead of value itself. It also avoids the NULL value problem in find_first.

### Test plan - (Please fill in how you tested your changes)

Add unit tests

```
== RELEASE NOTES ==

General Changes
* Add UDF find_first_index
   Returns the index of the first element which satisfies the condition
```
