### PR TITLE
Fix resource loading issues in presto-orc test code

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
@@ -51,7 +51,6 @@ import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.FOOTER;
 import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX;
 import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
-import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
@@ -87,43 +86,43 @@ public abstract class AbstractTestDwrfStripeCaching
     }
 
     @DataProvider(name = "Stripe cache for ALL stripes with mode BOTH")
-    public Object[][] bothAllStripesFilesProvider()
+    public Object[][] bothAllStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_BOTH_AllStripes.orc"), bothAllStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache for HALF stripes with mode BOTH")
-    public Object[][] bothHalfStripesFilesProvider()
+    public Object[][] bothHalfStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_BOTH_HalfStripes.orc"), bothHalfStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache for ALL stripes with mode INDEX")
-    public Object[][] indexAllStripesFilesProvider()
+    public Object[][] indexAllStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_INDEX_AllStripes.orc"), indexAllStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache for HALF stripes with mode INDEX")
-    public Object[][] indexHalfStripesFilesProvider()
+    public Object[][] indexHalfStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_INDEX_HalfStripes.orc"), indexHalfStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache for ALL stripes with mode FOOTER")
-    public Object[][] footerAllStripesFilesProvider()
+    public Object[][] footerAllStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_FOOTER_AllStripes.orc"), footerAllStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache for HALF stripes with mode FOOTER")
-    public Object[][] footerHalfStripesFilesProvider()
+    public Object[][] footerHalfStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_FOOTER_HalfStripes.orc"), footerHalfStripesFile.getFile());
     }
 
     @DataProvider(name = "Stripe cache with mode NONE")
-    public Object[][] noneAllStripesFilesProvider()
+    public Object[][] noneAllStripesFilesProvider() throws IOException
     {
         return toArray(getResourceFile("DwrfStripeCache_NONE.orc"), noneAllStripesFile.getFile());
     }
@@ -134,10 +133,10 @@ public abstract class AbstractTestDwrfStripeCaching
         return new Object[][] {{stripeCacheDisabledFile.getFile()}};
     }
 
-    static File getResourceFile(String fileName)
+    static File getResourceFile(String fileName) throws IOException
     {
         String resourceName = "dwrf_stripe_cache/" + fileName;
-        return new File(getResource(resourceName).getFile());
+        return OrcReaderTestingUtils.getResourceFile(resourceName);
     }
 
     private static Object[][] toArray(File file1, File file2)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
@@ -15,6 +15,11 @@ package com.facebook.presto.orc;
 
 import io.airlift.units.DataSize;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class OrcReaderTestingUtils
@@ -35,5 +40,16 @@ public class OrcReaderTestingUtils
                 .withMaxBlockSize(dataSize)
                 .withZstdJniDecompressionEnabled(zstdJniDecompressionEnabled)
                 .build();
+    }
+
+    public static File getResourceFile(String resourceName)
+            throws IOException
+    {
+        File resourceFile = File.createTempFile("presto-orc-test", null);
+        resourceFile.deleteOnExit();
+
+        Files.copy(OrcReaderTestingUtils.class.getClassLoader().getResourceAsStream(resourceName), resourceFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        return resourceFile;
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -32,7 +32,6 @@ import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,7 +69,6 @@ import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.STRUCT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_INDEX;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -477,7 +475,7 @@ public class TestDecryption
             throws Exception
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(
-                new File(getResource("encrypted_2splits.dwrf").getFile()),
+                OrcReaderTestingUtils.getResourceFile("encrypted_2splits.dwrf"),
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -39,7 +39,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,7 +64,6 @@ import static com.facebook.presto.orc.TestMapFlatBatchStreamReader.ExpectedValue
 import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.collect.Iterators.advance;
-import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -440,7 +438,7 @@ public class TestMapFlatBatchStreamReader
             throws Exception
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(
-                new File(getResource(testOrcFileName).getFile()),
+                OrcReaderTestingUtils.getResourceFile(testOrcFileName),
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
@@ -37,7 +37,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,7 +70,6 @@ import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
 import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.io.Resources.getResource;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
@@ -455,7 +453,7 @@ public class TestMapFlatSelectiveStreamReader
         Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(1, ImmutableMap.of(new Subfield("c"), toBigintValues(new long[] {1, 5, 6}, true)));
         assertFileContentsPresto(
                 types,
-                new File(getResource(testOrcFileName).getFile()),
+                OrcReaderTestingUtils.getResourceFile(testOrcFileName),
                 filterRows(types, ImmutableList.of(expectedValues, ids), filters),
                 OrcEncoding.DWRF,
                 OrcPredicate.TRUE,
@@ -467,7 +465,7 @@ public class TestMapFlatSelectiveStreamReader
         TestingFilterFunction filterFunction = new TestingFilterFunction(mapType);
         assertFileContentsPresto(
                 types,
-                new File(getResource(testOrcFileName).getFile()),
+                OrcReaderTestingUtils.getResourceFile(testOrcFileName),
                 filterFunction.filterRows(ImmutableList.of(expectedValues, ids)),
                 OrcEncoding.DWRF,
                 OrcPredicate.TRUE,
@@ -515,7 +513,7 @@ public class TestMapFlatSelectiveStreamReader
 
         assertFileContentsPresto(
                 types,
-                new File(getResource(testOrcFileName).getFile()),
+                OrcReaderTestingUtils.getResourceFile(testOrcFileName),
                 filters.map(f -> filterRows(types, ImmutableList.of(expectedValues), f)).orElse(ImmutableList.of(expectedValues)),
                 OrcEncoding.DWRF,
                 orcPredicate,


### PR DESCRIPTION
Fix resource loading issues in presto-orc test code when running test in different test environment like buck where test resources are pack into a jar.

Test plan - (Please fill in how you tested your changes)
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```
