### PR TITLE
[native] Fix link order of Thrift and FBThrift libraries

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -40,8 +40,6 @@ target_link_libraries(
   $<TARGET_OBJECTS:presto_protocol>
   presto_adapters
   presto_common
-  presto_thrift-cpp2
-  presto_thrift_extra
   presto_exception
   presto_http
   presto_operators
@@ -57,13 +55,23 @@ target_link_libraries(
   velox_functions_lib
   velox_hive_partition_function
   velox_window
-  ${THRIFT_LIBRARY}
+  velox_dwio_dwrf_reader
   ${RE2}
   ${FOLLY_WITH_DEPENDENCIES}
   ${ANTLR4_RUNTIME}
   ${GLOG}
   ${GFLAGS_LIBRARIES}
   pthread)
+
+if(PRESTO_ENABLE_PARQUET)
+  target_link_libraries(presto_server_lib velox_dwio_parquet_reader)
+endif()
+
+# Enabling Parquet causes build errors with missing symbols on MacOS. This is
+# likely due to a conflict between Thrift and FBThrift libraries. The build
+# issue is fixed by linking Thrift dependencies first followed by FBThrift.
+target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra
+                      ${THRIFT_LIBRARY})
 
 add_executable(presto_server PrestoMain.cpp)
 
@@ -74,12 +82,7 @@ target_link_libraries(
   velox_aggregates
   velox_hive_connector
   velox_tpch_connector
-  velox_presto_serializer
-  velox_dwio_dwrf_reader)
-
-if(PRESTO_ENABLE_PARQUET)
-  target_link_libraries(presto_server velox_dwio_parquet_reader)
-endif()
+  velox_presto_serializer)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)


### PR DESCRIPTION
Enabling Parquet causes build errors with missing symbols on MacOS only.
This is likely due to a conflict between Thrift and FBThrift libraries.
The build issue is now fixed by linking Thrift dependencies first followed by FBThrift.

Resolves https://github.com/prestodb/presto/issues/18261

```
== NO RELEASE NOTE ==
```
