### PR TITLE
Remove Travis CI badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Presto [![Build Status](https://travis-ci.com/prestodb/presto.svg?branch=master)](https://travis-ci.com/prestodb/presto)
+# Presto
 
 Presto is a distributed SQL query engine for big data.
 


### PR DESCRIPTION
Travis CI builds are deprecated and we can remove the badge.

Test plan - verified README.md file rendering.



```
== NO RELEASE NOTE ==
```
