### PR TITLE
Prefilter GROUPBY LIMIT queries

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -53,7 +53,6 @@ import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
-import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,6 +73,7 @@ import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMin
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static com.facebook.presto.sql.planner.PlannerUtils.getHashExpression;
 import static com.facebook.presto.sql.relational.VariableToChannelTranslator.translate;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -222,7 +222,7 @@ public abstract class AbstractOperatorBenchmark
             projections.add(new PageProjectionWithOutputs(new InputPageProjection(channel), new int[] {channel}));
         }
 
-        Optional<RowExpression> hashExpression = HashGenerationOptimizer.getHashExpression(localQueryRunner.getMetadata().getFunctionAndTypeManager(), variables.build());
+        Optional<RowExpression> hashExpression = getHashExpression(localQueryRunner.getMetadata().getFunctionAndTypeManager(), variables.build());
         verify(hashExpression.isPresent());
         RowExpression translatedHashExpression = translate(hashExpression.get(), variableToInputMapping.build());
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -252,6 +252,8 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED = "optimize_conditional_aggregation_enabled";
     public static final String ANALYZER_TYPE = "analyzer_type";
     public static final String REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED = "remove_redundant_distinct_aggregation_enabled";
+    public static final String PREFILTER_FOR_GROUPBY_LIMIT = "prefilter_for_groupby_limit";
+    public static final String PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS = "prefilter_for_groupby_limit_timeout_ms";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1432,6 +1434,16 @@ public final class SystemSessionProperties
                         PUSH_AGGREGATION_BELOW_JOIN_BYTE_REDUCTION_THRESHOLD,
                         "Byte reduction ratio threshold at which to disable pushdown of aggregation below inner join",
                         featuresConfig.getPushAggregationBelowJoinByteReductionThreshold(),
+                        false),
+                booleanProperty(
+                        PREFILTER_FOR_GROUPBY_LIMIT,
+                        "Prefilter aggregation source for queries that have aggregations on simple tables with filters",
+                        featuresConfig.isPrefilterForGroupbyLimit(),
+                        false),
+                integerProperty(
+                        PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS,
+                        "Timeout for finding the LIMIT number of keys for group by",
+                        10000,
                         false));
     }
 
@@ -2400,6 +2412,11 @@ public final class SystemSessionProperties
         return session.getSystemProperty(REMOVE_REDUNDANT_DISTINCT_AGGREGATION_ENABLED, Boolean.class);
     }
 
+    public static boolean isPrefilterForGroupbyLimit(Session session)
+    {
+        return session.getSystemProperty(PREFILTER_FOR_GROUPBY_LIMIT, Boolean.class);
+    }
+
     public static boolean isInPredicatesAsInnerJoinsEnabled(Session session)
     {
         return session.getSystemProperty(IN_PREDICATES_AS_INNER_JOINS_ENABLED, Boolean.class);
@@ -2408,5 +2425,10 @@ public final class SystemSessionProperties
     public static double getPushAggregationBelowJoinByteReductionThreshold(Session session)
     {
         return session.getSystemProperty(PUSH_AGGREGATION_BELOW_JOIN_BYTE_REDUCTION_THRESHOLD, Double.class);
+    }
+
+    public static int getPrefilterForGroupbyLimitTimeoutMS(Session session)
+    {
+        return session.getSystemProperty(PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -41,7 +41,7 @@ import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.toTypes;
-import static com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer.INITIAL_HASH_VALUE;
+import static com.facebook.presto.sql.planner.PlannerUtils.INITIAL_HASH_VALUE;
 import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;

--- a/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntFunction;
 
-import static com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer.INITIAL_HASH_VALUE;
+import static com.facebook.presto.sql.planner.PlannerUtils.INITIAL_HASH_VALUE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -244,6 +244,7 @@ public class FeaturesConfig
     private boolean isRemoveRedundantDistinctAggregationEnabled = true;
     private boolean inPredicatesAsInnerJoinsEnabled;
     private double pushAggregationBelowJoinByteReductionThreshold = 1;
+    private boolean prefilterForGroupbyLimit;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2326,6 +2327,19 @@ public class FeaturesConfig
     public FeaturesConfig setPushAggregationBelowJoinByteReductionThreshold(double pushAggregationBelowJoinByteReductionThreshold)
     {
         this.pushAggregationBelowJoinByteReductionThreshold = pushAggregationBelowJoinByteReductionThreshold;
+        return this;
+    }
+
+    public boolean isPrefilterForGroupbyLimit()
+    {
+        return prefilterForGroupbyLimit;
+    }
+
+    @Config("optimizer.prefilter-for-groupby-limit")
+    @ConfigDescription("Enable optimizations for groupby limit queries")
+    public FeaturesConfig setPrefilterForGroupbyLimit(boolean prefilterForGroupbyLimit)
+    {
+        this.prefilterForGroupbyLimit = prefilterForGroupbyLimit;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -682,7 +682,8 @@ public class CanonicalPlanGenerator
                 node.getLimit(),
                 node.isPartial(),
                 distinctVariables,
-                Optional.empty());
+                Optional.empty(),
+                0);
         context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1265,7 +1265,8 @@ public class LocalExecutionPlanner
                     distinctChannels,
                     node.getLimit(),
                     hashChannel,
-                    joinCompiler);
+                    joinCompiler,
+                    node.getTimeoutMillis());
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, source);
         }
 
@@ -3061,7 +3062,7 @@ public class LocalExecutionPlanner
             List<Integer> valueChannels = new ArrayList<>();
             for (RowExpression argument : aggregation.getArguments()) {
                 if (!(argument instanceof LambdaDefinitionExpression)) {
-                    checkArgument(argument instanceof VariableReferenceExpression, "argument must be variable reference");
+                    checkArgument(argument instanceof VariableReferenceExpression, "argument: " + argument + " must be variable reference");
                     valueChannels.add(source.getLayout().get(argument));
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -145,6 +145,7 @@ import com.facebook.presto.sql.planner.optimizations.MetadataQueryOptimizer;
 import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggregations;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
+import com.facebook.presto.sql.planner.optimizations.PrefilterForLimitingAggregation;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
@@ -303,6 +304,7 @@ public class PlanOptimizers
                 new RewriteCaseExpressionPredicate(metadata.getFunctionAndTypeManager()).rules());
 
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser));
+        PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata));
 
         builder.add(
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
@@ -424,11 +426,13 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new PullConstantsAboveGroupBy())));
+                        ImmutableSet.of(
+                                new PullConstantsAboveGroupBy())));
 
         // TODO: move this before optimization if possible!!
         // Replace all expressions with row expressions
-        builder.add(new IterativeOptimizer(
+        builder.add(
+                new IterativeOptimizer(
                 ruleStats,
                 statsCalculator,
                 costCalculator,
@@ -496,6 +500,7 @@ public class PlanOptimizers
                         ImmutableSet.of(new SimplifyCountOverConstant(metadata.getFunctionAndTypeManager()))),
                 new LimitPushDown(), // Run LimitPushDown before WindowFilterPushDown
                 new WindowFilterPushDown(metadata), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
+                prefilterForLimitingAggregation,
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -13,28 +13,64 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayout;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
+import java.lang.invoke.MethodHandle;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.getSourceLocation;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.variable;
+import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.forEachPair;
 
 public class PlannerUtils
 {
+    public static final long INITIAL_HASH_VALUE = 0;
+    public static final String HASH_CODE = OperatorType.HASH_CODE.getFunctionName().getObjectName();
+
     private PlannerUtils() {}
 
     public static SortOrder toSortOrder(SortItem sortItem)
@@ -86,5 +122,156 @@ public class PlannerUtils
     {
         checkArgument(expression instanceof SymbolReference);
         return variable(getSourceLocation(expression), ((SymbolReference) expression).getName(), types.get(expression));
+    }
+
+    public static Type createMapType(FunctionAndTypeManager functionAndTypeManager, Type keyType, Type valueType)
+    {
+        MethodHandle keyNativeEquals = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.resolveOperator(OperatorType.EQUAL, fromTypes(keyType, keyType))).getMethodHandle();
+        MethodHandle keyNativeHashCode = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.resolveOperator(OperatorType.HASH_CODE, fromTypes(keyType))).getMethodHandle();
+        return new MapType(keyType, valueType, keyNativeEquals, keyNativeHashCode);
+    }
+
+    public static RowExpression orNullHashCode(RowExpression expression)
+    {
+        checkArgument(BIGINT.equals(expression.getType()), "expression should be BIGINT type");
+        return new SpecialFormExpression(expression.getSourceLocation(), SpecialFormExpression.Form.COALESCE, BIGINT, expression, constant(NULL_HASH_CODE, BIGINT));
+    }
+
+    public static Optional<RowExpression> getHashExpression(FunctionAndTypeManager functionAndTypeManager, List<VariableReferenceExpression> variables)
+    {
+        if (variables.isEmpty()) {
+            return Optional.empty();
+        }
+
+        RowExpression result = constant(INITIAL_HASH_VALUE, BIGINT);
+        for (VariableReferenceExpression variable : variables) {
+            RowExpression hashField = call(functionAndTypeManager, HASH_CODE, BIGINT, variable);
+            hashField = orNullHashCode(hashField);
+            result = call(functionAndTypeManager, "combine_hash", BIGINT, result, hashField);
+        }
+        return Optional.of(result);
+    }
+
+    public static PlanNode projectExpressions(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, List<? extends RowExpression> expressions)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        for (RowExpression expression : expressions) {
+            assignments.put(variableAllocator.newVariable("expr", expression.getType()), expression);
+        }
+
+        return new ProjectNode(
+                source.getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                source,
+                assignments.build(),
+                LOCAL);
+    }
+
+    public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, List<RowExpression> expressions)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        for (VariableReferenceExpression variableReferenceExpression : source.getOutputVariables()) {
+            assignments.put(variableReferenceExpression, variableReferenceExpression);
+        }
+
+        for (RowExpression expression : expressions) {
+            assignments.put(variableAllocator.newVariable("expr", expression.getType()), expression);
+        }
+
+        return new ProjectNode(
+                source.getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                source,
+                assignments.build(),
+                LOCAL);
+    }
+
+    public static PlanNode addAggregation(PlanNode planNode, FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, String aggregationFunction, Type type, List<VariableReferenceExpression> groupingKeys, VariableReferenceExpression resultVariable, RowExpression... args)
+    {
+        CallExpression callExpression = call(functionAndTypeManager, aggregationFunction, type, args);
+        Map<VariableReferenceExpression, AggregationNode.Aggregation> aggregationMap = ImmutableMap.of(
+                resultVariable,
+                new AggregationNode.Aggregation(
+                        callExpression,
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        Optional.empty()));
+
+        AggregationNode.GroupingSetDescriptor groupingSetDescriptor = new AggregationNode.GroupingSetDescriptor(groupingKeys, 1, ImmutableSet.of(1));
+        return projectExpressions(
+                new AggregationNode(
+                    Optional.empty(),
+                    planNodeIdAllocator.getNextId(),
+                    planNode,
+                    aggregationMap,
+                    groupingSetDescriptor,
+                    ImmutableList.of(),
+                    AggregationNode.Step.SINGLE,
+                    Optional.empty(),
+                    Optional.empty()),
+                planNodeIdAllocator,
+                variableAllocator,
+                ImmutableList.of(resultVariable));
+    }
+
+    private static PlanNode cloneFilterNode(FilterNode filterNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> variablesToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap, PlanNodeIdAllocator idAllocator)
+    {
+        PlanNode newSource = clonePlanNode(filterNode.getSource(), session, metadata, planNodeIdAllocator, variablesToKeep, varMap);
+
+        return new FilterNode(
+                filterNode.getSourceLocation(),
+                idAllocator.getNextId(),
+                newSource,
+                filterNode.getPredicate());
+    }
+
+    private static PlanNode cloneProjectNode(ProjectNode projectNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap, PlanNodeIdAllocator idAllocator)
+    {
+        PlanNode newSource = clonePlanNode(projectNode.getSource(), session, metadata, planNodeIdAllocator, fieldsToKeep, varMap);
+
+        return new ProjectNode(
+                idAllocator.getNextId(),
+                newSource,
+                projectNode.getAssignments());
+    }
+
+    private static TableScanNode cloneTableScan(TableScanNode scanNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)
+    {
+        Map<VariableReferenceExpression, ColumnHandle> assignments = scanNode.getAssignments();
+
+        TableLayout scanLayout = metadata.getLayout(session, scanNode.getTable());
+
+        return new TableScanNode(
+                scanNode.getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                scanLayout.getNewTableHandle(),
+                scanNode.getOutputVariables(),
+                scanNode.getAssignments(),
+                scanNode.getTableConstraints(),
+                scanNode.getCurrentConstraint(),
+                scanNode.getEnforcedConstraint());
+    }
+
+    public static PlanNode clonePlanNode(PlanNode planNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)
+    {
+        if (planNode instanceof TableScanNode) {
+            TableScanNode scanNode = (TableScanNode) planNode;
+            return cloneTableScan(scanNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap);
+        }
+        else if (planNode instanceof FilterNode) {
+            return cloneFilterNode((FilterNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap, planNodeIdAllocator);
+        }
+        else if (planNode instanceof ProjectNode) {
+            return cloneProjectNode((ProjectNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap, planNodeIdAllocator);
+        }
+
+        checkState(false, "Currently cannot clone: " + planNode.getClass().getName() + " nodes.");
+        return null;
+    }
+
+    public static String getPlanString(PlanNode planNode, Session session, TypeProvider types, Metadata metadata)
+    {
+        return PlanPrinter.textLogicalPlan(planNode, types, StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 0);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
@@ -54,6 +54,7 @@ public class MergeLimitWithDistinct
                         parent.getCount(),
                         false,
                         child.getGroupingKeys(),
-                        child.getHashVariable()));
+                        child.getHashVariable(),
+                        0));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -565,7 +565,7 @@ public class AddExchanges
                         gatheringExchange(
                                 idAllocator.getNextId(),
                                 REMOTE_STREAMING,
-                                new DistinctLimitNode(child.getNode().getSourceLocation(), idAllocator.getNextId(), child.getNode(), node.getLimit(), true, node.getDistinctVariables(), node.getHashVariable())),
+                                new DistinctLimitNode(child.getNode().getSourceLocation(), idAllocator.getNextId(), child.getNode(), node.getLimit(), true, node.getDistinctVariables(), node.getHashVariable(), 0)),
                         child.getProperties());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -143,7 +143,7 @@ public class LimitPushDown
                     node.getOutputVariables().size() == node.getGroupingKeys().size() &&
                     node.getOutputVariables().containsAll(node.getGroupingKeys())) {
                 PlanNode rewrittenSource = context.rewrite(node.getSource());
-                return new DistinctLimitNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenSource, limit.getCount(), false, rewrittenSource.getOutputVariables(), Optional.empty());
+                return new DistinctLimitNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenSource, limit.getCount(), false, rewrittenSource.getOutputVariables(), Optional.empty(), 0);
             }
             PlanNode rewrittenNode = context.defaultRewrite(node);
             if (limit != null) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.tree.Join;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.PlannerUtils.addAggregation;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
+import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
+import static com.facebook.presto.sql.planner.PlannerUtils.createMapType;
+import static com.facebook.presto.sql.planner.PlannerUtils.getHashExpression;
+import static com.facebook.presto.sql.planner.PlannerUtils.projectExpressions;
+import static com.facebook.presto.sql.planner.optimizations.JoinNodeUtils.typeConvert;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static java.lang.Boolean.TRUE;
+
+/**
+ * An optimization for quicker execution of simple group by + limit queres. In SQL terms, it will be:
+ *
+ * Original:
+ *
+ * SELECT SUM(x), userid FROM Table GROUP BY userid LIMIT 1000
+ *
+ * Rewritten:
+ *
+ * SELECT SUM(x) , userid FROM Table
+ * CROSS JOIN (SELECT MAP_AGG(hash(userid)) m FROM (SELECT DISTINCT userid FROM Table LIMIT 1000)))
+ * WHERE IF(CARDINALITY(m)=1000, m[hash(userid)], TRUE)
+ *
+ * In addition we also add a timeout to the distinctlimit we add so that we don't get stuck trying to find the keys
+ */
+
+public class PrefilterForLimitingAggregation
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+    public PrefilterForLimitingAggregation(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public PlanNode optimize(
+            PlanNode plan,
+            Session session,
+            TypeProvider types,
+            PlanVariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator,
+            WarningCollector warningCollector)
+    {
+        if (SystemSessionProperties.isPrefilterForGroupbyLimit(session)) {
+            return SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata, types, idAllocator, variableAllocator), plan);
+        }
+
+        return plan;
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final TypeProvider types;
+        private final PlanNodeIdAllocator idAllocator;
+        private final PlanVariableAllocator variableAllocator;
+
+        private Rewriter(
+                Session session,
+                Metadata metadata,
+                TypeProvider types,
+                PlanNodeIdAllocator idAllocator,
+                PlanVariableAllocator variableAllocator)
+        {
+            this.session = session;
+            this.metadata = metadata;
+            this.types = types;
+            this.idAllocator = idAllocator;
+            this.variableAllocator = variableAllocator;
+        }
+
+        @Override
+        public PlanNode visitSort(SortNode sortNode, RewriteContext<Void> context)
+        {
+            return sortNode;
+        }
+
+        @Override
+        public PlanNode visitLimit(LimitNode limitNode, RewriteContext<Void> context)
+        {
+            PlanNode source = limitNode.getSource();
+            AggregationNode aggregationNode;
+
+            if (source instanceof ProjectNode && ((ProjectNode) source).getSource() instanceof AggregationNode) {
+                aggregationNode = (AggregationNode) ((ProjectNode) source).getSource();
+            }
+            else if (source instanceof AggregationNode) {
+                aggregationNode = (AggregationNode) source;
+            }
+            else {
+                return limitNode;
+            }
+
+            if (!aggregationNode.getGroupingKeys().isEmpty() && isScanFilterProject(aggregationNode.getSource())) {
+                PlanNode rewrittenAggregation = addPrefilter(aggregationNode, limitNode.getCount());
+                if (rewrittenAggregation == aggregationNode) {
+                    return limitNode;
+                }
+
+                PlanNode newLimitNode;
+                if (source == aggregationNode) {
+                    newLimitNode = replaceChildren(limitNode, ImmutableList.of(rewrittenAggregation));
+                }
+                else {
+                    newLimitNode = replaceChildren(limitNode, ImmutableList.of(replaceChildren(source, ImmutableList.of(rewrittenAggregation))));
+                }
+
+                return newLimitNode;
+            }
+
+            return limitNode;
+        }
+
+        private PlanNode addPrefilter(AggregationNode aggregationNode, long count)
+        {
+            List<VariableReferenceExpression> keys = aggregationNode.getGroupingKeys().stream().collect(Collectors.toList());
+            if (keys.isEmpty()) {
+                return aggregationNode;
+            }
+
+            PlanNode originalSource = aggregationNode.getSource();
+            PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, keys, ImmutableMap.of());
+            DistinctLimitNode timedDistinctLimitNode = new DistinctLimitNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    keySource,
+                    count,
+                    false,
+                    keys,
+                    Optional.empty(),
+                    SystemSessionProperties.getPrefilterForGroupbyLimitTimeoutMS(session));
+
+            FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+            RowExpression leftHashExpression = getHashExpression(functionAndTypeManager, keys).get();
+            RowExpression rightHashExpression = getHashExpression(functionAndTypeManager, timedDistinctLimitNode.getOutputVariables()).get();
+
+            Type mapType = createMapType(functionAndTypeManager, BIGINT, BOOLEAN);
+            PlanNode rightProjectNode = projectExpressions(timedDistinctLimitNode, idAllocator, variableAllocator, ImmutableList.of(rightHashExpression, constant(TRUE, BOOLEAN)));
+
+            VariableReferenceExpression mapAggVariable = variableAllocator.newVariable("expr", mapType);
+            PlanNode crossJoinRhs = addAggregation(rightProjectNode, functionAndTypeManager, idAllocator, variableAllocator, "MAP_AGG", mapType, ImmutableList.of(), mapAggVariable, rightProjectNode.getOutputVariables().get(0), rightProjectNode.getOutputVariables().get(1));
+            PlanNode crossJoinLhs = addProjections(originalSource, idAllocator, variableAllocator, ImmutableList.of(leftHashExpression));
+            ImmutableList.Builder<VariableReferenceExpression> crossJoinOutput = ImmutableList.builder();
+
+            crossJoinOutput.addAll(crossJoinLhs.getOutputVariables());
+            crossJoinOutput.addAll(crossJoinRhs.getOutputVariables());
+
+            PlanNode crossJoin = new JoinNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    typeConvert(Join.Type.CROSS),
+                    crossJoinLhs,
+                    crossJoinRhs,
+                    ImmutableList.of(),
+                    crossJoinOutput.build(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(REPLICATED),
+                    ImmutableMap.of());
+
+            VariableReferenceExpression mapVariable = crossJoinRhs.getOutputVariables().get(0);
+            VariableReferenceExpression lookupVariable = crossJoinLhs.getOutputVariables().get(crossJoinLhs.getOutputVariables().size() - 1);
+            RowExpression cardinality = call(functionAndTypeManager, "CARDINALITY", BIGINT, mapVariable);
+            RowExpression countExpr = constant(count, BIGINT);
+
+            FunctionHandle equalsFunctionHandle = metadata.getFunctionAndTypeManager().resolveOperator(EQUAL, fromTypes(BIGINT, BIGINT));
+            RowExpression foundAllEntires = call(EQUAL.name(), equalsFunctionHandle, BOOLEAN, cardinality, countExpr);
+            RowExpression mapElementAt = call(functionAndTypeManager, "element_at", BOOLEAN, mapVariable, lookupVariable);
+            RowExpression check = specialForm(IF, BOOLEAN, foundAllEntires, mapElementAt, constant(TRUE, BOOLEAN));
+
+            FilterNode filterNode = new FilterNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    crossJoin,
+                    check);
+
+            Assignments.Builder originalOutputs = Assignments.builder();
+            for (VariableReferenceExpression variableReferenceExpression : originalSource.getOutputVariables()) {
+                originalOutputs.put(variableReferenceExpression, variableReferenceExpression);
+            }
+
+            ProjectNode filteredSource = new ProjectNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    filterNode,
+                    originalOutputs.build(),
+                    LOCAL);
+
+            return replaceChildren(aggregationNode, ImmutableList.of(filteredSource));
+        }
+
+        private static boolean isScanFilterProject(PlanNode source)
+        {
+            if (source instanceof FilterNode) {
+                return isScanFilterProject(((FilterNode) source).getSource());
+            }
+            if (source instanceof ProjectNode) {
+                return isScanFilterProject(((ProjectNode) source).getSource());
+            }
+            if (source instanceof TableScanNode) {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -621,7 +621,7 @@ public class PruneUnreferencedOutputs
                 expectedInputs = ImmutableSet.copyOf(node.getDistinctVariables());
             }
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
-            return new DistinctLimitNode(node.getSourceLocation(), node.getId(), source, node.getLimit(), node.isPartial(), node.getDistinctVariables(), node.getHashVariable());
+            return new DistinctLimitNode(node.getSourceLocation(), node.getId(), source, node.getLimit(), node.isPartial(), node.getDistinctVariables(), node.getHashVariable(), node.getTimeoutMillis());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -383,7 +383,7 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitDistinctLimit(DistinctLimitNode node, RewriteContext<Void> context)
         {
-            return new DistinctLimitNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), node.getLimit(), node.isPartial(), canonicalizeAndDistinct(node.getDistinctVariables()), canonicalize(node.getHashVariable()));
+            return new DistinctLimitNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), node.getLimit(), node.isPartial(), canonicalizeAndDistinct(node.getDistinctVariables()), canonicalize(node.getHashVariable()), node.getTimeoutMillis());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.LiteralInterpreter;
 import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 
 import java.util.List;
 
@@ -52,7 +53,11 @@ public final class RowExpressionFormatter
 
     public String formatRowExpression(ConnectorSession session, RowExpression expression)
     {
-        return expression.accept(new Formatter(), requireNonNull(session, "session is null"));
+        if (!OriginalExpressionUtils.isExpression(expression)) {
+            return expression.accept(new Formatter(), requireNonNull(session, "session is null"));
+        }
+
+        return "Original Expression: " + expression;
     }
 
     private List<String> formatRowExpressions(ConnectorSession session, List<RowExpression> rowExpressions)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
@@ -130,7 +130,7 @@ public final class OriginalExpressionUtils
         @Override
         public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
         {
-            throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
+            throw new UnsupportedOperationException("OriginalExpression: " + expression + " cannot appear in a RowExpression tree");
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -214,7 +214,8 @@ public class TestFeaturesConfig
                 .setOptimizeConditionalAggregationEnabled(false)
                 .setRemoveRedundantDistinctAggregationEnabled(true)
                 .setInPredicatesAsInnerJoinsEnabled(false)
-                .setPushAggregationBelowJoinByteReductionThreshold(1));
+                .setPushAggregationBelowJoinByteReductionThreshold(1)
+                .setPrefilterForGroupbyLimit(false));
     }
 
     @Test
@@ -380,6 +381,7 @@ public class TestFeaturesConfig
                 .put("optimizer.remove-redundant-distinct-aggregation-enabled", "false")
                 .put("optimizer.in-predicates-as-inner-joins-enabled", "true")
                 .put("optimizer.push-aggregation-below-join-byte-reduction-threshold", "0.9")
+                .put("optimizer.prefilter-for-groupby-limit", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -542,7 +544,8 @@ public class TestFeaturesConfig
                 .setOptimizeConditionalAggregationEnabled(true)
                 .setRemoveRedundantDistinctAggregationEnabled(false)
                 .setInPredicatesAsInnerJoinsEnabled(true)
-                .setPushAggregationBelowJoinByteReductionThreshold(0.9);
+                .setPushAggregationBelowJoinByteReductionThreshold(0.9)
+                .setPrefilterForGroupbyLimit(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -291,7 +291,8 @@ public class PlanBuilder
                 count,
                 false,
                 distinctSymbols,
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     public SampleNode sample(double sampleRatio, SampleNode.Type type, PlanNode source)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -245,7 +245,7 @@ public class TestPinotQueryBase
 
     protected DistinctLimitNode distinctLimit(PlanBuilder pb, List<VariableReferenceExpression> distinctVariables, long count, PlanNode source)
     {
-        return new DistinctLimitNode(source.getSourceLocation(), pb.getIdAllocator().getNextId(), source, count, false, distinctVariables, Optional.empty());
+        return new DistinctLimitNode(source.getSourceLocation(), pb.getIdAllocator().getNextId(), source, count, false, distinctVariables, Optional.empty(), 0);
     }
 
     protected TopNNode topN(PlanBuilder pb, long count, List<String> orderingColumns, List<Boolean> ascending, PlanNode source)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/DistinctLimitNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/DistinctLimitNode.java
@@ -34,6 +34,7 @@ public final class DistinctLimitNode
 {
     private final PlanNode source;
     private final long limit;
+    private final int timeoutMillis;
     private final boolean partial;
     private final List<VariableReferenceExpression> distinctVariables;
     private final Optional<VariableReferenceExpression> hashVariable;
@@ -46,9 +47,10 @@ public final class DistinctLimitNode
             @JsonProperty("limit") long limit,
             @JsonProperty("partial") boolean partial,
             @JsonProperty("distinctVariables") List<VariableReferenceExpression> distinctVariables,
-            @JsonProperty("hashVariable") Optional<VariableReferenceExpression> hashVariable)
+            @JsonProperty("hashVariable") Optional<VariableReferenceExpression> hashVariable,
+            @JsonProperty("timeoutMillis")int timeoutMillis)
     {
-        this(sourceLocation, id, Optional.empty(), source, limit, partial, distinctVariables, hashVariable);
+        this(sourceLocation, id, Optional.empty(), source, limit, partial, distinctVariables, hashVariable, timeoutMillis);
     }
 
     public DistinctLimitNode(
@@ -59,7 +61,8 @@ public final class DistinctLimitNode
             long limit,
             boolean partial,
             List<VariableReferenceExpression> distinctVariables,
-            Optional<VariableReferenceExpression> hashVariable)
+            Optional<VariableReferenceExpression> hashVariable,
+            int timeoutMillis)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.source = requireNonNull(source, "source is null");
@@ -68,6 +71,7 @@ public final class DistinctLimitNode
         this.partial = partial;
         this.distinctVariables = unmodifiableList(distinctVariables);
         this.hashVariable = requireNonNull(hashVariable, "hashVariable is null");
+        this.timeoutMillis = timeoutMillis;
         checkArgument(!hashVariable.isPresent() || !distinctVariables.contains(hashVariable.get()), "distinctVariables should not contain hash variable");
     }
 
@@ -131,14 +135,14 @@ public final class DistinctLimitNode
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new DistinctLimitNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, limit, partial, distinctVariables, hashVariable);
+        return new DistinctLimitNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, limit, partial, distinctVariables, hashVariable, timeoutMillis);
     }
 
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 1, "Unexpected number of elements in list newChildren");
-        return new DistinctLimitNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), limit, partial, distinctVariables, hashVariable);
+        return new DistinctLimitNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), limit, partial, distinctVariables, hashVariable, timeoutMillis);
     }
 
     private static void checkArgument(boolean condition, String message)
@@ -146,5 +150,11 @@ public final class DistinctLimitNode
         if (!condition) {
             throw new IllegalArgumentException(message);
         }
+    }
+
+    @JsonProperty
+    public int getTimeoutMillis()
+    {
+        return timeoutMillis;
     }
 }


### PR DESCRIPTION
We have seen users running ad-hoc queries like:

```
SELECT SUM(x), userid FROM Table GROUP BY userid LIMIT 1000
```
if the Table has a large number of distinct userid, these queries often OOM or timeout. So we added a new optimization that first tries to scan the table looking for LIMIT number of distinct keys (in a short time like 10s, configurable) and if it finds them, makes a map of those and filters out the original table using that. Roughly:

```
SELECT SUM(x) , userid FROM Table
CROSS JOIN (SELECT MAP_AGG(hash(userid)) m FROM (SELECT DISTINCT userid FROM Table LIMIT 1000)))
WHERE IF(CARDINALITY(m)=1000, m[hash(userid)], TRUE)
```

So the idea is if there are 1000 keys and if we find them quickly then those are returned for quick lookup (prefilter), if not there are no 1000 distinct keys or if we could not find them within the timeout limit, this filter becomes a no-op.

Test plan - AbstractTestQueries

```
== RELEASE NOTES ==

General Changes
* Added a new optimization for filtering large tables with LIMIT number of keys for queries that do simple GROUP BY LIMIT with no ORDER BY. Added a boolean session param: `prefilter_for_groupby_limit` that can enable this feature

```
