### PR TITLE
Rearrange entries in the Assignments

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/Assignments.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/Assignments.java
@@ -36,6 +36,16 @@ import static java.util.Objects.requireNonNull;
 
 public class Assignments
 {
+    private final Map<VariableReferenceExpression, RowExpression> assignments;
+    private final List<VariableReferenceExpression> outputs;
+
+    @JsonCreator
+    public Assignments(@JsonProperty("assignments") Map<VariableReferenceExpression, RowExpression> assignments)
+    {
+        this.assignments = unmodifiableMap(new LinkedHashMap<>(requireNonNull(assignments, "assignments is null")));
+        this.outputs = unmodifiableList(new ArrayList<>(assignments.keySet()));
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -66,16 +76,6 @@ public class Assignments
     public static Assignments of(VariableReferenceExpression variable1, RowExpression expression1, VariableReferenceExpression variable2, RowExpression expression2)
     {
         return builder().put(variable1, expression1).put(variable2, expression2).build();
-    }
-
-    private final Map<VariableReferenceExpression, RowExpression> assignments;
-    private final List<VariableReferenceExpression> outputs;
-
-    @JsonCreator
-    public Assignments(@JsonProperty("assignments") Map<VariableReferenceExpression, RowExpression> assignments)
-    {
-        this.assignments = unmodifiableMap(new LinkedHashMap<>(requireNonNull(assignments, "assignments is null")));
-        this.outputs = unmodifiableList(new ArrayList<>(assignments.keySet()));
     }
 
     public List<VariableReferenceExpression> getOutputs()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
@@ -35,9 +35,7 @@ public final class ConstantExpression
     private final Object value;
     private final Type type;
 
-    public ConstantExpression(
-            Optional<SourceLocation> sourceLocation,
-            Object value, Type type)
+    public ConstantExpression(Optional<SourceLocation> sourceLocation, Object value, Type type)
     {
         super(sourceLocation);
         requireNonNull(type, "type is null");


### PR DESCRIPTION
1. Rearrange entries in the Assignments
2. Make ConstantExpression constructor more readable

```
== NO RELEASE NOTE ==
```
