### PR TITLE
Add access logs to presto_cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -154,6 +154,11 @@ bool SystemConfig::useMmapAllocator() const {
   return opt.value_or(kUseMmapAllocatorDefault);
 }
 
+bool SystemConfig::enableHttpAccessLog() const {
+  auto opt = optionalProperty<bool>(std::string(kHttpEnableAccessLog));
+  return opt.value_or(kHttpEnableAccessLogDefault);
+}
+
 NodeConfig* NodeConfig::instance() {
   static std::unique_ptr<NodeConfig> instance = std::make_unique<NodeConfig>();
   return instance.get();

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -110,6 +110,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kLocalShuffleMaxPartitionBytes{
       "shuffle.local.max-partition-bytes"};
   static constexpr std::string_view kShuffleName{"shuffle.name"};
+  static constexpr std::string_view kHttpEnableAccessLog{
+      "http-server.enable-access-log"};
   // Most server nodes today (May 2022) have at least 16 cores.
   // Setting the default maximum drivers per task to this value will
   // provide a better off-shelf experience.
@@ -131,6 +133,7 @@ class SystemConfig : public ConfigBase {
   static constexpr bool kEnableVeloxExprSetLoggingDefault = false;
   static constexpr bool kUseMmapArenaDefault = false;
   static constexpr bool kUseMmapAllocatorDefault{true};
+  static constexpr bool kHttpEnableAccessLogDefault = false;
 
   static SystemConfig* instance();
 
@@ -180,6 +183,8 @@ class SystemConfig : public ConfigBase {
   int32_t mmapArenaCapacityRatio() const;
 
   bool useMmapAllocator() const;
+
+  bool enableHttpAccessLog() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.cpp
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+#include <proxygen/httpserver/Filters.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+#include <string>
+
+#include "presto_cpp/main/http/filters/AccessLogFilter.h"
+
+namespace facebook::presto::http::filters {
+
+AccessLogFilter::AccessLogFilter(proxygen::RequestHandler* upstream)
+    : Filter(upstream) {}
+
+void AccessLogFilter::onRequest(
+    std::unique_ptr<proxygen::HTTPMessage> msg) noexcept {
+  startTime_ = msg->getStartTime();
+  method_ = msg->getMethodString();
+  url_ = msg->getURL();
+  version_ = getVersion(*msg);
+  remoteAddr_ = msg->getClientIP();
+
+  const auto& headers = msg->getHeaders();
+  httpReferer_ = headers.getSingleOrEmpty(proxygen::HTTP_HEADER_REFERER);
+  httpUserAgent_ = headers.getSingleOrEmpty(proxygen::HTTP_HEADER_USER_AGENT);
+
+  Filter::onRequest(std::move(msg));
+}
+
+void AccessLogFilter::requestComplete() noexcept {
+  writeLog(generateLog());
+  Filter::requestComplete();
+}
+
+void AccessLogFilter::onError(proxygen::ProxygenError err) noexcept {
+  writeLog(generateLog());
+  Filter::onError(err);
+}
+
+// Response handler
+void AccessLogFilter::sendHeaders(proxygen::HTTPMessage& msg) noexcept {
+  statusCode_ = msg.getStatusCode();
+  Filter::sendHeaders(msg);
+}
+
+void AccessLogFilter::sendBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  bytesSent_ += body->computeChainDataLength();
+  Filter::sendBody(std::move(body));
+}
+
+std::string AccessLogFilter::getVersion(
+    const proxygen::HTTPMessage& msg) const noexcept {
+  if (!msg.isAdvancedProto()) {
+    return "HTTP/" + msg.getVersionString();
+  } else {
+    return *msg.getAdvancedProtocolString();
+  }
+}
+
+void AccessLogFilter::writeLog(std::string logLine) const noexcept {
+  LOG(INFO) << logLine;
+}
+
+std::string AccessLogFilter::generateLog() const noexcept {
+  std::time_t requestStartTime = proxygen::toTimeT(proxygen::getCurrentTime());
+  static struct tm formattedStartTime;
+  localtime_r(&requestStartTime, &formattedStartTime);
+  char timeBuf[64];
+  std::strftime(timeBuf, 64, "%F %T", &formattedStartTime);
+  const auto latency = proxygen::millisecondsSince(startTime_);
+
+  std::string logLine = fmt::format(
+      "{} - - [{}] \"{} {} {}\" {:d} {:d} {} {} {:d}",
+      remoteAddr_.c_str(),
+      timeBuf,
+      method_.c_str(),
+      url_.c_str(),
+      version_.c_str(),
+      statusCode_,
+      bytesSent_,
+      httpReferer_.c_str(),
+      httpUserAgent_.c_str(),
+      latency.count());
+
+  return logLine;
+}
+
+} // namespace facebook::presto::http::filters

--- a/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.h
+++ b/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.h
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+#include <proxygen/httpserver/Filters.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+#include <time.h>
+
+namespace facebook::presto::http::filters {
+
+/// A filter that does access logging in nginx `combined` format
+class AccessLogFilter : public proxygen::Filter {
+ public:
+  explicit AccessLogFilter(proxygen::RequestHandler* upstream);
+
+  void onRequest(std::unique_ptr<proxygen::HTTPMessage> msg) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+  void sendHeaders(proxygen::HTTPMessage& msg) noexcept override;
+
+  void sendBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+ private:
+  std::string getVersion(const proxygen::HTTPMessage& msg) const noexcept;
+
+  virtual void writeLog(std::string logLine) const noexcept;
+
+  std::string generateLog() const noexcept;
+
+  proxygen::TimePoint startTime_;
+  std::string method_;
+  std::string url_;
+  std::string version_;
+  std::string remoteAddr_;
+
+  uint16_t statusCode_{0};
+  size_t bytesSent_{0};
+
+  std::string httpReferer_;
+  std::string httpUserAgent_;
+};
+
+class AccessLogFilterFactory : public proxygen::RequestHandlerFactory {
+ public:
+  explicit AccessLogFilterFactory() {}
+
+  void onServerStart(folly::EventBase* /*evb*/) noexcept override {}
+
+  void onServerStop() noexcept override {}
+
+  proxygen::RequestHandler* onRequest(
+      proxygen::RequestHandler* handler,
+      proxygen::HTTPMessage*) noexcept override {
+    return new AccessLogFilter(handler);
+  }
+
+ private:
+};
+
+} // namespace facebook::presto::http::filters

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/AccessLogFilterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/AccessLogFilterTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/http/filters/AccessLogFilter.h"
+
+#include <gtest/gtest.h>
+#include <proxygen/httpserver/Mocks.h>
+#include <proxygen/lib/http/HTTPMessage.h>
+
+TEST(AccessLogFilterTest, logFormat) {
+  class MockedAccessLogFilter
+      : public facebook::presto::http::filters::AccessLogFilter {
+   public:
+    explicit MockedAccessLogFilter(proxygen::RequestHandler* upstream)
+        : AccessLogFilter(upstream) {}
+    mutable std::string accessLog = "";
+    void writeLog(std::string logLine) const noexcept override {
+      accessLog = logLine;
+    }
+  };
+
+  std::unique_ptr<proxygen::HTTPMessage> request =
+      std::make_unique<proxygen::HTTPMessage>();
+  request->setMethod(proxygen::HTTPMethod::POST);
+  request->setURL("/testing/url1");
+
+  std::unique_ptr<proxygen::MockRequestHandler> mock =
+      std::unique_ptr<proxygen::MockRequestHandler>(
+          new proxygen::MockRequestHandler());
+  EXPECT_CALL(*mock.get(), requestComplete);
+
+  std::unique_ptr<MockedAccessLogFilter> requestFilter =
+      std::make_unique<MockedAccessLogFilter>(std::move(mock.get()));
+  requestFilter->onRequest(std::move(request));
+  requestFilter->requestComplete();
+
+  EXPECT_TRUE(requestFilter->accessLog.find("POST") != std::string::npos);
+  EXPECT_TRUE(
+      requestFilter->accessLog.find("/testing/url1") != std::string::npos);
+  EXPECT_TRUE(requestFilter->accessLog.find("HTTP") != std::string::npos);
+}

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
@@ -9,24 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(presto_http HttpClient.cpp HttpServer.cpp
-                        filters/AccessLogFilter.cpp)
+add_executable(access_log_test AccessLogFilterTest.cpp)
 
-target_link_libraries(
-  presto_http
-  presto_common
-  velox_memory
-  velox_exception
-  ${PROXYGEN_LIBRARIES}
-  ${LIBSODIUM_LIBRARY}
-  ${OPENSSL_SSL_LIBRARY}
-  ${OPENSSL_CRYPTO_LIBRARY}
-  ${FOLLY_WITH_DEPENDENCIES}
-  ${GLOG}
-  ${GFLAGS_LIBRARIES}
-  ${FMT}
-  ${RE2})
+add_test(access_log_test access_log_test)
 
-if(PRESTO_ENABLE_TESTING)
-  add_subdirectory(tests)
-endif()
+target_link_libraries(access_log_test presto_http gtest gtest_main)


### PR DESCRIPTION
Summary: Added access logs to stderr for easier debugging.

Differential Revision: D43942506

