### PR TITLE
Refactor to remove duplicate LogicalPlanner constructor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -119,6 +119,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.zip;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+
 public class LogicalPlanner
 {
     public enum Stage
@@ -151,25 +152,9 @@ public class LogicalPlanner
             WarningCollector warningCollector,
             PlanChecker planChecker)
     {
-        this(explain, session, planOptimizers, planChecker, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
-    }
-
-    public LogicalPlanner(
-            boolean explain,
-            Session session,
-            List<PlanOptimizer> planOptimizers,
-            PlanChecker planChecker,
-            PlanNodeIdAllocator idAllocator,
-            Metadata metadata,
-            SqlParser sqlParser,
-            StatsCalculator statsCalculator,
-            CostCalculator costCalculator,
-            WarningCollector warningCollector)
-    {
         this.explain = explain;
         this.session = requireNonNull(session, "session is null");
         this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
-        this.planChecker = requireNonNull(planChecker, "planChecker is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
@@ -177,6 +162,7 @@ public class LogicalPlanner
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.planChecker = requireNonNull(planChecker, "planChecker is null");
     }
 
     public Plan plan(Analysis analysis)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -1053,7 +1053,7 @@ public class LocalQueryRunner
                 distributedPlanChecker);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), preparedQuery.getParameters(), parameterExtractor(preparedQuery.getStatement(), preparedQuery.getParameters()), warningCollector);
 
-        LogicalPlanner logicalPlanner = new LogicalPlanner(preparedQuery.getWrappedStatement() instanceof Explain, session, optimizers, singleNodePlanChecker, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(preparedQuery.getWrappedStatement() instanceof Explain, session, optimizers, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector, singleNodePlanChecker);
 
         Analysis analysis = analyzer.analyze(preparedQuery.getStatement());
         return logicalPlanner.plan(analysis, stage);


### PR DESCRIPTION
Refactor to remove duplicate LogicalPlanner constructor There were two LogicalPlanner constructors which only differed in the order of arguments. This commit removes the second constructor which is only used at one place.



```
== NO RELEASE NOTE ==
```
