### PR TITLE
Push correlated subqueries to inner side of outer joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -121,6 +121,8 @@ import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identitiesAsS
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.asSymbolReference;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.Join.Type.INNER;
+import static com.facebook.presto.sql.tree.Join.Type.LEFT;
+import static com.facebook.presto.sql.tree.Join.Type.RIGHT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -392,8 +394,38 @@ class RelationPlanner
                 }
             }
 
-            // subqueries can be applied only to one side of join - left side is selected in arbitrary way
-            leftPlanBuilder = subqueryPlanner.handleUncorrelatedSubqueries(leftPlanBuilder, complexJoinExpressions, node, context);
+            if (node.getType() == LEFT || node.getType() == RIGHT) {
+                RelationType left = analysis.getOutputDescriptor(node.getLeft());
+                RelationType right = analysis.getOutputDescriptor(node.getRight());
+
+                for (Expression complexJoinExpression : complexJoinExpressions) {
+                    Set<QualifiedName> dependencies = VariablesExtractor.extractNames(complexJoinExpression, analysis.getColumnReferences());
+                    // If there are no dependencies, no subqueries, or if the expression references both inputs,
+                    // then treat the expression as an uncorrelated subquery (error checking will happen later)
+                    // IN subqueries are not allowed in (outer) join conditions - so no need to check for them here
+                    boolean noSubqueriesPresent = subqueryPlanner.collectScalarSubqueries(complexJoinExpression, node).isEmpty() &&
+                            subqueryPlanner.collectExistsSubqueries(complexJoinExpression, node).isEmpty() &&
+                            subqueryPlanner.collectQuantifiedComparisonSubqueries(complexJoinExpression, node).isEmpty();
+                    if (noSubqueriesPresent ||
+                            dependencies.isEmpty() ||
+                            (dependencies.stream().anyMatch(left::canResolve) && dependencies.stream().anyMatch(right::canResolve))) {
+                        // Subqueries are applied only to one side of join - left side is selected arbitrarily
+                        // If the subquery references the right input, those variables will remain unresolved and caught in NoIdentifierLeftChecker
+                        leftPlanBuilder = subqueryPlanner.handleUncorrelatedSubqueries(leftPlanBuilder, ImmutableList.of(complexJoinExpression), node, context);
+                    }
+                    else if (node.getType() == LEFT && !dependencies.stream().allMatch(left::canResolve)) {
+                        rightPlanBuilder = subqueryPlanner.handleSubqueries(rightPlanBuilder, complexJoinExpression, node, context);
+                    }
+                    else {
+                        leftPlanBuilder = subqueryPlanner.handleSubqueries(leftPlanBuilder, complexJoinExpression, node, context);
+                    }
+                }
+            }
+            else {
+                // subqueries are applied only to one side of join - left side is selected arbitrarily
+                // If the subquery references the right input, those variables will remain unresolved and caught in NoIdentifierLeftChecker
+                leftPlanBuilder = subqueryPlanner.handleUncorrelatedSubqueries(leftPlanBuilder, complexJoinExpressions, node, context);
+            }
         }
 
         RelationPlan intermediateRootRelationPlan = new RelationPlan(root, analysis.getScope(node), outputs);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1724,4 +1724,86 @@ public class TestLogicalPlanner
     {
         assertPlanSucceeded("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(array[2, 3], ARRAY[2, 3]) AS r(r1, r2)", this.getQueryRunner().getDefaultSession());
     }
+
+    @Test
+    public void testCorrelatedSubqueriesWithOuterJoins()
+    {
+        // Subquery pushed to partsupp and therefore final join order is (part LOJ (partsupp JOIN supplier))
+        assertPlan("SELECT COUNT(*) FROM part p LEFT JOIN partsupp ps ON p.partkey=ps.partkey AND EXISTS (SELECT 1 FROM supplier s WHERE s.suppkey=ps.suppkey)",
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("partkey", "partkey_0")),
+                                anyTree(
+                                        tableScan("part", ImmutableMap.of("partkey", "partkey"))),
+                                anyTree(
+                                        join(INNER,
+                                                ImmutableList.of(equiJoinClause("suppkey", "suppkey_4")),
+                                                anyTree(
+                                                        tableScan("partsupp", ImmutableMap.of("partkey_0", "partkey", "suppkey", "suppkey"))),
+                                                anyTree(
+                                                        tableScan("supplier", ImmutableMap.of("suppkey_4", "suppkey"))))))));
+
+        // Same query with a right join fails with legacy error
+        String expectedErrorMsg = "Unexpected identifier in logical plan: ";
+        assertPlanFailedWithException("SELECT COUNT(*) FROM part p RIGHT JOIN partsupp ps ON p.partkey=ps.partkey AND EXISTS (SELECT 1 FROM supplier s WHERE s.suppkey=ps.suppkey)",
+                this.getQueryRunner().getDefaultSession(),
+                expectedErrorMsg + "ps");
+
+        // Subquery pushed to part and therefore final join order is ((part JOIN supplier) ROJ partsupp)
+        assertPlan("SELECT COUNT(*) FROM part p RIGHT JOIN partsupp ps ON p.partkey=ps.partkey AND EXISTS (SELECT 1 FROM supplier s WHERE s.suppkey=p.partkey)",
+                anyTree(
+                        join(RIGHT,
+                                ImmutableList.of(equiJoinClause("partkey", "partkey_0")),
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("partkey", "suppkey_4")),
+                                        anyTree(
+                                                tableScan("part", ImmutableMap.of("partkey", "partkey"))),
+                                        anyTree(
+                                                tableScan("supplier", ImmutableMap.of("suppkey_4", "suppkey")))),
+                                anyTree(
+                                        tableScan("partsupp", ImmutableMap.of("partkey_0", "partkey"))))));
+
+        // subquery gets pushed to join of partsupp, supplier
+        assertPlan("SELECT COUNT(*) FROM part p LEFT JOIN (SELECT * FROM partsupp ps, supplier s WHERE ps.suppkey=s.suppkey) sq ON sq.partkey=p.partkey AND NOT EXISTS (SELECT 1 FROM lineitem l WHERE sq.supplycost+sq.acctbal = l.extendedprice)",
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("partkey", "partkey_0")),
+                                anyTree(
+                                        tableScan("part", ImmutableMap.of("partkey", "partkey"))),
+                                anyTree(
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("add", "extendedprice")),
+                                                anyTree(
+                                                        project(
+                                                                ImmutableMap.of("add", new ExpressionMatcher("supplycost + acctbal")),
+                                                                join(INNER,
+                                                                        ImmutableList.of(equiJoinClause("suppkey", "suppkey_3")),
+                                                                        anyTree(
+                                                                                tableScan("partsupp", ImmutableMap.of("suppkey", "suppkey", "supplycost", "supplycost", "partkey_0", "partkey"))),
+                                                                        anyTree(
+                                                                                tableScan("supplier", ImmutableMap.of("suppkey_3", "suppkey", "acctbal", "acctbal")))))),
+                                                anyTree(
+                                                        tableScan("lineitem", ImmutableMap.of("extendedprice", "extendedprice"))))))));
+
+        // Same query with a right join fails with legacy error
+        assertPlanFailedWithException("SELECT COUNT(*) FROM part p RIGHT JOIN (SELECT * FROM partsupp ps, supplier s WHERE ps.suppkey=s.suppkey) sq ON sq.partkey=p.partkey AND NOT EXISTS (SELECT 1 FROM lineitem l WHERE sq.supplycost+sq.acctbal = l.extendedprice)",
+                this.getQueryRunner().getDefaultSession(),
+                expectedErrorMsg + "sq");
+
+        // Ensure subquery and filter get pushed to partsupp
+        assertPlan("SELECT COUNT(*) FROM part p LEFT JOIN partsupp ps ON p.partkey=ps.partkey AND EXISTS (SELECT 1 FROM supplier s WHERE s.suppkey=ps.suppkey) AND ps.availqty<1000",
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("partkey", "partkey_0")),
+                                anyTree(
+                                        tableScan("part", ImmutableMap.of("partkey", "partkey"))),
+                                anyTree(
+                                        anyNot(FilterNode.class,
+                                                join(INNER,
+                                                        ImmutableList.of(equiJoinClause("suppkey", "suppkey_4")),
+                                                        anyTree(
+                                                                tableScan("partsupp", ImmutableMap.of("partkey_0", "partkey", "suppkey", "suppkey"))),
+                                                        anyTree(
+                                                                tableScan("supplier", ImmutableMap.of("suppkey_4", "suppkey")))))))));
+    }
 }


### PR DESCRIPTION
Currently in Presto there is an [acknowledged limitation](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java#L393) that only pushes correlated subqueries into the left side of an outer join. 

This results in surprising errors like 
presto:tiny> SELECT COUNT(*) FROM part p LEFT JOIN partsupp ps ON p.partkey=ps.partkey AND EXISTS (SELECT 1 FROM supplier s WHERE s.suppkey=ps.suppkey);
Query 20230214_075508_00001_65c7w failed: Unexpected identifier in logical plan: ps

presto:tiny> SELECT COUNT(*) FROM part p LEFT JOIN partsupp ps ON p.partkey=ps.partkey AND (SELECT COUNT(*) FROM supplier s where s.suppkey=ps.suppkey)>0;
Query 20230214_075546_00002_65c7w failed: Unexpected identifier in logical plan: ps


This PR attempts to push the correlated subquery into the inner side of the outer join where possible.

```
== NO RELEASE NOTE ==
```
