### PR TITLE
Reduce memory consumed during parquet reads

### DIFF
--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -192,6 +192,12 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>sizeof</artifactId>
+            <version>0.4.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/AbstractNestedBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/AbstractNestedBatchReader.java
@@ -82,7 +82,7 @@ public abstract class AbstractNestedBatchReader
     {
         Preconditions.checkState(!isInitialized(), "already initialized");
         this.pageReader = requireNonNull(pageReader, "pageReader is null");
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
+        checkArgument(pageReader.getValueCountInColumnChunk() > 0, "page is empty");
 
         this.field = requireNonNull(field, "field is null");
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BinaryFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BinaryFlatBatchReader.java
@@ -77,7 +77,7 @@ public class BinaryFlatBatchReader
     {
         checkArgument(!isInitialized(), "Parquet batch reader already initialized");
         this.pageReader = requireNonNull(pageReader, "pageReader is null");
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
+        checkArgument(pageReader.getValueCountInColumnChunk() > 0, "page is empty");
         this.field = requireNonNull(field, "field is null");
 
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int32FlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int32FlatBatchReader.java
@@ -72,7 +72,7 @@ public class Int32FlatBatchReader
     {
         checkArgument(!isInitialized(), "Parquet batch reader already initialized");
         this.pageReader = requireNonNull(pageReader, "pageReader is null");
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
+        checkArgument(pageReader.getValueCountInColumnChunk() > 0, "page is empty");
         this.field = requireNonNull(field, "field is null");
 
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/AbstractColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/AbstractColumnReader.java
@@ -113,8 +113,8 @@ public abstract class AbstractColumnReader
         else {
             dictionary = null;
         }
-        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
-        totalValueCount = pageReader.getTotalValueCount();
+        checkArgument(pageReader.getValueCountInColumnChunk() > 0, "page is empty");
+        totalValueCount = pageReader.getValueCountInColumnChunk();
         indexIterator = (rowRanges == null) ? null : rowRanges.iterator();
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PageReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PageReader.java
@@ -25,7 +25,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.Iterator;
 import java.util.Optional;
 
 import static com.facebook.presto.parquet.ParquetCompressionUtils.decompress;
@@ -34,8 +34,8 @@ import static java.lang.Math.toIntExact;
 
 public class PageReader
 {
-    private final long valueCount;
-    private final LinkedList<DataPage> compressedPages;
+    private final long valueCountInColumnChunk;
+    private final Iterator<DataPage> dataPageIterator;
     private final DictionaryPage compressedDictionaryPage;
     private final OffsetIndex offsetIndex;
     private final Optional<BlockCipher.Decryptor> blockDecryptor;
@@ -45,20 +45,9 @@ public class PageReader
 
     protected final CompressionCodecName codec;
 
-    /**
-     * @param compressedPages This parameter will be mutated destructively as {@link DataPage} entries are removed as part of {@link #readPage()}. The caller
-     * should not retain a reference to this list after passing it in as a constructor argument.
-     */
     public PageReader(CompressionCodecName codec,
-            LinkedList<DataPage> compressedPages,
-            DictionaryPage compressedDictionaryPage)
-            throws IOException
-    {
-        this(codec, compressedPages, compressedDictionaryPage, null, Optional.empty(), null, -1, -1);
-    }
-
-    public PageReader(CompressionCodecName codec,
-                      LinkedList<DataPage> compressedPages,
+                      Iterator<DataPage> dataPageIterator,
+                      long valueCountInColumnChunk,
                       DictionaryPage compressedDictionaryPage,
                       OffsetIndex offsetIndex,
                       Optional<BlockCipher.Decryptor> blockDecryptor,
@@ -67,13 +56,9 @@ public class PageReader
                       int columnOrdinal)
     {
         this.codec = codec;
-        this.compressedPages = compressedPages;
+        this.dataPageIterator = dataPageIterator;
+        this.valueCountInColumnChunk = valueCountInColumnChunk;
         this.compressedDictionaryPage = compressedDictionaryPage;
-        int count = 0;
-        for (DataPage page : compressedPages) {
-            count += page.getValueCount();
-        }
-        this.valueCount = count;
         this.offsetIndex = offsetIndex;
         this.pageIndex = 0;
         this.blockDecryptor = blockDecryptor;
@@ -83,20 +68,20 @@ public class PageReader
         }
     }
 
-    public long getTotalValueCount()
+    public long getValueCountInColumnChunk()
     {
-        return valueCount;
+        return valueCountInColumnChunk;
     }
 
     public DataPage readPage()
     {
-        if (compressedPages.isEmpty()) {
+        if (!dataPageIterator.hasNext()) {
             return null;
         }
         if (blockDecryptor.isPresent()) {
             AesCipher.quickUpdatePageAAD(dataPageAdditionalAuthenticationData, pageIndex);
         }
-        DataPage compressedPage = compressedPages.remove(0);
+        DataPage compressedPage = dataPageIterator.next();
         try {
             Slice slice = decryptSliceIfNeeded(compressedPage.getSlice(), dataPageAdditionalAuthenticationData);
             long firstRowIndex = getFirstRowIndex(pageIndex, offsetIndex);

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
@@ -25,6 +25,7 @@ import com.facebook.presto.parquet.ParquetDataSourceId;
 import com.facebook.presto.parquet.PrimitiveField;
 import com.facebook.presto.parquet.RichColumnDescriptor;
 import com.facebook.presto.parquet.cache.MetadataReader;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
@@ -55,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getArrayElementColumn;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
@@ -84,12 +86,13 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("GZIP")
                 .withExtraMeta(extraMetadata)
                 .withPageSize(1000)
+                .withDictionaryEnabled()
                 .withFooterEncryption()
                 .build();
         decryptAndValidate(inputFile);
@@ -100,13 +103,14 @@ public class TestEncryption
             throws IOException
     {
         MessageType schema = createSchema();
-        String[] encryptColumns = {"id", "name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        String[] encryptColumns = {"id", "bal", "name", "gender"};
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("GZIP")
                 .withPageSize(1000)
                 .withFooterEncryption()
+                .withDictionaryEnabled()
                 .build();
         decryptAndValidate(inputFile);
     }
@@ -117,11 +121,12 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("GZIP")
                 .withPageSize(1000)
+                .withDictionaryEnabled()
                 .withFooterEncryption()
                 .build();
         decryptAndValidate(inputFile);
@@ -133,11 +138,12 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {"name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(1)
                 .withCodec("GZIP")
                 .withPageSize(1000)
+                .withDictionaryEnabled()
                 .withFooterEncryption()
                 .build();
         decryptAndValidate(inputFile);
@@ -149,11 +155,12 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {"name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(1000000)
                 .withCodec("GZIP")
                 .withPageSize(1000)
+                .withDictionaryEnabled()
                 .withFooterEncryption()
                 .build();
         decryptAndValidate(inputFile);
@@ -165,10 +172,11 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {"name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("SNAPPY")
+                .withDictionaryEnabled()
                 .withPageSize(1000)
                 .build();
         decryptAndValidate(inputFile);
@@ -180,11 +188,12 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {"name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(100000)
                 .withCodec("GZIP")
                 .withPageSize(100000)
+                .withDictionaryEnabled()
                 .withFooterEncryption()
                 .build();
         decryptAndValidate(inputFile);
@@ -196,11 +205,12 @@ public class TestEncryption
     {
         MessageType schema = createSchema();
         String[] encryptColumns = {"name", "gender"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(100000)
                 .withCodec("GZIP")
                 .withPageSize(1000)
+                .withDictionaryEnabled()
                 .withEncrytionAlgorithm(ParquetCipher.AES_GCM_CTR_V1)
                 .build();
         decryptAndValidate(inputFile);
@@ -213,7 +223,7 @@ public class TestEncryption
         MessageType schema = createSchema();
         String[] encryptColumns = {"name"};
         String[] maskingColumn = {"name"};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("GZIP")
@@ -235,7 +245,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withCodec("GZIP")
@@ -258,7 +268,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withDataMaskingTest()
                 .withCodec("GZIP")
@@ -278,7 +288,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withDataMaskingTest()
                 .withCodec("GZIP")
@@ -297,7 +307,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withDataMaskingTest()
                 .withCodec("GZIP")
@@ -317,7 +327,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withDataMaskingTest()
                 .withCodec("GZIP")
@@ -337,7 +347,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(1)
                 .withDataMaskingTest()
@@ -357,7 +367,7 @@ public class TestEncryption
                 put("key1", "value1");
                 put("key2", "value2");
             }};
-        EncryptionTestFile inputFile = new EncryptionTestFileBuilder(conf, schema)
+        TestFile inputFile = new TestFileBuilder(conf, schema)
                 .withEncryptColumns(encryptColumns)
                 .withNumRecord(10000)
                 .withDataMaskingTest()
@@ -370,19 +380,19 @@ public class TestEncryption
     {
         return new MessageType("schema",
                 new PrimitiveType(OPTIONAL, INT64, "id"),
+                new PrimitiveType(OPTIONAL, INT32, "bal"),
                 new PrimitiveType(REQUIRED, BINARY, "name"),
                 new PrimitiveType(OPTIONAL, BINARY, "gender"));
     }
 
-    private void decryptAndValidate(EncryptionTestFile inputFile)
+    private void decryptAndValidate(TestFile inputFile)
             throws IOException
     {
         Path path = new Path(inputFile.getFileName());
         FileSystem fileSystem = path.getFileSystem(conf);
         FSDataInputStream inputStream = fileSystem.open(path);
-        long fileSize = fileSystem.getFileStatus(path).getLen();
         Optional<InternalFileDecryptor> fileDecryptor = createFileDecryptor();
-        ParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), fileSize, inputStream);
+        ParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), inputStream);
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, inputFile.getFileSize(), fileDecryptor, false).getParquetMetadata();
         FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
         MessageType fileSchema = fileMetaData.getSchema();
@@ -391,15 +401,14 @@ public class TestEncryption
         validateFile(parquetReader, messageColumn, inputFile);
     }
 
-    private void validateMasking(EncryptionTestFile inputFile, String[] maskingColumn)
+    private void validateMasking(TestFile inputFile, String[] maskingColumn)
             throws IOException
     {
         Path path = new Path(inputFile.getFileName());
         FileSystem fileSystem = path.getFileSystem(conf);
         FSDataInputStream inputStream = fileSystem.open(path);
-        long fileSize = fileSystem.getFileStatus(path).getLen();
         Optional<InternalFileDecryptor> fileDecryptor = createFileDecryptor();
-        ParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), fileSize, inputStream);
+        ParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), inputStream);
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, inputFile.getFileSize(), fileDecryptor, true).getParquetMetadata();
         FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
         MessageType fileSchema = fileMetaData.getSchema();
@@ -417,50 +426,21 @@ public class TestEncryption
         return Optional.empty();
     }
 
-    private ParquetReader createParquetReader(ParquetMetadata parquetMetadata,
-                                              MessageColumnIO messageColumn,
-                                              ParquetDataSource dataSource,
-                                              Optional<InternalFileDecryptor> fileDecryptor)
-    {
-        ImmutableList.Builder<BlockMetaData> blocks = ImmutableList.builder();
-        ImmutableList.Builder<Long> blockStarts = ImmutableList.builder();
-
-        long nextStart = 0;
-        for (BlockMetaData block : parquetMetadata.getBlocks()) {
-            blocks.add(block);
-            blockStarts.add(nextStart);
-            nextStart += block.getRowCount();
-        }
-
-        return new ParquetReader(
-                messageColumn,
-                blocks.build(),
-                Optional.empty(),
-                dataSource,
-                com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext(),
-                new DataSize(100000, DataSize.Unit.BYTE),
-                false,
-                false,
-                null,
-                null,
-                false,
-                fileDecryptor);
-    }
-
-    private void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn, EncryptionTestFile inputFile)
+    private static void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn, TestFile inputFile)
             throws IOException
     {
         String[] maskingColumn = {};
         validateFile(parquetReader, messageColumn, inputFile, maskingColumn);
     }
 
-    private void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn, EncryptionTestFile inputFile, String[] maskingColumn)
+    private static void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn, TestFile inputFile, String[] maskingColumn)
             throws IOException
     {
         int rowIndex = 0;
         int batchSize = parquetReader.nextBatch();
         while (batchSize > 0) {
             validateColumn("id", BIGINT, rowIndex, parquetReader, messageColumn, inputFile, maskingColumn);
+            validateColumn("bal", INTEGER, rowIndex, parquetReader, messageColumn, inputFile, maskingColumn);
             validateColumn("name", VARCHAR, rowIndex, parquetReader, messageColumn, inputFile, maskingColumn);
             validateColumn("gender", VARCHAR, rowIndex, parquetReader, messageColumn, inputFile, maskingColumn);
             rowIndex += batchSize;
@@ -468,7 +448,8 @@ public class TestEncryption
         }
     }
 
-    private void validateColumn(String name, Type type, int rowIndex, ParquetReader parquetReader, MessageColumnIO messageColumn, EncryptionTestFile inputFile, String[] maskingColumn)
+    @VisibleForTesting
+    static void validateColumn(String name, Type type, int rowIndex, ParquetReader parquetReader, MessageColumnIO messageColumn, TestFile inputFile, String[] maskingColumn)
             throws IOException
     {
         HashSet<String> maskingColumnSet = new HashSet<>(Arrays.asList(maskingColumn));
@@ -492,7 +473,8 @@ public class TestEncryption
         }
     }
 
-    private Optional<Field> constructField(Type type, ColumnIO columnIO)
+    @VisibleForTesting
+    static Optional<Field> constructField(Type type, ColumnIO columnIO)
     {
         if (columnIO == null) {
             return Optional.empty();
@@ -541,5 +523,46 @@ public class TestEncryption
         PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
         RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
         return Optional.of(new PrimitiveField(type, repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+    }
+
+    @VisibleForTesting
+    static ParquetReader createParquetReader(ParquetMetadata parquetMetadata,
+            MessageColumnIO messageColumn,
+            ParquetDataSource dataSource,
+            Optional<InternalFileDecryptor> fileDecryptor)
+    {
+        return createParquetReader(parquetMetadata, messageColumn, dataSource, fileDecryptor, new DataSize(100000, DataSize.Unit.BYTE));
+    }
+
+    @VisibleForTesting
+    static ParquetReader createParquetReader(ParquetMetadata parquetMetadata,
+            MessageColumnIO messageColumn,
+            ParquetDataSource dataSource,
+            Optional<InternalFileDecryptor> fileDecryptor,
+            DataSize maxReadBlockSize)
+    {
+        ImmutableList.Builder<BlockMetaData> blocks = ImmutableList.builder();
+        ImmutableList.Builder<Long> blockStarts = ImmutableList.builder();
+
+        long nextStart = 0;
+        for (BlockMetaData block : parquetMetadata.getBlocks()) {
+            blocks.add(block);
+            blockStarts.add(nextStart);
+            nextStart += block.getRowCount();
+        }
+
+        return new ParquetReader(
+                messageColumn,
+                blocks.build(),
+                Optional.empty(),
+                dataSource,
+                com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext(),
+                maxReadBlockSize,
+                false,
+                false,
+                null,
+                null,
+                false,
+                fileDecryptor);
     }
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestFile.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestFile.java
@@ -22,12 +22,12 @@ import java.io.IOException;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-public class EncryptionTestFile
+public class TestFile
 {
     private final String fileName;
     private final SimpleGroup[] fileContent;
 
-    public EncryptionTestFile(String fileName, SimpleGroup[] fileContent)
+    public TestFile(String fileName, SimpleGroup[] fileContent)
     {
         checkArgument(!isNullOrEmpty(fileName), "file name cannot be null or empty");
         this.fileName = fileName;

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestLargeRowGroup.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestLargeRowGroup.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.parquet.Field;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.parquet.cache.MetadataReader;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.ehcache.sizeof.SizeOf;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.facebook.presto.parquet.reader.TestEncryption.constructField;
+import static com.facebook.presto.parquet.reader.TestEncryption.createParquetReader;
+import static com.facebook.presto.parquet.reader.TestEncryption.validateColumn;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestLargeRowGroup
+{
+    private static final DataSize MAX_DATA_SOURCE_BUFFER_SIZE = new DataSize(16, DataSize.Unit.MEGABYTE);
+    private final Configuration conf = new Configuration(false);
+
+    @Test
+    public void testDataSourceIsReadInBoundedChunksForALargeColumnChunk()
+            throws IOException
+    {
+        MessageType schema = new MessageType("schema", new PrimitiveType(OPTIONAL, BINARY, "col1"));
+        //Create a parquet file with a columnChunk has more than MAX_DATA_SOURCE_BUFFER_SIZE of data
+        TestFile inputFile = new TestFileBuilder(conf, schema)
+                .withCodec("UNCOMPRESSED")
+                //20000 record count => more than 16 MiB of data
+                .withNumRecord(200000)
+                //Allow for a very large row group
+                .withRowGroupSize(1024 * 1024 * 1024)
+                .build();
+
+        TestParquetFileProperties parquetFile = createTestParquetFile(inputFile);
+        List<BlockMetaData> rowGroupsMetadata = parquetFile.getParquetMetadata().getBlocks();
+        assertEquals(rowGroupsMetadata.size(), 1, "Test requires only 1 row group to be created");
+
+        ColumnChunkMetaData col1ColChunkMetadata = rowGroupsMetadata.get(0).getColumns().get(0);
+        long totalSize = col1ColChunkMetadata.getTotalSize();
+
+        assertTrue(totalSize > MAX_DATA_SOURCE_BUFFER_SIZE.toBytes(), "Test setup requires a single ColumnChunk more than MAX_DATA_SOURCE_BUFFER_SIZE");
+
+        //Read all columns in the file
+        validateFile(parquetFile.getParquetReader(), parquetFile.getMessageColumnIO(), inputFile);
+
+        List<Integer> bytesFetchedPerCall = parquetFile.getDataSource().getDataSourceBytesFetchedPerCall();
+        assertTrue(bytesFetchedPerCall.size() > 1, "Expected more than one call to dataSource");
+
+        //Verify that we don't read more tha MAX_DATA_SOURCE_BUFFER_SIZE in any 'read' from the dataSource
+        for (Integer length : bytesFetchedPerCall) {
+            assertTrue(length <= MAX_DATA_SOURCE_BUFFER_SIZE.toBytes());
+        }
+    }
+
+    //We test that the total memory consumed to parse and read this column chunk is NOT a function of the number of data pages
+    // in a ColumnChunk. Instead, we use a bounded amount of memory to read any ColumnChunk since we don't materialize the full
+    // chunk in memory at any time
+    @Test
+    public void testMemoryUsedIsNotAFunctionOfDataPageCount()
+            throws IOException
+    {
+        MessageType schema = new MessageType("schema", new PrimitiveType(OPTIONAL, BINARY, "col1"));
+
+        //These max memory used by the parquet reader will change based on the implementation/memory accounting changes
+        //Update this value as needed
+        //We set the expected max to 30% more than MAX_DATA_SOURCE_BUFFER_SIZE
+        long expectedMaxMemoryUsage = (long) (MAX_DATA_SOURCE_BUFFER_SIZE.toBytes() * 1.30);
+
+        SizeOf sizeOf = SizeOf.newInstance();
+        for (Integer testPageCount : Arrays.asList(1000, 5000, 10000, 20000)) {
+            //Create an input file with 1 row group, 1 column and a pre-determined number of data pages
+            TestParquetFileProperties parquetFile = createTestParquetFile(schema, testPageCount);
+            long expectedRowCount = parquetFile.getParquetMetadata().getBlocks().get(0).getRowCount();
+
+            //Read the column completely
+            Field col1 = constructField(VARCHAR, lookupColumnByName(parquetFile.getMessageColumnIO(), "col1")).orElse(null);
+            long maxSystemMemoryUsed = 0;
+
+            ParquetReader parquetReader = parquetFile.getParquetReader();
+            long parquetReaderDeepSize = sizeOf.deepSizeOf(parquetReader);
+            long totalRowsRead = 0;
+            while (totalRowsRead < expectedRowCount) {
+                parquetReader.nextBatch();
+                int rowsRead = parquetReader.readBlock(col1).getPositionCount();
+                totalRowsRead += rowsRead;
+                //Check the max memory used during each batch read
+                parquetReaderDeepSize = Math.max(parquetReaderDeepSize, sizeOf.deepSizeOf(parquetReader));
+                //Same check will work on system memory context; the upper bound here can be 'tightened' more
+                maxSystemMemoryUsed = Math.max(maxSystemMemoryUsed, parquetReader.getSystemMemoryContext().getBytes());
+            }
+
+            String testAssertFormat = "[%d] pages :: %s :: actual [%d], expected < [%d]";
+            assertTrue(maxSystemMemoryUsed < expectedMaxMemoryUsage,
+                    format(testAssertFormat, testPageCount, "maxSystemMemoryUsed", maxSystemMemoryUsed, expectedMaxMemoryUsage));
+            assertTrue(parquetReaderDeepSize < expectedMaxMemoryUsage,
+                    format(testAssertFormat, testPageCount, "parquetReaderDeepSize", parquetReaderDeepSize, expectedMaxMemoryUsage));
+
+            parquetReader.close();
+        }
+    }
+    private TestParquetFileProperties createTestParquetFile(MessageType schema, int requestedPageCount)
+            throws IOException
+    {
+        int pageSize = 100;
+        TestFile inputFile = new TestFileBuilder(conf, schema)
+                .withCodec("UNCOMPRESSED")
+                .withPageSize(pageSize) //Keep page size small, so we get a column chunk with a lot of pages
+                .withNumRecord(requestedPageCount * pageSize) //Since we're using an UNCOMPRESSED file, we can set the record count to an exact multiple of the pageSize
+                //Keep row group size large, so we get can fit all pages in one row group
+                .withRowGroupSize(1024 * 1024 * 1024)
+                .build();
+
+        TestParquetFileProperties parquetFile = createTestParquetFile(inputFile);
+        List<BlockMetaData> rowGroupsMetadata = parquetFile.getParquetMetadata().getBlocks();
+        assertEquals(rowGroupsMetadata.size(), 1, "Test requires only 1 row group to be created");
+
+        ColumnChunkMetaData col1ColChunkMetadata = rowGroupsMetadata.get(0).getColumns().get(0);
+        int actualDataPageCount = col1ColChunkMetadata.getEncodingStats().getNumDataPagesEncodedAs(Encoding.PLAIN);
+        assertEquals(actualDataPageCount, requestedPageCount);
+
+        return parquetFile;
+    }
+
+    private TestParquetFileProperties createTestParquetFile(TestFile inputFile)
+            throws IOException
+    {
+        Path path = new Path(inputFile.getFileName());
+        FileSystem fileSystem = path.getFileSystem(conf);
+        FSDataInputStream inputStream = fileSystem.open(path);
+        MockParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), inputStream);
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, inputFile.getFileSize(), Optional.empty(), false).getParquetMetadata();
+        FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+        MessageType fileSchema = fileMetaData.getSchema();
+        MessageColumnIO messageColumn = getColumnIO(fileSchema, fileSchema);
+        ParquetReader parquetReader = createParquetReader(parquetMetadata, messageColumn, dataSource, Optional.empty(), MAX_DATA_SOURCE_BUFFER_SIZE);
+
+        return new TestParquetFileProperties(messageColumn, parquetReader, dataSource, parquetMetadata);
+    }
+
+    private static void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn, TestFile inputFile)
+            throws IOException
+    {
+        int rowIndex = 0;
+        int batchSize = parquetReader.nextBatch();
+        while (batchSize > 0) {
+            validateColumn("col1", VARCHAR, rowIndex, parquetReader, messageColumn, inputFile, new String[0]);
+            rowIndex += batchSize;
+            batchSize = parquetReader.nextBatch();
+        }
+    }
+    private static class TestParquetFileProperties
+    {
+        private MessageColumnIO messageColumnIO;
+        private ParquetReader parquetReader;
+        private MockParquetDataSource dataSource;
+        private ParquetMetadata parquetMetadata;
+
+        public TestParquetFileProperties(MessageColumnIO messageColumnIO, ParquetReader parquetReader, MockParquetDataSource dataSource, ParquetMetadata parquetMetadata)
+        {
+            this.messageColumnIO = messageColumnIO;
+            this.parquetReader = parquetReader;
+            this.dataSource = dataSource;
+            this.parquetMetadata = parquetMetadata;
+        }
+
+        public MessageColumnIO getMessageColumnIO()
+        {
+            return messageColumnIO;
+        }
+
+        public ParquetReader getParquetReader()
+        {
+            return parquetReader;
+        }
+
+        public MockParquetDataSource getDataSource()
+        {
+            return dataSource;
+        }
+
+        public ParquetMetadata getParquetMetadata()
+        {
+            return parquetMetadata;
+        }
+    }
+}


### PR DESCRIPTION
Read parquet data source in bounded chunks :  
This helps reduce memory pressure while reading
large row groups
Lazy load data pages in PageReader :  
Instead of building an in memory list of all pages, we switch to an
Iterator that will build a DataPage on demand. This reduces memory pressure
since already read pages can be garbage collected

Fixes #prestodb/presto/issues/18956


### Test plan
- New unit tests added
-  Ran TPCH-SF10 verifier on a S3  parquet schema

```
== RELEASE NOTES ==

General Changes
* Reduce memory usage in parquet reader
```
