### PR TITLE
Add ConnectorSession parameter to JdbcClient methods

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -33,27 +33,27 @@ import java.util.Set;
 
 public interface JdbcClient
 {
-    default boolean schemaExists(JdbcIdentity identity, String schema)
+    default boolean schemaExists(ConnectorSession session, JdbcIdentity identity, String schema)
     {
-        return getSchemaNames(identity).contains(schema);
+        return getSchemaNames(session, identity).contains(schema);
     }
 
     String getIdentifierQuote();
 
-    Set<String> getSchemaNames(JdbcIdentity identity);
+    Set<String> getSchemaNames(ConnectorSession session, JdbcIdentity identity);
 
-    List<SchemaTableName> getTableNames(JdbcIdentity identity, Optional<String> schema);
+    List<SchemaTableName> getTableNames(ConnectorSession session, JdbcIdentity identity, Optional<String> schema);
 
     @Nullable
-    JdbcTableHandle getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName);
+    JdbcTableHandle getTableHandle(ConnectorSession session, JdbcIdentity identity, SchemaTableName schemaTableName);
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
     Optional<ReadMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle);
 
-    ConnectorSplitSource getSplits(JdbcIdentity identity, JdbcTableLayoutHandle layoutHandle);
+    ConnectorSplitSource getSplits(ConnectorSession session, JdbcIdentity identity, JdbcTableLayoutHandle layoutHandle);
 
-    Connection getConnection(JdbcIdentity identity, JdbcSplit split)
+    Connection getConnection(ConnectorSession session, JdbcIdentity identity, JdbcSplit split)
             throws SQLException;
 
     default void abortReadConnection(Connection connection)
@@ -65,36 +65,36 @@ public interface JdbcClient
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
 
-    void addColumn(JdbcIdentity identity, JdbcTableHandle handle, ColumnMetadata column);
+    void addColumn(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, ColumnMetadata column);
 
-    void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column);
+    void dropColumn(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column);
 
-    void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName);
+    void renameColumn(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName);
 
-    void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName);
+    void renameTable(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName);
 
     void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
     JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
-    void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void commitCreateTable(ConnectorSession session, JdbcIdentity identity, JdbcOutputTableHandle handle);
 
     JdbcOutputTableHandle beginInsertTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
-    void finishInsertTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void finishInsertTable(ConnectorSession session, JdbcIdentity identity, JdbcOutputTableHandle handle);
 
-    void dropTable(JdbcIdentity identity, JdbcTableHandle jdbcTableHandle);
+    void dropTable(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle jdbcTableHandle);
 
-    void truncateTable(JdbcIdentity identity, JdbcTableHandle jdbcTableHandle);
+    void truncateTable(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle jdbcTableHandle);
 
-    void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void rollbackCreateTable(ConnectorSession session, JdbcIdentity identity, JdbcOutputTableHandle handle);
 
-    String buildInsertSql(JdbcOutputTableHandle handle);
+    String buildInsertSql(ConnectorSession session, JdbcOutputTableHandle handle);
 
-    Connection getConnection(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    Connection getConnection(ConnectorSession session, JdbcIdentity identity, JdbcOutputTableHandle handle)
             throws SQLException;
 
-    PreparedStatement getPreparedStatement(Connection connection, String sql)
+    PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException;
 
     TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, List<JdbcColumnHandle> columnHandles, TupleDomain<ColumnHandle> tupleDomain);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -66,19 +66,19 @@ public class JdbcMetadata
     @Override
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
-        return jdbcClient.schemaExists(JdbcIdentity.from(session), schemaName);
+        return jdbcClient.schemaExists(session, JdbcIdentity.from(session), schemaName);
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return ImmutableList.copyOf(jdbcClient.getSchemaNames(JdbcIdentity.from(session)));
+        return ImmutableList.copyOf(jdbcClient.getSchemaNames(session, JdbcIdentity.from(session)));
     }
 
     @Override
     public JdbcTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        return jdbcClient.getTableHandle(JdbcIdentity.from(session), tableName);
+        return jdbcClient.getTableHandle(session, JdbcIdentity.from(session), tableName);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class JdbcMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        return jdbcClient.getTableNames(JdbcIdentity.from(session), schemaName);
+        return jdbcClient.getTableNames(session, JdbcIdentity.from(session), schemaName);
     }
 
     @Override
@@ -138,7 +138,7 @@ public class JdbcMetadata
         }
         for (SchemaTableName tableName : tables) {
             try {
-                JdbcTableHandle tableHandle = jdbcClient.getTableHandle(JdbcIdentity.from(session), tableName);
+                JdbcTableHandle tableHandle = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), tableName);
                 if (tableHandle == null) {
                     continue;
                 }
@@ -164,14 +164,14 @@ public class JdbcMetadata
             throw new PrestoException(PERMISSION_DENIED, "DROP TABLE is disabled in this catalog");
         }
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
-        jdbcClient.dropTable(JdbcIdentity.from(session), handle);
+        jdbcClient.dropTable(session, JdbcIdentity.from(session), handle);
     }
 
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
         JdbcOutputTableHandle handle = jdbcClient.beginCreateTable(session, tableMetadata);
-        setRollback(() -> jdbcClient.rollbackCreateTable(JdbcIdentity.from(session), handle));
+        setRollback(() -> jdbcClient.rollbackCreateTable(session, JdbcIdentity.from(session), handle));
         return handle;
     }
 
@@ -185,7 +185,7 @@ public class JdbcMetadata
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         JdbcOutputTableHandle handle = (JdbcOutputTableHandle) tableHandle;
-        jdbcClient.commitCreateTable(JdbcIdentity.from(session), handle);
+        jdbcClient.commitCreateTable(session, JdbcIdentity.from(session), handle);
         clearRollback();
         return Optional.empty();
     }
@@ -209,7 +209,7 @@ public class JdbcMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         JdbcOutputTableHandle handle = jdbcClient.beginInsertTable(session, getTableMetadata(session, tableHandle));
-        setRollback(() -> jdbcClient.rollbackCreateTable(JdbcIdentity.from(session), handle));
+        setRollback(() -> jdbcClient.rollbackCreateTable(session, JdbcIdentity.from(session), handle));
         return handle;
     }
 
@@ -217,7 +217,7 @@ public class JdbcMetadata
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         JdbcOutputTableHandle jdbcInsertHandle = (JdbcOutputTableHandle) tableHandle;
-        jdbcClient.finishInsertTable(JdbcIdentity.from(session), jdbcInsertHandle);
+        jdbcClient.finishInsertTable(session, JdbcIdentity.from(session), jdbcInsertHandle);
         return Optional.empty();
     }
 
@@ -225,7 +225,7 @@ public class JdbcMetadata
     public void addColumn(ConnectorSession session, ConnectorTableHandle table, ColumnMetadata columnMetadata)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        jdbcClient.addColumn(JdbcIdentity.from(session), tableHandle, columnMetadata);
+        jdbcClient.addColumn(session, JdbcIdentity.from(session), tableHandle, columnMetadata);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class JdbcMetadata
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
-        jdbcClient.dropColumn(JdbcIdentity.from(session), tableHandle, columnHandle);
+        jdbcClient.dropColumn(session, JdbcIdentity.from(session), tableHandle, columnHandle);
     }
 
     @Override
@@ -241,14 +241,14 @@ public class JdbcMetadata
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
-        jdbcClient.renameColumn(JdbcIdentity.from(session), tableHandle, columnHandle, target);
+        jdbcClient.renameColumn(session, JdbcIdentity.from(session), tableHandle, columnHandle, target);
     }
 
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle table, SchemaTableName newTableName)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        jdbcClient.renameTable(JdbcIdentity.from(session), tableHandle, newTableName);
+        jdbcClient.renameTable(session, JdbcIdentity.from(session), tableHandle, newTableName);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
@@ -73,7 +73,7 @@ public class JdbcPageSink
     public JdbcPageSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient)
     {
         try {
-            connection = jdbcClient.getConnection(JdbcIdentity.from(session), handle);
+            connection = jdbcClient.getConnection(session, JdbcIdentity.from(session), handle);
         }
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
@@ -81,7 +81,7 @@ public class JdbcPageSink
 
         try {
             connection.setAutoCommit(false);
-            statement = connection.prepareStatement(jdbcClient.buildInsertSql(handle));
+            statement = connection.prepareStatement(jdbcClient.buildInsertSql(session, handle));
         }
         catch (SQLException e) {
             closeWithSuppression(connection, e);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -86,7 +86,7 @@ public class JdbcRecordCursor
         }
 
         try {
-            connection = jdbcClient.getConnection(JdbcIdentity.from(session), split);
+            connection = jdbcClient.getConnection(session, JdbcIdentity.from(session), split);
             statement = jdbcClient.buildSql(session, connection, split, columnHandles);
             log.debug("Executing: %s", statement.toString());
             resultSet = statement.executeQuery();

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplitManager.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplitManager.java
@@ -42,6 +42,6 @@ public class JdbcSplitManager
             SplitSchedulingContext splitSchedulingContext)
     {
         JdbcTableLayoutHandle layoutHandle = (JdbcTableLayoutHandle) layout;
-        return jdbcClient.getSplits(JdbcIdentity.from(session), layoutHandle);
+        return jdbcClient.getSplits(session, JdbcIdentity.from(session), layoutHandle);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -147,7 +147,7 @@ public class QueryBuilder
                     .append(Joiner.on(" AND ").join(clauses));
         }
         sql.append(String.format("/* %s : %s */", session.getUser(), session.getQueryId()));
-        PreparedStatement statement = client.getPreparedStatement(connection, sql.toString());
+        PreparedStatement statement = client.getPreparedStatement(session, connection, sql.toString());
 
         for (int i = 0; i < accumulator.size(); i++) {
             TypeAndValue typeAndValue = accumulator.get(i);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -77,17 +77,17 @@ public class TestJdbcClient
     public void testMetadata()
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
-        assertTrue(jdbcClient.getSchemaNames(identity).containsAll(ImmutableSet.of("example", "tpch")));
-        assertEquals(jdbcClient.getTableNames(identity, Optional.of("example")), ImmutableList.of(
+        assertTrue(jdbcClient.getSchemaNames(session, identity).containsAll(ImmutableSet.of("example", "tpch")));
+        assertEquals(jdbcClient.getTableNames(session, identity, Optional.of("example")), ImmutableList.of(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
-        assertEquals(jdbcClient.getTableNames(identity, Optional.of("tpch")), ImmutableList.of(
+        assertEquals(jdbcClient.getTableNames(session, identity, Optional.of("tpch")), ImmutableList.of(
                 new SchemaTableName("tpch", "lineitem"),
                 new SchemaTableName("tpch", "orders")));
 
         SchemaTableName schemaTableName = new SchemaTableName("example", "numbers");
-        JdbcTableHandle table = jdbcClient.getTableHandle(identity, schemaTableName);
+        JdbcTableHandle table = jdbcClient.getTableHandle(session, identity, schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(table.getCatalogName(), catalogName.toUpperCase(ENGLISH));
         assertEquals(table.getSchemaName(), "EXAMPLE");
@@ -103,7 +103,7 @@ public class TestJdbcClient
     public void testMetadataWithSchemaPattern()
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "num_ers");
-        JdbcTableHandle table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        JdbcTableHandle table = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(session, table), ImmutableList.of(
                 new JdbcColumnHandle(CONNECTOR_ID, "TE_T", JDBC_VARCHAR, VARCHAR, true, Optional.empty()),
@@ -114,7 +114,7 @@ public class TestJdbcClient
     public void testMetadataWithFloatAndDoubleCol()
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "table_with_float_col");
-        JdbcTableHandle table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        JdbcTableHandle table = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(session, table), ImmutableList.of(
                 new JdbcColumnHandle(CONNECTOR_ID, "COL1", JDBC_BIGINT, BIGINT, true, Optional.empty()),
@@ -136,7 +136,7 @@ public class TestJdbcClient
 
         jdbcClient.createTable(session, new ConnectorTableMetadata(schemaTableName, expectedColumns));
 
-        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), schemaTableName);
 
         try {
             assertEquals(tableHandle.getTableName(), tableName);
@@ -147,7 +147,7 @@ public class TestJdbcClient
                     new JdbcColumnHandle(CONNECTOR_ID, "COLUMND", JDBC_DATE, DateType.DATE, false, Optional.empty())));
         }
         finally {
-            jdbcClient.dropTable(JdbcIdentity.from(session), tableHandle);
+            jdbcClient.dropTable(session, JdbcIdentity.from(session), tableHandle);
         }
     }
 
@@ -162,24 +162,24 @@ public class TestJdbcClient
 
         jdbcClient.createTable(session, new ConnectorTableMetadata(schemaTableName, expectedColumns));
 
-        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), schemaTableName);
 
         try {
             assertEquals(tableHandle.getTableName(), tableName);
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
                     new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true, Optional.empty())));
 
-            jdbcClient.addColumn(JdbcIdentity.from(session), tableHandle, new ColumnMetadata("columnB", DoubleType.DOUBLE, null, null, false));
+            jdbcClient.addColumn(session, JdbcIdentity.from(session), tableHandle, new ColumnMetadata("columnB", DoubleType.DOUBLE, null, null, false));
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
                     new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true, Optional.empty()),
                     new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_DOUBLE, DoubleType.DOUBLE, true, Optional.empty())));
 
-            jdbcClient.dropColumn(JdbcIdentity.from(session), tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_BIGINT, BigintType.BIGINT, true, Optional.empty()));
+            jdbcClient.dropColumn(session, JdbcIdentity.from(session), tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_BIGINT, BigintType.BIGINT, true, Optional.empty()));
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
                     new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true, Optional.empty())));
         }
         finally {
-            jdbcClient.dropTable(JdbcIdentity.from(session), tableHandle);
+            jdbcClient.dropTable(session, JdbcIdentity.from(session), tableHandle);
         }
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -67,7 +67,7 @@ public class TestJdbcRecordSetProvider
         jdbcClient = database.getJdbcClient();
         split = database.getSplit("example", "numbers");
 
-        table = jdbcClient.getTableHandle(IDENTITY, new SchemaTableName("example", "numbers"));
+        table = jdbcClient.getTableHandle(SESSION, IDENTITY, new SchemaTableName("example", "numbers"));
 
         Map<String, JdbcColumnHandle> columns = database.getColumnHandles("example", "numbers");
         textColumn = columns.get("text");
@@ -182,7 +182,7 @@ public class TestJdbcRecordSetProvider
     private RecordCursor getCursor(JdbcTableHandle jdbcTableHandle, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> domain)
     {
         JdbcTableLayoutHandle layoutHandle = new JdbcTableLayoutHandle(SESSION.getSqlFunctionProperties(), jdbcTableHandle, domain, Optional.empty());
-        ConnectorSplitSource splits = jdbcClient.getSplits(IDENTITY, layoutHandle);
+        ConnectorSplitSource splits = jdbcClient.getSplits(SESSION, IDENTITY, layoutHandle);
         JdbcSplit split = (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
 
         ConnectorTransactionHandle transaction = new JdbcTransactionHandle();

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -100,15 +100,15 @@ final class TestingDatabase
     public JdbcSplit getSplit(String schemaName, String tableName)
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
-        JdbcTableHandle jdbcTableHandle = jdbcClient.getTableHandle(identity, new SchemaTableName(schemaName, tableName));
+        JdbcTableHandle jdbcTableHandle = jdbcClient.getTableHandle(session, identity, new SchemaTableName(schemaName, tableName));
         JdbcTableLayoutHandle jdbcLayoutHandle = new JdbcTableLayoutHandle(session.getSqlFunctionProperties(), jdbcTableHandle, TupleDomain.all(), Optional.empty());
-        ConnectorSplitSource splits = jdbcClient.getSplits(identity, jdbcLayoutHandle);
+        ConnectorSplitSource splits = jdbcClient.getSplits(session, identity, jdbcLayoutHandle);
         return (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
     }
 
     public Map<String, JdbcColumnHandle> getColumnHandles(String schemaName, String tableName)
     {
-        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(JdbcIdentity.from(session), new SchemaTableName(schemaName, tableName));
+        JdbcTableHandle tableHandle = jdbcClient.getTableHandle(session, JdbcIdentity.from(session), new SchemaTableName(schemaName, tableName));
         List<JdbcColumnHandle> columns = jdbcClient.getColumns(session, tableHandle);
         checkArgument(columns != null, "table not found: %s.%s", schemaName, tableName);
 

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -123,7 +123,7 @@ public class MySqlClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
@@ -205,7 +205,7 @@ public class MySqlClient
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(identity)) {
             DatabaseMetaData metadata = connection.getMetaData();

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -94,7 +94,7 @@ public class OracleClient
                 getTableTypes());
     }
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -81,7 +81,7 @@ public class PostgreSqlClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         connection.setAutoCommit(false);

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -18,6 +18,7 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import org.postgresql.Driver;
@@ -41,7 +42,7 @@ public class RedshiftClient
     }
 
     @Override
-    public PreparedStatement getPreparedStatement(Connection connection, String sql)
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
         connection.setAutoCommit(false);

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -20,6 +20,7 @@ import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Joiner;
@@ -60,7 +61,7 @@ public class SqlServerClient
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(identity)) {
             String sql = format(


### PR DESCRIPTION
Add ConnectorSession parameter to all methods of JdbcBaceClinet interface. This change is needed for allowing users to change the settings of the JDBC connector via session properties.


```
== RELEASE NOTES ==
JDBC Changes
* Add ConnectorSession parameter to  all methods of JdbcClient interface. That makes it possible to pass specific options to JDBC driver implementation via session parameters.
```
