### PR TITLE
[native] Use variable for path to velox gtest include

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -171,6 +171,9 @@ include_directories(velox/velox/external/xxhash)
 include_directories(${VELOX_ROOT})
 include_directories(${CMAKE_BINARY_DIR})
 
+# set this for backwards compatibility, will be overwritten in velox/
+set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
+
 add_subdirectory(velox)
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -175,7 +175,7 @@ add_subdirectory(velox)
 
 if(PRESTO_ENABLE_TESTING)
   include(CTest) # include after project() but before add_subdirectory()
-  include_directories(velox/third_party/googletest/googletest/include)
+  include_directories(${VELOX_GTEST_INCUDE_DIR})
 else()
   add_definitions(-DVELOX_DISABLE_GOOGLETEST)
 endif()


### PR DESCRIPTION
This PR updates the cmake so it will continue to work with velox after the googletest submodule is removed in favour of FetchContent: https://github.com/facebookincubator/velox/pull/4218. 
cc @kgpai 

Test plan - tested locally with docker

== NO RELEASE NOTE ==
