### PR TITLE
[native] Support FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1957,10 +1957,6 @@ core::ExecutionStrategy toStrategy(protocol::StageExecutionStrategy strategy) {
 
     case protocol::StageExecutionStrategy::
         FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION:
-      VELOX_UNSUPPORTED(
-          "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION "
-          "Stage Execution Strategy is not supported");
-
     case protocol::StageExecutionStrategy::
         DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION:
       return core::ExecutionStrategy::kGrouped;
@@ -1987,6 +1983,12 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   planFragment.numSplitGroups = descriptor.totalLifespans;
   for (const auto& planNodeId : descriptor.groupedExecutionScanNodes) {
     planFragment.groupedExecutionLeafNodeIds.emplace(planNodeId);
+  }
+  if (planFragment.executionStrategy == core::ExecutionStrategy::kGrouped) {
+    VELOX_CHECK(
+        !planFragment.groupedExecutionLeafNodeIds.empty(),
+        "groupedExecutionScanNodes cannot be empty if stage execution strategy "
+        "is grouped execution");
   }
 
   if (auto output = std::dynamic_pointer_cast<const protocol::OutputNode>(


### PR DESCRIPTION
Test plan - Existing integration tests.

Include FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION support just like
we have DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION already.
The difference between two is not super clear, it looks like there is no
extra requirements from the worker.

Also added sanity check (similar to java) to have groupedExecutionScanNodes
non-empty during grouped execution.


```
== NO RELEASE NOTE ==
```
