### PR TITLE
[native] Let TaskManager/TaskResource catch clause catch exact type w…

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -739,6 +739,9 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
       return std::move(future).via(eventBase).onTimeout(
           std::chrono::microseconds(maxWaitMicros), timeoutFn);
     }
+  } catch (const velox::VeloxException& e) {
+    promiseHolder->promise.setException(e);
+    return std::move(future).via(eventBase);
   } catch (const std::exception& e) {
     promiseHolder->promise.setException(e);
     return std::move(future).via(eventBase);

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -898,4 +898,24 @@ TEST_F(TaskManagerTest, getDataOnAbortedTask) {
   std::move(future).get();
   ASSERT_TRUE(promiseFulfilled);
 }
+
+TEST_F(TaskManagerTest, getResultsErrorPropagation) {
+  const protocol::TaskId taskId = "error-task.0.0.0";
+  std::exception e;
+  taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e));
+
+  // We expect the exception type VeloxException to be reserved still.
+  EXPECT_THROW(
+      taskManager_
+          ->getResults(
+              taskId,
+              0,
+              0,
+              protocol::DataSize("32MB"),
+              protocol::Duration("300s"),
+              http::CallbackRequestHandlerState::create())
+          .get(),
+      VeloxException);
+}
+
 // TODO: add disk spilling test for order by and hash join later.


### PR DESCRIPTION
TaskManager and TaskResource, when processing requests, do not catch the exact exception type, but instead let all fall into the wide std::exception exception type. This will cause exception details be lost and the resulting error message is not able to show the actual error. This fix allow these catches to catch exception by its child type to persist error details.
```
== NO RELEASE NOTE ==
```
