### PR TITLE
[Native] Use Native Parquet Reader by default

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -244,7 +244,8 @@ void PrestoServer::run() {
 
   velox::dwrf::registerDwrfReaderFactory();
 #ifdef PRESTO_ENABLE_PARQUET
-  velox::parquet::registerParquetReaderFactory();
+  velox::parquet::registerParquetReaderFactory(
+      velox::parquet::ParquetReaderType::NATIVE);
 #endif
 
   taskManager_ = std::make_unique<TaskManager>(


### PR DESCRIPTION
Native Parquet Reader provides much better performance.

```
== NO RELEASE NOTE ==
```
