### PR TITLE
[native] Expose num_query_threads via config properties.

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -21,16 +21,11 @@ using namespace facebook::velox;
 using facebook::presto::protocol::QueryId;
 using facebook::presto::protocol::TaskId;
 
-DEFINE_int32(
-    num_query_threads,
-    std::thread::hardware_concurrency() * 4,
-    "Process-wide number of query execution threads");
-
 namespace facebook::presto {
 namespace {
 static std::shared_ptr<folly::CPUThreadPoolExecutor>& executor() {
   static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      FLAGS_num_query_threads,
+      SystemConfig::instance()->numQueryThreads(),
       std::make_shared<folly::NamedThreadFactory>("Driver"));
   return executor;
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -78,6 +78,11 @@ int32_t SystemConfig::numIoThreads() const {
   return opt.value_or(kNumIoThreadsDefault);
 }
 
+int32_t SystemConfig::numQueryThreads() const {
+  auto opt = optionalProperty<int32_t>(std::string(kNumQueryThreads));
+  return opt.value_or(std::thread::hardware_concurrency() * 4);
+}
+
 int32_t SystemConfig::numSpillThreads() const {
   auto opt = optionalProperty<int32_t>(std::string(kNumSpillThreads));
   return opt.hasValue() ? opt.value() : std::thread::hardware_concurrency();

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -89,6 +89,7 @@ class SystemConfig : public ConfigBase {
       "task.concurrent-lifespans-per-task"};
   static constexpr std::string_view kHttpExecThreads{"http_exec_threads"};
   static constexpr std::string_view kNumIoThreads{"num-io-threads"};
+  static constexpr std::string_view kNumQueryThreads{"num-query-threads"};
   static constexpr std::string_view kNumSpillThreads{"num-spill-threads"};
   static constexpr std::string_view kSpillerSpillPath =
       "experimental.spiller-spill-path";
@@ -147,7 +148,10 @@ class SystemConfig : public ConfigBase {
 
   int32_t httpExecThreads() const;
 
+  // Process-wide number of query execution threads
   int32_t numIoThreads() const;
+
+  int32_t numQueryThreads() const;
 
   int32_t numSpillThreads() const;
 


### PR DESCRIPTION
Exposing num_query_threads is useful to performance tuning. 