### PR TITLE
Add support for User-Defined Aggregate Functions in json file based function namespace manager

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.functionNamespace.json;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.UserDefinedType;
 import com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager;
@@ -23,7 +24,9 @@ import com.facebook.presto.functionNamespace.ServingCatalog;
 import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
 import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
@@ -40,7 +43,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
@@ -62,6 +64,7 @@ public class JsonFileBasedFunctionNamespaceManager
     private final Map<QualifiedObjectName, UserDefinedType> userDefinedTypes = new ConcurrentHashMap<>();
     private final JsonFileBasedFunctionNamespaceManagerConfig managerConfig;
     private final FunctionDefinitionProvider functionDefinitionProvider;
+    private final Map<SqlFunctionHandle, AggregationFunctionImplementation> aggregationImplementationByHandle = new ConcurrentHashMap<>();
 
     @Inject
     public JsonFileBasedFunctionNamespaceManager(
@@ -77,6 +80,29 @@ public class JsonFileBasedFunctionNamespaceManager
         bootstrapNamespaceFromFile();
     }
 
+    @Override
+    public final AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle, TypeManager typeManager)
+    {
+        checkCatalog(functionHandle);
+        checkArgument(functionHandle instanceof SqlFunctionHandle, "Unsupported FunctionHandle type '%s'", functionHandle.getClass().getSimpleName());
+
+        SqlFunctionHandle sqlFunctionHandle = (SqlFunctionHandle) functionHandle;
+
+        // Cache results if applicable
+        if (!aggregationImplementationByHandle.containsKey(sqlFunctionHandle)) {
+            SqlFunctionId functionId = sqlFunctionHandle.getFunctionId();
+            if (!latestFunctions.containsKey(functionId)) {
+                throw new PrestoException(GENERIC_USER_ERROR, format("Function '%s' is missing from cache", functionId.getId()));
+            }
+
+            aggregationImplementationByHandle.put(
+                    sqlFunctionHandle,
+                    sqlInvokedFunctionToAggregationImplementation(latestFunctions.get(functionId), typeManager));
+        }
+
+        return aggregationImplementationByHandle.get(sqlFunctionHandle);
+    }
+
     private static SqlInvokedFunction copyFunction(SqlInvokedFunction function)
     {
         return new SqlInvokedFunction(
@@ -86,7 +112,9 @@ public class JsonFileBasedFunctionNamespaceManager
                 function.getDescription(),
                 function.getRoutineCharacteristics(),
                 function.getBody(),
-                function.getVersion());
+                function.getVersion(),
+                function.getSignature().getKind(),
+                function.getAggregationMetadata());
     }
 
     private void bootstrapNamespaceFromFile()
@@ -109,24 +137,26 @@ public class JsonFileBasedFunctionNamespaceManager
 
     private SqlInvokedFunction createSqlInvokedFunction(String functionName, JsonBasedUdfFunctionMetadata jsonBasedUdfFunctionMetaData)
     {
-        checkState(jsonBasedUdfFunctionMetaData.getRoutineCharacteristics().getLanguage().equals(CPP), "JsonFileBasedInMemoryFunctionNameSpaceManager only supports CPP UDF");
+        checkState(jsonBasedUdfFunctionMetaData.getRoutineCharacteristics().getLanguage().equals(CPP), "JsonFileBasedFunctionNamespaceManager only supports CPP UDF");
         QualifiedObjectName qualifiedFunctionName = QualifiedObjectName.valueOf(new CatalogSchemaName(getCatalogName(), jsonBasedUdfFunctionMetaData.getSchema()), functionName);
         List<String> parameterNameList = jsonBasedUdfFunctionMetaData.getParamNames();
-        List<String> parameterTypeList = jsonBasedUdfFunctionMetaData.getParamTypes();
+        List<TypeSignature> parameterTypeList = jsonBasedUdfFunctionMetaData.getParamTypes();
 
         ImmutableList.Builder<Parameter> parameterBuilder = ImmutableList.builder();
         for (int i = 0; i < parameterNameList.size(); i++) {
-            parameterBuilder.add(new Parameter(parameterNameList.get(i), parseTypeSignature(parameterTypeList.get(i))));
+            parameterBuilder.add(new Parameter(parameterNameList.get(i), parameterTypeList.get(i)));
         }
 
         return new SqlInvokedFunction(
                 qualifiedFunctionName,
                 parameterBuilder.build(),
-                parseTypeSignature(jsonBasedUdfFunctionMetaData.getOutputType()),
+                jsonBasedUdfFunctionMetaData.getOutputType(),
                 jsonBasedUdfFunctionMetaData.getDocString(),
                 jsonBasedUdfFunctionMetaData.getRoutineCharacteristics(),
                 "",
-                notVersioned());
+                notVersioned(),
+                jsonBasedUdfFunctionMetaData.getFunctionKind(),
+                jsonBasedUdfFunctionMetaData.getAggregateMetadata());
     }
 
     @Override
@@ -182,13 +212,13 @@ public class JsonFileBasedFunctionNamespaceManager
     @Override
     public void alterFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
     {
-        throw new PrestoException(NOT_SUPPORTED, "Drop Function is not supported in JsonFileBasedInMemoryFunctionNameSpaceManager");
+        throw new PrestoException(NOT_SUPPORTED, "Alter Function is not supported in JsonFileBasedFunctionNamespaceManager");
     }
 
     @Override
     public void dropFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, boolean exists)
     {
-        throw new PrestoException(NOT_SUPPORTED, "Drop Function is not supported in JsonFileBasedInMemoryFunctionNameSpaceManager");
+        throw new PrestoException(NOT_SUPPORTED, "Drop Function is not supported in JsonFileBasedFunctionNamespaceManager");
     }
 
     @Override

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
@@ -40,7 +40,7 @@ public class TestJsonFileBasedFunctionNamespaceManager
     {
         JsonFileBasedFunctionNamespaceManager jsonFileBasedFunctionNameSpaceManager = createFunctionNamespaceManager();
         Collection<SqlInvokedFunction> functionList = jsonFileBasedFunctionNameSpaceManager.listFunctions(Optional.empty(), Optional.empty());
-        assertEquals(functionList.size(), 7);
+        assertEquals(functionList.size(), 9);
     }
 
     private JsonFileBasedFunctionNamespaceManager createFunctionNamespaceManager() throws IOException

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
@@ -203,7 +203,7 @@ public class TestMySqlFunctionNamespaceManager
         assertListFunctions(FUNCTION_POWER_TOWER_DOUBLE.withVersion("1"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*function 'unittest\\.memory\\.power_tower\\(x double\\):double:1 \\{RETURN pow\\(x, x\\)\\} \\(SQL, DETERMINISTIC, CALLED_ON_NULL_INPUT\\)' is already versioned")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*function 'unittest\\.memory\\.power_tower\\(x double\\):double:1 \\[SCALAR] \\{RETURN pow\\(x, x\\)\\} \\(SQL, DETERMINISTIC, CALLED_ON_NULL_INPUT\\)' is already versioned")
     public void testCreateFunctionFailedVersioned()
     {
         createFunction(FUNCTION_POWER_TOWER_DOUBLE.withVersion("1"), true);

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
@@ -3,6 +3,7 @@
 "add_ARRAY_element_wise":[
          {
             "docString":"function to add two string vectors element-wise",
+           "functionKind": "SCALAR",
             "outputType": "ARRAY<ARRAY<BOOLEAN>>",
             "paramTypes":[
                  "ARRAY<ARRAY<BOOLEAN>>",
@@ -17,6 +18,7 @@
          },
          {
             "docString":"function to add two float vectors element-wise",
+           "functionKind": "SCALAR",
             "outputType": "ARRAY<ARRAY<BIGINT>>",
             "paramTypes":[
                 "ARRAY<ARRAY<BIGINT>>",
@@ -31,6 +33,7 @@
          },
          {
             "docString":"function to add two int64_t vectors element-wise",
+           "functionKind": "SCALAR",
             "outputType": "ARRAY<DOUBLE>",
             "paramTypes":[
                  "ARRAY<DOUBLE>",
@@ -47,6 +50,7 @@
  "ads_product_types_transform":[
          {
             "docString":"gff ads product types transform",
+           "functionKind": "SCALAR",
             "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
             "paramTypes":[
                  "ARRAY<map<BIGINT, DOUBLE>>",
@@ -61,6 +65,7 @@
          },
          {
             "docString":"gff ads product types transform",
+           "functionKind": "SCALAR",
             "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
             "paramTypes":[
                  "ARRAY<map<BIGINT, DOUBLE>>",
@@ -78,6 +83,7 @@
   "square": [
     {
       "docString":"square an integer",
+      "functionKind": "SCALAR",
       "outputType": "int",
       "paramTypes":[
         "int"
@@ -91,6 +97,7 @@
     },
     {
       "docString":"square a double",
+      "functionKind": "SCALAR",
       "outputType": "double",
       "paramTypes":[
         "double"
@@ -100,6 +107,44 @@
         "language":"CPP",
         "determinism":"DETERMINISTIC",
         "nullCallClause":"CALLED_ON_NULL_INPUT"
+      }
+    }
+  ],
+  "avg": [
+    {
+      "docString":"Returns mean of integers",
+      "functionKind": "AGGREGATE",
+      "outputType": "int",
+      "paramTypes":[
+        "int"
+      ],
+      "schema":"f3",
+      "routineCharacteristics": {
+        "language":"CPP",
+        "determinism":"DETERMINISTIC",
+        "nullCallClause":"CALLED_ON_NULL_INPUT"
+      },
+      "aggregateMetadata": {
+        "intermediateType": "ROW(bigint, int)",
+        "isOrderSensitive": false
+      }
+    },
+    {
+      "docString":"Returns mean of doubles",
+      "functionKind": "AGGREGATE",
+      "outputType": "double",
+      "paramTypes":[
+        "double"
+      ],
+      "schema":"f3",
+      "routineCharacteristics": {
+        "language":"CPP",
+        "determinism":"DETERMINISTIC",
+        "nullCallClause":"CALLED_ON_NULL_INPUT"
+      },
+      "aggregateMetadata": {
+        "intermediateType": "ROW(double, int)",
+        "isOrderSensitive": false
       }
     }
   ]

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
@@ -226,7 +226,7 @@ public class HiveFunctionNamespaceManager
     }
 
     @Override
-    public AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle)
+    public AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle, TypeManager typeManager)
     {
         checkArgument(functionHandle instanceof HiveFunctionHandle);
         HiveFunction function = functions.getUnchecked(FunctionKey.from(((HiveFunctionHandle) functionHandle)));

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -1114,7 +1114,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         }
     }
 
-    public AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle)
+    public AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle, TypeManager typeManager)
     {
         checkArgument(functionHandle instanceof BuiltInFunctionHandle, "Expect BuiltInFunctionHandle");
         Signature signature = ((BuiltInFunctionHandle) functionHandle).getSignature();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -510,7 +510,7 @@ public class FunctionAndTypeManager
     {
         Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
         checkArgument(functionNamespaceManager.isPresent(), "Cannot find function namespace for '%s'", functionHandle.getCatalogSchemaName());
-        return functionNamespaceManager.get().getAggregateFunctionImplementation(functionHandle);
+        return functionNamespaceManager.get().getAggregateFunctionImplementation(functionHandle, this);
     }
 
     public CompletableFuture<SqlFunctionResult> executeFunction(String source, FunctionHandle functionHandle, Page inputPage, List<Integer> channels)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -24,7 +24,7 @@ import com.facebook.presto.operator.aggregation.state.CorrelationState;
 import com.facebook.presto.operator.aggregation.state.CovarianceState;
 import com.facebook.presto.operator.aggregation.state.RegressionState;
 import com.facebook.presto.operator.aggregation.state.VarianceState;
-import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.sql.gen.CompilerOperations;
 import com.google.common.base.CaseFormat;
@@ -52,8 +52,8 @@ public final class AggregationUtils
 
         boolean decomposableFunctions = aggregationNode.getAggregations().values().stream()
                 .map(AggregationNode.Aggregation::getFunctionHandle)
-                .map(functionAndTypeManager::getJavaAggregateFunctionImplementation)
-                .allMatch(JavaAggregationFunctionImplementation::isDecomposable);
+                .map(functionAndTypeManager::getAggregateFunctionImplementation)
+                .allMatch(AggregationFunctionImplementation::isDecomposable);
 
         return !hasOrderBy && !hasDistinct && decomposableFunctions;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
 import static com.facebook.presto.operator.annotations.FunctionsParserHelper.findPublicStaticMethods;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.NOT_DETERMINISTIC;
@@ -172,7 +173,9 @@ public final class SqlInvokedScalarFromAnnotationsParser
                         functionDescription,
                         routineCharacteristics,
                         body,
-                        notVersioned()))
+                        notVersioned(),
+                        SCALAR,
+                        Optional.empty()))
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -60,7 +60,7 @@ public class PruneOrderByInAggregation
                 aggregations.put(entry);
             }
             // getAggregateFunctionImplementation can be expensive, so check it last.
-            else if (functionAndTypeManager.getJavaAggregateFunctionImplementation(aggregation.getFunctionHandle()).isOrderSensitive()) {
+            else if (functionAndTypeManager.getAggregateFunctionImplementation(aggregation.getFunctionHandle()).isOrderSensitive()) {
                 aggregations.put(entry);
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -19,8 +19,8 @@ import com.facebook.presto.matching.Capture;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.function.FunctionHandle;
-import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -218,7 +218,7 @@ public class PushPartialAggregationThroughExchange
             AggregationNode.Aggregation originalAggregation = entry.getValue();
             String functionName = functionAndTypeManager.getFunctionMetadata(originalAggregation.getFunctionHandle()).getName().getObjectName();
             FunctionHandle functionHandle = originalAggregation.getFunctionHandle();
-            JavaAggregationFunctionImplementation function = functionAndTypeManager.getJavaAggregateFunctionImplementation(functionHandle);
+            AggregationFunctionImplementation function = functionAndTypeManager.getAggregateFunctionImplementation(functionHandle);
             VariableReferenceExpression intermediateVariable = context.getVariableAllocator().newVariable(entry.getValue().getCall().getSourceLocation(), functionName, function.getIntermediateType());
 
             checkState(!originalAggregation.getOrderBy().isPresent(), "Aggregate with ORDER BY does not support partial aggregation");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TranslateExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TranslateExpressions.java
@@ -19,7 +19,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
 import com.facebook.presto.spi.VariableAllocator;
-import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ExistsExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -99,9 +99,9 @@ public class TranslateExpressions
                             .filter(typeSignature -> typeSignature.getBase().equals(FunctionType.NAME))
                             .map(typeSignature -> (FunctionType) (metadata.getFunctionAndTypeManager().getType(typeSignature)))
                             .collect(toImmutableList());
-                    JavaAggregationFunctionImplementation javaAggregateFunctionImplementation = metadata.getFunctionAndTypeManager().getJavaAggregateFunctionImplementation(callExpression.getFunctionHandle());
-                    if (javaAggregateFunctionImplementation instanceof BuiltInAggregationFunctionImplementation) {
-                        List<Class> lambdaInterfaces = ((BuiltInAggregationFunctionImplementation) javaAggregateFunctionImplementation).getLambdaInterfaces();
+                    AggregationFunctionImplementation aggregateFunctionImplementation = metadata.getFunctionAndTypeManager().getAggregateFunctionImplementation(callExpression.getFunctionHandle());
+                    if (aggregateFunctionImplementation instanceof BuiltInAggregationFunctionImplementation) {
+                        List<Class> lambdaInterfaces = ((BuiltInAggregationFunctionImplementation) aggregateFunctionImplementation).getLambdaInterfaces();
                         verify(lambdaExpressions.size() == functionTypes.size());
                         verify(lambdaExpressions.size() == lambdaInterfaces.size());
                     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregations.java
@@ -15,8 +15,8 @@ package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.function.FunctionHandle;
-import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -75,7 +75,7 @@ public class StatisticAggregations
         for (Map.Entry<VariableReferenceExpression, Aggregation> entry : aggregations.entrySet()) {
             Aggregation originalAggregation = entry.getValue();
             FunctionHandle functionHandle = originalAggregation.getFunctionHandle();
-            JavaAggregationFunctionImplementation function = functionAndTypeManager.getJavaAggregateFunctionImplementation(functionHandle);
+            AggregationFunctionImplementation function = functionAndTypeManager.getAggregateFunctionImplementation(functionHandle);
 
             // create partial aggregation
             VariableReferenceExpression partialVariable = variableAllocator.newVariable(entry.getValue().getCall().getSourceLocation(), functionAndTypeManager.getFunctionMetadata(functionHandle).getName().getObjectName(), function.getIntermediateType());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionImplementation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionImplementation.java
@@ -14,9 +14,17 @@
 
 package com.facebook.presto.spi.function;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.api.Experimental;
 
 @Experimental
 public interface AggregationFunctionImplementation
 {
+    Type getIntermediateType();
+
+    Type getFinalType();
+
+    boolean isDecomposable();
+
+    boolean isOrderSensitive();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import com.facebook.presto.common.type.TypeSignature;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The class contains the extra metadata required for AGGREGATE functions used in {@link SqlInvokedFunction}.
+ */
+public class AggregationFunctionMetadata
+{
+    /**
+     * intermediate TypeSignature for the aggregation function.
+     * This is converted to an intermediate Type using a {@link com.facebook.presto.common.type.TypeManager}
+     */
+    private final TypeSignature intermediateType;
+
+    /**
+     * Determines if the corresponding aggregation function is order-sensitive.
+     */
+    private final boolean isOrderSensitive;
+
+    @JsonCreator
+    public AggregationFunctionMetadata(
+            @JsonProperty("intermediateType") TypeSignature intermediateType,
+            @JsonProperty("isOrderSensitive") boolean isOrderSensitive)
+    {
+        this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
+        this.isOrderSensitive = isOrderSensitive;
+    }
+
+    @JsonProperty
+    public TypeSignature getIntermediateType()
+    {
+        return intermediateType;
+    }
+
+    @JsonProperty
+    public boolean isOrderSensitive()
+    {
+        return isOrderSensitive;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format(
+                "%s(%s,%s)",
+                getClass().getSimpleName(),
+                getIntermediateType(),
+                isOrderSensitive());
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -118,7 +118,7 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
 
     Optional<UserDefinedType> getUserDefinedType(QualifiedObjectName typeName);
 
-    default AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle)
+    default AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle, TypeManager typeManager)
     {
         throw new UnsupportedOperationException("Does not support get aggregation function");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/JavaAggregationFunctionImplementation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/JavaAggregationFunctionImplementation.java
@@ -24,15 +24,7 @@ import java.util.List;
 public interface JavaAggregationFunctionImplementation
         extends AggregationFunctionImplementation
 {
-    boolean isDecomposable();
-
     List<Type> getParameterTypes();
-
-    Type getIntermediateType();
-
-    Type getFinalType();
-
-    boolean isOrderSensitive();
 
     AggregationMetadata getAggregationMetadata();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedAggregationFunctionImplementation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedAggregationFunctionImplementation.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.api.Experimental;
+
+import static java.util.Objects.requireNonNull;
+
+@Experimental
+public class SqlInvokedAggregationFunctionImplementation
+        implements AggregationFunctionImplementation
+{
+    private final Type intermediateType;
+
+    private final Type finalType;
+
+    private final boolean isOrderSensitive;
+
+    public SqlInvokedAggregationFunctionImplementation(Type intermediateType, Type finalType, boolean isOrderSensitive)
+    {
+        this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
+        this.finalType = requireNonNull(finalType, "finalType is null");
+        this.isOrderSensitive = isOrderSensitive;
+    }
+
+    @Override
+    public Type getIntermediateType()
+    {
+        return intermediateType;
+    }
+
+    @Override
+    public Type getFinalType()
+    {
+        return finalType;
+    }
+
+    @Override
+    public boolean isDecomposable()
+    {
+        // This class assumes the aggregation function is decomposable.
+        return true;
+    }
+
+    @Override
+    public boolean isOrderSensitive()
+    {
+        return isOrderSensitive;
+    }
+}


### PR DESCRIPTION
Add support for registering (CPP) User-Defined Aggregate Functions (UDAFs) in Presto. This uses the same contract for UDFs with minor changes.
- To register a scalar or aggregate user-defined function, now you must provide the FunctionKind as well (`"SCALAR"`, `"AGGREGATE"`)
- To register an aggregate user-defined function, you must provide an extra field (`"aggregateMetadata"`) as well.

Test plan - Added a unit-test which asserts the distributed-plan is as expected.

```
== NO RELEASE NOTE ==
```
