### PR TITLE
Enable outer join null key optimization in some case

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -242,6 +242,7 @@ public class FeaturesConfig
     private boolean nativeExecutionEnabled;
     private String nativeExecutionExecutablePath = "./presto_server";
     private boolean randomizeOuterJoinNullKey;
+    private RandomizeOuterJoinNullKeyStrategy randomizeOuterJoinNullKeyStrategy = RandomizeOuterJoinNullKeyStrategy.DISABLED;
     private boolean isOptimizeConditionalAggregationEnabled;
     private boolean isRemoveRedundantDistinctAggregationEnabled = true;
     private boolean inPredicatesAsInnerJoinsEnabled;
@@ -330,6 +331,13 @@ public class FeaturesConfig
         FILTER_WITH_IF, // Rewrites AGG(IF(condition, expr)) to AGG(IF(condition, expr)) FILTER (WHERE condition).
         UNWRAP_IF_SAFE, // Rewrites AGG(IF(condition, expr)) to AGG(expr) FILTER (WHERE condition) if it is safe to do so.
         UNWRAP_IF // Rewrites AGG(IF(condition, expr)) to AGG(expr) FILTER (WHERE condition).
+    }
+
+    public enum RandomizeOuterJoinNullKeyStrategy
+    {
+        DISABLED,
+        KEY_FROM_OUTER_JOIN, // Enabled only when join keys are from output of outer joins
+        ALWAYS
     }
 
     public double getCpuCostWeight()
@@ -2295,6 +2303,19 @@ public class FeaturesConfig
     public FeaturesConfig setRandomizeOuterJoinNullKeyEnabled(boolean randomizeOuterJoinNullKey)
     {
         this.randomizeOuterJoinNullKey = randomizeOuterJoinNullKey;
+        return this;
+    }
+
+    public RandomizeOuterJoinNullKeyStrategy getRandomizeOuterJoinNullKeyStrategy()
+    {
+        return randomizeOuterJoinNullKeyStrategy;
+    }
+
+    @Config("optimizer.randomize-outer-join-null-key-strategy")
+    @ConfigDescription("When to apply randomization to null keys in outer join")
+    public FeaturesConfig setRandomizeOuterJoinNullKeyStrategy(RandomizeOuterJoinNullKeyStrategy randomizeOuterJoinNullKeyStrategy)
+    {
+        this.randomizeOuterJoinNullKeyStrategy = randomizeOuterJoinNullKeyStrategy;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -29,25 +30,33 @@ import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slices;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
-import static com.facebook.presto.SystemSessionProperties.randomizeOuterJoinNullKeyEnabled;
+import static com.facebook.presto.SystemSessionProperties.getRandomizeOuterJoinNullKeyStrategy;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.CastType.CAST;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy.ALWAYS;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy.DISABLED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy.KEY_FROM_OUTER_JOIN;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -57,8 +66,77 @@ import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
+
+/**
+ * Randomize the join key of outer joins if the join key has many NULL values so as to mitigate skew.
+ * The optimization has three strategies, `DISABLED` to skip the optimization, `ALWAYS` to always enabled for all outer joins, and `KEY_FROM_OUTER_JOIN` to enable only when the
+ * join key is from the outer side of a outer join which is likely to have many NULLs.
+ *
+ * When Strategy is `KEY_FROM_OUTER_JOIN`:
+ * <pre>
+ * - LeftJoin
+ *          l.key = r.key
+ *      - Project
+ *          l.key = T2.v
+ *          - LeftJoin
+ *              T1.k = T2.k
+ *              - Scan T1(k, v)
+ *              - Scan T2(k, v)
+ *      - Project
+ *          r.key = T3.k
+ *          - Scan T3(k)
+ * </pre>
+ * to
+ * <pre>
+ * - LeftJoin
+ *          l.key = r.key
+ *      - Project
+ *          l.key = COALESCE(T2.v, Randomize(T2.v))
+ *          - LeftJoin
+ *              T1.k = T2.k
+ *              - Scan T1(k, v)
+ *              - Scan T2(k, v)
+ *      - Project
+ *          r.key = COALESCE(T3.k, Randomize(T3.k))
+ *          - Scan T3(k)
+ * </pre>
+ *
+ * When Strategy is `ALWAYS`:
+ * <pre>
+ * - LeftJoin
+ *          l.key = r.key
+ *      - Project
+ *          l.key = T2.v
+ *          - LeftJoin
+ *              T1.k = T2.k
+ *              - Scan T1(k, v)
+ *              - Scan T2(k, v)
+ *      - Project
+ *          r.key = T3.k
+ *          - Scan T3(k)
+ * </pre>
+ * to
+ * <pre>
+ * - LeftJoin
+ *          l.key = r.key
+ *      - Project
+ *          l.key = COALESCE(T2.v, Randomize(T2.v))
+ *          - LeftJoin
+ *              T1.randK = T2.randK
+ *              - Project
+ *                  T1.randK = COALESCE(T1.k, Randomize(T1.k))
+ *                  - Scan T1(k, v)
+ *              - Project
+ *                  T2.randK = COALESCE(T2.k, Randomize(T2.k))
+ *                  - Scan T2(k, v)
+ *      - Project
+ *          r.key = COALESCE(T3.k, Randomize(T3.k))
+ *          - Scan T3(k)
+ * </pre>
+ */
 
 public class RandomizeNullKeyInOuterJoin
         implements PlanOptimizer
@@ -73,15 +151,15 @@ public class RandomizeNullKeyInOuterJoin
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (getJoinDistributionType(session).canPartition() && randomizeOuterJoinNullKeyEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator), plan);
+        if (getJoinDistributionType(session).canPartition() && !getRandomizeOuterJoinNullKeyStrategy(session).equals(DISABLED)) {
+            return SimplePlanRewriter.rewriteWith(new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator), plan, new HashSet<>());
         }
 
         return plan;
     }
 
     private static class Rewriter
-            extends SimplePlanRewriter<Void>
+            extends SimplePlanRewriter<Set<VariableReferenceExpression>>
     {
         private static final String LEFT_PREFIX = "l";
         private static final String RIGHT_PREFIX = "r";
@@ -90,6 +168,7 @@ public class RandomizeNullKeyInOuterJoin
         private final PlanNodeIdAllocator planNodeIdAllocator;
         private final VariableAllocator planVariableAllocator;
         private final Map<String, Map<VariableReferenceExpression, VariableReferenceExpression>> keyToRandomKeyMap;
+        private final RandomizeOuterJoinNullKeyStrategy strategy;
 
         private Rewriter(Session session,
                 FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator planVariableAllocator)
@@ -99,6 +178,7 @@ public class RandomizeNullKeyInOuterJoin
             this.planNodeIdAllocator = requireNonNull(planNodeIdAllocator, "planNodeIdAllocator is null");
             this.planVariableAllocator = requireNonNull(planVariableAllocator, "planVariableAllocator is null");
             this.keyToRandomKeyMap = new HashMap<>();
+            this.strategy = getRandomizeOuterJoinNullKeyStrategy(session);
         }
 
         private static boolean isSupportedType(VariableReferenceExpression variable)
@@ -112,7 +192,23 @@ public class RandomizeNullKeyInOuterJoin
         }
 
         @Override
-        public PlanNode visitJoin(JoinNode joinNode, RewriteContext<Void> context)
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Set<VariableReferenceExpression>> context)
+        {
+            if (strategy.equals(KEY_FROM_OUTER_JOIN)) {
+                ImmutableMultimap.Builder<VariableReferenceExpression, VariableReferenceExpression> renameAssignmentBuilder = ImmutableMultimap.builder();
+                node.getAssignments().getMap().forEach((k, v) -> {
+                    if (v instanceof VariableReferenceExpression) {
+                        renameAssignmentBuilder.put((VariableReferenceExpression) v, k);
+                    }
+                });
+                ImmutableMultimap<VariableReferenceExpression, VariableReferenceExpression> renameAssignment = renameAssignmentBuilder.build();
+                context.get().addAll(context.get().stream().flatMap(x -> renameAssignment.get(x).stream()).collect(toImmutableSet()));
+            }
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode joinNode, RewriteContext<Set<VariableReferenceExpression>> context)
         {
             // In this optimization, we add the randomized key to output so it can be reused in case the same key is used in outer join in later stage.
             // However this can change the input for a cross join (if the input of the cross join gets optimized). For cross join, it does not allow mismatch
@@ -147,16 +243,21 @@ public class RandomizeNullKeyInOuterJoin
                 return result;
             }
 
-            List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
-                    .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
-                    .collect(toImmutableList());
-            if (candidateEquiJoinClauses.isEmpty()) {
-                PlanNode result = context.defaultRewrite(joinNode, context.get());
-                return result;
-            }
-
             PlanNode rewrittenLeft = context.rewrite(joinNode.getLeft(), context.get());
             PlanNode rewrittenRight = context.rewrite(joinNode.getRight(), context.get());
+
+            List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
+                    .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
+                    .filter(x -> strategy.equals(ALWAYS) || (strategy.equals(KEY_FROM_OUTER_JOIN) && (context.get().contains(x.getLeft()) || context.get().contains(x.getRight()))))
+                    .collect(toImmutableList());
+            if (candidateEquiJoinClauses.isEmpty()) {
+                PlanNode result = replaceChildren(joinNode, ImmutableList.of(rewrittenLeft, rewrittenRight));
+                if (strategy.equals(KEY_FROM_OUTER_JOIN)) {
+                    checkState(result instanceof JoinNode);
+                    updateCandidates((JoinNode) result, context);
+                }
+                return result;
+            }
 
             List<VariableReferenceExpression> leftJoinKeys = candidateEquiJoinClauses.stream()
                     .map(x -> x.getLeft())
@@ -195,7 +296,9 @@ public class RandomizeNullKeyInOuterJoin
             joinOutputBuilder.addAll(rightKeyRandomVariableMap.keySet());
             joinOutputBuilder.addAll(joinNode.getOutputVariables());
 
-            return new JoinNode(
+            session.getOptimizerInformationCollector().addInformation(
+                    new PlanOptimizerInformation(RandomizeNullKeyInOuterJoin.class.getSimpleName(), true, Optional.empty()));
+            JoinNode newJoinNode = new JoinNode(
                     joinNode.getSourceLocation(),
                     joinNode.getId(),
                     joinNode.getStatsEquivalentPlanNode(),
@@ -209,6 +312,10 @@ public class RandomizeNullKeyInOuterJoin
                     joinNode.getRightHashVariable(),
                     joinNode.getDistributionType(),
                     joinNode.getDynamicFilters());
+            if (strategy.equals(KEY_FROM_OUTER_JOIN)) {
+                updateCandidates(newJoinNode, context);
+            }
+            return newJoinNode;
         }
 
         private RowExpression randomizeJoinKey(RowExpression keyExpression, String prefix)
@@ -258,6 +365,20 @@ public class RandomizeNullKeyInOuterJoin
                     .collect(toImmutableMap(randomVariable::get, randomExpressions::get));
 
             return result;
+        }
+
+        private void updateCandidates(JoinNode joinNode, RewriteContext<Set<VariableReferenceExpression>> context)
+        {
+            if (joinNode.getType().equals(LEFT)) {
+                context.get().addAll(joinNode.getOutputVariables().stream().filter(x -> joinNode.getRight().getOutputVariables().contains(x)).collect(toImmutableSet()));
+            }
+            else if (joinNode.getType().equals(RIGHT)) {
+                context.get().addAll(joinNode.getOutputVariables().stream().filter(x -> joinNode.getLeft().getOutputVariables().contains(x)).collect(toImmutableSet()));
+            }
+            else {
+                checkState(joinNode.getType().equals(FULL));
+                context.get().addAll(joinNode.getOutputVariables());
+            }
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
@@ -212,6 +213,7 @@ public class TestFeaturesConfig
                 .setNativeExecutionEnabled(false)
                 .setNativeExecutionExecutablePath("./presto_server")
                 .setRandomizeOuterJoinNullKeyEnabled(false)
+                .setRandomizeOuterJoinNullKeyStrategy(RandomizeOuterJoinNullKeyStrategy.DISABLED)
                 .setOptimizeConditionalAggregationEnabled(false)
                 .setRemoveRedundantDistinctAggregationEnabled(true)
                 .setInPredicatesAsInnerJoinsEnabled(false)
@@ -381,6 +383,7 @@ public class TestFeaturesConfig
                 .put("native-execution-enabled", "true")
                 .put("native-execution-executable-path", "/bin/echo")
                 .put("optimizer.randomize-outer-join-null-key", "true")
+                .put("optimizer.randomize-outer-join-null-key-strategy", "key_from_outer_join")
                 .put("optimizer.optimize-conditional-aggregation-enabled", "true")
                 .put("optimizer.remove-redundant-distinct-aggregation-enabled", "false")
                 .put("optimizer.in-predicates-as-inner-joins-enabled", "true")
@@ -548,6 +551,7 @@ public class TestFeaturesConfig
                 .setNativeExecutionEnabled(true)
                 .setNativeExecutionExecutablePath("/bin/echo")
                 .setRandomizeOuterJoinNullKeyEnabled(true)
+                .setRandomizeOuterJoinNullKeyStrategy(RandomizeOuterJoinNullKeyStrategy.KEY_FROM_OUTER_JOIN)
                 .setOptimizeConditionalAggregationEnabled(true)
                 .setRemoveRedundantDistinctAggregationEnabled(false)
                 .setInPredicatesAsInnerJoinsEnabled(true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
+import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
@@ -34,10 +35,19 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 public class TestRandomizeNullKeyInOuterJoin
         extends BasePlanTest
 {
-    private Session enableOptimization()
+    private Session getSessionAlwaysEnabled()
     {
         return Session.builder(this.getQueryRunner().getDefaultSession())
                 .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, "true")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .build();
+    }
+
+    private Session getSessionEnabledWhenJoinKeyFromOuterJoin()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, "false")
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY, "key_from_outer_join")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
                 .build();
     }
@@ -46,7 +56,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testLeftJoin()
     {
         assertPlan("SELECT * FROM orders LEFT JOIN lineitem ON orders.orderkey = lineitem.orderkey",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 LEFT,
@@ -66,7 +76,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testRightJoin()
     {
         assertPlan("SELECT * FROM orders RIGHT JOIN lineitem ON orders.orderkey = lineitem.orderkey ",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 RIGHT,
@@ -86,7 +96,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testLeftJoinOnSameKey()
     {
         assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 LEFT,
@@ -113,7 +123,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testLeftJoinOnDifferentKey()
     {
         assertPlan("select * from part p left join lineitem l on p.partkey = l.partkey left join orders o on l.orderkey = o.orderkey",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 LEFT,
@@ -142,7 +152,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testLeftJoinOnMixedKey()
     {
         assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey left join orders o on l.orderkey = o.orderkey",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(LEFT,
                                 ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
@@ -174,10 +184,39 @@ public class TestRandomizeNullKeyInOuterJoin
     }
 
     @Test
+    public void testJoinKeyFromOuterJoin()
+    {
+        assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey left join orders o on l.orderkey = o.orderkey",
+                getSessionEnabledWhenJoinKeyFromOuterJoin(),
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                anyTree(
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                join(
+                                                        LEFT,
+                                                        ImmutableList.of(equiJoinClause("ps_partkey", "l_partkey")),
+                                                        join(
+                                                                LEFT,
+                                                                ImmutableList.of(equiJoinClause("ps_partkey", "p_partkey")),
+                                                                anyTree(
+                                                                        tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey"))),
+                                                                anyTree(
+                                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
+                                                        anyTree(
+                                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey")))))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
+                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                false);
+    }
+
+    @Test
     public void testCrossJoin()
     {
         assertPlan("SELECT * FROM orders CROSS JOIN lineitem",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 INNER,
@@ -192,7 +231,7 @@ public class TestRandomizeNullKeyInOuterJoin
     public void testCrossJoinOverLeftJoin()
     {
         assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey CROSS JOIN lineitem l",
-                enableOptimization(),
+                getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 INNER,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.SystemSessionProperties.PREFILTER_FOR_GROUPBY_
 import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID;
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
+import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -6242,6 +6243,11 @@ public abstract class AbstractTestQueries
 
         String multipleJoin = "SELECT o.orderkey, l.partkey, p.name FROM orders o LEFT JOIN lineitem l ON o.orderkey = l.orderkey LEFT JOIN part p ON l.partkey=p.partkey";
         assertQuery(enableRandomize, multipleJoin, getSession(), multipleJoin);
+
+        Session enableKeyFromOuterJoin = Session.builder(getSession())
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY, "key_from_outer_join")
+                .build();
+        assertQuery(enableKeyFromOuterJoin, multipleJoin, getSession(), multipleJoin);
     }
 
     @Test


### PR DESCRIPTION
Fix the issue https://github.com/prestodb/presto/issues/17657

We have an optimization rule `RandomizeNullKeyInOuterJoin` which mitigates null skew in outer join (many join keys with null value). One query pattern which could lead to null skew is the case when the join key is from an outer join (output from right side of a left join, left side of a right join, and both sides of a full outer join). One example is `A LOJ B ON A.x=B.x LOJ C ON B.y = C.y` listed in the issue, where B.y can have many nulls. In this PR, I enable the optimization if detecting such query pattern.

### Test plan - (Please fill in how you tested your changes)
Add a unit test.

The test of a production query (20230312_084012_00014_bcv47) shows that the latency changed from failed with timeout to less than 2 minutes!

```
== RELEASE NOTES ==

General Changes
* Enable optimization for outer join where the join key is from the output of another outer join which 
  can have many null values. The optimization is controlled by session property
 `randomize_outer_join_null_key_strategy`.

```
