### PR TITLE
[native] Export SSD counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -125,6 +125,32 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeAllocClocks,
       facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumAllocClocks, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeReadEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheReadEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeReadBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheReadBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeWrittenEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheWrittenEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeWrittenBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheWrittenBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeCachedEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCachedEntries, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeCachedBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCachedBytes, facebook::velox::StatType::AVG);
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -197,4 +197,28 @@ constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAllocClocks{
 // entries, since last counter retrieval
 constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
     "presto_cpp.memory_cache_num_alloc_clocks"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeReadEntries{
+    "presto_cpp.ssd_cache_cumulative_read_entries"};
+constexpr folly::StringPiece kCounterSsdCacheReadEntries{
+    "presto_cpp.ssd_cache_read_entries"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeReadBytes{
+    "presto_cpp.ssd_cache_cumulative_read_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheReadBytes{
+    "presto_cpp.ssd_cache_read_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenEntries{
+    "presto_cpp.ssd_cache_cumulative_written_entries"};
+constexpr folly::StringPiece kCounterSsdCacheWrittenEntries{
+    "presto_cpp.ssd_cache_written_entries"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenBytes{
+    "presto_cpp.ssd_cache_cumulative_written_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheWrittenBytes{
+    "presto_cpp.ssd_cache_written_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedEntries{
+    "presto_cpp.ssd_cache_cumulative_cached_entries"};
+constexpr folly::StringPiece kCounterSsdCacheCachedEntries{
+    "presto_cpp.ssd_cache_cached_entries"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedBytes{
+    "presto_cpp.ssd_cache_cumulative_cached_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheCachedBytes{
+    "presto_cpp.ssd_cache_cached_bytes"};
 } // namespace facebook::presto


### PR DESCRIPTION
Export the following SSD counters
    "presto_cpp.ssd_cache_cumulative_read_bytes"
    "presto_cpp.ssd_cache_read_bytes"
    "presto_cpp.ssd_cache_cumulative_written_bytes"
    "presto_cpp.ssd_cache_written_bytes"
    "presto_cpp.ssd_cache_cumulative_cached_bytes"
    "presto_cpp.ssd_cache_cached_bytes"

```
== NO RELEASE NOTE ==
```
