### PR TITLE
Add writer's hostname to ORC file metadata

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
@@ -54,6 +55,7 @@ public class OrcFileWriterConfig
     private boolean isStringDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionarySortingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
     private boolean isFlatMapWriterEnabled = DEFAULT_FLAT_MAP_WRITER_ENABLED;
+    private boolean addHostnameToFileMetadataEnabled;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
@@ -279,6 +281,19 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setDwrfStripeCacheMode(DwrfStripeCacheMode dwrfStripeCacheMode)
     {
         this.dwrfStripeCacheMode = dwrfStripeCacheMode;
+        return this;
+    }
+
+    public boolean isAddHostnameToFileMetadataEnabled()
+    {
+        return addHostnameToFileMetadataEnabled;
+    }
+
+    @Config("hive.orc.writer.add-hostname-to-file-metadata-enabled")
+    @ConfigDescription("Add writer's hostname to the ORC/DWRF file footer. Can be used to troubleshoot file corruption issues.")
+    public OrcFileWriterConfig setAddHostnameToFileMetadataEnabled(boolean addHostnameToFileMetadataEnabled)
+    {
+        this.addHostnameToFileMetadataEnabled = addHostnameToFileMetadataEnabled;
         return this;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -64,7 +64,8 @@ public class TestOrcFileWriterConfig
                 .setIntegerDictionaryEncodingEnabled(false)
                 .setStringDictionaryEncodingEnabled(true)
                 .setStringDictionarySortingEnabled(true)
-                .setFlatMapWriterEnabled(false));
+                .setFlatMapWriterEnabled(false)
+                .setAddHostnameToFileMetadataEnabled(false));
     }
 
     @Test
@@ -87,6 +88,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.string-dictionary-encoding-enabled", "false")
                 .put("hive.orc.writer.string-dictionary-sorting-enabled", "false")
                 .put("hive.orc.writer.flat-map-writer-enabled", "true")
+                .put("hive.orc.writer.add-hostname-to-file-metadata-enabled", "true")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -105,7 +107,8 @@ public class TestOrcFileWriterConfig
                 .setIntegerDictionaryEncodingEnabled(true)
                 .setStringDictionaryEncodingEnabled(false)
                 .setStringDictionarySortingEnabled(false)
-                .setFlatMapWriterEnabled(true);
+                .setFlatMapWriterEnabled(true)
+                .setAddHostnameToFileMetadataEnabled(true);
 
         assertFullMapping(properties, expected);
     }
@@ -199,5 +202,16 @@ public class TestOrcFileWriterConfig
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();
 
         assertEquals(OptionalInt.empty(), options.getCompressionLevel());
+    }
+
+    @Test
+    public void testAddHostnameToFileMetadata()
+    {
+        OrcFileWriterConfig config = new OrcFileWriterConfig();
+        config.setAddHostnameToFileMetadataEnabled(false);
+        assertFalse(config.isAddHostnameToFileMetadataEnabled());
+
+        config.setAddHostnameToFileMetadataEnabled(true);
+        assertTrue(config.isAddHostnameToFileMetadataEnabled());
     }
 }


### PR DESCRIPTION
Add a capability to write the writer's hostname to the ORC file footer. This feature is gated 
by a flag in the cluster config, the flag is disabled by default.

This feature is very useful for troubleshooting file corruption issues caused by bad hardware.

Test plan:
- added unit test for the config
- deployed to a cluster, created a table, verified manually that the file footer has the hostname

```
== NO RELEASE NOTE ==
```
