### PR TITLE
Fix resource loading issue in some tests

### DIFF
--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -179,5 +179,11 @@
             <artifactId>drift-transport-netty</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -25,11 +25,15 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.Assert.ThrowingRunnable;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.Files.newTemporaryFile;
 import static org.testng.Assert.assertThrows;
 
 public class TestFileBasedAccessControl
@@ -114,10 +118,19 @@ public class TestFileBasedAccessControl
     private ConnectorAccessControl createAccessControl(String fileName)
             throws IOException
     {
-        String path = this.getClass().getClassLoader().getResource(fileName).getPath();
         FileBasedAccessControlConfig config = new FileBasedAccessControlConfig();
-        config.setConfigFile(path);
+        config.setConfigFile(getResourceFile(fileName).getPath());
         return new FileBasedAccessControl(config);
+    }
+
+    private static File getResourceFile(String resourceName)
+            throws IOException
+    {
+        File resourceFile = newTemporaryFile();
+        resourceFile.deleteOnExit();
+        Files.copy(TestFileBasedAccessControl.class.getClassLoader().getResourceAsStream(resourceName), resourceFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        return resourceFile;
     }
 
     private static void assertDenied(ThrowingRunnable runnable)


### PR DESCRIPTION
To run the tests under 'buck test', fix file loading issue in presto-plugin-toolkit/presto-function-namespace-manager test code by using class loader and making a temporary copy.

Test plan - (Please fill in how you tested your changes)

Make sure all CI runs are green.

```
== NO RELEASE NOTE ==
```
