### PR TITLE
Fix a build failure caused by git version update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
             steps {
                 sh 'apt update && apt install -y awscli git tree'
                 sh 'unset MAVEN_CONFIG && ./mvnw versions:set -DremoveSnapshot'
+                sh 'git config --global --add safe.directory ${WORKSPACE}'
 
                 script {
                     env.PRESTO_VERSION = sh(

--- a/jenkins/agent-dind.yaml
+++ b/jenkins/agent-dind.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         containers: dind
 spec:
+    nodeSelector:
+      eks.amazonaws.com/nodegroup: eks-oss-presto-dynamic-managed-ng
     serviceAccountName: oss-agent
     containers:
     - name: dind

--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         containers: maven
 spec:
+    nodeSelector:
+      eks.amazonaws.com/nodegroup: eks-oss-presto-dynamic-managed-ng
     serviceAccountName: oss-agent
     containers:
     - name: maven


### PR DESCRIPTION
Git version updated in the build system agent container repo.
from
[2023-01-23T15:03:48.748Z] Setting up git (1:2.30.2-1) ...
to
[2023-01-31T12:08:18.057Z] Setting up git (1:2.30.2-1+deb11u1) ...

Test plan -
The fix was tested in a private pipeline




```
== NO RELEASE NOTE ==
```
