### PR TITLE
Account for current and expanded tables in tryRehash

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -278,12 +278,11 @@ public class BigintGroupByHash
 
         // An estimate of how much extra memory is needed before we can go ahead and expand the hash table.
         // This includes the new capacity for values, groupIds, and valuesByGroupId as well as the size of the current page
-        preallocatedMemoryInBytes = (newCapacity - hashCapacity) * (long) (Long.BYTES + Integer.BYTES) + (calculateMaxFill(newCapacity) - maxFill) * Long.BYTES + currentPageSizeInBytes;
+        preallocatedMemoryInBytes = newCapacity * (long) (Long.BYTES + Integer.BYTES) + calculateMaxFill(newCapacity) * Long.BYTES + currentPageSizeInBytes;
         if (!updateMemory.update()) {
             // reserved memory but has exceeded the limit
             return false;
         }
-        preallocatedMemoryInBytes = 0;
 
         expectedHashCollisions += estimateNumberOfHashCollisions(getGroupCount(), hashCapacity);
 
@@ -318,6 +317,10 @@ public class BigintGroupByHash
         groupIds = newGroupIds;
 
         this.valuesByGroupId.ensureCapacity(maxFill);
+
+        preallocatedMemoryInBytes = 0;
+        // release temporary memory reservation
+        updateMemory.update();
         return true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -387,14 +387,13 @@ public class MultiChannelGroupByHash
 
         // An estimate of how much extra memory is needed before we can go ahead and expand the hash table.
         // This includes the new capacity for groupAddressByHash, rawHashByHashPosition, groupIdsByHash, and groupAddressByGroupId as well as the size of the current page
-        preallocatedMemoryInBytes = (newCapacity - hashCapacity) * (long) (Long.BYTES + Integer.BYTES + Byte.BYTES) +
-                (calculateMaxFill(newCapacity) - maxFill) * Long.BYTES +
+        preallocatedMemoryInBytes = newCapacity * (long) (Long.BYTES + Integer.BYTES + Byte.BYTES) +
+                calculateMaxFill(newCapacity) * Long.BYTES +
                 currentPageSizeInBytes;
         if (!updateMemory.update()) {
             // reserved memory but has exceeded the limit
             return false;
         }
-        preallocatedMemoryInBytes = 0;
 
         expectedHashCollisions += estimateNumberOfHashCollisions(getGroupCount(), hashCapacity);
 
@@ -436,6 +435,10 @@ public class MultiChannelGroupByHash
         this.rawHashByHashPosition = rawHashes;
         this.groupIdsByHash = newValue;
         groupAddressByGroupId.ensureCapacity(maxFill);
+
+        preallocatedMemoryInBytes = 0;
+        // release temporary memory reservation
+        updateMemory.update();
         return true;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
@@ -282,7 +282,7 @@ public class TestGroupByHash
                 });
         groupByHash.addPage(new Page(valuesBlock, hashBlock)).process();
 
-        // assert we call update memory twice every time we rehash; the rehash count = log2(length / FILL_RATIO)
+        // assert we call update memory twice every time we rehash; the rehash count = 2 * log2(length / FILL_RATIO)
         assertEquals(rehashCount.get(), 2 * log2(length / 0.75, RoundingMode.FLOOR));
     }
 


### PR DESCRIPTION
manually cherry-pick the memory accounting fix from trino: https://github.com/trinodb/trino/pull/15678

Test plan - (Please fill in how you tested your changes)

* Relies on the unit tests to verify the memory accounted numbers.
* When growing the hash table, the Presto is using the strategy to double the allocated size and rehash every value in the old table into the new table.
* Previously we only account for the size of the new table, however, it is not the real memory consumption while rehashing the values. While rehashing we are pretty much keep the old table and the new table around to do the rehash. It is only when we finish the rehashing then we release the old table. This change is to account for this fact.


```
== RELEASE NOTES ==

General Changes
* Improve memory accounting for rehashing.



