### PR TITLE
[native] Remove deprecated.legacy-date-timestamp-to-varchar-coercion …

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
@@ -84,8 +84,7 @@ public class HiveExternalWorkerQueryRunner
                         ImmutableMap.of(
                                 "parse-decimal-literals-as-double", "true",
                                 "regex-library", "RE2J",
-                                "offset-clause-enabled", "true",
-                                "deprecated.legacy-date-timestamp-to-varchar-coercion", "true"),
+                                "offset-clause-enabled", "true"),
                         "sql-standard",
                         ImmutableMap.of(
                                 "hive.storage-format", "DWRF",

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestHiveQueries.java
@@ -540,8 +540,8 @@ abstract class TestHiveQueries
     @Test
     public void testWidthBucket()
     {
-        assertQuery("SELECT width_bucket(to_unixtime(ds), array[1609487900, 1619740800, 1622419200]) FROM customer_bucketed");
-        assertQuery("SELECT width_bucket(to_unixtime(ds), array[1609487900.1, 1619740800.2, 1622419200.3]) FROM customer_bucketed");
+        assertQuery("SELECT width_bucket(to_unixtime(cast(ds as timestamp)), array[1609487900, 1619740800, 1622419200]) FROM customer_bucketed");
+        assertQuery("SELECT width_bucket(to_unixtime(cast(ds as timestamp)), array[1609487900.1, 1619740800.2, 1622419200.3]) FROM customer_bucketed");
     }
 
     @Test

--- a/presto-native-execution/src/test/resources/tpch/queries/q1.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q1.sql
@@ -16,8 +16,8 @@ select
 from
 	lineitem
 where
-    shipdate >= date '1998-12-01' - interval '90' day
-    and shipdate <= date '1998-12-01'
+    cast(shipdate as date) >= date '1998-12-01' - interval '90' day
+    and shipdate <= '1998-12-01'
 group by
 	returnflag,
 	linestatus

--- a/presto-native-execution/src/test/resources/tpch/queries/q10.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q10.sql
@@ -18,8 +18,8 @@ from
 where
 	c.custkey = o.custkey
 	and l.orderkey = o.orderkey
-	and o.orderdate >= date '1993-10-01'
-	and o.orderdate < date '1993-10-01' + interval '3' month
+	and o.orderdate >= '1993-10-01'
+	and cast(o.orderdate as date) < date '1993-10-01' + interval '3' month
 	and l.returnflag = 'R'
 	and c.nationkey = n.nationkey
 group by

--- a/presto-native-execution/src/test/resources/tpch/queries/q12.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q12.sql
@@ -23,8 +23,8 @@ where
 	and l.shipmode in ('MAIL', 'SHIP')
 	and l.commitdate < l.receiptdate
 	and l.shipdate < l.commitdate
-	and l.receiptdate >= date '1994-01-01'
-	and l.receiptdate < date '1994-01-01' + interval '1' year
+	and l.receiptdate >= '1994-01-01'
+	and cast(l.receiptdate as date) < date '1994-01-01' + interval '1' year
 group by
 	l.shipmode
 order by

--- a/presto-native-execution/src/test/resources/tpch/queries/q14.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q14.sql
@@ -12,5 +12,5 @@ from
 	part as p
 where
 	l.partkey = p.partkey
-	and l.shipdate >= date '1995-09-01'
-	and l.shipdate < date '1995-09-01' + interval '1' month;
+	and l.shipdate >= '1995-09-01'
+	and cast(l.shipdate as date) < date '1995-09-01' + interval '1' month;

--- a/presto-native-execution/src/test/resources/tpch/queries/q20.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q20.sql
@@ -30,8 +30,8 @@ where
 				where
 					l.partkey = ps.partkey
 					and l.suppkey = ps.suppkey
-					and l.shipdate >= date('1994-01-01')
-					and l.shipdate < date('1994-01-01') + interval '1' year
+					and l.shipdate >= '1994-01-01'
+					and cast(l.shipdate as date) < date('1994-01-01') + interval '1' year
 			)
 	)
 	and s.nationkey = n.nationkey

--- a/presto-native-execution/src/test/resources/tpch/queries/q3.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q3.sql
@@ -14,8 +14,8 @@ where
 	c.mktsegment = 'BUILDING'
 	and c.custkey = o.custkey
 	and l.orderkey = o.orderkey
-	and o.orderdate < date '1995-03-15'
-	and l.shipdate > date '1995-03-15'
+	and o.orderdate < '1995-03-15'
+	and l.shipdate > '1995-03-15'
 group by
 	l.orderkey,
 	o.orderdate,

--- a/presto-native-execution/src/test/resources/tpch/queries/q4.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q4.sql
@@ -7,8 +7,8 @@ select
 from
 	orders as o
 where
-	o.orderdate >= date '1993-07-01'
-	and o.orderdate < date '1993-07-01' + interval '3' month
+	o.orderdate >= '1993-07-01'
+	and cast(o.orderdate as date) < date '1993-07-01' + interval '3' month
 	and exists (
 		select
 			*

--- a/presto-native-execution/src/test/resources/tpch/queries/q5.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q5.sql
@@ -19,8 +19,8 @@ where
 	and s.nationkey = n.nationkey
 	and n.regionkey = r.regionkey
 	and r.name = 'ASIA'
-        and o.orderdate >= date '1994-01-01'
-        and o.orderdate < date '1994-01-01' + interval '1' year
+        and o.orderdate >= '1994-01-01'
+        and cast(o.orderdate as date) < date '1994-01-01' + interval '1' year
 group by
 	n.name
 order by

--- a/presto-native-execution/src/test/resources/tpch/queries/q6.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q6.sql
@@ -6,7 +6,7 @@ select
 from
 	lineitem
 where
-	shipdate >= date '1994-01-01'
-        and shipdate < date '1994-01-01' + interval '1' year
+	shipdate >= '1994-01-01'
+        and cast(shipdate as date) < date '1994-01-01' + interval '1' year
         and discount between decimal '0.06' - decimal '0.01' and decimal '0.06' + decimal '0.01'
 	and quantity < 24;

--- a/presto-native-execution/src/test/resources/tpch/queries/q7.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q7.sql
@@ -30,7 +30,7 @@ from
 				(n1.name = 'FRANCE' and n2.name = 'GERMANY')
 				or (n1.name = 'GERMANY' and n2.name = 'FRANCE')
 			)
-			and l.shipdate between date '1995-01-01' and date '1996-12-31'
+			and l.shipdate between '1995-01-01' and '1996-12-31'
 	) as shipping
 group by
 	supp_nation,

--- a/presto-native-execution/src/test/resources/tpch/queries/q8.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q8.sql
@@ -31,7 +31,7 @@ from
 			and n1.regionkey = r.regionkey
 			and r.name = 'AMERICA'
 			and s.nationkey = n2.nationkey
-			and o.orderdate between date '1995-01-01' and date '1996-12-31'
+			and o.orderdate between '1995-01-01' and '1996-12-31'
 			and p.type = 'ECONOMY ANODIZED STEEL'
 	) as all_nations
 group by


### PR DESCRIPTION
`deprecated.legacy-date-timestamp-to-varchar-coercion` was developed for Raptor to Presto migration. We are removing this option from Presto. Here updating the tests and changing sql so that this option can be deleted without any issue.