### PR TITLE
Fix filter evaluation on CHAR(n) dictionary columns in SliceDictionarySelectiveReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -76,7 +76,7 @@ public class SelectiveReaderContext
     }
 
     @Nullable
-    public TupleDomainFilter getRowGroupFilter(BooleanInputStream presentStream)
+    public TupleDomainFilter getFilter(BooleanInputStream presentStream)
     {
         if (isOutputRequired() && presentStream == null && filter == TupleDomainFilter.IS_NOT_NULL) {
             // Readers don't handle the outputRequired == false and filter = null. When that is fixed

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -237,13 +237,8 @@ public class SliceDictionarySelectiveReader
                 boolean inRowDictionary = inDictionaryStream != null && !inDictionaryStream.nextBit();
                 int rawIndex = toIntExact(dataStream.next());
                 int index = inRowDictionary ? stripeDictionarySize + rawIndex : rawIndex;
-                int length;
-                if (isCharType) {
-                    length = maxCodePointCount;
-                }
-                else {
-                    length = inRowDictionary ? rowGroupDictionaryLength[rawIndex] : stripeDictionaryLength[rawIndex];
-                }
+                int length = dictionaryOffsetVector[index + 1] - dictionaryOffsetVector[index];
+
                 if (evaluationStatus == null) {
                     evaluateFilter(position, index, length);
                 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -361,10 +361,29 @@ public class OrcTester
     public void testRoundTrip(Type type, List<?> readValues, List<Map<Subfield, TupleDomainFilter>> filters)
             throws Exception
     {
-        List<Map<Integer, Map<Subfield, TupleDomainFilter>>> columnFilters = filters.stream().map(filter -> ImmutableMap.of(0, filter)).collect(toImmutableList());
+        testRoundTrip(type, readValues, filters, filters);
+    }
+
+    /**
+     *
+     * @param type          Presto data type for the readValues.
+     * @param readValues    The values to be written, read and compared against.
+     * @param columnFilters The filters for the readers. For CHAR(n) values, the columnFilters should remove the paddings.
+     * @param valuesFilters The filters for the readValues. For CHAR(n) values, valuesFilters keeps the original paddings.
+     * @throws Exception
+     */
+    public void testRoundTrip(
+            Type type,
+            List<?> readValues,
+            List<Map<Subfield, TupleDomainFilter>> columnFilters,
+            List<Map<Subfield, TupleDomainFilter>> valuesFilters)
+            throws Exception
+    {
+        List<Map<Integer, Map<Subfield, TupleDomainFilter>>> streamReaderFilters = columnFilters.stream().map(filter -> ImmutableMap.of(0, filter)).collect(toImmutableList());
+        List<Map<Integer, Map<Subfield, TupleDomainFilter>>> expectedValuesFilters = valuesFilters.stream().map(filter -> ImmutableMap.of(0, filter)).collect(toImmutableList());
 
         // just the values
-        testRoundTripTypes(ImmutableList.of(type), ImmutableList.of(readValues), columnFilters);
+        testRoundTripTypes(ImmutableList.of(type), ImmutableList.of(readValues), streamReaderFilters, expectedValuesFilters);
 
         // all nulls
         if (nullTestsEnabled) {
@@ -373,7 +392,8 @@ public class OrcTester
                     readValues.stream()
                             .map(value -> null)
                             .collect(toList()),
-                    columnFilters);
+                    streamReaderFilters,
+                    expectedValuesFilters);
         }
 
         // values wrapped in struct
@@ -522,10 +542,21 @@ public class OrcTester
     public void testRoundTripTypes(List<Type> types, List<List<?>> readValues, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters)
             throws Exception
     {
-        testRoundTripTypes(types, readValues, filters, ImmutableList.of());
+        testRoundTripTypes(types, readValues, filters, filters);
     }
 
-    public void testRoundTripTypes(List<Type> types, List<List<?>> readValues, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters, List<List<Integer>> expectedFilterOrder)
+    public void testRoundTripTypes(List<Type> types, List<List<?>> readValues, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> valuesFilters)
+            throws Exception
+    {
+        testRoundTripTypes(types, readValues, filters, valuesFilters, ImmutableList.of());
+    }
+
+    public void testRoundTripTypes(
+            List<Type> types,
+            List<List<?>> readValues,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> valuesfilters,
+            List<List<Integer>> expectedFilterOrder)
             throws Exception
     {
         assertEquals(types.size(), readValues.size());
@@ -534,20 +565,20 @@ public class OrcTester
         }
 
         // forward order
-        assertRoundTrip(types, readValues, filters, expectedFilterOrder);
+        assertRoundTrip(types, readValues, filters, valuesfilters, expectedFilterOrder);
 
         // reverse order
         if (reverseTestsEnabled) {
-            assertRoundTrip(types, Lists.transform(readValues, OrcTester::reverse), filters, expectedFilterOrder);
+            assertRoundTrip(types, Lists.transform(readValues, OrcTester::reverse), filters, valuesfilters, expectedFilterOrder);
         }
 
         if (nullTestsEnabled) {
             // forward order with nulls
-            assertRoundTrip(types, insertNulls(types, readValues), filters, expectedFilterOrder);
+            assertRoundTrip(types, insertNulls(types, readValues), filters, valuesfilters, expectedFilterOrder);
 
             // reverse order with nulls
             if (reverseTestsEnabled) {
-                assertRoundTrip(types, insertNulls(types, Lists.transform(readValues, OrcTester::reverse)), filters, expectedFilterOrder);
+                assertRoundTrip(types, insertNulls(types, Lists.transform(readValues, OrcTester::reverse)), filters, valuesfilters, expectedFilterOrder);
             }
         }
     }
@@ -559,7 +590,7 @@ public class OrcTester
         assertEquals(filters.size(), expectedFilterOrder.size());
 
         // Forward order
-        testRoundTripTypes(types, readValues, filters, expectedFilterOrder);
+        testRoundTripTypes(types, readValues, filters, filters, expectedFilterOrder);
 
         // Reverse order
         int columnCount = types.size();
@@ -569,7 +600,7 @@ public class OrcTester
         List<List<Integer>> reverseFilterOrder = expectedFilterOrder.stream()
                 .map(columns -> columns.stream().map(column -> columnCount - 1 - column).collect(toImmutableList()))
                 .collect(toImmutableList());
-        testRoundTripTypes(Lists.reverse(types), Lists.reverse(readValues), reverseFilters, reverseFilterOrder);
+        testRoundTripTypes(Lists.reverse(types), Lists.reverse(readValues), reverseFilters, reverseFilters, reverseFilterOrder);
     }
 
     private List<List<?>> insertNulls(List<Type> types, List<List<?>> values)
@@ -590,17 +621,29 @@ public class OrcTester
     public void assertRoundTripWithSettings(Type type, List<?> readValues, List<OrcReaderSettings> settings)
             throws Exception
     {
+        if (settings != null) {
+            for (OrcReaderSettings setting : settings) {
+                if (setting.expectedValuesFilters.isEmpty() && !setting.columnFilters.isEmpty()) {
+                    setting.setExpectedValuesFilters(setting.columnFilters);
+                }
+            }
+        }
         assertRoundTrip(type, type, readValues, readValues, true, settings);
     }
 
-    public void assertRoundTrip(Type type, List<?> readValues, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters)
+    public void assertRoundTrip(
+            Type type,
+            List<?> readValues,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> valuesFilters)
             throws Exception
     {
-        List<OrcReaderSettings> settings = filters.stream()
-                .map(entry -> OrcReaderSettings.builder().setColumnFilters(entry).build())
-                .collect(toImmutableList());
+        ImmutableList.Builder<OrcReaderSettings> settingsBuilder = ImmutableList.builder();
+        for (int i = 0; i < filters.size(); i++) {
+            settingsBuilder.add(OrcReaderSettings.builder().setColumnFilters(filters.get(i)).setExpectedValuesFilters(valuesFilters.get(i)).build());
+        }
 
-        assertRoundTrip(type, type, readValues, readValues, true, settings);
+        assertRoundTrip(type, type, readValues, readValues, true, settingsBuilder.build());
     }
 
     public void assertRoundTrip(Type type, List<?> readValues, boolean verifyWithHiveReader)
@@ -609,12 +652,17 @@ public class OrcTester
         assertRoundTrip(type, type, readValues, readValues, verifyWithHiveReader, ImmutableList.of());
     }
 
-    public void assertRoundTrip(List<Type> types, List<List<?>> readValues, List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters, List<List<Integer>> expectedFilterOrder)
+    public void assertRoundTrip(
+            List<Type> types, List<List<?>> readValues,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> columnFilters,
+            List<Map<Integer, Map<Subfield, TupleDomainFilter>>> readValuesFilters,
+            List<List<Integer>> expectedFilterOrder)
             throws Exception
     {
-        List<OrcReaderSettings> settings = IntStream.range(0, filters.size())
+        List<OrcReaderSettings> settings = IntStream.range(0, columnFilters.size())
                 .mapToObj(i -> OrcReaderSettings.builder()
-                        .setColumnFilters(filters.get(i))
+                        .setColumnFilters(columnFilters.get(i))
+                        .setExpectedValuesFilters(readValuesFilters.get(i))
                         .setExpectedFilterOrder(expectedFilterOrder.isEmpty() ? ImmutableList.of() : expectedFilterOrder.get(i))
                         .build())
                 .collect(toImmutableList());
@@ -749,8 +797,13 @@ public class OrcTester
         private final Map<Integer, List<Subfield>> requiredSubfields;
         private final OrcFileTailSource orcFileTailSource;
 
+        // The filter for the expected values. Normally they are the same as the columnFilters which are passed to the StreamReaders. But when the data type is CHAR(n), the filter
+        // for the StreamReader would be trimmed without paddings, therefore the filters for the expected values need to be stored separately.
+        private Map<Integer, Map<Subfield, TupleDomainFilter>> expectedValuesFilters;
+
         private OrcReaderSettings(
                 Map<Integer, Map<Subfield, TupleDomainFilter>> columnFilters,
+                Map<Integer, Map<Subfield, TupleDomainFilter>> expectedValuesFilters,
                 List<Integer> expectedFilterOrder,
                 List<FilterFunction> filterFunctions,
                 Map<Integer, Integer> filterFunctionInputMapping,
@@ -758,6 +811,7 @@ public class OrcTester
                 OrcFileTailSource orcFileTailSource)
         {
             this.columnFilters = requireNonNull(columnFilters, "columnFilters is null");
+            this.expectedValuesFilters = requireNonNull(expectedValuesFilters, "expectedValuesFilters is null");
             this.expectedFilterOrder = requireNonNull(expectedFilterOrder, "expectedFilterOrder is null");
             this.filterFunctions = requireNonNull(filterFunctions, "filterFunctions is null");
             this.filterFunctionInputMapping = requireNonNull(filterFunctionInputMapping, "filterFunctionInputMapping is null");
@@ -768,6 +822,16 @@ public class OrcTester
         public Map<Integer, Map<Subfield, TupleDomainFilter>> getColumnFilters()
         {
             return columnFilters;
+        }
+
+        public Map<Integer, Map<Subfield, TupleDomainFilter>> getExpectedValuesFilters()
+        {
+            return expectedValuesFilters;
+        }
+
+        public void setExpectedValuesFilters(Map<Integer, Map<Subfield, TupleDomainFilter>> filters)
+        {
+            expectedValuesFilters = filters;
         }
 
         public List<Integer> getExpectedFilterOrder()
@@ -803,6 +867,7 @@ public class OrcTester
         public static class Builder
         {
             private Map<Integer, Map<Subfield, TupleDomainFilter>> columnFilters = ImmutableMap.of();
+            private Map<Integer, Map<Subfield, TupleDomainFilter>> expectedValuesFilters = ImmutableMap.of();
             private List<Integer> expectedFilterOrder = ImmutableList.of();
             private List<FilterFunction> filterFunctions = ImmutableList.of();
             private Map<Integer, Integer> filterFunctionInputMapping = ImmutableMap.of();
@@ -812,6 +877,12 @@ public class OrcTester
             public Builder setColumnFilters(Map<Integer, Map<Subfield, TupleDomainFilter>> columnFilters)
             {
                 this.columnFilters = requireNonNull(columnFilters, "columnFilters is null");
+                return this;
+            }
+
+            public Builder setExpectedValuesFilters(Map<Integer, Map<Subfield, TupleDomainFilter>> expectedValuesFilters)
+            {
+                this.expectedValuesFilters = requireNonNull(expectedValuesFilters, "expectedValuesFilters is null");
                 return this;
             }
 
@@ -855,7 +926,7 @@ public class OrcTester
 
             public OrcReaderSettings build()
             {
-                return new OrcReaderSettings(columnFilters, expectedFilterOrder, filterFunctions, filterFunctionInputMapping, requiredSubfields, orcFileTailSource);
+                return new OrcReaderSettings(columnFilters, expectedValuesFilters, expectedFilterOrder, filterFunctions, filterFunctionInputMapping, requiredSubfields, orcFileTailSource);
             }
         }
     }
@@ -1035,7 +1106,8 @@ public class OrcTester
                 assertTrue(entry.getFilterFunctionInputMapping().isEmpty(), "Filter functions are not supported yet");
 
                 Map<Integer, Map<Subfield, TupleDomainFilter>> columnFilters = entry.getColumnFilters();
-                List<List<?>> prunedAndFilteredRows = pruneValues(types, filterRows(types, expectedValues, columnFilters), entry.getRequiredSubfields());
+                Map<Integer, Map<Subfield, TupleDomainFilter>> valuesFilters = entry.getExpectedValuesFilters();
+                List<List<?>> prunedAndFilteredRows = pruneValues(types, filterRows(types, expectedValues, valuesFilters), entry.getRequiredSubfields());
 
                 Optional<TupleDomainFilterOrderChecker> orderChecker = Optional.empty();
                 List<Integer> expectedFilterOrder = entry.getExpectedFilterOrder();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1252,6 +1252,32 @@ public abstract class AbstractTestDistributedQueries
         assertEquals((Long) countStarQuery.getOnlyValue(), 60175);
     }
 
+    @Test
+    public void testStringFilters()
+    {
+        assertUpdate("CREATE TABLE test_charn_filter (shipmode CHAR(10))");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_charn_filter"));
+        assertTableColumnNames("test_charn_filter", "shipmode");
+        assertUpdate("INSERT INTO test_charn_filter SELECT shipmode FROM lineitem", 60175);
+
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'AIR'", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'AIR    '", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'AIR       '", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'AIR            '", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'NONEXIST'", "VALUES (0)");
+
+        assertUpdate("CREATE TABLE test_varcharn_filter (shipmode VARCHAR(10))");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_varcharn_filter"));
+        assertTableColumnNames("test_varcharn_filter", "shipmode");
+        assertUpdate("INSERT INTO test_varcharn_filter SELECT shipmode FROM lineitem", 60175);
+
+        assertQuery("SELECT count(*) FROM test_varcharn_filter WHERE shipmode = 'AIR'", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_varcharn_filter WHERE shipmode = 'AIR    '", "VALUES (0)");
+        assertQuery("SELECT count(*) FROM test_varcharn_filter WHERE shipmode = 'AIR       '", "VALUES (0)");
+        assertQuery("SELECT count(*) FROM test_varcharn_filter WHERE shipmode = 'AIR            '", "VALUES (0)");
+        assertQuery("SELECT count(*) FROM test_varcharn_filter WHERE shipmode = 'NONEXIST'", "VALUES (0)");
+    }
+
     private String sanitizePlan(String explain)
     {
         return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX");


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/19138

When a filter for a column of CHAR(n) type is pushed down to the stream readers, the padded spaces would be removed. This is different than the filter on VARCHAR(n), where the trailing spaces would be preserved. 
For example, `c = 'AIR         '` would be come `c = 'AIR'` when `SliceDictionarySelectiveReader` takes it at construction time. However the existing code still thinks the filter is with paddings therefore causing the bug in https://github.com/prestodb/presto/issues/19138. When testing a value's length while evaluating the filter on CHAR(n), it is incorrect to use the `maxCodePointCount`(n in CHAR(n)) as the value's length. Instead, the filter's length shall be compared with the value's real length, which was already calculated and stored in `dictionaryOffsetVector`. The tests are updated to take filters with paddings removed.

```
== RELEASE NOTES ==
Hive Changes
* Fix a bug where the filter on a CHAR(n) column is not evaluated correctly for ORC/DWRF files when filter pushdown is enabled.
```
