### PR TITLE
Increase number of threads for parallel partition fetches in glue

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -28,7 +28,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> glueEndpointUrl = Optional.empty();
     private boolean pinGlueClientToCurrentRegion;
     private int maxGlueErrorRetries = 10;
-    private int maxGlueConnections = 5;
+    private int maxGlueConnections = 50;
     private Optional<String> defaultWarehouseDir = Optional.empty();
     private Optional<String> catalogId = Optional.empty();
     private int partitionSegments = 5;
@@ -77,6 +77,7 @@ public class GlueHiveMetastoreConfig
     }
 
     @Min(1)
+    @Max(1000)
     public int getMaxGlueConnections()
     {
         return maxGlueConnections;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -32,7 +32,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> defaultWarehouseDir = Optional.empty();
     private Optional<String> catalogId = Optional.empty();
     private int partitionSegments = 5;
-    private int getPartitionThreads = 20;
+    private int getPartitionThreads = 50;
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
@@ -146,6 +146,7 @@ public class GlueHiveMetastoreConfig
     }
 
     @Min(1)
+    @Max(1000)
     public int getGetPartitionThreads()
     {
         return getPartitionThreads;

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -36,7 +36,7 @@ public class TestGlueHiveMetastoreConfig
                 .setDefaultWarehouseDir(null)
                 .setCatalogId(null)
                 .setPartitionSegments(5)
-                .setGetPartitionThreads(20)
+                .setGetPartitionThreads(50)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null));

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -31,7 +31,7 @@ public class TestGlueHiveMetastoreConfig
                 .setGlueRegion(null)
                 .setGlueEndpointUrl(null)
                 .setPinGlueClientToCurrentRegion(false)
-                .setMaxGlueConnections(5)
+                .setMaxGlueConnections(50)
                 .setMaxGlueErrorRetries(10)
                 .setDefaultWarehouseDir(null)
                 .setCatalogId(null)


### PR DESCRIPTION
In continuation with https://github.com/prestodb/presto/pull/19108, the number of threads for parallel partition fetches from glue metastore should be set to 50 as well for optimum performance. Prior to the mentioned PR getting merged, the number of max glue connections was 5 by default and number of threads for partition fetches was 20, which meant only 5 threads will be able to connect to metastore concurrently and the rest would be waiting. 



```
== NO RELEASE NOTE ==
```
