### PR TITLE
Optimize join execution at runtime if build side is empty

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -140,7 +140,8 @@ public class HashBuildAndJoinBenchmark
                 hashChannel,
                 Optional.empty(),
                 OptionalInt.empty(),
-                unsupportedPartitioningSpillerFactory());
+                unsupportedPartitioningSpillerFactory(),
+                false);
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test")));
         DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -99,7 +99,8 @@ public class HashBuildBenchmark
                 OptionalInt.empty(),
                 Optional.empty(),
                 OptionalInt.empty(),
-                unsupportedPartitioningSpillerFactory());
+                unsupportedPartitioningSpillerFactory(),
+                false);
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test")));
         DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -100,7 +100,17 @@ public class HashJoinBenchmark
 
             List<Type> lineItemTypes = getColumnTypes("lineitem", "orderkey", "quantity");
             OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
-            OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactoryManager, lineItemTypes, Ints.asList(0), OptionalInt.empty(), Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
+            OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(
+                    1,
+                    new PlanNodeId("test"),
+                    lookupSourceFactoryManager,
+                    lineItemTypes,
+                    Ints.asList(0),
+                    OptionalInt.empty(),
+                    Optional.empty(),
+                    OptionalInt.empty(),
+                    unsupportedPartitioningSpillerFactory(),
+                    false);
             NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"));
             this.probeDriverFactory = new DriverFactory(1, true, true, ImmutableList.of(lineItemTableScan, joinOperator, output), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -254,6 +254,7 @@ public final class SystemSessionProperties
     public static final String REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED = "remove_redundant_distinct_aggregation_enabled";
     public static final String PREFILTER_FOR_GROUPBY_LIMIT = "prefilter_for_groupby_limit";
     public static final String PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS = "prefilter_for_groupby_limit_timeout_ms";
+    public static final String OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME = "optimize_join_probe_for_empty_build_runtime";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1444,6 +1445,11 @@ public final class SystemSessionProperties
                         PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS,
                         "Timeout for finding the LIMIT number of keys for group by",
                         10000,
+                        false),
+                booleanProperty(
+                        OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME,
+                        "Optimize join probe at runtime if build side is empty",
+                        featuresConfig.isOptimizeJoinProbeForEmptyBuildRuntimeEnabled(),
                         false));
     }
 
@@ -2430,5 +2436,10 @@ public final class SystemSessionProperties
     public static int getPrefilterForGroupbyLimitTimeoutMS(Session session)
     {
         return session.getSystemProperty(PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS, Integer.class);
+    }
+
+    public static boolean isOptimizeJoinProbeForEmptyBuildRuntimeEnabled(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -95,6 +95,7 @@ public class LookupJoinOperator
     private Optional<Partition<Supplier<LookupSource>>> currentPartition = Optional.empty();
     private Optional<ListenableFuture<Supplier<LookupSource>>> unspilledLookupSource = Optional.empty();
     private Iterator<Page> unspilledInputPages = emptyIterator();
+    private final boolean optimizeProbeForEmptyBuild;
 
     public LookupJoinOperator(
             OperatorContext operatorContext,
@@ -106,7 +107,8 @@ public class LookupJoinOperator
             Runnable afterClose,
             OptionalInt lookupJoinsCount,
             HashGenerator hashGenerator,
-            PartitioningSpillerFactory partitioningSpillerFactory)
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
@@ -127,6 +129,7 @@ public class LookupJoinOperator
         operatorContext.setInfoSupplier(this.statisticsCounter);
 
         this.pageBuilder = new LookupJoinPageBuilder(buildOutputTypes);
+        this.optimizeProbeForEmptyBuild = optimizeProbeForEmptyBuild;
     }
 
     @Override
@@ -184,6 +187,18 @@ public class LookupJoinOperator
     @Override
     public boolean needsInput()
     {
+        // We can skip probe for empty build input only when probeOnOuterSide is false
+        if (optimizeProbeForEmptyBuild && !probeOnOuterSide) {
+            if (tryFetchLookupSourceProvider()) {
+                lookupSourceProvider.withLease(lookupSourceLease -> {
+                    // Do not have spill, build side is empty and probe side does not output for non match, skip and finish the operator
+                    if (!lookupSourceLease.hasSpilled() && lookupSourceLease.getLookupSource().isEmpty()) {
+                        finish();
+                    }
+                    return null;
+                });
+            }
+        }
         return !finishing
                 && lookupSourceProviderFuture.isDone()
                 && spillInProgress.isDone()

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -47,6 +47,7 @@ public class LookupJoinOperatorFactory
     private final OptionalInt totalOperatorsCount;
     private final HashGenerator probeHashGenerator;
     private final PartitioningSpillerFactory partitioningSpillerFactory;
+    private final boolean optimizeProbeForEmptyBuild;
 
     private boolean closed;
 
@@ -62,7 +63,8 @@ public class LookupJoinOperatorFactory
             OptionalInt totalOperatorsCount,
             List<Integer> probeJoinChannels,
             OptionalInt probeHashChannel,
-            PartitioningSpillerFactory partitioningSpillerFactory)
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
         this.operatorId = operatorId;
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -102,6 +104,7 @@ public class LookupJoinOperatorFactory
         }
 
         this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
+        this.optimizeProbeForEmptyBuild = optimizeProbeForEmptyBuild;
     }
 
     private LookupJoinOperatorFactory(LookupJoinOperatorFactory other)
@@ -120,6 +123,7 @@ public class LookupJoinOperatorFactory
         totalOperatorsCount = other.totalOperatorsCount;
         probeHashGenerator = other.probeHashGenerator;
         partitioningSpillerFactory = other.partitioningSpillerFactory;
+        optimizeProbeForEmptyBuild = other.optimizeProbeForEmptyBuild;
 
         closed = false;
         joinBridgeManager.incrementProbeFactoryCount();
@@ -151,7 +155,8 @@ public class LookupJoinOperatorFactory
                 () -> joinBridgeManager.probeOperatorClosed(driverContext.getLifespan()),
                 totalOperatorsCount,
                 probeHashGenerator,
-                partitioningSpillerFactory);
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -58,24 +58,108 @@ public class LookupJoinOperators
     {
     }
 
-    public OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory, List<Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory innerJoin(
+            int operatorId,
+            PlanNodeId planNodeId,
+            JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
+            List<Type> probeTypes,
+            List<Integer> probeJoinChannel,
+            OptionalInt probeHashChannel,
+            Optional<List<Integer>> probeOutputChannels,
+            OptionalInt totalOperatorsCount,
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
-        return createJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.INNER, totalOperatorsCount, partitioningSpillerFactory);
+        return createJoinOperatorFactory(
+                operatorId,
+                planNodeId,
+                lookupSourceFactory,
+                probeTypes,
+                probeJoinChannel,
+                probeHashChannel,
+                probeOutputChannels.orElse(rangeList(probeTypes.size())),
+                JoinType.INNER,
+                totalOperatorsCount,
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 
-    public OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory, List<Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory probeOuterJoin(
+            int operatorId,
+            PlanNodeId planNodeId,
+            JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
+            List<Type> probeTypes,
+            List<Integer> probeJoinChannel,
+            OptionalInt probeHashChannel,
+            Optional<List<Integer>> probeOutputChannels,
+            OptionalInt totalOperatorsCount,
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
-        return createJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.PROBE_OUTER, totalOperatorsCount, partitioningSpillerFactory);
+        return createJoinOperatorFactory(
+                operatorId,
+                planNodeId,
+                lookupSourceFactory,
+                probeTypes,
+                probeJoinChannel,
+                probeHashChannel,
+                probeOutputChannels.orElse(rangeList(probeTypes.size())),
+                JoinType.PROBE_OUTER,
+                totalOperatorsCount,
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 
-    public OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory, List<Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory lookupOuterJoin(
+            int operatorId,
+            PlanNodeId planNodeId,
+            JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
+            List<Type> probeTypes,
+            List<Integer> probeJoinChannel,
+            OptionalInt probeHashChannel,
+            Optional<List<Integer>> probeOutputChannels,
+            OptionalInt totalOperatorsCount,
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
-        return createJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.LOOKUP_OUTER, totalOperatorsCount, partitioningSpillerFactory);
+        return createJoinOperatorFactory(
+                operatorId,
+                planNodeId,
+                lookupSourceFactory,
+                probeTypes,
+                probeJoinChannel,
+                probeHashChannel,
+                probeOutputChannels.orElse(rangeList(probeTypes.size())),
+                JoinType.LOOKUP_OUTER,
+                totalOperatorsCount,
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 
-    public OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory, List<Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory fullOuterJoin(
+            int operatorId,
+            PlanNodeId planNodeId,
+            JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
+            List<Type> probeTypes,
+            List<Integer> probeJoinChannel,
+            OptionalInt probeHashChannel,
+            Optional<List<Integer>> probeOutputChannels,
+            OptionalInt totalOperatorsCount,
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
-        return createJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.FULL_OUTER, totalOperatorsCount, partitioningSpillerFactory);
+        return createJoinOperatorFactory(
+                operatorId,
+                planNodeId,
+                lookupSourceFactory,
+                probeTypes,
+                probeJoinChannel,
+                probeHashChannel,
+                probeOutputChannels.orElse(rangeList(probeTypes.size())),
+                JoinType.FULL_OUTER,
+                totalOperatorsCount,
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 
     private static List<Integer> rangeList(int endExclusive)
@@ -95,7 +179,8 @@ public class LookupJoinOperators
             List<Integer> probeOutputChannels,
             JoinType joinType,
             OptionalInt totalOperatorsCount,
-            PartitioningSpillerFactory partitioningSpillerFactory)
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            boolean optimizeProbeForEmptyBuild)
     {
         List<Type> probeOutputChannelTypes = probeOutputChannels.stream()
                 .map(probeTypes::get)
@@ -113,6 +198,7 @@ public class LookupJoinOperators
                 totalOperatorsCount,
                 probeJoinChannel,
                 probeHashChannel,
-                partitioningSpillerFactory);
+                partitioningSpillerFactory,
+                optimizeProbeForEmptyBuild);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -245,6 +245,7 @@ public class FeaturesConfig
     private boolean inPredicatesAsInnerJoinsEnabled;
     private double pushAggregationBelowJoinByteReductionThreshold = 1;
     private boolean prefilterForGroupbyLimit;
+    private boolean isOptimizeJoinProbeWithEmptyBuildRuntime;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2340,6 +2341,19 @@ public class FeaturesConfig
     public FeaturesConfig setPrefilterForGroupbyLimit(boolean prefilterForGroupbyLimit)
     {
         this.prefilterForGroupbyLimit = prefilterForGroupbyLimit;
+        return this;
+    }
+
+    public boolean isOptimizeJoinProbeForEmptyBuildRuntimeEnabled()
+    {
+        return isOptimizeJoinProbeWithEmptyBuildRuntime;
+    }
+
+    @Config("optimizer.optimize-probe-for-empty-build-runtime")
+    @ConfigDescription("Optimize join probe at runtime if build side is empty")
+    public FeaturesConfig setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(boolean isOptimizeJoinProbeWithEmptyBuildRuntime)
+    {
+        this.isOptimizeJoinProbeWithEmptyBuildRuntime = isOptimizeJoinProbeWithEmptyBuildRuntime;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -339,7 +339,8 @@ public class BenchmarkHashBuildAndJoinOperators
                 joinContext.getHashChannel(),
                 Optional.of(joinContext.getOutputChannels()),
                 OptionalInt.empty(),
-                unsupportedPartitioningSpillerFactory());
+                unsupportedPartitioningSpillerFactory(),
+                false);
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(0, true, true, false).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -243,7 +243,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         instantiateBuildDrivers(buildSideSetup, taskContext);
         buildLookupSource(buildSideSetup);
@@ -1267,7 +1268,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         // drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
@@ -1303,7 +1305,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         // drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
@@ -1345,7 +1348,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         // build drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
@@ -1390,7 +1394,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         // build drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
@@ -1434,7 +1439,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
 
         // build drivers and operators
         instantiateBuildDrivers(buildSideSetup, taskContext);
@@ -1483,7 +1489,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                PARTITIONING_SPILLER_FACTORY,
+                false);
     }
 
     private OperatorFactory innerJoinOperatorFactory(
@@ -1509,7 +1516,8 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 totalOperatorsCount,
-                partitioningSpillerFactory);
+                partitioningSpillerFactory,
+                false);
     }
 
     private BuildSideSetup setupBuildSide(

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -215,7 +215,8 @@ public class TestFeaturesConfig
                 .setRemoveRedundantDistinctAggregationEnabled(true)
                 .setInPredicatesAsInnerJoinsEnabled(false)
                 .setPushAggregationBelowJoinByteReductionThreshold(1)
-                .setPrefilterForGroupbyLimit(false));
+                .setPrefilterForGroupbyLimit(false)
+                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(false));
     }
 
     @Test
@@ -382,6 +383,7 @@ public class TestFeaturesConfig
                 .put("optimizer.in-predicates-as-inner-joins-enabled", "true")
                 .put("optimizer.push-aggregation-below-join-byte-reduction-threshold", "0.9")
                 .put("optimizer.prefilter-for-groupby-limit", "true")
+                .put("optimizer.optimize-probe-for-empty-build-runtime", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -545,7 +547,8 @@ public class TestFeaturesConfig
                 .setRemoveRedundantDistinctAggregationEnabled(false)
                 .setInPredicatesAsInnerJoinsEnabled(true)
                 .setPushAggregationBelowJoinByteReductionThreshold(0.9)
-                .setPrefilterForGroupbyLimit(true);
+                .setPrefilterForGroupbyLimit(true)
+                .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
This is an optimization for joins which has empty build side at runtime.

This PR only works for inner and right join, i.e. no output when build side is empty. In this case, probe will be skipped.

### Test Plan
Unit test.

```
== RELEASE NOTES ==

General Changes
* Add optimization for joins when build side is empty at runtime.
   Controlled by session parameter: optimize_join_probe_for_empty_build_runtime
```
