### PR TITLE
Fix merge window optimizers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/GatherAndMergeWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/GatherAndMergeWindows.java
@@ -184,7 +184,12 @@ public class GatherAndMergeWindows
                 || parent.getWindowFunctions().values().stream()
                 .map(function -> VariablesExtractor.extractUnique(function.getFunctionCall().getArguments()))
                 .flatMap(Collection::stream)
-                .anyMatch(child.getCreatedVariable()::contains);
+                .anyMatch(child.getCreatedVariable()::contains)
+                || parent.getWindowFunctions().values().stream()
+                .map(function -> function.getFrame())
+                .map(frame -> ImmutableList.of(frame.getStartValue(), frame.getEndValue()))
+                .flatMap(Collection::stream)
+                .anyMatch(x -> x.isPresent() && child.getCreatedVariable().contains(x.get()));
     }
 
     public static class MergeAdjacentWindowsOverProjects


### PR DESCRIPTION
### What's the change?
When the optimizer `GatherAndMergeWindows` merges or reorders two window nodes, it will check if one window node takes the other window's output as input or not. If yes, the two window nodes cannot be merged or reordered.

However, the current implementation to check this dependency misses the input used in Frame. For example, 
```
SELECT
    a, b, c, rnk, SUM(c) OVER (PARTITION BY a ORDER BY b rows BETWEEN rnk PRECEDING AND rnk FOLLOWING)
FROM (
    SELECT
        a, b, c, RANK() OVER (PARTITION BY a ORDER BY b) AS rnk
    FROM (
        VALUES (1, 1, 1), (1, 2, 1), (1, 3, 1), (2, 1, 1), (2, 2, 1), (2, 3, 1)
    ) AS t(a, b, c)
)
```
This query will throw error (GENERIC_INTERNAL_ERROR) Invalid node. Frame bounds ([rank, rank]) not in source plan output .

This PR fixes it by adding the Frame into account.

### Test plan - (Please fill in how you tested your changes)

Add unit tests. Also run locally to make sure that the query above runs fine.

```
== RELEASE NOTES ==

General Changes
* Fix bug in `GatherAndMergeWindows` optimization rule.
```
