### PR TITLE
Fix some test failures in presto-main

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -371,7 +371,7 @@ public class TestLocalDispatchQuery
 
         query.startWaitingForResources();
 
-        Thread.sleep(300); // Sleep long enough to ensure resource exhaustion error
+        Thread.sleep(2000); // Sleep long enough to ensure resource exhaustion error
 
         assertEquals(query.getBasicQueryInfo().getState(), FAILED);
         assertEquals(query.getBasicQueryInfo().getErrorCode(), GENERIC_INSUFFICIENT_RESOURCES.toErrorCode());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -81,7 +81,7 @@ public class TestSqlStageExecution
         scheduledExecutor = null;
     }
 
-    @Test(timeOut = 2 * 60 * 1000)
+    @Test(timeOut = 3 * 60 * 1000)
     public void testFinalStageInfo()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -409,7 +409,7 @@ public class TestResourceGroups
         }
     }
 
-    @Test(timeOut = 10_000)
+    @Test(timeOut = 20_000)
     public void testWeightedScheduling()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false);
@@ -458,7 +458,7 @@ public class TestResourceGroups
         assertGreaterThan(group2Ran, lowerBound);
     }
 
-    @Test(timeOut = 10_000)
+    @Test(timeOut = 30_000)
     public void testWeightedFairScheduling()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false);
@@ -560,7 +560,7 @@ public class TestResourceGroups
         assertBetweenInclusive(group3Ran, 2 * lowerBound, 2 * upperBound);
     }
 
-    @Test(timeOut = 10_000)
+    @Test(timeOut = 20_000)
     public void testWeightedFairSchedulingNoStarvation()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false);

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -100,8 +100,8 @@ public class TestPartialResultQueryTaskTracker
         // Assert that the query is added to query manager, queue size = 1 since the query reached minCompletion ratio of 0.5 and is eligible for partial results
         assertEquals(1, partialResultQueryManager.getQueueSize());
 
-        // Sleep for 2 seconds so that we give enough time for query manager to cancel tasks and complete the query with partial results
-        Thread.sleep(2000);
+        // Sleep for 6 seconds so that we give enough time for query manager to cancel tasks and complete the query with partial results
+        Thread.sleep(6000);
         assertEquals(0, partialResultQueryManager.getQueueSize());
 
         // Assert that partial result warning is set correctly

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -396,7 +396,7 @@ public class TestExchangeClient
 
             do {
                 // there is no thread coordination here, so sleep is the best we can do
-                assertLessThan(Duration.nanosSince(start), new Duration(5, TimeUnit.SECONDS));
+                assertLessThan(Duration.nanosSince(start), new Duration(10, TimeUnit.SECONDS));
                 sleepUninterruptibly(100, MILLISECONDS);
             }
             while (processor.getRequestMaxSizes().size() < 64);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -672,7 +672,7 @@ public class TestHashJoinOperator
         return OperatorAssertion.toMaterializedResult(joinOperator.getOperatorContext().getSession(), types, actualPages);
     }
 
-    @Test(timeOut = 30_000)
+    @Test(timeOut = 40_000)
     public void testBuildGracefulSpill()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -111,7 +111,7 @@ public class TestResourceManagerClusterStatusSender
                 format("Expect number of heartbeats to fall within target range (%s), +/- 50%%.  Was: %s", TARGET_HEARTBEATS, nodeHeartbeats));
     }
 
-    @Test(timeOut = 4_000)
+    @Test(timeOut = 6_000)
     public void testQueryHeartbeat()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -134,7 +134,7 @@ public class TestHttpRemoteTask
     // This 30 sec per-test timeout should never be reached because the test should fail and do proper cleanup after 20 sec.
     private static final Duration POLL_TIMEOUT = new Duration(100, MILLISECONDS);
     private static final Duration IDLE_TIMEOUT = new Duration(3, SECONDS);
-    private static final Duration FAIL_TIMEOUT = new Duration(20, SECONDS);
+    private static final Duration FAIL_TIMEOUT = new Duration(40, SECONDS);
     private static final TaskManagerConfig TASK_MANAGER_CONFIG = new TaskManagerConfig()
             // Shorten status refresh wait and info update interval so that we can have a shorter test timeout
             .setStatusRefreshMaxWait(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 100, MILLISECONDS))
@@ -148,28 +148,28 @@ public class TestHttpRemoteTask
         return new Object[][] {{true}, {false}};
     }
 
-    @Test(timeOut = 30000, dataProvider = "thriftEncodingToggle")
+    @Test(timeOut = 50000, dataProvider = "thriftEncodingToggle")
     public void testRemoteTaskMismatch(boolean useThriftEncoding)
             throws Exception
     {
         runTest(FailureScenario.TASK_MISMATCH, useThriftEncoding);
     }
 
-    @Test(timeOut = 30000, dataProvider = "thriftEncodingToggle")
+    @Test(timeOut = 50000, dataProvider = "thriftEncodingToggle")
     public void testRejectedExecutionWhenVersionIsHigh(boolean useThriftEncoding)
             throws Exception
     {
         runTest(FailureScenario.TASK_MISMATCH_WHEN_VERSION_IS_HIGH, useThriftEncoding);
     }
 
-    @Test(timeOut = 30000, dataProvider = "thriftEncodingToggle")
+    @Test(timeOut = 40000, dataProvider = "thriftEncodingToggle")
     public void testRejectedExecution(boolean useThriftEncoding)
             throws Exception
     {
         runTest(FailureScenario.REJECTED_EXECUTION, useThriftEncoding);
     }
 
-    @Test(timeOut = 30000, dataProvider = "thriftEncodingToggle")
+    @Test(timeOut = 60000, dataProvider = "thriftEncodingToggle")
     public void testRegular(boolean useThriftEncoding)
             throws Exception
     {
@@ -201,7 +201,7 @@ public class TestHttpRemoteTask
         httpRemoteTaskFactory.stop();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 50000)
     public void testHTTPRemoteTaskSize()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
@@ -68,7 +68,7 @@ public class TestIterativeOptimizer
         }
     }
 
-    @Test(timeOut = 1000)
+    @Test(timeOut = 8000)
     public void optimizerTimeoutsOnNonConvergingPlan()
     {
         PlanOptimizer optimizer = new IterativeOptimizer(


### PR DESCRIPTION
Summary: Fix some test failures (all time-out related) in presto-main. Those failures were found in local buck test runs.

```
== NO RELEASE NOTE ==
```

Differential Revision: D42592350

