### PR TITLE
Support complex joins and aggregations in AQE

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveAggregations.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveAggregations.java
@@ -22,18 +22,6 @@ public class TestPrestoSparkAdaptiveAggregations
         extends TestPrestoSparkAggregations
 {
     @Override
-    public void testAggregationPushedBelowOuterJoin()
-    {
-        // TODO Fix test (issue #18969).
-    }
-
-    @Override
-    public void testSingleDistinctOptimizer()
-    {
-        // TODO Fix test (issue #18969).
-    }
-
-    @Override
     protected Session getSession()
     {
         return Session.builder(super.getSession())

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveJoinQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveJoinQueries.java
@@ -22,20 +22,6 @@ public class TestPrestoSparkAdaptiveJoinQueries
         extends TestPrestoSparkJoinQueries
 {
     @Override
-    protected void assertQuery(String sql)
-    {
-        // Disabling these tests for now as many non-trivial joins are failing.
-        // TODO Fix tests (issue #18969).
-    }
-
-    @Override
-    protected void assertQuery(String actual, String expected)
-    {
-        // Disabling these tests for now as many non-trivial joins are failing.
-        // TODO Fix tests (issue #18969).
-    }
-
-    @Override
     protected Session getSession()
     {
         return Session.builder(super.getSession())


### PR DESCRIPTION
Support complex joins and aggregations in AQE :
- 49420bf - Add query completion event for intermediate stages with no shuffle
- a1d8692 - Fix issue while visiting exchange node. Use separate fragement properties object for child nodes of an exchange node

Test plan - 
Unit tests

== NO RELEASE NOTE ==

