### PR TITLE
Set DriverYieldSignal in Driver#close()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -188,6 +188,8 @@ public class Driver
             return;
         }
 
+        // set the yield signal and interrupt any actively running driver to stop them as soon as possible
+        driverContext.getYieldSignal().yieldImmediatelyForTermination();
         exclusiveLock.interruptCurrentOwner();
 
         // if we can get the lock, attempt a clean shutdown; otherwise someone else will shutdown

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverYieldSignal.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverYieldSignal.java
@@ -103,6 +103,7 @@ public class DriverYieldSignal
         }
     }
 
+    @Override
     public synchronized String toString()
     {
         return toStringHelper(this)


### PR DESCRIPTION
Cross port of https://github.com/trinodb/trino/pull/16395

Attempts to speed up driver termination by setting the `DriverYieldSignal` as part of `Driver#close()` so that long running in-memory operations that don't respond to interrupts can detect task termination sooner and stop.

```
== NO RELEASE NOTE ==
```
