### PR TITLE
[native] Fix for ssh-keyscan

### DIFF
--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -54,7 +54,9 @@ RUN --mount=type=ssh \
     set -exu && \
     dnf -y install openssh-clients git wget unzip make && \
     mkdir -p -m 0600 /root/.ssh && \
-    ! ssh-keyscan github.com >> /root/.ssh/known_hosts && \
+    ( \
+      ssh-keyscan github.com >> /root/.ssh/known_hosts || true \
+    ) $$ \
     git clone --progress ${PRESTODB_REPOSITORY} "${PRESTODB_HOME}/_repo" && \
     git -C "${PRESTODB_HOME}/_repo" checkout "${PRESTODB_CHECKOUT}" && \
     make --directory="${PRESTODB_HOME}/_repo/presto-native-execution" submodules && \

--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=ssh \
     mkdir -p -m 0600 /root/.ssh && \
     ( \
       ssh-keyscan github.com >> /root/.ssh/known_hosts || true \
-    ) $$ \
+    ) && \
     git clone --progress ${PRESTODB_REPOSITORY} "${PRESTODB_HOME}/_repo" && \
     git -C "${PRESTODB_HOME}/_repo" checkout "${PRESTODB_CHECKOUT}" && \
     make --directory="${PRESTODB_HOME}/_repo/presto-native-execution" submodules && \


### PR DESCRIPTION
Fix for a bug that I have created in `scripts/release-centos-dockerfile/Dockerfile` with connection to `ssh-keyscan`.

This is a fix to: https://github.com/prestodb/presto/issues/19074

```
== NO RELEASE NOTE ==
```
