### PR TITLE
Fix native execution process shutdown hanging issue

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -42,6 +42,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.HttpStatus.OK;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
@@ -148,6 +149,20 @@ public class NativeExecutionProcess
     {
         if (process != null && process.isAlive()) {
             process.destroy();
+            try {
+                // For native process it takes 10s to initiate SHUTDOWN. The task cleanup interval is 60s. To be sure task cleanup is run at least once we just roughly double the
+                // wait time.
+                process.waitFor(120, TimeUnit.SECONDS);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                if (process.isAlive()) {
+                    log.warn("Graceful shutdown of native execution process failed. Force killing it.");
+                    process.destroyForcibly();
+                }
+            }
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
@@ -159,6 +159,7 @@ public class NativeExecutionTask
     {
         taskInfoFetcher.stop();
         taskResultFetcher.stop();
+        workerClient.abortResults();
     }
 
     private CompletableFuture<Void> sendUpdateRequest()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
@@ -189,6 +189,7 @@ public class NativeExecutionOperator
             this.process = processFactory.createNativeExecutionProcess(
                     operatorContext.getSession(),
                     URI.create(NATIVE_EXECUTION_SERVER_URI));
+            log.info("Starting native execution process of task" + getOperatorContext().getDriverContext().getTaskId().toString());
             process.start();
         }
         catch (ExecutionException | InterruptedException | IOException e) {
@@ -277,6 +278,7 @@ public class NativeExecutionOperator
             task.stop();
         }
         if (process != null) {
+            log.info("Closing native execution process for task " + getOperatorContext().getDriverContext().getTaskId().toString());
             process.close();
         }
     }


### PR DESCRIPTION
Current native execution shutdown does not abort the task. This can cause a left over result fetching request to create a shell task that is in running state in native process. The running task will then prevent native process to shutdown, causing a lingering scenario.
This PR resolves the issue by issuing an abort task request before shutting down so that there will not be any running tasks when shutdown is triggered. The PR also adds a force shutdown mechanism if things go wrong. 
```
== NO RELEASE NOTE ==
```
