### PR TITLE
AQE - Add support for table write and other missing features

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -91,7 +91,7 @@ public class PlanFragmenter
         PlanNode root = SimplePlanRewriter.rewriteWith(fragmenter, plan.getRoot(), properties);
 
         SubPlan subPlan = fragmenter.buildRootFragment(root, properties);
-        return finalizeSubPlan(subPlan, config, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector);
+        return finalizeSubPlan(subPlan, config, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, subPlan.getFragment().getPartitioning());
     }
 
     private static class Fragmenter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -25,12 +25,16 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
+import com.facebook.presto.sql.planner.plan.MetadataDeleteNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
@@ -55,6 +59,11 @@ public class PlanFragmenterUtils
     public static final int ROOT_FRAGMENT_ID = 0;
     public static final String TOO_MANY_STAGES_MESSAGE = "If the query contains multiple DISTINCTs, please set the 'use_mark_distinct' session property to false. " +
             "If the query contains multiple CTEs that are referenced more than once, please create temporary table(s) for one or more of the CTEs.";
+    private static final Set<Class> PLAN_NODES_WITH_COORDINATOR_ONLY_DISTRIBUTION = ImmutableSet.of(
+            ExplainAnalyzeNode.class,
+            StatisticsWriterNode.class,
+            TableFinishNode.class,
+            MetadataDeleteNode.class);
 
     private PlanFragmenterUtils() {}
 
@@ -277,5 +286,10 @@ public class PlanFragmenterUtils
     public static boolean isRootFragment(PlanFragment fragment)
     {
         return fragment.getId().getId() == ROOT_FRAGMENT_ID;
+    }
+
+    public static boolean isCoordinatorOnlyDistribution(PlanNode planNode)
+    {
+        return PLAN_NODES_WITH_COORDINATOR_ONLY_DISTRIBUTION.contains(planNode.getClass());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -77,9 +77,10 @@ public class PlanFragmenterUtils
             NodePartitioningManager nodePartitioningManager,
             Session session,
             boolean forceSingleNode,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            PartitioningHandle partitioningHandle)
     {
-        subPlan = reassignPartitioningHandleIfNecessary(metadata, session, subPlan);
+        subPlan = reassignPartitioningHandleIfNecessary(metadata, session, subPlan, partitioningHandle);
         if (!forceSingleNode) {
             // grouped execution is not supported for SINGLE_DISTRIBUTION
             subPlan = analyzeGroupedExecution(session, subPlan, false, metadata, nodePartitioningManager);
@@ -181,9 +182,9 @@ public class PlanFragmenterUtils
         return root instanceof OutputNode && getOnlyElement(root.getSources()) instanceof TableFinishNode;
     }
 
-    private static SubPlan reassignPartitioningHandleIfNecessary(Metadata metadata, Session session, SubPlan subPlan)
+    private static SubPlan reassignPartitioningHandleIfNecessary(Metadata metadata, Session session, SubPlan subPlan, PartitioningHandle partitioningHandle)
     {
-        return reassignPartitioningHandleIfNecessaryHelper(metadata, session, subPlan, subPlan.getFragment().getPartitioning());
+        return reassignPartitioningHandleIfNecessaryHelper(metadata, session, subPlan, partitioningHandle);
     }
 
     private static SubPlan reassignPartitioningHandleIfNecessaryHelper(Metadata metadata, Session session, SubPlan subPlan, PartitioningHandle newOutputPartitioningHandle)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -46,8 +46,10 @@ import com.facebook.presto.spark.PrestoSparkStorageBasedBroadcastDependency;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.RddAndMore;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
+import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkExecutionException;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkJavaExecutionTaskInputs;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkPartitioner;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
@@ -56,6 +58,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
+import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.SerializedTaskInfo;
 import com.facebook.presto.spark.planner.PrestoSparkPlanFragmenter;
 import com.facebook.presto.spark.planner.PrestoSparkQueryPlanner.PlanAndMore;
@@ -68,6 +71,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.storage.StorageCapabilities;
 import com.facebook.presto.spi.storage.TempDataOperationContext;
 import com.facebook.presto.spi.storage.TempStorage;
@@ -90,6 +94,7 @@ import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SimpleFutureAction;
 import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaFutureAction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -126,9 +131,12 @@ import static com.facebook.presto.spark.SparkErrorCode.GENERIC_SPARK_ERROR;
 import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_LOST;
 import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_OOM;
 import static com.facebook.presto.spark.SparkErrorCode.UNSUPPORTED_STORAGE_TYPE;
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collectScalaIterator;
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
 import static com.facebook.presto.spark.planner.PrestoSparkRddFactory.getRDDName;
 import static com.facebook.presto.spark.util.PrestoSparkFailureUtils.toPrestoSparkFailure;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.classTag;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.deserializeZstdCompressed;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
@@ -144,6 +152,8 @@ import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.Futures.getUnchecked;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.Math.min;
 import static java.util.Collections.unmodifiableList;
@@ -438,6 +448,70 @@ public abstract class AbstractPrestoSparkQueryExecution
     protected abstract List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> doExecute()
             throws SparkException, TimeoutException;
 
+    protected List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> collectPages(TableWriteInfo tableWriteInfo, PlanFragment rootFragment, Map<PlanFragmentId, RddAndMore<PrestoSparkSerializedPage>> inputRdds)
+            throws SparkException, TimeoutException
+    {
+        PrestoSparkTaskDescriptor taskDescriptor = new PrestoSparkTaskDescriptor(
+                session.toSessionRepresentation(),
+                session.getIdentity().getExtraCredentials(),
+                rootFragment,
+                tableWriteInfo);
+        SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor = new SerializedPrestoSparkTaskDescriptor(sparkTaskDescriptorJsonCodec.toJsonBytes(taskDescriptor));
+
+        Map<String, JavaFutureAction<List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>>>> inputFutures = inputRdds.entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().toString(), entry -> entry.getValue().getRdd().collectAsync()));
+
+        PrestoSparkQueryExecutionFactory.waitForActionsCompletionWithTimeout(inputFutures.values(), computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics);
+
+        // release memory retained by the RDDs (splits and dependencies)
+        inputRdds = null;
+
+        ImmutableMap.Builder<String, List<PrestoSparkSerializedPage>> inputs = ImmutableMap.builder();
+        long totalNumberOfPagesReceived = 0;
+        long totalCompressedSizeInBytes = 0;
+        long totalUncompressedSizeInBytes = 0;
+        for (Map.Entry<String, JavaFutureAction<List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>>>> inputFuture : inputFutures.entrySet()) {
+            // Use a mutable list to allow memory release on per page basis
+            List<PrestoSparkSerializedPage> pages = new ArrayList<>();
+            List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> tuples = getUnchecked(inputFuture.getValue());
+            long currentFragmentOutputCompressedSizeInBytes = 0;
+            long currentFragmentOutputUncompressedSizeInBytes = 0;
+            for (Tuple2<MutablePartitionId, PrestoSparkSerializedPage> tuple : tuples) {
+                PrestoSparkSerializedPage page = tuple._2;
+                currentFragmentOutputCompressedSizeInBytes += page.getSize();
+                currentFragmentOutputUncompressedSizeInBytes += page.getUncompressedSizeInBytes();
+                pages.add(page);
+            }
+            log.info(
+                    "Received %s pages from fragment %s. Compressed size: %s. Uncompressed size: %s.",
+                    pages.size(),
+                    inputFuture.getKey(),
+                    DataSize.succinctBytes(currentFragmentOutputCompressedSizeInBytes),
+                    DataSize.succinctBytes(currentFragmentOutputUncompressedSizeInBytes));
+            totalNumberOfPagesReceived += pages.size();
+            totalCompressedSizeInBytes += currentFragmentOutputCompressedSizeInBytes;
+            totalUncompressedSizeInBytes += currentFragmentOutputUncompressedSizeInBytes;
+            inputs.put(inputFuture.getKey(), pages);
+        }
+
+        log.info(
+                "Received %s pages in total. Compressed size: %s. Uncompressed size: %s.",
+                totalNumberOfPagesReceived,
+                DataSize.succinctBytes(totalCompressedSizeInBytes),
+                DataSize.succinctBytes(totalUncompressedSizeInBytes));
+
+        IPrestoSparkTaskExecutor<PrestoSparkSerializedPage> prestoSparkTaskExecutor = taskExecutorFactory.create(
+                0,
+                0,
+                serializedTaskDescriptor,
+                emptyScalaIterator(),
+                new PrestoSparkJavaExecutionTaskInputs(ImmutableMap.of(), ImmutableMap.of(), inputs.build()),
+                taskInfoCollector,
+                shuffleStatsCollector,
+                PrestoSparkSerializedPage.class);
+        return collectScalaIterator(prestoSparkTaskExecutor);
+    }
+
     @VisibleForTesting
     public <T extends PrestoSparkTaskOutput> RddAndMore<T> createRdd(SubPlan subPlan, Class<T> outputType, TableWriteInfo tableWriteInfo)
             throws SparkException, TimeoutException
@@ -670,6 +744,16 @@ public abstract class AbstractPrestoSparkQueryExecution
         return tableWriteInfo;
     }
 
+    @VisibleForTesting
+    public TableWriteInfo getTableWriteInfo(Session session, PlanNode planNode)
+    {
+        TableWriteInfo tableWriteInfo = createTableWriteInfo(planNode, metadata, session);
+        if (tableWriteInfo.getWriterTarget().isPresent()) {
+            checkPageSinkCommitIsSupported(session, tableWriteInfo.getWriterTarget().get());
+        }
+        return tableWriteInfo;
+    }
+
     private void checkPageSinkCommitIsSupported(Session session, ExecutionWriterTarget writerTarget)
     {
         ConnectorId connectorId;
@@ -698,7 +782,9 @@ public abstract class AbstractPrestoSparkQueryExecution
     // Returns RDD for specified fragmented SubPlan
     // This method ensures that RDD is created only once for a sub-plan, where identity is determined by fragment id
     // For broadcast RDDs, it returns RDD to be broadcasted.
-    protected synchronized <T extends PrestoSparkTaskOutput> RddAndMore<T> createRddForSubPlan(SubPlan subPlan, TableWriteInfo tableWriteInfo)
+    protected synchronized <T extends PrestoSparkTaskOutput> RddAndMore<T> createRddForSubPlan(SubPlan subPlan,
+            TableWriteInfo tableWriteInfo,
+            Optional<Class<?>> outputTypeOptional)
             throws SparkException, TimeoutException
     {
         if (fragmentIdToRdd.containsKey(subPlan.getFragment().getId())) {
@@ -708,9 +794,8 @@ public abstract class AbstractPrestoSparkQueryExecution
         ImmutableMap.Builder<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> rddInputs = ImmutableMap.builder();
         ImmutableMap.Builder<PlanFragmentId, Broadcast<?>> broadcastInputs = ImmutableMap.builder();
         ImmutableList.Builder<PrestoSparkBroadcastDependency<?>> broadcastDependencies = ImmutableList.builder();
-
         for (SubPlan child : subPlan.getChildren()) {
-            RddAndMore<?> childRdd = createRddForSubPlan(child, tableWriteInfo);
+            RddAndMore<?> childRdd = createRddForSubPlan(child, tableWriteInfo, Optional.empty());
             if (childRdd.isBroadcastDistribution()) {
                 PrestoSparkBroadcastDependency<?> broadcastDependency = createBroadcastDependency(childRdd);
                 broadcastInputs.put(child.getFragment().getId(), broadcastDependency.executeBroadcast(sparkContext));
@@ -722,6 +807,7 @@ public abstract class AbstractPrestoSparkQueryExecution
             }
         }
 
+        Class outputType = outputTypeOptional.orElse(getOutputType(subPlan));
         JavaPairRDD<MutablePartitionId, T> rdd = rddFactory.createSparkRdd(
                 sparkContext,
                 session,
@@ -732,16 +818,22 @@ public abstract class AbstractPrestoSparkQueryExecution
                 taskInfoCollector,
                 shuffleStatsCollector,
                 tableWriteInfo,
-                getOutputType(subPlan));
+                outputType);
 
         // For intermediate, non-broadcast stages - we use partitioned RDD
-        if (!isRootFragment(subPlan.getFragment()) && !isBroadcastDistribution(subPlan)) {
+        // These stages produce PrestoSparkMutableRow
+        if (outputType == PrestoSparkMutableRow.class) {
             rdd = (JavaPairRDD<MutablePartitionId, T>) partitionBy(subPlan.getFragment().getId().getId(), (JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>) rdd, subPlan.getFragment().getPartitioningScheme());
         }
 
         RddAndMore rddAndMore = new RddAndMore<T>(rdd, broadcastDependencies.build(), Optional.ofNullable(subPlan.getFragment().getPartitioningScheme().getPartitioning().getHandle()));
         fragmentIdToRdd.put(subPlan.getFragment().getId(), rddAndMore);
         return rddAndMore;
+    }
+
+    protected Optional<RddAndMore> getRdd(PlanFragmentId planFragmentId)
+    {
+        return Optional.ofNullable(fragmentIdToRdd.get(planFragmentId));
     }
 
     // Returns output type of RDD for a subPlan
@@ -752,13 +844,11 @@ public abstract class AbstractPrestoSparkQueryExecution
             return PrestoSparkSerializedPage.class;
         }
         // Broadcast node can have SerializedPage vs Storage handle depending on how broadcast is done
-        else if (isBroadcastDistribution(subPlan)) {
+        if (isBroadcastDistribution(subPlan)) {
             return getOutputTypeForBroadcastNode();
         }
         // Everything else is Mutable row
-        else {
-            return PrestoSparkMutableRow.class;
-        }
+        return PrestoSparkMutableRow.class;
     }
 
     private Class getOutputTypeForBroadcastNode()
@@ -813,10 +903,11 @@ public abstract class AbstractPrestoSparkQueryExecution
 
     @VisibleForTesting
     public FragmentExecutionResult executeFragment(SubPlan plan,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            Optional<Class<?>> outputType)
             throws SparkException, TimeoutException
     {
-        RddAndMore rddAndMore = createRddForSubPlan(plan, tableWriteInfo);
+        RddAndMore rddAndMore = createRddForSubPlan(plan, tableWriteInfo, outputType);
         List<ShuffleDependency> shuffleDependencies = rddAndMore.getShuffleDependencies();
         SimpleFutureAction<MapOutputStatistics> mapOutputStatisticsFutureAction = null;
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -913,7 +913,9 @@ public abstract class AbstractPrestoSparkQueryExecution
 
         // For PoS, we don't expect more than 1 shuffle dependency.
         verify(shuffleDependencies.size() <= 1, "More than 1 shuffle dependency found");
-        if (!shuffleDependencies.isEmpty()) {
+        if (!shuffleDependencies.isEmpty()
+                // We can only execute map stage on RDD with more than 0 partition(Non-Empty tables)
+                && shuffleDependencies.get(0).rdd().partitions().length > 0) {
             ShuffleDependency shuffleDependency = shuffleDependencies.get(0);
             mapOutputStatisticsFutureAction = sparkContext.sc().submitMapStage(shuffleDependency);
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -277,8 +277,9 @@ public class PrestoSparkAdaptiveQueryExecution
             }
             if (fragmentEvent instanceof FragmentCompletionFailureEvent) {
                 FragmentCompletionFailureEvent failureEvent = (FragmentCompletionFailureEvent) fragmentEvent;
-                // TODO Consider what is the right retry logic for the whole job in case of failure.
-                throw executionExceptionFactory.toPrestoSparkExecutionException(failureEvent.getExecutionError());
+                propagateIfPossible(failureEvent.getExecutionError(), SparkException.class);
+                propagateIfPossible(failureEvent.getExecutionError(), RuntimeException.class);
+                throw new UncheckedExecutionException(failureEvent.getExecutionError());
             }
 
             verify(fragmentEvent instanceof FragmentCompletionSuccessEvent, String.format("Unexpected FragmentCompletionEvent type: %s", fragmentEvent.getClass().getSimpleName()));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -45,15 +45,22 @@ import com.facebook.presto.spark.planner.PrestoSparkQueryPlanner.PlanAndMore;
 import com.facebook.presto.spark.planner.PrestoSparkRddFactory;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.storage.TempStorage;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
+import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.units.Duration;
 import org.apache.spark.MapOutputStatistics;
 import org.apache.spark.SimpleFutureAction;
@@ -67,7 +74,9 @@ import scala.concurrent.impl.ExecutionContextImpl;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -75,9 +84,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spark.execution.RuntimeStatistics.createRuntimeStats;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
+import static com.facebook.presto.sql.planner.PlanFragmenterUtils.isCoordinatorOnlyDistribution;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
+import static com.google.common.base.Throwables.propagateIfPossible;
 import static com.google.common.base.Verify.verify;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -205,18 +218,19 @@ public class PrestoSparkAdaptiveQueryExecution
         ExecutionContextExecutorService executorService = !planAndFragments.hasRemainingPlan() ? null :
                 (ExecutionContextExecutorService) ExecutionContextImpl.fromExecutorService(ThreadUtils.newDaemonCachedThreadPool("AdaptiveExecution", 16, 60), null);
 
-        TableWriteInfo tableWriteInfo = null;
+        TableWriteInfo tableWriteInfo = getTableWriteInfo(session, this.planAndMore.getPlan().getRoot());
 
         while (planAndFragments.hasRemainingPlan()) {
             List<SubPlan> readyFragments = planAndFragments.getReadyFragments();
-
+            Set<PlanFragmentId> rootChildren = getRootChildNodeFragmentIDs(planAndFragments.getRemainingPlan().get());
             for (SubPlan fragment : readyFragments) {
+                Optional<Class<?>> outputType = Optional.empty();
+                if (isCoordinatorOnly(this.planAndMore.getPlan()) && rootChildren.contains(fragment.getFragment().getId())) {
+                    outputType = Optional.of(PrestoSparkSerializedPage.class);
+                }
+
                 SubPlan currentFragment = configureOutputPartitioning(session, fragment, planAndMore.getPhysicalResourceSettings().getHashPartitionCount());
-
-                // Initialize tableWriteInfo only the first time it's used (given these are not the final fragments, it is not really being used).
-                tableWriteInfo = (tableWriteInfo != null) ? tableWriteInfo : getTableWriteInfo(session, currentFragment);
-
-                FragmentExecutionResult fragmentExecutionResult = executeFragment(currentFragment, tableWriteInfo);
+                FragmentExecutionResult fragmentExecutionResult = executeFragment(currentFragment, tableWriteInfo, outputType);
 
                 // Create the corresponding event when the fragment finishes execution (successfully or not) and place it in the event queue.
                 // Note that these are Scala futures that we manipulate here in Java.
@@ -282,7 +296,29 @@ public class PrestoSparkAdaptiveQueryExecution
 
         setFinalFragmentedPlan(finalFragment);
 
-        return executeFinalFragment(finalFragment);
+        return executeFinalFragment(session, finalFragment, tableWriteInfo);
+    }
+
+    private static Set<PlanFragmentId> getRootChildNodeFragmentIDs(PlanNode rootPlanNode)
+    {
+        return PlanNodeSearcher.searchFrom(rootPlanNode)
+                .recurseOnlyWhen(node -> !(node instanceof ExchangeNode && ((ExchangeNode) node).getScope() == ExchangeNode.Scope.REMOTE_STREAMING))
+                .where(node1 -> node1 instanceof RemoteSourceNode)
+                .findAll()
+                .stream()
+                .map(n -> ((RemoteSourceNode) n).getSourceFragmentIds())
+                .flatMap(l -> l.stream())
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isCoordinatorOnly(Plan plan)
+    {
+        if (!(plan.getRoot() instanceof OutputNode)) {
+            return false;
+        }
+
+        PlanNode outputSourceNode = ((OutputNode) plan.getRoot()).getSource();
+        return isCoordinatorOnlyDistribution(outputSourceNode);
     }
 
     private void publishFragmentCompletionEvent(FragmentCompletionEvent fragmentCompletionEvent)
@@ -298,12 +334,20 @@ public class PrestoSparkAdaptiveQueryExecution
     /**
      * Execute the final fragment of the plan and collect the result.
      */
-    private List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> executeFinalFragment(SubPlan finalFragment)
-            throws SparkException, TimeoutException
+    private List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> executeFinalFragment(Session session,
+            SubPlan finalFragment,
+            TableWriteInfo tableWriteInfo
+    ) throws SparkException, TimeoutException
     {
-        TableWriteInfo tableWriteInfo = getTableWriteInfo(session, finalFragment);
-        RddAndMore rddAndMore = createRddForSubPlan(finalFragment, tableWriteInfo);
+        if (finalFragment.getFragment().getPartitioning().equals(COORDINATOR_DISTRIBUTION)) {
+            Map<PlanFragmentId, RddAndMore<PrestoSparkSerializedPage>> inputRdds = new HashMap<>();
+            for (SubPlan child : finalFragment.getChildren()) {
+                inputRdds.put(child.getFragment().getId(), getRdd(child.getFragment().getId()).get());
+            }
+            return collectPages(tableWriteInfo, finalFragment.getFragment(), inputRdds);
+        }
 
+        RddAndMore rddAndMore = createRddForSubPlan(finalFragment, tableWriteInfo, Optional.of(PrestoSparkSerializedPage.class));
         return rddAndMore.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
@@ -40,6 +40,7 @@ import com.facebook.presto.sql.planner.BasePlanFragmenter;
 import com.facebook.presto.sql.planner.BasePlanFragmenter.FragmentProperties;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
@@ -183,8 +184,9 @@ public class IterativePlanFragmenter
 
         // apply fragment rewrites like grouped execution tagging
         // and rewriting the partition handle
+        PartitioningHandle partitioningHandle = properties.getPartitioningHandle();
         subPlans = subPlans.stream()
-                .map(subPlan -> finalizeSubPlan(subPlan, queryManagerConfig, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector))
+                .map(subPlan -> finalizeSubPlan(subPlan, queryManagerConfig, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, partitioningHandle))
                 .collect(toImmutableList());
 
         return new PlanAndFragments(remainingPlan, subPlans);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
@@ -122,7 +122,7 @@ public class TestPrestoSparkQueryExecution
     }
 
     @Test
-    public void testQroupByAdaptiveExecution()
+    public void testGroupByAdaptiveExecution()
     {
         String sqlText = "SELECT custkey, orderstatus FROM orders ORDER BY orderkey DESC LIMIT 10";
         Session session = Session.builder(getSession())
@@ -249,23 +249,24 @@ public class TestPrestoSparkQueryExecution
         rootFragmentedPlan.getChildren().stream()
                 .map(SubPlan::getChildren)
                 .flatMap(Collection::stream)
-                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo));
+                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo, Optional.empty()));
 
         // Level 1
         rootFragmentedPlan.getChildren().stream()
-                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo));
+                .forEach(subPlan -> excecuteSubPlanWithUncheckedException(execution, subPlan, tableWriteInfo, Optional.empty()));
 
         // Level 0 - Root
-        return excecuteSubPlanWithUncheckedException(execution, rootFragmentedPlan, tableWriteInfo);
+        return excecuteSubPlanWithUncheckedException(execution, rootFragmentedPlan, tableWriteInfo, Optional.empty());
     }
 
     // This exists as forEach can't handle methods with checked exception
     private FragmentExecutionResult excecuteSubPlanWithUncheckedException(PrestoSparkStaticQueryExecution execution,
             SubPlan subPlan,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            Optional<Class<?>> outputType)
     {
         try {
-            return execution.executeFragment(subPlan, tableWriteInfo);
+            return execution.executeFragment(subPlan, tableWriteInfo, outputType);
         }
         catch (Exception e) {
             throwIfUnchecked(e);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveQueryRunner.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.adaptive.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spark.TestPrestoSparkQueryRunner;
+
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED;
+
+// Test class to run adaptive version of existing Presto-on-Spark tests.
+// Tests which aren't applicable to AQE(like retries), should be excluded/updated here
+public class TestPrestoSparkAdaptiveQueryRunner
+        extends TestPrestoSparkQueryRunner
+{
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED, "true")
+                .build();
+    }
+}


### PR DESCRIPTION
Add adaptive version of presto-on-spark tests
Use parent partitioning handle when reassigning partitioning
Add support for table write queries in aqe by handling COORDINATOR_ONLY distribution and fixing TableWriteInfo
Consistent error handling in aqe and non-aqe path
Add support for empty tables in aqe

Test plan - 
Tested with unit tests

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
