### PR TITLE
Add dependency-check-maven plugin to detect CPEs and CVEs

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -17,7 +17,7 @@ on:
 env:
   MAVEN_OPTS: "-Xmx1024M -XX:+ExitOnOutOfMemoryError"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
-  MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+  MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8"
   MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
 
 jobs:
@@ -98,7 +98,10 @@ jobs:
 
       - name: Maven Install
         run: |
+          printenv | sort
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          export LANG=C.UTF-8
+          export LC_ALL=C.UTF-8          
           ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm,!presto-test-coverage'
 
       - name: Run e2e tests

--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -13,14 +13,14 @@ spec:
       image: maven:3.8.6-openjdk-8-slim
       env:
       - name: MAVEN_OPTS
-        value: "-Xmx6000m -Xms6000m"
+        value: "-Xmx8000m -Xms8000m"
       resources:
         requests:
-          memory: "8Gi"
-          cpu: "4000m"
+          memory: "10Gi"
+          cpu: "2000m"
         limits:
-          memory: "8Gi"
-          cpu: "4000m"
+          memory: "10Gi"
+          cpu: "2000m"
       tty: true
       command:
       - cat

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -2396,6 +2396,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>8.0.2</version>
+                <configuration>
+                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                    <failBuildOnCVSS>11</failBuildOnCVSS>
+                    <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+                    <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
+                    <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <skipSystemScope>true</skipSystemScope>
+                    <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>
+                    <suppressionFiles>
+                        <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>            
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR is the first step to resolve issue #19030. The goal is to expose the known vulnerabilities in current code base.

Integrate the dependency-check-maven plugin into the build process.
All detected are set to be ignored, for now, to not block the current CI processes.

One example report of detected CPEs(Common Platform Enumeration) and CVEs (Common Vulnerabilities and Exposures) can be viewed here: https://ci.ahana.dev/job/prestodb/job/presto/job/PR-19047/17/artifact/

The next steps are to gradually update the code/dependencies to fix CPEs and CVEs, or to suppress CPEs and CVEs if they are considered as false positives.
One possible approach is to lower `failBuildOnCVSS` score in the plugin configuration to expose the detected CVSS.

Plugin reference: http://jeremylong.github.io/DependencyCheck/.

### Background information.
CVE: Common Vulnerabilities and Exposures. The mission of the CVE® Program is to identify, define, and catalog publicly disclosed cybersecurity vulnerabilities. (from https://www.cve.org/About/Overview).

CPE: Common Platform Enumeration. A standardized method of describing and identifying classes of applications, operating systems, and hardware devices present among an enterprise's computing assets. (from https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe#:~:text=Common%20Platform%20Enumeration%20(CPE)%20is,among%20an%20enterprise's%20computing%20assets.)


```
== NO RELEASE NOTE ==
```
