### PR TITLE
Make file formats in Hive integration tests customizable

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -574,11 +574,7 @@ public abstract class AbstractTestHiveClient
             row -> row.getField(0) != null && (short) row.getField(0) + 1 > 0,
             row -> row.getField(0) != null && (short) row.getField(0) + 1 < 0);
 
-    protected Set<HiveStorageFormat> createTableFormats = difference(
-            ImmutableSet.copyOf(HiveStorageFormat.values()),
-            // exclude formats that change table schema with serde
-            // exclude ALPHA because it does not support DML yet
-            ImmutableSet.of(AVRO, CSV, ALPHA));
+    protected Set<HiveStorageFormat> createTableFormats = getSupportedCreateTableHiveStorageFormats();
 
     private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig());
 
@@ -5706,6 +5702,15 @@ public abstract class AbstractTestHiveClient
             List<TableConstraint<String>> expectedConstraints = tableConstraintsMap.get(table);
             compareTableConstraints(tableConstraints, expectedConstraints);
         }
+    }
+
+    protected Set<HiveStorageFormat> getSupportedCreateTableHiveStorageFormats()
+    {
+        return difference(
+                ImmutableSet.copyOf(HiveStorageFormat.values()),
+                // exclude formats that change table schema with serde
+                // exclude ALPHA because it does not support DML yet
+                ImmutableSet.of(AVRO, CSV, ALPHA));
     }
 
     private List<TableConstraint<String>> getTableConstraints(SchemaTableName tableName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -53,6 +53,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -116,16 +117,7 @@ public class TestHivePageSink
         File tempDir = Files.createTempDir();
         try {
             ExtendedHiveMetastore metastore = createTestingFileHiveMetastore(new File(tempDir, "metastore"));
-            for (HiveStorageFormat format : HiveStorageFormat.values()) {
-                if (format == HiveStorageFormat.CSV) {
-                    // CSV supports only unbounded VARCHAR type, which is not provided by lineitem
-                    continue;
-                }
-                if (format == HiveStorageFormat.ALPHA) {
-                    // Alpha read/write is not supported yet
-                    continue;
-                }
-
+            for (HiveStorageFormat format : getSupportedHiveStorageFormats()) {
                 config.setHiveStorageFormat(format);
                 config.setCompressionCodec(NONE);
                 long uncompressedLength = writeTestFile(config, metastoreClientConfig, metastore, makeFileName(tempDir, config));
@@ -144,6 +136,14 @@ public class TestHivePageSink
         finally {
             deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
         }
+    }
+
+    protected List<HiveStorageFormat> getSupportedHiveStorageFormats()
+    {
+        // CSV supports only unbounded VARCHAR type, and Alpha does not support DML yet
+        return Arrays.stream(HiveStorageFormat.values())
+                .filter(format -> format != HiveStorageFormat.CSV && format != HiveStorageFormat.ALPHA)
+                .collect(toImmutableList());
     }
 
     private static String makeFileName(File tempDir, HiveClientConfig config)


### PR DESCRIPTION
Open up file formats used by Hive integration tests for subclasses to make them customizable.

Alpha is not available in the OSS, but we would like to run Hive integ tests on the customized version.
Openning up the formats used in tests will allow us to do this.

Test plan:
- integration tests in the PR

```
== NO RELEASE NOTE ==
```
