### PR TITLE
Fix Strongly Encapsulate JDK for modifying static final fields since …

### DIFF
--- a/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystemCache.java
+++ b/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystemCache.java
@@ -16,39 +16,44 @@ package org.apache.hadoop.fs;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.InaccessibleObjectException;
+import sun.misc.Unsafe;
 
 public class HadoopExtendedFileSystemCache
 {
     private static PrestoExtendedFileSystemCache cache;
-
+    private static Unsafe unsafe;
     private HadoopExtendedFileSystemCache() {}
-
+    
     public static synchronized void initialize()
     {
         if (cache == null) {
             cache = setFinalStatic(FileSystem.class, "CACHE", new PrestoExtendedFileSystemCache());
         }
     }
-
+    
     private static <T> T setFinalStatic(Class<?> clazz, String name, T value)
     {
         try {
             Field field = clazz.getDeclaredField(name);
             field.setAccessible(true);
-
+            
             Field modifiersField = getModifiersField();
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
+            
             field.set(null, value);
-
+            
             return value;
+        }
+        catch (InaccessibleObjectException inaccessible){
+            return setFinalStaticByUnsafe(clazz, name, value);
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
     }
-
+    
     private static Field getModifiersField() throws NoSuchFieldException
     {
         try {
@@ -69,6 +74,22 @@ public class HadoopExtendedFileSystemCache
                 e.addSuppressed(ex);
             }
             throw e;
+        }
+    }
+    
+    private static <T> T setFinalStaticByUnsafe(Class<?> clazz, String name, T value) {
+        try {
+            if(unsafe == null){
+                Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                unsafe = (Unsafe) field.get(null);
+            }
+            Field field = clazz.getDeclaredField(name);
+            long offset = unsafe.staticFieldOffset(field);
+            unsafe.putObject(clazz, offset, value);
+            return value;
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
         }
     }
 }


### PR DESCRIPTION
…JDK 16

Make PrestoExtendedFileSystemCache::setFinalStatic support for Java 16+. Since Java 16, the JEP 396 has been delivered.
Strongly encapsulate all internal elements of the JDK by default, except for critical internal APIs such as sun.misc.Unsafe. Therefore, to modify the final field, We have no choice but to unsafe, and the implementation details refer to PrestoExtendedFileSystemCache::setFinalStaticByUnsafe.

```
== NO RELEASE NOTE ==
```
