### PR TITLE
[wip] Testing https for native worker..

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
@@ -370,6 +370,8 @@ public class HeartbeatFailureDetector
                     @Override
                     public Exception handleException(Request request, Exception exception)
                     {
+                        log.error("--> Error happened during ping: " + exception.toString() + ", response: " + request.toString() + ", uri: " + uri.toString());
+
                         // ignore error
                         stats.recordFailure(exception);
 
@@ -381,6 +383,8 @@ public class HeartbeatFailureDetector
                     @Override
                     public Object handle(Request request, Response response)
                     {
+                        log.info("Ping is successfull.") ;
+
                         stats.recordSuccess();
                         return null;
                     }

--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
@@ -383,7 +383,7 @@ public class HeartbeatFailureDetector
                     @Override
                     public Object handle(Request request, Response response)
                     {
-                        log.info("Ping is successfull.") ;
+                        log.info("Ping is successfull.");
 
                         stats.recordSuccess();
                         return null;


### PR DESCRIPTION

Error we are seeing now

```
2023-03-02T17:43:38.927-0800    ERROR   http-client-failure-detector-3174       com.facebook.presto.failureDetector.HeartbeatFailureDetector    --> Error happened during ping: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure, response: Request{uri=https://[2401:db00:135c:1f2d:face:0:3d:0]:7778/v1/status, method=HEAD, headers={}, bodyGenerator=null, followRedirects=true, preserveAuthorizationOnRedirect=false}, uri: https://[2401:db00:135c:1f2d:face:0:3d:0]:7778/v1/status
```