### PR TITLE
Handle interruption in RetryDriver and TaskRunner

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -139,6 +139,11 @@ public class RetryDriver
                 return callable.call();
             }
             catch (Exception e) {
+                // Immediately stop retry attempts once an interrupt has been received
+                if (e instanceof InterruptedException || Thread.currentThread().isInterrupted()) {
+                    addSuppressed(e, suppressedExceptions);
+                    throw e;
+                }
                 e = exceptionMapper.apply(e);
                 for (Class<? extends Exception> clazz : exceptionWhiteList) {
                     if (clazz.isInstance(e)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -665,7 +665,7 @@ public class PrestoS3FileSystem
             return retry()
                     .maxAttempts(maxAttempts)
                     .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
-                    .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                    .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, AbortedException.class)
                     .onRetry(STATS::newGetMetadataRetry)
                     .run("getS3ObjectMetadata", () -> {
                         try {
@@ -931,7 +931,7 @@ public class PrestoS3FileSystem
                 return retry()
                         .maxAttempts(maxAttempts)
                         .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
-                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, EOFException.class, FileNotFoundException.class)
+                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, EOFException.class, FileNotFoundException.class, AbortedException.class)
                         .onRetry(STATS::newGetObjectRetry)
                         .run("getS3Object", () -> {
                             InputStream stream;
@@ -1101,7 +1101,7 @@ public class PrestoS3FileSystem
                 return retry()
                         .maxAttempts(maxAttempts)
                         .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
-                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, FileNotFoundException.class)
+                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, FileNotFoundException.class, AbortedException.class)
                         .onRetry(STATS::newGetObjectRetry)
                         .run("getS3Object", () -> {
                             try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectLineRecordReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectLineRecordReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.s3select;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CompressionType;
 import com.amazonaws.services.s3.model.InputSerialization;
@@ -180,7 +181,7 @@ public abstract class S3SelectLineRecordReader
             return retry()
                     .maxAttempts(maxAttempts)
                     .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
-                    .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                    .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, AbortedException.class)
                     .run("readRecordsContentStream", () -> {
                         if (isFirstLine) {
                             recordsFromS3 = 0;

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -642,6 +642,17 @@ public class TaskExecutor
                         }
                         splitFinished(split);
                     }
+                    finally {
+                        // Clear the interrupted flag on the current thread, driver cancellation may have triggered an interrupt
+                        // without TaskExecutor being shut down
+                        if (Thread.interrupted()) {
+                            if (closed) {
+                                // reset interrupted flag if TaskExecutor was closed, since that interrupt may have been the
+                                // shutdown signal to this TaskRunner thread
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                    }
                 }
             }
             finally {


### PR DESCRIPTION
Cross port of https://github.com/trinodb/trino/pull/15803 with one additional commit to fix handling of S3 client exceptions when interrupted. At a high level, this PR:

1. Adds `AbortedException` to the list of `RetryDriver#stopOn` exceptions for all S3 client operations in `PrestoS3FileSystem` and `S3SelectLineRecordReader`. When the S3 client receives an `InterruptedException` internally during an API call operation, it re-sets the current threads interrupted flag, but re-throws an `AbortedException`. When this occurs, the retry driver should stop attempting retries.
2. Adds logic to `RetryDriver` exception handling to stop retries when an `InterruptedException` is caught or `Thread.currentThread().isInterrupted()`. Failing to do so could result in drivers that were interrupted as part of task cancellation running significantly longer than necessary by proceeding to retry / backoff instead of exiting.
3. Changes `TaskRunner` to continue processing new splits instead of terminating when the current thread was interrupted as a result of task cancellation interrupting the current driver being processed without `TaskExecutor`  having been shut down. Before this change, those interruptions would cause the `TaskRunner` to stop processing new splits and submit a new `TaskRunner` into the cached threadpool executor, which could needlessly create new worker threads.



```
== NO RELEASE NOTE ==
```
