### PR TITLE
Upgrade Apache Hudi version to 0.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>0.12.0</dep.hudi.version>
+        <dep.hudi.version>0.12.1</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.jayway.version>2.6.0</dep.jayway.version>


### PR DESCRIPTION
Fixes #19095 

I have tested the change with both Hive Connector and Hudi Connector. The tables can be accessed successfully after the version upgrade and we no longer observe the error mentioned in the above linked issue. PFB the examples:

**HUDI MOR Read-optimised using Hive Connector**
<img width="1744" alt="Screenshot 2023-02-27 at 12 00 40 PM" src="https://user-images.githubusercontent.com/6432146/221612978-00cb0a59-d8b7-44a8-a5a4-f5f3f1e92ef9.png">

**HUDI MOR Realtime using Hive Connector**
<img width="1720" alt="Screenshot 2023-02-27 at 7 32 31 PM" src="https://user-images.githubusercontent.com/6432146/221613243-92ce1194-87f6-46dd-a20b-64dd0b11b923.png">

**HUDI MOR Read-optimised using Hudi Connector**
<img width="1739" alt="Screenshot 2023-02-27 at 11 58 42 AM" src="https://user-images.githubusercontent.com/6432146/221613365-04469928-3c36-4db4-ac24-d07244364442.png">

**HUDI MOR Realtime using Hudi Connector**
<img width="1739" alt="Screenshot 2023-02-27 at 11 59 17 AM" src="https://user-images.githubusercontent.com/6432146/221613467-7f7603ea-cf35-4db0-bd70-3f643a8eac05.png">



If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
