### PR TITLE
Update maven-gpg-plugin to enable artifact signing in mvn deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2448,6 +2448,26 @@
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Test: the update was tested in a release Jenkins pipeline, and is needed to run `mvn deploy`.

```
== NO RELEASE NOTE ==
```
