### PR TITLE
Bring back TestLocalExecutionPlanner and disable testCompilerFailure() in it

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -523,16 +523,6 @@
                     </ignorePackages>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- these tests take a very long time so only run them in the CI server -->
-                    <excludes>
-                        <exclude>**/TestLocalExecutionPlanner.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -562,20 +552,6 @@
                                 <argument>com.facebook.presto.benchmark.BenchmarkSuite</argument>
                             </arguments>
                             <classpathScope>test</classpathScope>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes combine.self="override" />
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -118,7 +118,7 @@ public class TestLocalExecutionPlanner
         runner = null;
     }
 
-    @Test
+    @Test(enabled = false)
     public void testCompilerFailure()
     {
         // structure the query this way to avoid stack overflow when parsing


### PR DESCRIPTION
The file was excluded from tests 7 years ago but most test cases in it were added after that except for testCompilerFailure().
So bring back TestLocalExecutionPlanner.java
 by reverting https://github.com/prestodb/presto/commit/eebc85a368d25816c0e202bfdb98121aa10c48be and disabled testCompilerFailure() specifically. It looks to me testCompilerFailure() is not a valid test case anymore. We probably need to update it or remove it altogether.
In the future, if we do really want to disable the test, we should disable it in test code instead of silently excluding it in pom.xml so people won't miss it that easily.

Test plan - (Please fill in how you tested your changes)
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```
