### PR TITLE
Return false for low distinctness of group by keys when not stats not…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
@@ -83,9 +83,9 @@ public class AggregationNodeUtils
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
         PlanNodeStatsEstimate estimate = statsProvider.getStats(scanNode);
         if (!estimate.isConfident()) {
-            // For safety, we assume they are low card if not confident
+            // Looks like we are mostly not confident in stats so we return false in that case.
             // TODO(kaikalur) : maybe return low card only for partition keys if/when we can detect that
-            return true;
+            return false;
         }
 
         return groupbyKeys.stream().noneMatch(x -> estimate.getVariableStatistics(x).getDistinctValuesCount() >= count);


### PR DESCRIPTION
Looks like we are most often not confident of stats! This rendered my previous prefilter for group by limit optimization totally useless. So changing it to return false. We should really do the partition column change that I wanted to.

Test plan - tests exist


```
== NO RELEASE NOTE ==
```
