### PR TITLE
[native] Allow http server port reuse

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -44,6 +44,11 @@ int SystemConfig::httpServerHttpPort() const {
   return requiredProperty<int>(std::string(kHttpServerHttpPort));
 }
 
+bool SystemConfig::httpServerReusePort() const {
+  auto opt = optionalProperty<bool>(std::string(kHttpServerReusePort));
+  return opt.value_or(kHttpServerReusePortDefault);
+}
+
 std::string SystemConfig::prestoVersion() const {
   return requiredProperty(std::string(kPrestoVersion));
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -76,6 +76,12 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kPrestoVersion{"presto.version"};
   static constexpr std::string_view kHttpServerHttpPort{
       "http-server.http.port"};
+  // This option allows a port closed in TIME_WAIT state to be reused
+  // immediately upon worker startup. This property is mainly used by batch
+  // processing. For interactive query, the worker uses a dynamic port upon
+  // startup.
+  static constexpr std::string_view kHttpServerReusePort{
+      "http-server.reuse-port"};
   static constexpr std::string_view kDiscoveryUri{"discovery.uri"};
   static constexpr std::string_view kMaxDriversPerTask{
       "task.max-drivers-per-task"};
@@ -107,6 +113,7 @@ class SystemConfig : public ConfigBase {
   // Setting the default maximum drivers per task to this value will
   // provide a better off-shelf experience.
   static constexpr int32_t kMaxDriversPerTaskDefault = 16;
+  static constexpr bool kHttpServerReusePortDefault = false;
   static constexpr int32_t kConcurrentLifespansPerTaskDefault = 1;
   static constexpr int32_t kHttpExecThreadsDefault = 8;
   static constexpr int32_t kNumIoThreadsDefault = 30;
@@ -127,6 +134,8 @@ class SystemConfig : public ConfigBase {
   static SystemConfig* instance();
 
   int httpServerHttpPort() const;
+
+  bool httpServerReusePort() const;
 
   std::string prestoVersion() const;
 

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(presto_http HttpClient.cpp HttpServer.cpp)
 
 target_link_libraries(
   presto_http
+  presto_common
   velox_memory
   velox_exception
   ${PROXYGEN_LIBRARIES}

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/http/HttpServer.h"
+#include "presto_cpp/main/common/Configs.h"
 
 namespace facebook::presto::http {
 
@@ -100,6 +101,12 @@ void HttpServer::start(
     std::function<void(std::exception_ptr)> onError) {
   proxygen::HTTPServer::IPConfig cfg{
       httpAddress_, proxygen::HTTPServer::Protocol::HTTP};
+
+  if (SystemConfig::instance()->httpServerReusePort()) {
+    folly::SocketOptionKey portReuseOpt = {SOL_SOCKET, SO_REUSEPORT};
+    cfg.acceptorSocketOptions.emplace();
+    cfg.acceptorSocketOptions->insert({portReuseOpt, 1});
+  }
 
   proxygen::HTTPServerOptions options;
   // The 'threads' field is not used when we provide our own executor (see us


### PR DESCRIPTION
Batch processing needs port to be reusable. We add this optional property to accommodate that
```
== NO RELEASE NOTE ==
```
