### PR TITLE
Increase default number of max connections for glue client

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -28,7 +28,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> glueEndpointUrl = Optional.empty();
     private boolean pinGlueClientToCurrentRegion;
     private int maxGlueErrorRetries = 10;
-    private int maxGlueConnections = 5;
+    private int maxGlueConnections = 50;
     private Optional<String> defaultWarehouseDir = Optional.empty();
     private Optional<String> catalogId = Optional.empty();
     private int partitionSegments = 5;
@@ -77,6 +77,7 @@ public class GlueHiveMetastoreConfig
     }
 
     @Min(1)
+    @Max(1000)
     public int getMaxGlueConnections()
     {
         return maxGlueConnections;

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -31,7 +31,7 @@ public class TestGlueHiveMetastoreConfig
                 .setGlueRegion(null)
                 .setGlueEndpointUrl(null)
                 .setPinGlueClientToCurrentRegion(false)
-                .setMaxGlueConnections(5)
+                .setMaxGlueConnections(50)
                 .setMaxGlueErrorRetries(10)
                 .setDefaultWarehouseDir(null)
                 .setCatalogId(null)


### PR DESCRIPTION
AWS has a service quota of 1000 connections per account and by default maxConnections in ClientConfiguration class is set as 50.
Reference link - https://docs.aws.amazon.com/general/latest/gr/glue.html

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
