### PR TITLE
[native] Convert Presto's groupedExecutionScanNodes to Velox.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1206,7 +1206,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const bool constantValue =
         joinType.value() == core::JoinType::kLeftSemiFilter;
     projections.emplace_back(
-        std::make_shared<core::ConstantTypedExpr>(constantValue));
+        std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), constantValue));
 
     return std::make_shared<core::ProjectNode>(
         node->id,
@@ -1985,6 +1985,9 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   planFragment.executionStrategy =
       toStrategy(fragment.stageExecutionDescriptor.stageExecutionStrategy);
   planFragment.numSplitGroups = descriptor.totalLifespans;
+  for (const auto& planNodeId : descriptor.groupedExecutionScanNodes) {
+    planFragment.groupedExecutionLeafNodeIds.emplace(planNodeId);
+  }
 
   if (auto output = std::dynamic_pointer_cast<const protocol::OutputNode>(
           fragment.root)) {


### PR DESCRIPTION
Convert Presto's groupedExecutionScanNodes to Velox's groupedExecutionLeafNodeIds.
Limit 'unlimited concurrent lifespans' to 16.
Advance Velox's version.

Test plan - Existing tests.

```
== NO RELEASE NOTE ==
```
