### PR TITLE
[native] Add support for ShuffleRead for batch processing

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -316,13 +316,10 @@ proxygen::RequestHandler* TaskResource::createOrUpdateBatchTask(
         auto fragment =
             velox::encoding::Base64::decode(*taskUpdateRequest.fragment);
         protocol::PlanFragment prestoPlan = json::parse(fragment);
-        VeloxQueryPlanConverter converter(pool_.get());
-        planFragment = converter.toBatchVeloxQueryPlan(
-            prestoPlan,
-            taskUpdateRequest.tableWriteInfo,
-            taskId,
-            shuffleName,
-            std::move(serializedShuffleWriteInfo));
+        VeloxBatchQueryPlanConverter converter(
+            shuffleName, std::move(serializedShuffleWriteInfo), pool_.get());
+        planFragment = converter.toVeloxQueryPlan(
+            prestoPlan, taskUpdateRequest.tableWriteInfo, taskId);
       });
 }
 
@@ -343,7 +340,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTask(
           auto fragment =
               velox::encoding::Base64::decode(*taskUpdateRequest.fragment);
           protocol::PlanFragment prestoPlan = json::parse(fragment);
-          VeloxQueryPlanConverter converter(pool_.get());
+          auto converter = VeloxInteractiveQueryPlanConverter(pool_.get());
           planFragment = converter.toVeloxQueryPlan(
               prestoPlan, taskUpdateRequest.tableWriteInfo, taskId);
         }

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(
-  presto_operators PartitionAndSerialize.cpp ShuffleWrite.cpp
+  presto_operators PartitionAndSerialize.cpp ShuffleRead.cpp ShuffleWrite.cpp
                    UnsafeRowExchangeSource.cpp LocalPersistentShuffle.cpp)
 
 target_link_libraries(presto_operators presto_common velox_core velox_exec

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/operators/ShuffleRead.h"
+#include "velox/exec/Exchange.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox;
+
+namespace facebook::presto::operators {
+namespace {
+class ShuffleReadOperator : public Exchange {
+ public:
+  ShuffleReadOperator(
+      int32_t operatorId,
+      DriverCtx* FOLLY_NONNULL ctx,
+      const std::shared_ptr<const ShuffleReadNode>& shuffleReadNode,
+      std::shared_ptr<ExchangeClient> exchangeClient)
+      : Exchange(
+            operatorId,
+            ctx,
+            std::make_shared<core::ExchangeNode>(
+                shuffleReadNode->id(),
+                shuffleReadNode->outputType()),
+            exchangeClient,
+            "ShuffleRead"),
+        serde_(std::make_unique<serializer::spark::UnsafeRowVectorSerde>()) {}
+
+ protected:
+  VectorSerde* getSerde() override {
+    return serde_.get();
+  }
+
+ private:
+  std::unique_ptr<serializer::spark::UnsafeRowVectorSerde> serde_;
+};
+} // namespace
+
+std::unique_ptr<Operator> ShuffleReadTranslator::toOperator(
+    DriverCtx* ctx,
+    int32_t id,
+    const core::PlanNodePtr& node,
+    std::shared_ptr<ExchangeClient> exchangeClient) {
+  if (auto shuffleReadNode =
+          std::dynamic_pointer_cast<const ShuffleReadNode>(node)) {
+    return std::make_unique<ShuffleReadOperator>(
+        id, ctx, shuffleReadNode, exchangeClient);
+  }
+  return nullptr;
+}
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::presto::operators {
+class ShuffleReadNode : public velox::core::PlanNode {
+ public:
+  ShuffleReadNode(const velox::core::PlanNodeId& id, velox::RowTypePtr type)
+      : PlanNode(id), outputType_(type) {}
+
+  const velox::RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<velox::core::PlanNodePtr>& sources() const override {
+    static const std::vector<velox::core::PlanNodePtr> kEmptySources;
+    return kEmptySources;
+  }
+
+  bool requiresExchangeClient() const override {
+    return true;
+  }
+
+  bool requiresSplits() const override {
+    return true;
+  }
+
+  std::string_view name() const override {
+    return "ShuffleRead";
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override {
+    // Nothing to add
+  }
+
+  velox::RowTypePtr outputType_;
+};
+
+class ShuffleReadTranslator : public velox::exec::Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<velox::exec::Operator> toOperator(
+      velox::exec::DriverCtx* ctx,
+      int32_t id,
+      const velox::core::PlanNodePtr& node,
+      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient) override;
+};
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
@@ -63,7 +63,7 @@ TEST_F(TestValues, valuesRowVector) {
   testJsonRoundtrip(j, p);
 
   auto pool = memory::getDefaultMemoryPool();
-  VeloxQueryPlanConverter converter(pool.get());
+  VeloxInteractiveQueryPlanConverter converter(pool.get());
   auto values = std::dynamic_pointer_cast<const core::ValuesNode>(
       converter.toVeloxQueryPlan(
           std::dynamic_pointer_cast<protocol::PlanNode>(p),
@@ -102,7 +102,7 @@ TEST_F(TestValues, valuesPlan) {
   testJsonRoundtrip(j, p);
 
   auto pool = memory::getDefaultMemoryPool();
-  VeloxQueryPlanConverter converter(pool.get());
+  VeloxInteractiveQueryPlanConverter converter(pool.get());
   auto values = converter.toVeloxQueryPlan(
       std::dynamic_pointer_cast<protocol::OutputNode>(p->root)->source,
       nullptr,


### PR DESCRIPTION
Batch plans used to use Exchange operator directly for shuffle read. This is incompatible with Velox system as the system only allows 1 homogeneous systematic vector serde to be registered. This is because in batch processing, we use Unsaferow serde in Exchange operator and ShuffleWrite operator to deserialize/serialize data from shuffle service but when returning final table write result we use Presto serde in PartitionedOutput operator to send meta info back to coordinator.

A better design is to create a ShuffleRead operator to pair with ShuffleWrite instead of using Exchange directly. This PR does that and also made necessary refactoring to VeloxQueryPlanConverter in order for it to convert to correct batch plan.

```
== NO RELEASE NOTE ==
```
