### PR TITLE
Modify get partition threads in glue

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -32,7 +32,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> defaultWarehouseDir = Optional.empty();
     private Optional<String> catalogId = Optional.empty();
     private int partitionSegments = 5;
-    private int getPartitionThreads = 20;
+    private int getPartitionThreads = 50;
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
@@ -146,6 +146,7 @@ public class GlueHiveMetastoreConfig
     }
 
     @Min(1)
+    @Max(1000)
     public int getGetPartitionThreads()
     {
         return getPartitionThreads;

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -36,7 +36,7 @@ public class TestGlueHiveMetastoreConfig
                 .setDefaultWarehouseDir(null)
                 .setCatalogId(null)
                 .setPartitionSegments(5)
-                .setGetPartitionThreads(20)
+                .setGetPartitionThreads(50)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null));


### PR DESCRIPTION
With default glue max connections set to 50, the number of threads for parallel partition fetches from glue metastore should be set to 50 for optimum performance.

In continuation with https://github.com/prestodb/presto/pull/19108, the number of threads for parallel partition fetches from glue metastore should be set to 50 as well for optimum performance. Prior to the mentioned PR getting merged, the number of max glue connections was 5 by default and number of threads for partition fetches was 20, which meant only 5 threads will be able to connect to metastore concurrently and the rest would be waiting.

```
== NO RELEASE NOTE ==
```
