### PR TITLE
[native] Update openssl to align with Velox

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -144,8 +144,8 @@ include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 find_package(Protobuf REQUIRED)
 
-find_path(OPT_OPENSSL_DIR NAMES opt/openssl)
-set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl")
+find_path(OPT_OPENSSL_DIR NAMES opt/openssl@1.1)
+set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl@1.1")
 find_package(OpenSSL REQUIRED)
 
 find_library(LIBSODIUM_LIBRARY NAMES sodium)


### PR DESCRIPTION
To align building with Velox, we align the openssl version to be openssl@1.1 similar to how Velox configured the dependency.
```
== NO RELEASE NOTE ==
```
