### PR TITLE
Fix resource loadings issues in presto-tests test code

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.execution.TestQueues.createResourceGroupId;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.stream.Collectors.toSet;
 import static org.testng.Assert.assertEquals;
@@ -71,11 +72,6 @@ public class TestEventListener
         queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", Integer.toString(SPLITS_PER_NODE)));
         queryRunner.getCoordinator().getResourceGroupManager().get()
                 .forceSetConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -63,6 +63,7 @@ import static com.facebook.presto.spi.StandardErrorCode.ADMINISTRATIVELY_KILLED;
 import static com.facebook.presto.spi.StandardErrorCode.ADMINISTRATIVELY_PREEMPTED;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -392,11 +393,6 @@ public class TestQueues
             DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
             assertEquals(dispatchManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
         }
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
     private QueryId createDashboardQuery(DistributedQueryRunner queryRunner)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -64,11 +65,6 @@ public class TestResourceGroupIntegration
             assertEquals(path.get(2).getHardConcurrencyLimit(), 100);
             assertEquals(path.get(2).getRunningQueries(), null);
         }
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
     public static void waitForGlobalResourceGroup(DistributedQueryRunner queryRunner)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static com.facebook.presto.utils.QueryExecutionClientUtil.runToFirstResult;
 import static com.facebook.presto.utils.QueryExecutionClientUtil.runToQueued;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.lang.Thread.sleep;
@@ -104,11 +105,6 @@ public class TestDistributedClusterStatsResource
         coordinator2 = null;
         resourceManager = null;
         client = null;
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
     @Test(timeOut = 60_000, enabled = false)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 import static com.facebook.airlift.testing.Closeables.closeQuietly;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static org.testng.Assert.assertTrue;
 
 public class TestRaftServer
@@ -97,11 +98,6 @@ public class TestRaftServer
         resourceManager1 = null;
         resourceManager2 = null;
         client = null;
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
     @Test(timeOut = 120_000)

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestClusterStatsResource.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.server.ClusterStatsResource.ClusterStats;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static com.facebook.presto.utils.QueryExecutionClientUtil.runToExecuting;
 import static com.facebook.presto.utils.QueryExecutionClientUtil.runToQueued;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -128,10 +129,5 @@ public class TestClusterStatsResource
         else {
             return client.execute(request, createJsonResponseHandler(jsonCodec(ClusterStats.class)));
         }
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestQueryResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestQueryResource.java
@@ -351,9 +351,4 @@ public class TestQueryResource
         assertEquals(running, expectedRunning);
         assertEquals(queued, expectedQueued);
     }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
-    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_SCAN_RAW_BYTES_
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder.builder;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -223,10 +224,5 @@ public class TestQueryManager
             assertEquals(queryInfo.getState(), FAILED);
             assertEquals(queryInfo.getErrorCode(), EXCEEDED_OUTPUT_SIZE_LIMIT.toErrorCode());
         }
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_L
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -127,10 +128,5 @@ public class TestResourceGroupPerQueryLimitEnforcement
         assertEquals(queryInfo.getState(), FAILED);
         assertEquals(queryInfo.getErrorCode(), EXCEEDED_TIME_LIMIT.toErrorCode());
         assertTrue(queryInfo.getFailureInfo().getMessage().contains(RESOURCE_GROUP.name()));
-    }
-
-    private String getResourceFilePath(String fileName)
-    {
-        return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/utils/ResourceUtils.java
+++ b/presto-tests/src/test/java/com/facebook/presto/utils/ResourceUtils.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.utils;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 public class ResourceUtils
 {
     private ResourceUtils()
@@ -21,6 +27,16 @@ public class ResourceUtils
 
     public static String getResourceFilePath(String fileName)
     {
-        return ResourceUtils.class.getClassLoader().getResource(fileName).getPath();
+        try {
+            File resourceFile = File.createTempFile("presto-tests", null);
+            resourceFile.deleteOnExit();
+
+            Files.copy(ResourceUtils.class.getClassLoader().getResourceAsStream(fileName), resourceFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+            return resourceFile.toPath().toString();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }


### PR DESCRIPTION
As described in https://github.com/prestodb/presto/pull/18314, tests couldn't read resource files directly from file system as buck packages all classes and resources in a jar. So we need to copy the resource to a temp file and have the tests read the temp files.
Fix the same resource loadings issues in presto-tests test code. Move the common code to a method in class ResourceUtils for better code re-use.

Test plan - (Please fill in how you tested your changes)
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```
