### PR TITLE
Use default literals for correlated aggregations

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q01.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q01.plan.txt
@@ -1,41 +1,36 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        cross join:
-            join (LEFT, REPLICATED):
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, [c_customer_sk])
-                        scan customer
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [sr_customer_sk])
-                            join (INNER, REPLICATED):
-                                final aggregation over (sr_customer_sk, sr_store_sk)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [sr_customer_sk, sr_store_sk])
-                                            partial aggregation over (sr_customer_sk, sr_store_sk)
-                                                join (INNER, REPLICATED):
-                                                    scan store_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan store
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
-                        final aggregation over (sr_store_sk_24)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [sr_store_sk_24])
-                                    partial aggregation over (sr_store_sk_24)
-                                        final aggregation over (sr_customer_sk_20, sr_store_sk_24)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [sr_customer_sk_20, sr_store_sk_24])
-                                                    partial aggregation over (sr_customer_sk_20, sr_store_sk_24)
-                                                        join (INNER, REPLICATED):
-                                                            scan store_returns
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+        join (INNER, PARTITIONED):
+            remote exchange (REPARTITION, HASH, [c_customer_sk])
+                scan customer
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPLICATE, BROADCAST, [])
-                    single aggregation over ()
-                        values (1 rows)
+                remote exchange (REPARTITION, HASH, [sr_customer_sk])
+                    join (INNER, REPLICATED):
+                        final aggregation over (sr_customer_sk, sr_store_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [sr_customer_sk, sr_store_sk])
+                                    partial aggregation over (sr_customer_sk, sr_store_sk)
+                                        join (INNER, REPLICATED):
+                                            scan store_returns
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
+                                join (INNER, PARTITIONED):
+                                    final aggregation over (sr_store_sk_24)
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [sr_store_sk_24])
+                                                partial aggregation over (sr_store_sk_24)
+                                                    final aggregation over (sr_customer_sk_20, sr_store_sk_24)
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [sr_customer_sk_20, sr_store_sk_24])
+                                                                partial aggregation over (sr_customer_sk_20, sr_store_sk_24)
+                                                                    join (INNER, REPLICATED):
+                                                                        scan store_returns
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [s_store_sk])
+                                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q06.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q06.plan.txt
@@ -4,45 +4,40 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [ca_state])
                     partial aggregation over (ca_state)
-                        cross join:
-                            join (LEFT, REPLICATED):
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_customer_sk])
                                 join (INNER, REPLICATED):
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [ss_customer_sk])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        join (INNER, REPLICATED):
-                                                            scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (GATHER, SINGLE, [])
-                                                                            final aggregation over (d_month_seq_3)
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPARTITION, HASH, [d_month_seq_3])
-                                                                                        partial aggregation over (d_month_seq_3)
-                                                                                            scan date_dim
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [c_customer_sk])
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, [c_current_addr_sk])
-                                                        scan customer
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                join (INNER, REPLICATED):
+                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [ca_address_sk])
-                                                            scan customer_address
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (GATHER, SINGLE, [])
+                                                                    final aggregation over (d_month_seq_3)
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, [d_month_seq_3])
+                                                                                partial aggregation over (d_month_seq_3)
+                                                                                    scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan item
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        final aggregation over (i_category_43)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [i_category_43])
-                                                    partial aggregation over (i_category_43)
-                                                        scan item
+                                            join (INNER, REPLICATED):
+                                                scan item
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        final aggregation over (i_category_43)
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, [i_category_43])
+                                                                    partial aggregation over (i_category_43)
+                                                                        scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    single aggregation over ()
-                                        values (1 rows)
+                                remote exchange (REPARTITION, HASH, [c_customer_sk])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [c_current_addr_sk])
+                                            scan customer
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q30.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q30.plan.txt
@@ -1,50 +1,45 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        cross join:
-            join (LEFT, REPLICATED):
-                join (INNER, REPLICATED):
-                    final aggregation over (ca_state, wr_returning_customer_sk)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [ca_state, wr_returning_customer_sk])
-                                partial aggregation over (ca_state, wr_returning_customer_sk)
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [wr_returning_addr_sk])
-                                            join (INNER, REPLICATED):
-                                                scan web_returns
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [ca_address_sk])
-                                                scan customer_address
+        join (INNER, REPLICATED):
+            join (INNER, REPLICATED):
+                final aggregation over (ca_state, wr_returning_customer_sk)
                     local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
-                            join (INNER, REPLICATED):
-                                scan customer
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan customer_address
+                        remote exchange (REPARTITION, HASH, [ca_state, wr_returning_customer_sk])
+                            partial aggregation over (ca_state, wr_returning_customer_sk)
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [wr_returning_addr_sk])
+                                        join (INNER, REPLICATED):
+                                            scan web_returns
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                            scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
-                        final aggregation over (ca_state_90)
+                        join (INNER, REPLICATED):
+                            scan customer
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_state_90])
-                                    partial aggregation over (ca_state_90)
-                                        final aggregation over (ca_state_90, wr_returning_customer_sk_37)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [ca_state_90, wr_returning_customer_sk_37])
-                                                    partial aggregation over (ca_state_90, wr_returning_customer_sk_37)
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, [wr_returning_addr_sk_40])
-                                                                join (INNER, REPLICATED):
-                                                                    scan web_returns
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, [ca_address_sk_82])
-                                                                    scan customer_address
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
-                    single aggregation over ()
-                        values (1 rows)
+                    final aggregation over (ca_state_90)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ca_state_90])
+                                partial aggregation over (ca_state_90)
+                                    final aggregation over (ca_state_90, wr_returning_customer_sk_37)
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_state_90, wr_returning_customer_sk_37])
+                                                partial aggregation over (ca_state_90, wr_returning_customer_sk_37)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [wr_returning_addr_sk_40])
+                                                            join (INNER, REPLICATED):
+                                                                scan web_returns
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [ca_address_sk_82])
+                                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q32.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q32.plan.txt
@@ -2,29 +2,24 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                cross join:
-                    join (RIGHT, PARTITIONED):
-                        final aggregation over (cs_item_sk_15)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [cs_item_sk_15])
-                                    partial aggregation over (cs_item_sk_15)
-                                        join (INNER, REPLICATED):
-                                            scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                join (INNER, REPLICATED):
+                    join (INNER, REPLICATED):
+                        scan catalog_sales
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [cs_item_sk])
-                                join (INNER, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        scan catalog_sales
+                            remote exchange (REPLICATE, BROADCAST, [])
+                                join (INNER, PARTITIONED):
+                                    final aggregation over (cs_item_sk_15)
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan item
+                                            remote exchange (REPARTITION, HASH, [cs_item_sk_15])
+                                                partial aggregation over (cs_item_sk_15)
+                                                    join (INNER, REPLICATED):
+                                                        scan catalog_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
+                                        remote exchange (REPARTITION, HASH, [i_item_sk])
+                                            scan item
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            single aggregation over ()
-                                values (1 rows)
+                            scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q41.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q41.plan.txt
@@ -4,17 +4,12 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [i_product_name])
                     partial aggregation over (i_product_name)
-                        cross join:
-                            join (LEFT, REPLICATED):
-                                scan item
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        final aggregation over (i_manufact_14)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [i_manufact_14])
-                                                    partial aggregation over (i_manufact_14)
-                                                        scan item
+                        join (INNER, REPLICATED):
+                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    single aggregation over ()
-                                        values (1 rows)
+                                    final aggregation over (i_manufact_14)
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [i_manufact_14])
+                                                partial aggregation over (i_manufact_14)
+                                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
@@ -1,51 +1,46 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        cross join:
-            join (LEFT, REPLICATED):
-                join (INNER, PARTITIONED):
-                    remote exchange (REPARTITION, HASH, [cr_returning_customer_sk])
-                        final aggregation over (ca_state, cr_returning_customer_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_state, cr_returning_customer_sk])
-                                    partial aggregation over (ca_state, cr_returning_customer_sk)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, [cr_returning_addr_sk])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_returns
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [ca_address_sk])
-                                                    scan customer_address
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [c_customer_sk])
-                            join (INNER, REPLICATED):
-                                scan customer
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan customer_address
+        join (INNER, REPLICATED):
+            join (INNER, PARTITIONED):
+                remote exchange (REPARTITION, HASH, [cr_returning_customer_sk])
+                    final aggregation over (ca_state, cr_returning_customer_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ca_state, cr_returning_customer_sk])
+                                partial aggregation over (ca_state, cr_returning_customer_sk)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [cr_returning_addr_sk])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_returns
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                scan customer_address
                 local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
-                        final aggregation over (ca_state_93)
+                    remote exchange (REPARTITION, HASH, [c_customer_sk])
+                        join (INNER, REPLICATED):
+                            scan customer
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_state_93])
-                                    partial aggregation over (ca_state_93)
-                                        final aggregation over (ca_state_93, cr_returning_customer_sk_37)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [ca_state_93, cr_returning_customer_sk_37])
-                                                    partial aggregation over (ca_state_93, cr_returning_customer_sk_37)
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, [cr_returning_addr_sk_40])
-                                                                join (INNER, REPLICATED):
-                                                                    scan catalog_returns
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan date_dim
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, [ca_address_sk_85])
-                                                                    scan customer_address
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
-                    single aggregation over ()
-                        values (1 rows)
+                    final aggregation over (ca_state_93)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ca_state_93])
+                                partial aggregation over (ca_state_93)
+                                    final aggregation over (ca_state_93, cr_returning_customer_sk_37)
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_state_93, cr_returning_customer_sk_37])
+                                                partial aggregation over (ca_state_93, cr_returning_customer_sk_37)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [cr_returning_addr_sk_40])
+                                                            join (INNER, REPLICATED):
+                                                                scan catalog_returns
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [ca_address_sk_85])
+                                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q92.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q92.plan.txt
@@ -2,29 +2,24 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                cross join:
-                    join (RIGHT, PARTITIONED):
-                        final aggregation over (ws_item_sk_3)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ws_item_sk_3])
-                                    partial aggregation over (ws_item_sk_3)
-                                        join (INNER, REPLICATED):
-                                            scan web_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                join (INNER, REPLICATED):
+                    join (INNER, REPLICATED):
+                        scan web_sales
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [ws_item_sk])
-                                join (INNER, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        scan web_sales
+                            remote exchange (REPLICATE, BROADCAST, [])
+                                join (INNER, PARTITIONED):
+                                    final aggregation over (ws_item_sk_3)
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan item
+                                            remote exchange (REPARTITION, HASH, [ws_item_sk_3])
+                                                partial aggregation over (ws_item_sk_3)
+                                                    join (INNER, REPLICATED):
+                                                        scan web_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
+                                        remote exchange (REPARTITION, HASH, [i_item_sk])
+                                            scan item
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            single aggregation over ()
-                                values (1 rows)
+                            scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
@@ -1,47 +1,40 @@
 remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
-            cross join:
-                join (RIGHT, PARTITIONED):
-                    final aggregation over (partkey_15)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [partkey_15])
-                                partial aggregation over (partkey_15)
+            join (INNER, PARTITIONED):
+                remote exchange (REPARTITION, HASH, [suppkey_4])
+                    join (INNER, PARTITIONED):
+                        remote exchange (REPARTITION, HASH, [partkey_3])
+                            scan partsupp
+                        join (INNER, PARTITIONED):
+                            final aggregation over (partkey_15)
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, [partkey_15])
+                                        partial aggregation over (partkey_15)
+                                            join (INNER, REPLICATED):
+                                                scan partsupp
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, REPLICATED):
+                                                            scan supplier
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    join (INNER, REPLICATED):
+                                                                        scan nation
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan region
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [partkey])
+                                    scan part
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, [suppkey])
+                        join (INNER, REPLICATED):
+                            scan supplier
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
                                     join (INNER, REPLICATED):
-                                        scan partsupp
+                                        scan nation
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                join (INNER, REPLICATED):
-                                                    scan supplier
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            join (INNER, REPLICATED):
-                                                                scan nation
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan region
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [partkey])
-                            join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, [suppkey_4])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [partkey_3])
-                                            scan partsupp
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [partkey])
-                                                scan part
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [suppkey])
-                                        join (INNER, REPLICATED):
-                                            scan supplier
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan nation
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan region
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
-                        single aggregation over ()
-                            values (1 rows)
+                                                scan region

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q17.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q17.plan.txt
@@ -2,21 +2,16 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                cross join:
-                    join (RIGHT, PARTITIONED):
-                        final aggregation over (partkey_4)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [partkey_4])
-                                    partial aggregation over (partkey_4)
-                                        scan lineitem
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [partkey])
-                                join (INNER, REPLICATED):
-                                    scan lineitem
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan part
+                join (INNER, REPLICATED):
+                    scan lineitem
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            single aggregation over ()
-                                values (1 rows)
+                            join (INNER, PARTITIONED):
+                                final aggregation over (partkey_4)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [partkey_4])
+                                            partial aggregation over (partkey_4)
+                                                scan lineitem
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, [partkey_0])
+                                        scan part

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q20.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q20.plan.txt
@@ -10,22 +10,17 @@ remote exchange (GATHER, SINGLE, [])
                                 scan nation
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [suppkey_4])
-                        cross join:
-                            join (LEFT, PARTITIONED):
-                                semijoin (PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, [partkey])
-                                        scan partsupp
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [partkey_8])
-                                            scan part
+                        join (INNER, PARTITIONED):
+                            semijoin (PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [partkey])
+                                    scan partsupp
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [partkey_18])
-                                        final aggregation over (partkey_18, suppkey_19)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [partkey_18, suppkey_19])
-                                                    partial aggregation over (partkey_18, suppkey_19)
-                                                        scan lineitem
+                                    remote exchange (REPARTITION, HASH, [partkey_8])
+                                        scan part
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    single aggregation over ()
-                                        values (1 rows)
+                                remote exchange (REPARTITION, HASH, [partkey_18])
+                                    final aggregation over (partkey_18, suppkey_19)
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [partkey_18, suppkey_19])
+                                                partial aggregation over (partkey_18, suppkey_19)
+                                                    scan lineitem

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -737,6 +737,24 @@ Optimizer Properties
     .. warning:: The number of possible join orders scales factorially with the number of relations,
                  so increasing this value can cause serious performance issues.
 
+``optimizer.use-defaults-for-correlated-aggregation-pushdown-through-outer-joins``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    Aggregations can sometimes be pushed below outer joins (see optimizer.push-aggregation-through-join).
+    In general, aggregate functions have custom null-handling behavior. In order to correctly process the
+    null padded rows that may be produced by the outer join, the optimizer introduces a subsequent cross
+    join with corresponding aggregations over a single null value and then coalesces the aggregations
+    from the join output with these null aggregated values.
+
+    For certain aggregate functions (those that ignore nulls, ``COUNT``, etc) the cross join may be
+    avoided and the default/known aggregate value over ``NULL`` may be coalesced  directly with the aggregate
+    outputs of the join. This optimization eliminates the cross join, may convert the outer join into an inner
+    join and thereby produces more optimal plans.
+
+
 Planner Properties
 --------------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -255,6 +255,7 @@ public final class SystemSessionProperties
     public static final String PREFILTER_FOR_GROUPBY_LIMIT = "prefilter_for_groupby_limit";
     public static final String PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS = "prefilter_for_groupby_limit_timeout_ms";
     public static final String OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME = "optimize_join_probe_for_empty_build_runtime";
+    public static final String USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS = "use_defaults_for_correlated_aggregation_pushdown_through_outer_joins";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1450,6 +1451,11 @@ public final class SystemSessionProperties
                         OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME,
                         "Optimize join probe at runtime if build side is empty",
                         featuresConfig.isOptimizeJoinProbeForEmptyBuildRuntimeEnabled(),
+                        false),
+                booleanProperty(
+                        USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS,
+                        "Coalesce with defaults for correlated aggregations",
+                        featuresConfig.isUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(),
                         false));
     }
 
@@ -2441,5 +2447,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizeJoinProbeForEmptyBuildRuntimeEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME, Boolean.class);
+    }
+
+    public static boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(Session session)
+    {
+        return session.getSystemProperty(USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -246,7 +246,7 @@ public class FeaturesConfig
     private double pushAggregationBelowJoinByteReductionThreshold = 1;
     private boolean prefilterForGroupbyLimit;
     private boolean isOptimizeJoinProbeWithEmptyBuildRuntime;
-
+    private boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins = true;
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2354,6 +2354,19 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(boolean isOptimizeJoinProbeWithEmptyBuildRuntime)
     {
         this.isOptimizeJoinProbeWithEmptyBuildRuntime = isOptimizeJoinProbeWithEmptyBuildRuntime;
+        return this;
+    }
+
+    public boolean isUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins()
+    {
+        return useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins;
+    }
+
+    @Config("optimizer.use-defaults-for-correlated-aggregation-pushdown-through-outer-joins")
+    @ConfigDescription("Enable using defaults for well-defined aggregation functions when pushing them through outer joins")
+    public FeaturesConfig setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins)
+    {
+        this.useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins = useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -21,6 +21,7 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.Ordering;
@@ -36,9 +37,11 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +49,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.shouldPushAggregationThroughJoin;
+import static com.facebook.presto.SystemSessionProperties.useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins;
 import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.spi.plan.AggregationNode.globalAggregation;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
@@ -54,6 +58,7 @@ import static com.facebook.presto.sql.planner.optimizations.DistinctOutputQueryU
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -187,7 +192,7 @@ public class PushAggregationThroughOuterJoin
                     join.getDynamicFilters());
         }
 
-        Optional<PlanNode> resultNode = coalesceWithNullAggregation(rewrittenAggregation, rewrittenJoin, context.getVariableAllocator(), context.getIdAllocator(), context.getLookup());
+        Optional<PlanNode> resultNode = coalesceWithNullAggregation(rewrittenAggregation, rewrittenJoin, context.getVariableAllocator(), context.getIdAllocator(), context.getLookup(), useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(context.getSession()));
         if (!resultNode.isPresent()) {
             return Result.empty();
         }
@@ -231,7 +236,7 @@ public class PushAggregationThroughOuterJoin
     // of an aggregation over a single null row is one or zero rather than null. In order to ensure correct results,
     // we add a coalesce function with the output of the new outer join and the aggregation performed over a single
     // null row.
-    private Optional<PlanNode> coalesceWithNullAggregation(AggregationNode aggregationNode, PlanNode outerJoin, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
+    private Optional<PlanNode> coalesceWithNullAggregation(AggregationNode aggregationNode, PlanNode outerJoin, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup, boolean useDefaultsForCorrelatedAggregations)
     {
         // Create an aggregation node over a row of nulls.
         Optional<MappedAggregationInfo> aggregationOverNullInfoResultNode = createAggregationOverNull(
@@ -249,35 +254,60 @@ public class PushAggregationThroughOuterJoin
         AggregationNode aggregationOverNull = aggregationOverNullInfo.getAggregation();
         Map<VariableReferenceExpression, VariableReferenceExpression> sourceAggregationToOverNullMapping = aggregationOverNullInfo.getVariableMapping();
 
-        // Do a cross join with the aggregation over null
-        JoinNode crossJoin = new JoinNode(
-                outerJoin.getSourceLocation(),
-                idAllocator.getNextId(),
-                JoinNode.Type.INNER,
-                outerJoin,
-                aggregationOverNull,
-                ImmutableList.of(),
-                ImmutableList.<VariableReferenceExpression>builder()
-                        .addAll(outerJoin.getOutputVariables())
-                        .addAll(aggregationOverNull.getOutputVariables())
-                        .build(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of());
+        FunctionResolution functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        Map<VariableReferenceExpression, RowExpression> literalMap = new HashMap<>();
+
+        if (useDefaultsForCorrelatedAggregations) {
+            for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> aggregation : aggregationNode.getAggregations().entrySet()) {
+                FunctionHandle functionHandle = aggregation.getValue().getFunctionHandle();
+
+                Optional<RowExpression> defaultLiteral = Optional.empty();
+                if (functionResolution.isCountFunction(functionHandle) && !aggregation.getValue().getArguments().isEmpty()) { // Can also include count_if
+                    defaultLiteral = Optional.of(constant(Long.valueOf(0), aggregation.getKey().getType()));
+                }
+                else if (!functionAndTypeManager.getFunctionMetadata(functionHandle).isCalledOnNullInput()) {
+                    defaultLiteral = Optional.of(constantNull(aggregation.getKey().getType()));
+                }
+
+                if (defaultLiteral.isPresent()) {
+                    literalMap.put(aggregation.getKey(), defaultLiteral.get());
+                }
+            }
+        }
+
+        PlanNode finalJoinNode = outerJoin;
+        if (literalMap.size() < aggregationNode.getAggregations().size()) {
+            // Do a cross join with the aggregation over null
+            finalJoinNode = new JoinNode(
+                    outerJoin.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    JoinNode.Type.INNER,
+                    outerJoin,
+                    aggregationOverNull,
+                    ImmutableList.of(),
+                    ImmutableList.<VariableReferenceExpression>builder()
+                            .addAll(outerJoin.getOutputVariables())
+                            .addAll(aggregationOverNull.getOutputVariables())
+                            .build(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of());
+        }
 
         // Add coalesce expressions for all aggregation functions
         Assignments.Builder assignmentsBuilder = Assignments.builder();
         for (VariableReferenceExpression variable : outerJoin.getOutputVariables()) {
             if (aggregationNode.getAggregations().keySet().contains(variable)) {
-                assignmentsBuilder.put(variable, coalesce(ImmutableList.of(variable, sourceAggregationToOverNullMapping.get(variable))));
+                RowExpression coalesceArgument = literalMap.containsKey(variable) ? literalMap.get(variable) : sourceAggregationToOverNullMapping.get(variable);
+                assignmentsBuilder.put(variable, coalesce(ImmutableList.of(variable, coalesceArgument)));
             }
             else {
                 assignmentsBuilder.put(variable, variable);
             }
         }
-        return Optional.of(new ProjectNode(idAllocator.getNextId(), crossJoin, assignmentsBuilder.build()));
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), finalJoinNode, assignmentsBuilder.build()));
     }
 
     private static RowExpression coalesce(List<RowExpression> expressions)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -216,7 +216,8 @@ public class TestFeaturesConfig
                 .setInPredicatesAsInnerJoinsEnabled(false)
                 .setPushAggregationBelowJoinByteReductionThreshold(1)
                 .setPrefilterForGroupbyLimit(false)
-                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(false));
+                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(false)
+                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(true));
     }
 
     @Test
@@ -384,6 +385,7 @@ public class TestFeaturesConfig
                 .put("optimizer.push-aggregation-below-join-byte-reduction-threshold", "0.9")
                 .put("optimizer.prefilter-for-groupby-limit", "true")
                 .put("optimizer.optimize-probe-for-empty-build-runtime", "true")
+                .put("optimizer.use-defaults-for-correlated-aggregation-pushdown-through-outer-joins", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -548,7 +550,8 @@ public class TestFeaturesConfig
                 .setInPredicatesAsInnerJoinsEnabled(true)
                 .setPushAggregationBelowJoinByteReductionThreshold(0.9)
                 .setPrefilterForGroupbyLimit(true)
-                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(true);
+                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(true)
+                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestUseDefaultsforCorrelatedAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestUseDefaultsforCorrelatedAggregations.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+
+public class TestUseDefaultsforCorrelatedAggregations
+        extends BasePlanTest
+{
+    private ImmutableMap<String, String> nationColumns = ImmutableMap.<String, String>builder()
+            .put("regionkey", "regionkey")
+            .put("nationkey", "nationkey")
+            .put("name", "name")
+            .put("comment", "comment")
+            .build();
+
+    @Test
+    public void testConversionOfCrossJoinWithLeftOuterJoinToInnerJoin()
+    {
+        String query = "select * from nation n where (select count(*) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("coalesce(count, 0) > 0",
+                                                aggregation(ImmutableMap.of("count", functionCall("count", ImmutableList.of("count_6"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("count_6", functionCall("count", ImmutableList.of())),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey"))))))))));
+
+        query = "select * from nation n where (select min(custkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("min > 0",
+                                                aggregation(ImmutableMap.of("min", functionCall("min", ImmutableList.of("min_27"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("min_27", functionCall("min", ImmutableList.of("custkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "custkey", "custkey"))))))))));
+
+        query = "select * from nation n where (select max(custkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("max > 0",
+                                                aggregation(ImmutableMap.of("max", functionCall("max", ImmutableList.of("max_27"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("max_27", functionCall("max", ImmutableList.of("custkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "custkey", "custkey"))))))))));
+
+        query = "select * from nation n where (select sum(custkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("sum > 0",
+                                                aggregation(ImmutableMap.of("sum", functionCall("sum", ImmutableList.of("sum_27"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("sum_27", functionCall("sum", ImmutableList.of("custkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "custkey", "custkey"))))))))));
+
+        query = "select * from nation n where (select avg(custkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("avg > double '0.0'",
+                                                aggregation(ImmutableMap.of("avg", functionCall("avg", ImmutableList.of("avg_27"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("avg_27", functionCall("avg", ImmutableList.of("custkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "custkey", "custkey"))))))))));
+
+        query = "select * from nation n where (select arbitrary(custkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                anyTree(
+                                        tableScan("nation", nationColumns)),
+                                project(
+                                        filter("arbitrary > 0",
+                                                aggregation(ImmutableMap.of("arbitrary", functionCall("arbitrary", ImmutableList.of("arbitrary_27"))),
+                                                        FINAL,
+                                                        anyTree(
+                                                                aggregation(ImmutableMap.of("arbitrary_27", functionCall("arbitrary", ImmutableList.of("custkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "custkey", "custkey"))))))))));
+
+        // Negative tests
+        query = "select * from nation n where (select max_by(acctbal, nationkey) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                                anyTree(
+                                                        tableScan("nation", nationColumns)),
+                                                anyTree(
+                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                values("expr_25", "expr_26"))))));
+
+        query = "select * from nation n where (select count_if(acctbal > 0) from customer c where n.nationkey=c.nationkey)>0";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
+                                                anyTree(
+                                                        tableScan("nation", nationColumns)),
+                                                anyTree(
+                                                        tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                values("expr_24"))))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -18,13 +18,16 @@ import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -43,10 +46,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.co
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignmentsAsSymbolReferences;
 import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
 import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+import static java.util.Collections.emptyList;
 
 public class TestPushAggregationThroughOuterJoin
         extends BaseRuleTest
 {
+    @BeforeClass
+    public final void setUp()
+    {
+        tester = new RuleTester(emptyList(), ImmutableMap.of(USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS, Boolean.toString(false)));
+    }
+
     @Test
     public void testPushesAggregationThroughLeftJoin()
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoinWithDefaultsForCorrelatedAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoinWithDefaultsForCorrelatedAggregations.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+
+public class TestPushAggregationThroughOuterJoinWithDefaultsForCorrelatedAggregations
+        extends BaseRuleTest
+{
+    @Test
+    public void testPushesAggregationThroughLeftJoin()
+    {
+        tester().assertThat(new PushAggregationThroughOuterJoin(getFunctionManager()))
+                .on(p -> p.aggregation(ab -> ab
+                        .source(
+                                p.join(
+                                        JoinNode.Type.LEFT,
+                                        p.values(ImmutableList.of(p.variable("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10L))),
+                                        p.values(p.variable("COL2")),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                        ImmutableList.of(p.variable("COL1"), p.variable("COL2")),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()))
+                        .addAggregation(p.variable("AVG", DOUBLE), p.rowExpression("avg(COL2)"))
+                        .singleGroupingSet(p.variable("COL1"))))
+                .matches(
+                        project(ImmutableMap.of(
+                                        "COL1", expression("COL1"),
+                                        "COALESCE", expression("coalesce(AVG, NULL)")),
+                                join(JoinNode.Type.LEFT, ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                                        values(ImmutableMap.of("COL1", 0)),
+                                        aggregation(
+                                                singleGroupingSet("COL2"),
+                                                ImmutableMap.of(Optional.of("AVG"), functionCall("avg", ImmutableList.of("COL2"))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableMap.of("COL2", 0))))));
+    }
+
+    @Test
+    public void testPushesAggregationThroughLeftJoinWithOrderByFromRightSideColumn()
+    {
+        tester().assertThat(new PushAggregationThroughOuterJoin(getFunctionManager()))
+                .on(p -> p.aggregation(ab -> ab
+                        .source(
+                                p.join(
+                                        JoinNode.Type.LEFT,
+                                        p.values(
+                                                ImmutableList.of(p.variable("COL1"), p.variable("COL3")),
+                                                ImmutableList.of(constantExpressions(BIGINT, 10L, 20L))),
+                                        p.values(p.variable("COL2"), p.variable("COL4")),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                        ImmutableList.of(p.variable("COL1"), p.variable("COL2")),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()))
+                        .addAggregation(
+                                p.variable("AVG", DOUBLE),
+                                p.rowExpression("avg(COL2)"),
+                                Optional.empty(),
+                                Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(p.variable("COL4"), ASC_NULLS_LAST)))),
+                                false,
+                                Optional.empty())
+                        .singleGroupingSet(p.variable("COL1"), p.variable("COL3"))))
+                .matches(
+                        project(ImmutableMap.of(
+                                        "COL1", expression("COL1"),
+                                        "COL3", expression("COL3"),
+                                        "COALESCE", expression("coalesce(AVG, NULL)")),
+                                join(JoinNode.Type.LEFT, ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                                        values(ImmutableMap.of("COL1", 0, "COL3", 0)),
+                                        aggregation(
+                                                singleGroupingSet("COL2"),
+                                                ImmutableMap.of(Optional.of("AVG"),
+                                                        functionCall(
+                                                                "avg",
+                                                                ImmutableList.of("COL2"),
+                                                                ImmutableList.of(sort("COL4", ASCENDING, LAST)))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableList.of("COL2", "COL4"))))));
+    }
+
+    @Test
+    public void testPushesAggregationThroughRightJoin()
+    {
+        tester().assertThat(new PushAggregationThroughOuterJoin(getFunctionManager()))
+                .on(p -> p.aggregation(ab -> ab
+                        .source(p.join(
+                                JoinNode.Type.RIGHT,
+                                p.values(p.variable("COL2")),
+                                p.values(ImmutableList.of(p.variable("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10L))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL2"), p.variable("COL1"))),
+                                ImmutableList.of(p.variable("COL2"), p.variable("COL1")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                        .addAggregation(p.variable("AVG", DOUBLE), p.rowExpression("avg(COL2)"))
+                        .singleGroupingSet(p.variable("COL1"))))
+                .matches(
+                        project(ImmutableMap.of(
+                                        "COALESCE", expression("coalesce(AVG, NULL)"),
+                                        "COL1", expression("COL1")),
+                                join(JoinNode.Type.RIGHT, ImmutableList.of(equiJoinClause("COL2", "COL1")),
+                                        aggregation(
+                                                singleGroupingSet("COL2"),
+                                                ImmutableMap.of(Optional.of("AVG"), functionCall("avg", ImmutableList.of("COL2"))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableMap.of("COL2", 0))),
+                                        values(ImmutableMap.of("COL1", 0)))));
+    }
+}


### PR DESCRIPTION
Presto implements subqueries with correlated aggregations as an outer join with a subsequent cross join to ensure that the null values produced by the aggregation get coalesced appropriately. In some common cases we are able to substitute the default values directly as a filter. This results in three advantages - we avoid the cross join, the filter could get pushed down and the outer join may then get converted into an inner join (and therefore participate in join reordering) since the filter eliminates nulls. 

This behavior may be controlled through a session parameter "use_defaults_for_correlated_aggregations"

Test plan - (Please fill in how you tested your changes)

Verified results against tpc-h and tpc-ds. 
Test cases in TestUseDefaultsForCorrelatedAggregations and TestPushAggregationThroughOuterJoinWithDefaultsForCorrelatedAggregations



== NO RELEASE NOTE ==
