### PR TITLE
[native] Fix PartitionAndSerializeOperator when number of partitions is 1

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -102,10 +102,10 @@ class PartitionAndSerializeOperator : public Operator {
  private:
   void computePartitions(FlatVector<int32_t>& partitionsVector) {
     auto numInput = input_->size();
+    partitions_.resize(numInput);
     if (numPartitions_ == 1) {
       std::fill(partitions_.begin(), partitions_.end(), 0);
     } else {
-      partitions_.resize(numInput);
       partitionFunction_->partition(*input_, partitions_);
     }
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -704,6 +704,33 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperator) {
   }
 }
 
+TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
+  });
+
+  auto plan = exec::test::PlanBuilder()
+                  .values({data}, true)
+                  .addNode(addPartitionAndSerializeNode(1))
+                  .planNode();
+
+  exec::test::CursorParameters params;
+  params.planNode = plan;
+  params.maxDrivers = 2;
+
+  auto [taskCursor, serializedResults] =
+      readCursor(params, [](auto /*task*/) {});
+  EXPECT_EQ(serializedResults.size(), 2);
+
+  for (auto& serializedResult : serializedResults) {
+    // Verify that serialized data can be deserialized successfully into the
+    // original data.
+    auto deserialized = deserialize(serializedResult, asRowType(data->type()));
+    velox::test::assertEqualVectors(data, deserialized);
+  }
+}
+
 TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),


### PR DESCRIPTION
Currently, while computing partition value for each row, if the number of
partitions == 1, we do not initialize the output `partitions_` array correctly.
This change fixes that. This code path is particularly relavant when we are
doing global aggregations with partial aggregates enabled

```
== NO RELEASE NOTE ==
```
