### PR TITLE
[native] Export OS counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -58,6 +58,14 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterTotalPartitionedOutputBuffer, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterCumulativeUserCpuTimeMicros, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterCumulativeSystemCpuTimeMicros, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterNumCumulativeSoftPageFaults, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterNumCumulativeHardPageFaults, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMappedMemoryRawAllocBytesSmall, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMappedMemoryRawAllocBytesSizeClass,
@@ -114,8 +122,6 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeAllocClocks,
       facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterMemoryCacheNumAllocClocks, facebook::velox::StatType::AVG);
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -64,6 +64,25 @@ constexpr folly::StringPiece kCounterNumBlockedDrivers{
 constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{
     "presto_cpp.num_partitioned_output_buffer"};
 
+// ================== OS Counters =================
+
+// User CPU time of the presto_server process in microsecond since the process
+// start.
+constexpr folly::StringPiece kCounterCumulativeUserCpuTimeMicros{
+    "presto_cpp.cumulative_user_cpu_time_micros"};
+// System CPU time of the presto_server process in microsecond since the process
+// start.
+constexpr folly::StringPiece kCounterCumulativeSystemCpuTimeMicros{
+    "presto_cpp.cumulative_system_cpu_time_micros"};
+// Total number of soft page faults of the presto_server process in microsecond
+// since the process start.
+constexpr folly::StringPiece kCounterNumCumulativeSoftPageFaults{
+    "presto_cpp.num_cumulative_soft_page_faults"};
+// Total number of hard page faults of the presto_server process in microsecond
+// since the process start.
+constexpr folly::StringPiece kCounterNumCumulativeHardPageFaults{
+    "presto_cpp.num_cumulative_hard_page_faults"};
+
 // ================== Memory Counters =================
 
 // Number of bytes of memory MappedMemory currently maps (RSS). It also includes


### PR DESCRIPTION
Export the following OS counters
    "presto_cpp.cumulative_user_cpu_time_micros"
    "presto_cpp.cumulative_system_cpu_time_micros"
    "presto_cpp.num_cumulative_soft_page_faults"
    "presto_cpp.num_cumulative_hard_page_faults"

```
== NO RELEASE NOTE ==
```
