### PR TITLE
[native] Use query id to name memory pool

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
   const int64_t maxQueryMemoryPerNode =
       getMaxMemoryPerNode(kQueryMaxMemoryPerNode, kDefaultMaxMemoryPerNode);
   auto pool =
-      memory::getProcessDefaultMemoryManager().getRoot().addChild("query_root");
+      memory::getProcessDefaultMemoryManager().getRoot().addChild(queryId);
   pool->setMemoryUsageTracker(
       velox::memory::MemoryUsageTracker::create(maxQueryMemoryPerNode));
 


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
