### PR TITLE
[native] Allow ssh-keyscan to fail

### DIFF
--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=ssh \
     set -exu && \
     dnf -y install openssh-clients git wget unzip make && \
     mkdir -p -m 0600 /root/.ssh && \
-    ssh-keyscan github.com >> /root/.ssh/known_hosts && \
+    ! ssh-keyscan github.com >> /root/.ssh/known_hosts && \
     git clone --progress ${PRESTODB_REPOSITORY} "${PRESTODB_HOME}/_repo" && \
     git -C "${PRESTODB_HOME}/_repo" checkout "${PRESTODB_CHECKOUT}" && \
     make --directory="${PRESTODB_HOME}/_repo/presto-native-execution" submodules && \


### PR DESCRIPTION
Allow ssh-keyscan to fail so that the Dockerfile can be build without bash script.

```
== NO RELEASE NOTE ==
```
