### PR TITLE
Revert "Upgrade alluxio to 2.9.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.9.0</dep.alluxio.version>
+        <dep.alluxio.version>2.8.1</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.pinot.version>0.11.0</dep.pinot.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -19,8 +19,6 @@ import alluxio.client.quota.CacheScope;
 import com.facebook.presto.hive.HiveFileContext;
 import com.google.common.collect.ImmutableMap;
 
-import static com.facebook.presto.common.RuntimeUnit.BYTE;
-import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static java.util.Objects.requireNonNull;
 
@@ -45,25 +43,15 @@ public class PrestoCacheContext
         }
         return context;
     }
-
     private PrestoCacheContext(HiveFileContext hiveFileContext)
     {
         this.hiveFileContext = requireNonNull(hiveFileContext, "hiveFileContext is null");
     }
 
     @Override
-    public void incrementCounter(String name, StatsUnit unit, long value)
+    public void incrementCounter(String name, long value)
     {
-        switch (unit) {
-            case BYTE:
-                hiveFileContext.incrementCounter(name, BYTE, value);
-                break;
-            case NANO:
-                hiveFileContext.incrementCounter(name, NANO, value);
-                break;
-            default:
-                hiveFileContext.incrementCounter(name, NONE, value);
-        }
+        hiveFileContext.incrementCounter(name, NONE, value);
     }
 
     public HiveFileContext getHiveFileContext()


### PR DESCRIPTION
After rolling out 279, we noticed queries failing with the following error.

Caused by: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last destination index 1421312 out of bounds for byte[1048576]
	at java.base/java.lang.System.arraycopy(Native Method)
	at alluxio.client.file.cache.store.ByteArrayTargetBuffer.writeBytes(ByteArrayTargetBuffer.java:63)
	at alluxio.client.file.cache.LocalCacheFileInStream.localCachedRead(LocalCacheFileInStream.java:205)
	at alluxio.client.file.cache.LocalCacheFileInStream.bufferedRead(LocalCacheFileInStream.java:144)
	at alluxio.client.file.cache.LocalCacheFileInStream.readInternal(LocalCacheFileInStream.java:242)
	at alluxio.client.file.cache.LocalCacheFileInStream.positionedRead(LocalCacheFileInStream.java:287)
	at alluxio.hadoop.HdfsFileInputStream.read(HdfsFileInputStream.java:153)
	at alluxio.hadoop.HdfsFileInputStream.readFully(HdfsFileInputStream.java:170)
	at org.apache.hadoop.fs.FSDataInputStream.readFully(FSDataInputStream.java:107)
	at com.facebook.presto.hive.orc.HdfsOrcDataSource.readInternal(HdfsOrcDataSource.java:64)

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
