### PR TITLE
Optimize WindowOp's findEndPosition

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -924,17 +924,19 @@ public class WindowOperator
         checkArgument(startPosition < endPosition, "startPosition (%s) must be less than endPosition (%s)", startPosition, endPosition);
 
         int left = startPosition;
-        int right = endPosition;
+        int right = left + 1;
 
-        while (left + 1 < right) {
-            int middle = (left + right) >>> 1;
-
-            if (comparator.test(startPosition, middle)) {
-                left = middle;
+        while (right < endPosition) {
+            int distance = 1;
+            for (; distance < endPosition - left; distance *= 2) {
+                right = left + distance;
+                if (!comparator.test(startPosition, right)) {
+                    endPosition = right;
+                    break;
+                }
             }
-            else {
-                right = middle;
-            }
+            left = left + distance / 2;
+            right = left + 1;
         }
 
         return right;


### PR DESCRIPTION
This commit optimizes the findEndPosition function used by WindowOperator. 
The previous implementation has a **worst-case** complexity as **O(NlogN)**, general-case complexity as O(logN), while the proposed implementation has a **worst-case** complexity as **O(N)**, general-case complexity as O(logN).

The findEndPosition function is to find the endPosition of each window (after the data is sorted and in order already), so it might be called many times until all the windows are separate.
For example, the original data is
`111222334566777`
Then the endPositions are (indicated by ^)
`111^222^33^4^5^66^777^`

The previous implementation finds the endPosition **from tail to head** via binary search.
Although this algorithm has a general-case complexity as O(logN), it has a really bad case: 
if each window has very limited rows (say only 1 row), then the searching would be launched #window times. 
Suppose there are N rows, each of which forms a separate window, then the overall searching requires O(NlogN) comparison!
This bad case might happen in real-world cases when the window aggregation degree is very low, and the findEndPosition function would even become performance bottleneck.

This commit modifies the algorithm to search **from head to tail** via exponential search. 
This algorithm remains to have a general complexity as O(logN), and when the bad case mentioned above occurs, the worst-case complexity is O(N), which avoids the performance bottleneck.

Test plan - (Please fill in how you tested your changes)

The tests are implemented by `TestWindowOperator#testFindEndPosition`.

```
== NO RELEASE NOTE ==
```

