### PR TITLE
Fix race condition in InternalResourceManager initialization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.server.ResourceGroupInfo;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
+import com.facebook.presto.spi.resourceGroups.ResourceGroup;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
@@ -62,7 +63,10 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager.HARD_CONCURRENCY_LIMIT;
+import static com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager.MAX_QUEUED_QUERIES;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.facebook.presto.util.PropertiesUtil.loadProperties;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -89,7 +93,7 @@ public final class InternalResourceGroupManager<C>
     private final ConcurrentMap<ResourceGroupId, InternalResourceGroup> groups = new ConcurrentHashMap<>();
     private final AtomicReference<ResourceGroupConfigurationManager<C>> configurationManager;
     private final ResourceGroupConfigurationManagerContext configurationManagerContext;
-    private final ResourceGroupConfigurationManager<?> legacyManager;
+    private final ResourceGroupConfigurationManager<?> initializingConfigurationManager;
     private final MBeanExporter exporter;
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicLong lastCpuQuotaGenerationNanos = new AtomicLong(System.nanoTime());
@@ -104,10 +108,10 @@ public final class InternalResourceGroupManager<C>
     private final double concurrencyThreshold;
     private final Duration resourceGroupRuntimeInfoRefreshInterval;
     private final boolean isResourceManagerEnabled;
+    private final QueryManagerConfig queryManagerConfig;
 
     @Inject
     public InternalResourceGroupManager(
-            LegacyResourceGroupConfigurationManager legacyManager,
             ClusterMemoryPoolManager memoryPoolManager,
             QueryManagerConfig queryManagerConfig,
             NodeInfo nodeInfo,
@@ -115,17 +119,18 @@ public final class InternalResourceGroupManager<C>
             ResourceGroupService resourceGroupService,
             ServerConfig serverConfig)
     {
-        requireNonNull(queryManagerConfig, "queryManagerConfig is null");
+        this.queryManagerConfig = requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.exporter = requireNonNull(exporter, "exporter is null");
         this.configurationManagerContext = new ResourceGroupConfigurationManagerContextInstance(memoryPoolManager, nodeInfo.getEnvironment());
-        this.legacyManager = requireNonNull(legacyManager, "legacyManager is null");
-        this.configurationManager = new AtomicReference<>(cast(legacyManager));
+        this.initializingConfigurationManager = new InitializingConfigurationManager();
+        this.configurationManager = new AtomicReference(cast(initializingConfigurationManager));
         this.maxTotalRunningTaskCountToNotExecuteNewQuery = queryManagerConfig.getMaxTotalRunningTaskCountToNotExecuteNewQuery();
         this.resourceGroupService = requireNonNull(resourceGroupService, "resourceGroupService is null");
         this.concurrencyThreshold = queryManagerConfig.getConcurrencyThresholdToEnableResourceGroupRefresh();
         this.resourceGroupRuntimeInfoRefreshInterval = queryManagerConfig.getResourceGroupRunTimeInfoRefreshInterval();
         this.isResourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.resourceGroupRuntimeExecutor = new PeriodicTaskExecutor(resourceGroupRuntimeInfoRefreshInterval.toMillis(), refreshExecutor, this::refreshResourceGroupRuntimeInfo);
+        configurationManagerFactories.putIfAbsent(LegacyResourceGroupConfigurationManager.NAME, new LegacyResourceGroupConfigurationManager.Factory());
     }
 
     @Override
@@ -178,10 +183,15 @@ public final class InternalResourceGroupManager<C>
 
             setConfigurationManager(configurationManagerName, properties);
         }
+        else {
+            Map<String, String> legacyProperties = ImmutableMap.of(
+                    HARD_CONCURRENCY_LIMIT, Integer.toString(queryManagerConfig.getMaxConcurrentQueries()),
+                    MAX_QUEUED_QUERIES, Integer.toString(queryManagerConfig.getMaxQueuedQueries()));
+            setConfigurationManager(LegacyResourceGroupConfigurationManager.NAME, legacyProperties);
+        }
     }
 
-    @VisibleForTesting
-    public void setConfigurationManager(String name, Map<String, String> properties)
+    private void setConfigurationManager(String name, Map<String, String> properties)
     {
         requireNonNull(name, "name is null");
         requireNonNull(properties, "properties is null");
@@ -192,7 +202,27 @@ public final class InternalResourceGroupManager<C>
         checkState(configurationManagerFactory != null, "Resource group configuration manager %s is not registered", name);
 
         ResourceGroupConfigurationManager<C> configurationManager = cast(configurationManagerFactory.create(ImmutableMap.copyOf(properties), configurationManagerContext));
-        checkState(this.configurationManager.compareAndSet(cast(legacyManager), configurationManager), "configurationManager already set");
+        checkState(this.configurationManager.compareAndSet(cast(initializingConfigurationManager), configurationManager), "configurationManager already set");
+
+        log.info("-- Loaded resource group configuration manager %s --", name);
+    }
+
+    /**
+     * for use in testing to override the default configuration manager configured for the server
+     */
+    @VisibleForTesting
+    public void forceSetConfigurationManager(String name, Map<String, String> properties)
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(properties, "properties is null");
+
+        log.info("-- Loading new resource group configuration manager --");
+
+        ResourceGroupConfigurationManagerFactory configurationManagerFactory = configurationManagerFactories.get(name);
+        checkState(configurationManagerFactory != null, "Resource group configuration manager %s is not registered", name);
+
+        ResourceGroupConfigurationManager<C> configurationManager = cast(configurationManagerFactory.create(ImmutableMap.copyOf(properties), configurationManagerContext));
+        this.configurationManager.set(configurationManager);
 
         log.info("-- Loaded resource group configuration manager %s --", name);
     }
@@ -202,7 +232,7 @@ public final class InternalResourceGroupManager<C>
     public ResourceGroupConfigurationManager<C> getConfigurationManager()
     {
         ResourceGroupConfigurationManager<C> manager = configurationManager.get();
-        checkState(manager != legacyManager, "cannot fetch legacy manager");
+        checkState(manager != initializingConfigurationManager, "cannot fetch initializing manager");
         return manager;
     }
 
@@ -472,5 +502,21 @@ public final class InternalResourceGroupManager<C>
     private static <C> ResourceGroupConfigurationManager<C> cast(ResourceGroupConfigurationManager<?> manager)
     {
         return (ResourceGroupConfigurationManager<C>) manager;
+    }
+
+    private static class InitializingConfigurationManager
+            implements ResourceGroupConfigurationManager<Void>
+    {
+        @Override
+        public void configure(ResourceGroup group, SelectionContext criteria)
+        {
+            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+        }
+
+        @Override
+        public Optional<SelectionContext<Void>> match(SelectionCriteria criteria)
+        {
+            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/LegacyResourceGroupConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/LegacyResourceGroupConfigurationManager.java
@@ -13,19 +13,20 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
-import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager.VoidContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroup;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerContext;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 
-import javax.inject.Inject;
-
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public class LegacyResourceGroupConfigurationManager
         implements ResourceGroupConfigurationManager<VoidContext>
@@ -35,16 +36,41 @@ public class LegacyResourceGroupConfigurationManager
         NONE
     }
 
+    public static final String NAME = "legacy";
+    public static final String HARD_CONCURRENCY_LIMIT = "hard_concurrency_limit";
+    public static final String MAX_QUEUED_QUERIES = "max_queued_queries";
+
     private static final ResourceGroupId GLOBAL = new ResourceGroupId("global");
 
     private final int hardConcurrencyLimit;
     private final int maxQueued;
 
-    @Inject
-    public LegacyResourceGroupConfigurationManager(QueryManagerConfig config)
+    public LegacyResourceGroupConfigurationManager(int hardConcurrencyLimit, int maxQueued)
     {
-        hardConcurrencyLimit = config.getMaxConcurrentQueries();
-        maxQueued = config.getMaxQueuedQueries();
+        checkArgument(hardConcurrencyLimit > 0, "hardConcurrencyLimit must be greater than 0");
+        checkArgument(maxQueued > 0, "maxQueued must be greater than 0");
+        this.hardConcurrencyLimit = hardConcurrencyLimit;
+        this.maxQueued = maxQueued;
+    }
+
+    public static class Factory
+            implements ResourceGroupConfigurationManagerFactory
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
+        {
+            String hardConcurrencyLimitString = requireNonNull(config.get(HARD_CONCURRENCY_LIMIT), "LegacyResourceGroupConfigurationManager must have config hard_concurrency_liimt");
+            int hardConcurrencyLimit = Integer.parseInt(hardConcurrencyLimitString);
+            String maxQueuedString = requireNonNull(config.get(MAX_QUEUED_QUERIES), "LegacyResourceGroupConfigurationManager must have config max_queued_queries");
+            int maxQueued = Integer.parseInt(maxQueuedString);
+            return new LegacyResourceGroupConfigurationManager(hardConcurrencyLimit, maxQueued);
+        }
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -49,7 +49,6 @@ import com.facebook.presto.execution.SqlQueryManager;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
-import com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.AdaptivePhasedExecutionPolicy;
 import com.facebook.presto.execution.scheduler.AllAtOnceExecutionPolicy;
@@ -181,7 +180,6 @@ public class CoordinatorModule
         binder.bind(InternalResourceGroupManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(InternalResourceGroupManager.class).withGeneratedName();
         binder.bind(ResourceGroupManager.class).to(InternalResourceGroupManager.class);
-        binder.bind(LegacyResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
         binder.bind(RetryCircuitBreaker.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RetryCircuitBreaker.class).withGeneratedName();
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -361,6 +361,7 @@ public class TestingPrestoServer
             this.resourceGroupManager = resourceGroupManager instanceof InternalResourceGroupManager
                     ? Optional.of((InternalResourceGroupManager<?>) resourceGroupManager)
                     : Optional.empty();
+            resourceGroupManager.loadConfigurationManager();
             nodePartitioningManager = injector.getInstance(NodePartitioningManager.class);
             planOptimizerManager = injector.getInstance(ConnectorPlanOptimizerManager.class);
             clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestInternalResourceGroupManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestInternalResourceGroupManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution.resourceGroups;
+
+import com.facebook.airlift.node.NodeInfo;
+import com.facebook.presto.execution.MockManagedQueryExecution;
+import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.server.ServerConfig;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.resourceGroups.SelectionContext;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.testing.TestingMBeanServer;
+
+public class TestInternalResourceGroupManager
+{
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = ".*Presto server is still initializing.*")
+    public void testQueryFailsWithInitializingConfigurationManager()
+    {
+        InternalResourceGroupManager<ImmutableMap<Object, Object>> internalResourceGroupManager = new InternalResourceGroupManager<>((poolId, listener) -> {},
+                new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig());
+        internalResourceGroupManager.submit(new MockManagedQueryExecution(0), new SelectionContext<>(new ResourceGroupId("global"), ImmutableMap.of()), command -> {});
+    }
+
+    @Test
+    public void testQuerySucceedsWhenConfigurationManagerLoaded()
+            throws Exception
+    {
+        InternalResourceGroupManager<ImmutableMap<Object, Object>> internalResourceGroupManager = new InternalResourceGroupManager<>((poolId, listener) -> {},
+                new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig());
+        internalResourceGroupManager.loadConfigurationManager();
+        internalResourceGroupManager.submit(new MockManagedQueryExecution(0), new SelectionContext<>(new ResourceGroupId("global"), ImmutableMap.of()), command -> {});
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -58,7 +58,6 @@ import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.executor.MultilevelSplitQueue;
 import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
-import com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
@@ -485,7 +484,6 @@ public class PrestoSparkModule
         binder.bind(InternalResourceGroupManager.class).in(Scopes.SINGLETON);
         binder.bind(ResourceGroupManager.class).to(InternalResourceGroupManager.class);
         binder.bind(new TypeLiteral<ResourceGroupManager<?>>() {}).to(new TypeLiteral<InternalResourceGroupManager<?>>() {});
-        binder.bind(LegacyResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
         binder.bind(ClusterMemoryPoolManager.class).toInstance(((poolId, listener) -> {}));
         binder.bind(QueryPrerequisitesManager.class).in(Scopes.SINGLETON);
         binder.bind(ResourceGroupService.class).to(NoopResourceGroupService.class).in(Scopes.SINGLETON);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -70,7 +70,7 @@ public class TestEventListener
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
         queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", Integer.toString(SPLITS_PER_NODE)));
         queryRunner.getCoordinator().getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     private String getResourceFilePath(String fileName)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -88,7 +88,8 @@ public class TestQueues
         queryRunner = createQueryRunner();
         client = new JettyHttpClient();
         objectMapper = new JsonObjectMapperProvider().get();
-        objectMapper.registerModule(new SimpleModule() {
+        objectMapper.registerModule(new SimpleModule()
+        {
             {
                 addKeyDeserializer(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionDeserializer(createTestFunctionAndTypeManager()));
             }
@@ -108,7 +109,7 @@ public class TestQueues
             throws Exception
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-        queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
+        queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
         // submit first "dashboard" query
         QueryId firstDashboardQuery = createDashboardQuery(queryRunner);
@@ -145,7 +146,7 @@ public class TestQueues
             throws Exception
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-        queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_soft_limits.json")));
+        queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_soft_limits.json")));
 
         QueryId scheduled1 = createScheduledQuery(queryRunner);
         waitForQueryState(queryRunner, scheduled1, RUNNING);
@@ -207,7 +208,7 @@ public class TestQueues
             throws Exception
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-        queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
+        queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
         QueryId firstDashboardQuery = createDashboardQuery(queryRunner);
         QueryId secondDashboardQuery = createDashboardQuery(queryRunner);
@@ -222,7 +223,7 @@ public class TestQueues
             throws Exception
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-        queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
+        queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
         QueryId firstDashboardQuery = createDashboardQuery(queryRunner);
         waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
@@ -247,7 +248,7 @@ public class TestQueues
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
         queryRunner.getCoordinator().getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_client_tags_based_config.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_client_tags_based_config.json")));
         assertResourceGroup(queryRunner, newSessionWithTags(ImmutableSet.of("a")), LONG_LASTING_QUERY, createResourceGroupId("global", "a", "default"));
         assertResourceGroup(queryRunner, newSessionWithTags(ImmutableSet.of("b")), LONG_LASTING_QUERY, createResourceGroupId("global", "b"));
         assertResourceGroup(queryRunner, newSessionWithTags(ImmutableSet.of("a", "c")), LONG_LASTING_QUERY, createResourceGroupId("global", "a", "c"));
@@ -259,7 +260,7 @@ public class TestQueues
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
         queryRunner.getCoordinator().getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_resource_estimate_based_config.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_resource_estimate_based_config.json")));
 
         assertResourceGroup(
                 queryRunner,
@@ -319,7 +320,7 @@ public class TestQueues
         try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
             queryRunner.installPlugin(new ResourceGroupManagerPlugin());
             queryRunner.getCoordinator().getResourceGroupManager().get()
-                    .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_query_type_based_config.json")));
+                    .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_query_type_based_config.json")));
             assertResourceGroup(queryRunner, newAdhocSession(), LONG_LASTING_QUERY, createResourceGroupId("global", "select"));
             assertResourceGroup(queryRunner, newAdhocSession(), "SHOW TABLES", createResourceGroupId("global", "describe"));
             assertResourceGroup(queryRunner, newAdhocSession(), "EXPLAIN " + LONG_LASTING_QUERY, createResourceGroupId("global", "explain"));
@@ -333,7 +334,7 @@ public class TestQueues
             throws Exception
     {
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-        queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
+        queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
         // submit first "dashboard" query
         QueryId firstDashboardQuery = createDashboardQuery(queryRunner);
@@ -384,7 +385,7 @@ public class TestQueues
     {
         try (DistributedQueryRunner queryRunner = createQueryRunner()) {
             queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-            queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
+            queryRunner.getCoordinator().getResourceGroupManager().get().forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
             QueryId queryId = createQuery(queryRunner, newRejectionSession(), LONG_LASTING_QUERY);
             waitForQueryState(queryRunner, queryId, FAILED);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
@@ -38,7 +38,7 @@ public class TestResourceGroupIntegration
     {
         try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
             queryRunner.installPlugin(new ResourceGroupManagerPlugin());
-            getResourceGroupManager(queryRunner).setConfigurationManager("file", ImmutableMap.of(
+            getResourceGroupManager(queryRunner).forceSetConfigurationManager("file", ImmutableMap.of(
                     "resource-groups.config-file", getResourceFilePath("resource_groups_memory_percentage.json")));
 
             queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
@@ -53,7 +53,7 @@ public class TestResourceGroupIntegration
         try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
             queryRunner.installPlugin(new ResourceGroupManagerPlugin());
             InternalResourceGroupManager<?> manager = getResourceGroupManager(queryRunner);
-            manager.setConfigurationManager("file", ImmutableMap.of(
+            manager.forceSetConfigurationManager("file", ImmutableMap.of(
                     "resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json")));
 
             queryRunner.execute(testSessionBuilder().setCatalog("tpch").setSchema("tiny").setSource("dashboard-foo").build(), "SELECT COUNT(*), clerk FROM orders GROUP BY clerk");

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -170,7 +170,7 @@ class H2TestUtil
             queryRunner.installPlugin(h2ResourceGroupManagerPlugin);
             for (int coordinator = 0; coordinator < coordinatorCount; coordinator++) {
                 queryRunner.getCoordinator(coordinator).getResourceGroupManager().get()
-                        .setConfigurationManager(CONFIGURATION_MANAGER_TYPE, ImmutableMap.of("resource-groups.config-db-url", dbConfigUrl, "node.environment", environment));
+                        .forceSetConfigurationManager(CONFIGURATION_MANAGER_TYPE, ImmutableMap.of("resource-groups.config-db-url", dbConfigUrl, "node.environment", environment));
             }
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -89,7 +89,7 @@ public class TestDistributedClusterStatsResource
         runner.getCoordinators().stream().forEach(coordinator -> {
             coordinator.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
             coordinator.getResourceGroupManager().get()
-                    .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath(RESOURCE_GROUPS_CONFIG_FILE)));
+                    .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath(RESOURCE_GROUPS_CONFIG_FILE)));
         });
     }
 
@@ -206,7 +206,8 @@ public class TestDistributedClusterStatsResource
     }
 
     @Test(timeOut = 120_000)
-    public void testClusterStatsLocalInfoReturn() throws Exception
+    public void testClusterStatsLocalInfoReturn()
+            throws Exception
     {
         waitUntilCoordinatorsDiscoveredHealthyInRM(SECONDS.toMillis(15));
         runToFirstResult(client, coordinator2, "SELECT * from tpch.sf100.orders");

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryInfoResource.java
@@ -64,10 +64,10 @@ public class TestDistributedQueryInfoResource
         this.resourceManager = resourceManager.get();
         coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator1.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
         coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator2.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
@@ -61,10 +61,10 @@ public class TestDistributedQueryResource
         this.resourceManager = resourceManager.get();
         coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator1.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
         coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator2.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
@@ -66,10 +66,10 @@ public class TestDistributedResourceGroupInfoResource
         this.resourceManager = resourceManager.get();
         coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator1.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
         coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator2.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedTaskInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedTaskInfoResource.java
@@ -70,10 +70,10 @@ public class TestDistributedTaskInfoResource
         this.resourceManager = resourceManager.get();
         coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator1.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
         coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         coordinator2.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @Test(timeOut = 220_000)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
@@ -80,7 +80,7 @@ public class TestRaftServer
         runner.getCoordinators().stream().forEach(coordinator -> {
             coordinator.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
             coordinator.getResourceGroupManager().get()
-                    .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath(RESOURCE_GROUPS_CONFIG_FILE)));
+                    .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath(RESOURCE_GROUPS_CONFIG_FILE)));
         });
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestClusterStatsResource.java
@@ -60,7 +60,7 @@ public class TestClusterStatsResource
         server = runner.getCoordinator();
         server.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         server.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -62,7 +62,7 @@ public class TestQueryManager
         TestingPrestoServer server = queryRunner.getCoordinator();
         server.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         server.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterClass(alwaysRun = true)
@@ -86,11 +86,11 @@ public class TestQueryManager
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         QueryId queryId = dispatchManager.createQueryId();
         dispatchManager.createQuery(
-                queryId,
-                "slug",
-                0,
-                new TestingSessionContext(TEST_SESSION),
-                "SELECT * FROM lineitem")
+                        queryId,
+                        "slug",
+                        0,
+                        new TestingSessionContext(TEST_SESSION),
+                        "SELECT * FROM lineitem")
                 .get();
 
         // wait until query starts running
@@ -126,11 +126,11 @@ public class TestQueryManager
         createQueries(dispatchManager, 3);
         QueryId queryId = dispatchManager.createQueryId();
         dispatchManager.createQuery(
-                queryId,
-                "slug",
-                0,
-                new TestingSessionContext(TEST_SESSION),
-                "SELECT * FROM lineitem")
+                        queryId,
+                        "slug",
+                        0,
+                        new TestingSessionContext(TEST_SESSION),
+                        "SELECT * FROM lineitem")
                 .get();
 
         assertNotEquals(dispatchManager.getStats().getQueuedQueries(), 0L, "Expected 0 queued queries, found: " + dispatchManager.getStats().getQueuedQueries());
@@ -160,11 +160,11 @@ public class TestQueryManager
     {
         for (int i = 0; i < queryCount; i++) {
             dispatchManager.createQuery(
-                    dispatchManager.createQueryId(),
-                    "slug",
-                    0,
-                    new TestingSessionContext(TEST_SESSION),
-                    "SELECT * FROM lineitem")
+                            dispatchManager.createQueryId(),
+                            "slug",
+                            0,
+                            new TestingSessionContext(TEST_SESSION),
+                            "SELECT * FROM lineitem")
                     .get();
         }
     }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
@@ -52,7 +52,7 @@ public class TestResourceGroupPerQueryLimitEnforcement
         TestingPrestoServer server = queryRunner.getCoordinator();
         server.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
         server.getResourceGroupManager().get()
-                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+                .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Throw an exception if a query tries to create resource groups before the configuration manager has been loaded.  This fixes a race condition where a query can start constructing resource groups before the ResourceGroupConfigurationManager is loaded.  This would cause some resource groups to get created in the legacy manager and never recreated when the new resource manager is loaded. This is one theory about why we are seeing some clusters get into a state on restart where all queries fail with a NullPointerException in ReloadingResourceGroupConfigurationManager.

Test plan - CI, new unit tests, validated fix on test cluster

```
== RELEASE NOTES ==

General Changes
* Fix a bug where if a query was submitted before the resource group configuration had been loaded, all queries to the cluster would fail with a NullPointerException
```
