### PR TITLE
Add canCoerce method to MetadataResolver

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MetadataResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MetadataResolver.java
@@ -206,4 +206,9 @@ public interface MetadataResolver
     {
         throw new UnsupportedOperationException("resolveFunction is not supported");
     }
+
+    default FunctionHandle lookupCast(String castType, Type fromType, Type toType)
+    {
+        throw new UnsupportedOperationException("lookupCast is not supported");
+    }
 }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MetadataResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MetadataResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -25,10 +26,13 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
@@ -186,11 +190,20 @@ public interface MetadataResolver
 
     default FunctionHandle resolveOperator(OperatorType operatorType, List<TypeSignatureProvider> argumentTypes)
     {
-        throw new UnsupportedOperationException("resolveOperator is not supported!");
+        throw new UnsupportedOperationException("resolveOperator is not supported");
     }
 
     default FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
     {
-        throw new UnsupportedOperationException("getFunctionMetadata is not supported!");
+        throw new UnsupportedOperationException("getFunctionMetadata is not supported");
+    }
+
+    default FunctionHandle resolveFunction(
+            Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions,
+            Optional<TransactionId> transactionId,
+            QualifiedObjectName functionName,
+            List<TypeSignatureProvider> parameterTypes)
+    {
+        throw new UnsupportedOperationException("resolveFunction is not supported");
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -32,6 +33,8 @@ import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.sql.analyzer.MetadataResolver;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
@@ -272,6 +275,12 @@ public class RemoteMetadataManager
             public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
             {
                 return getFunctionAndTypeManager().getFunctionMetadata(functionHandle);
+            }
+
+            @Override
+            public FunctionHandle resolveFunction(Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions, Optional<TransactionId> transactionId, QualifiedObjectName functionName, List<TypeSignatureProvider> parameterTypes)
+            {
+                return getFunctionAndTypeManager().resolveFunction(sessionFunctions, transactionId, functionName, parameterTypes);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.metadata.DelegatingMetadataManager;
 import com.facebook.presto.metadata.MetadataManager;
@@ -281,6 +282,12 @@ public class RemoteMetadataManager
             public FunctionHandle resolveFunction(Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions, Optional<TransactionId> transactionId, QualifiedObjectName functionName, List<TypeSignatureProvider> parameterTypes)
             {
                 return getFunctionAndTypeManager().resolveFunction(sessionFunctions, transactionId, functionName, parameterTypes);
+            }
+
+            @Override
+            public FunctionHandle lookupCast(String castType, Type fromType, Type toType)
+            {
+                return getFunctionAndTypeManager().lookupCast(CastType.valueOf(castType), fromType, toType);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -17,7 +17,10 @@ import com.facebook.drift.client.DriftClient;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.metadata.DelegatingMetadataManager;
 import com.facebook.presto.metadata.MetadataManager;
@@ -26,8 +29,12 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableMetadata;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.sql.analyzer.MetadataResolver;
 import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
 import com.facebook.presto.sql.analyzer.ViewDefinition;
 import com.facebook.presto.transaction.TransactionManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -172,12 +180,6 @@ public class RemoteMetadataManager
             }
 
             @Override
-            public boolean tableExists(QualifiedObjectName tableName)
-            {
-                return getTableHandle(tableName).isPresent();
-            }
-
-            @Override
             public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
             {
                 return getOptionalTableHandle(session, tableName);
@@ -219,9 +221,57 @@ public class RemoteMetadataManager
             }
 
             @Override
+            public Type getType(TypeSignature signature)
+            {
+                return getFunctionAndTypeManager().getType(signature);
+            }
+
+            @Override
+            public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+            {
+                return getFunctionAndTypeManager().getParameterizedType(baseTypeName, typeParameters);
+            }
+
+            @Override
             public List<Type> getTypes()
             {
                 return getFunctionAndTypeManager().getTypes();
+            }
+
+            @Override
+            public boolean canCoerce(Type actualType, Type expectedType)
+            {
+                return getFunctionAndTypeManager().canCoerce(actualType, expectedType);
+            }
+
+            @Override
+            public boolean isTypeOnlyCoercion(Type actualType, Type expectedType)
+            {
+                return getFunctionAndTypeManager().isTypeOnlyCoercion(actualType, expectedType);
+            }
+
+            @Override
+            public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+            {
+                return getFunctionAndTypeManager().getCommonSuperType(firstType, secondType);
+            }
+
+            @Override
+            public Collection<SqlFunction> listBuiltInFunctions()
+            {
+                return getFunctionAndTypeManager().listBuiltInFunctions();
+            }
+
+            @Override
+            public FunctionHandle resolveOperator(OperatorType operatorType, List<TypeSignatureProvider> argumentTypes)
+            {
+                return getFunctionAndTypeManager().resolveOperator(operatorType, argumentTypes);
+            }
+
+            @Override
+            public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+            {
+                return getFunctionAndTypeManager().getFunctionMetadata(functionHandle);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -179,7 +179,7 @@ public class FilterStatsCalculator
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Session session, Expression expression, TypeProvider types)
     {
         ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                metadata.getFunctionAndTypeManager(),
+                metadata.getMetadataResolver(session),
                 session,
                 types,
                 emptyMap(),
@@ -461,7 +461,7 @@ public class FilterStatsCalculator
             }
 
             ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                    metadata.getFunctionAndTypeManager(),
+                    metadata.getMetadataResolver(session),
                     session,
                     types,
                     ImmutableMap.of(),

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -395,7 +395,7 @@ public class ScalarStatsCalculator
         private Map<NodeRef<Expression>, Type> getExpressionTypes(Session session, Expression expression, TypeProvider types)
         {
             ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                    metadata.getFunctionAndTypeManager(),
+                    metadata.getMetadataResolver(session),
                     session,
                     types,
                     emptyMap(),

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -57,6 +58,8 @@ import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -1323,12 +1326,6 @@ public class MetadataManager
             }
 
             @Override
-            public boolean tableExists(QualifiedObjectName tableName)
-            {
-                return getOptionalTableHandle(session, transactionManager, tableName).isPresent();
-            }
-
-            @Override
             public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
             {
                 return getOptionalTableHandle(session, transactionManager, tableName);
@@ -1384,9 +1381,57 @@ public class MetadataManager
             }
 
             @Override
+            public Type getType(TypeSignature signature)
+            {
+                return functionAndTypeManager.getType(signature);
+            }
+
+            @Override
+            public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+            {
+                return functionAndTypeManager.getParameterizedType(baseTypeName, typeParameters);
+            }
+
+            @Override
             public List<Type> getTypes()
             {
                 return functionAndTypeManager.getTypes();
+            }
+
+            @Override
+            public boolean canCoerce(Type actualType, Type expectedType)
+            {
+                return functionAndTypeManager.canCoerce(actualType, expectedType);
+            }
+
+            @Override
+            public boolean isTypeOnlyCoercion(Type actualType, Type expectedType)
+            {
+                return functionAndTypeManager.isTypeOnlyCoercion(actualType, expectedType);
+            }
+
+            @Override
+            public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+            {
+                return functionAndTypeManager.getCommonSuperType(firstType, secondType);
+            }
+
+            @Override
+            public Collection<SqlFunction> listBuiltInFunctions()
+            {
+                return functionAndTypeManager.listBuiltInFunctions();
+            }
+
+            @Override
+            public FunctionHandle resolveOperator(OperatorType operatorType, List<TypeSignatureProvider> argumentTypes)
+            {
+                return functionAndTypeManager.resolveOperator(operatorType, argumentTypes);
+            }
+
+            @Override
+            public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+            {
+                return functionAndTypeManager.getFunctionMetadata(functionHandle);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1442,6 +1442,12 @@ public class MetadataManager
             {
                 return functionAndTypeManager.resolveFunction(sessionFunctions, transactionId, functionName, parameterTypes);
             }
+
+            @Override
+            public FunctionHandle lookupCast(String castType, Type fromType, Type toType)
+            {
+                return functionAndTypeManager.lookupCast(CastType.valueOf(castType), fromType, toType);
+            }
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -61,6 +62,8 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -1432,6 +1435,12 @@ public class MetadataManager
             public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
             {
                 return functionAndTypeManager.getFunctionMetadata(functionHandle);
+            }
+
+            @Override
+            public FunctionHandle resolveFunction(Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions, Optional<TransactionId> transactionId, QualifiedObjectName functionName, List<TypeSignatureProvider> parameterTypes)
+            {
+                return functionAndTypeManager.resolveFunction(sessionFunctions, transactionId, functionName, parameterTypes);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SessionFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SessionFunctionUtils.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+// TODO: Move this to presto-analyzer
 public final class SessionFunctionUtils
 {
     private SessionFunctionUtils() {}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -114,9 +113,9 @@ public class Analyzer
                                 columns)));
     }
 
-    static void verifyNoAggregateWindowOrGroupingFunctions(Map<NodeRef<FunctionCall>, FunctionHandle> functionHandles, FunctionAndTypeManager functionAndTypeManager, Expression predicate, String clause)
+    static void verifyNoAggregateWindowOrGroupingFunctions(Map<NodeRef<FunctionCall>, FunctionHandle> functionHandles, MetadataResolver metadataResolver, Expression predicate, String clause)
     {
-        List<FunctionCall> aggregates = extractAggregateFunctions(functionHandles, ImmutableList.of(predicate), functionAndTypeManager);
+        List<FunctionCall> aggregates = extractAggregateFunctions(functionHandles, ImmutableList.of(predicate), metadataResolver);
 
         List<FunctionCall> windowExpressions = extractWindowFunctions(ImmutableList.of(predicate));
 
@@ -132,9 +131,9 @@ public class Analyzer
         }
     }
 
-    static void verifyNoExternalFunctions(Map<NodeRef<FunctionCall>, FunctionHandle> functionHandles, FunctionAndTypeManager functionAndTypeManager, Expression predicate, String clause)
+    static void verifyNoExternalFunctions(Map<NodeRef<FunctionCall>, FunctionHandle> functionHandles, MetadataResolver metadataResolver, Expression predicate, String clause)
     {
-        List<FunctionCall> externalFunctions = extractExternalFunctions(functionHandles, ImmutableList.of(predicate), functionAndTypeManager);
+        List<FunctionCall> externalFunctions = extractExternalFunctions(functionHandles, ImmutableList.of(predicate), metadataResolver);
         if (!externalFunctions.isEmpty()) {
             throw new SemanticException(NOT_SUPPORTED, predicate, "External functions in %s is not supported: %s", clause, externalFunctions);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -53,6 +53,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
+// TODO: Move this to presto-analyzer
 public final class ExpressionTreeUtils
 {
     private ExpressionTreeUtils() {}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -825,9 +825,9 @@ class StatementAnalyzer
             }
 
             // Check return type
-            Type returnType = metadata.getType(parseTypeSignature(node.getReturnType()));
+            Type returnType = metadataResolver.getType(parseTypeSignature(node.getReturnType()));
             List<Field> fields = node.getParameters().stream()
-                    .map(parameter -> Field.newUnqualified(parameter.getName().getLocation(), parameter.getName().getValue(), metadata.getType(parseTypeSignature(parameter.getType()))))
+                    .map(parameter -> Field.newUnqualified(parameter.getName().getLocation(), parameter.getName().getValue(), metadataResolver.getType(parseTypeSignature(parameter.getType()))))
                     .collect(toImmutableList());
             Scope functionScope = Scope.builder()
                     .withRelationType(RelationId.anonymous(), new RelationType(fields))
@@ -840,7 +840,7 @@ class StatementAnalyzer
                 }
 
                 verifyNoAggregateWindowOrGroupingFunctions(analysis.getFunctionHandles(), metadataResolver, returnExpression, "CREATE FUNCTION body");
-                verifyNoExternalFunctions(analysis.getFunctionHandles(), metadata.getFunctionAndTypeManager(), returnExpression, "CREATE FUNCTION body");
+                verifyNoExternalFunctions(analysis.getFunctionHandles(), metadataResolver, returnExpression, "CREATE FUNCTION body");
 
                 // TODO: Check body contains no SQL invoked functions
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -655,7 +655,8 @@ final class ShowQueriesRewrite
                 boolean builtIn = signature.getName().getCatalogSchemaName().equals(DEFAULT_NAMESPACE);
                 boolean temporary = signature.getName().getCatalogSchemaName().equals(SESSION_NAMESPACE);
                 rows.add(row(
-                        builtIn || temporary ? new StringLiteral(signature.getNameSuffix()) : new StringLiteral(signature.getName().toString()),
+                        builtIn || temporary ? new StringLiteral(signature.getNameSuffix()) : new StringLiteral(signature
+                                    .getName().toString()),
                         new StringLiteral(signature.getReturnType().toString()),
                         new StringLiteral(Joiner.on(", ").join(signature.getArgumentTypes())),
                         new StringLiteral(getFunctionType(function)),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.block.TestingBlockEncodingSerde;
@@ -27,7 +26,6 @@ import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -42,7 +40,6 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.analyzer.MetadataResolver;
-import com.facebook.presto.sql.analyzer.ViewDefinition;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateMaterializedView;
@@ -252,51 +249,9 @@ public class TestCreateMaterializedViewTask
             return new MetadataResolver()
             {
                 @Override
-                public boolean catalogExists(String catalogName)
-                {
-                    return false;
-                }
-
-                @Override
-                public boolean schemaExists(CatalogSchemaName schema)
-                {
-                    return false;
-                }
-
-                @Override
-                public boolean tableExists(QualifiedObjectName tableName)
-                {
-                    return false;
-                }
-
-                @Override
                 public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
                 {
                     return getOptionalTableHandle(session, tableName);
-                }
-
-                @Override
-                public Optional<List<ColumnMetadata>> getColumns(QualifiedObjectName tableName)
-                {
-                    return Optional.empty();
-                }
-
-                @Override
-                public Optional<ViewDefinition> getView(QualifiedObjectName viewName)
-                {
-                    return Optional.empty();
-                }
-
-                @Override
-                public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName viewName)
-                {
-                    return Optional.empty();
-                }
-
-                @Override
-                public List<Type> getTypes()
-                {
-                    return emptyList();
                 }
             };
         }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -55,8 +55,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
-import static java.util.Collections.emptyList;
-
 public abstract class AbstractMockMetadata
         implements Metadata
 {
@@ -86,56 +84,7 @@ public abstract class AbstractMockMetadata
     @Override
     public MetadataResolver getMetadataResolver(Session session)
     {
-        return new MetadataResolver()
-        {
-            @Override
-            public boolean catalogExists(String catalogName)
-            {
-                return false;
-            }
-
-            @Override
-            public boolean schemaExists(CatalogSchemaName schema)
-            {
-                return false;
-            }
-
-            @Override
-            public boolean tableExists(QualifiedObjectName tableName)
-            {
-                return false;
-            }
-
-            @Override
-            public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
-            {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<List<ColumnMetadata>> getColumns(QualifiedObjectName tableName)
-            {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<ViewDefinition> getView(QualifiedObjectName viewName)
-            {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName viewName)
-            {
-                return Optional.empty();
-            }
-
-            @Override
-            public List<Type> getTypes()
-            {
-                return emptyList();
-            }
-        };
+        return new MetadataResolver() {};
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -279,7 +279,7 @@ public class TestRowExpressionSerde
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
     {
         ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                metadata.getFunctionAndTypeManager(),
+                metadata.getMetadataResolver(TEST_SESSION),
                 TEST_SESSION,
                 TypeProvider.empty(),
                 emptyMap(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
@@ -98,7 +98,7 @@ public class TestingRowExpressionTranslator
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression, TypeProvider typeProvider)
     {
         ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                metadata.getFunctionAndTypeManager(),
+                metadata.getMetadataResolver(TEST_SESSION),
                 TEST_SESSION,
                 typeProvider,
                 emptyMap(),


### PR DESCRIPTION
Adding canCoerce method to MetadataResolver, and adding default implementation for all methods in the metadataResolver.

```
== NO RELEASE NOTE ==
```
