### PR TITLE
Add access control flow in pluggable analyzer framework

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -859,7 +859,12 @@ public class Analysis
         return ImmutableMap.copyOf(utilizedTableColumnReferences);
     }
 
-    public Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> getTableColumnAndSubfieldReferencesForAccessControl(boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)
+    public void populateTableColumnAndSubfieldReferencesForAccessControl(boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)
+    {
+        accessControlReferences.setTableColumnAndSubfieldReferencesForAccessControl(getTableColumnAndSubfieldReferencesForAccessControl(checkAccessControlOnUtilizedColumnsOnly, checkAccessControlWithSubfields));
+    }
+
+    private Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> getTableColumnAndSubfieldReferencesForAccessControl(boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)
     {
         Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> references;
         if (!checkAccessControlWithSubfields) {

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.security.AccessControl;
@@ -63,7 +64,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -1106,55 +1106,6 @@ public class Analysis
         public boolean isVisiting()
         {
             return this.value == VISITING.value;
-        }
-    }
-
-    public static final class AccessControlInfo
-    {
-        private final AccessControl accessControl;
-        private final Identity identity;
-
-        public AccessControlInfo(AccessControl accessControl, Identity identity)
-        {
-            this.accessControl = requireNonNull(accessControl, "accessControl is null");
-            this.identity = requireNonNull(identity, "identity is null");
-        }
-
-        public AccessControl getAccessControl()
-        {
-            return accessControl;
-        }
-
-        public Identity getIdentity()
-        {
-            return identity;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            AccessControlInfo that = (AccessControlInfo) o;
-            return Objects.equals(accessControl, that.accessControl) &&
-                    Objects.equals(identity, that.identity);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(accessControl, identity);
-        }
-
-        @Override
-        public String toString()
-        {
-            return format("AccessControl: %s, Identity: %s", accessControl.getClass(), identity);
         }
     }
 }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.QueryAnalysis;
 import com.facebook.presto.spi.function.FunctionKind;
 
@@ -51,5 +52,11 @@ public class BuiltInQueryAnalysis
     public Map<FunctionKind, Set<String>> getInvokedFunctions()
     {
         return analysis.getInvokedFunctions();
+    }
+
+    @Override
+    public AccessControlReferences getAccessControlReferences()
+    {
+        return analysis.getAccessControlReferences();
     }
 }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
@@ -13,9 +13,13 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.QueryAnalysis;
 import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.sql.tree.Explain;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Map;
 import java.util.Optional;
@@ -58,5 +62,28 @@ public class BuiltInQueryAnalysis
     public AccessControlReferences getAccessControlReferences()
     {
         return analysis.getAccessControlReferences();
+    }
+
+    @Override
+    public boolean isExplainAnalyzeQuery()
+    {
+        return analysis.getStatement() instanceof Explain && ((Explain) analysis.getStatement()).isAnalyze();
+    }
+
+    @Override
+    public Set<ConnectorId> extractConnectors()
+    {
+        ImmutableSet.Builder<ConnectorId> connectors = ImmutableSet.builder();
+
+        for (TableHandle tableHandle : analysis.getTables()) {
+            connectors.add(tableHandle.getConnectorId());
+        }
+
+        if (analysis.getInsert().isPresent()) {
+            TableHandle target = analysis.getInsert().get().getTarget();
+            connectors.add(target.getConnectorId());
+        }
+
+        return connectors.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -561,8 +561,8 @@ public class SqlQueryExecution
             // record analysis time
             stateMachine.endAnalysis();
 
-            boolean explainAnalyze = queryAnalyzer.isExplainAnalyzeQuery(queryAnalysis);
-            return new PlanRoot(fragmentedPlan, !explainAnalyze, queryAnalyzer.extractConnectors(queryAnalysis));
+            boolean explainAnalyze = queryAnalysis.isExplainAnalyzeQuery();
+            return new PlanRoot(fragmentedPlan, !explainAnalyze, queryAnalysis.extractConnectors());
         }
         catch (StackOverflowError e) {
             throw new PrestoException(NOT_SUPPORTED, "statement is too large (stack overflow during analysis)", e);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -94,6 +94,7 @@ import static com.facebook.presto.execution.buffer.OutputBuffers.createSpoolingO
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED;
 import static com.facebook.presto.sql.planner.PlanNodeCanonicalInfo.getCanonicalInfo;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static com.facebook.presto.util.AnalyzerUtil.getAnalyzerContext;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -206,7 +207,7 @@ public class SqlQueryExecution
             stateMachine.setExpandedQuery(queryAnalysis.getExpandedQuery());
 
             stateMachine.beginColumnAccessPermissionChecking();
-            queryAnalyzer.checkAccessPermissions(analyzerContext, queryAnalysis);
+            checkAccessPermissions(queryAnalysis.getAccessControlReferences());
             stateMachine.endColumnAccessPermissionChecking();
 
             // when the query finishes cache the final query info, and clear the reference to the output stage

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -42,7 +42,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractWindow
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.UtilizedColumnsAnalyzer.analyzeForUtilizedColumns;
-import static com.facebook.presto.util.AnalyzerUtil.checkAccessControlPermissions;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static java.util.Objects.requireNonNull;
 
 public class Analyzer
@@ -85,7 +85,7 @@ public class Analyzer
     public Analysis analyze(Statement statement, boolean isDescribe)
     {
         Analysis analysis = analyzeSemantic(statement, isDescribe);
-        checkAccessControlPermissions(analysis);
+        checkAccessPermissions(analysis.getAccessControlReferences());
         return analysis;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -85,7 +85,7 @@ public class Analyzer
     public Analysis analyze(Statement statement, boolean isDescribe)
     {
         Analysis analysis = analyzeSemantic(statement, isDescribe);
-        checkAccessControlPermissions(analysis, isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session));
+        checkAccessControlPermissions(analysis);
         return analysis;
     }
 
@@ -96,6 +96,7 @@ public class Analyzer
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session, warningCollector);
         analyzer.analyze(rewrittenStatement, Optional.empty());
         analyzeForUtilizedColumns(analysis, analysis.getStatement());
+        analysis.populateTableColumnAndSubfieldReferencesForAccessControl(isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session));
         return analysis;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractWindow
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.UtilizedColumnsAnalyzer.analyzeForUtilizedColumns;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessControlPermissions;
 import static java.util.Objects.requireNonNull;
 
 public class Analyzer
@@ -84,7 +85,7 @@ public class Analyzer
     public Analysis analyze(Statement statement, boolean isDescribe)
     {
         Analysis analysis = analyzeSemantic(statement, isDescribe);
-        checkColumnAccessPermissions(analysis);
+        checkAccessControlPermissions(analysis, isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session));
         return analysis;
     }
 
@@ -96,23 +97,6 @@ public class Analyzer
         analyzer.analyze(rewrittenStatement, Optional.empty());
         analyzeForUtilizedColumns(analysis, analysis.getStatement());
         return analysis;
-    }
-
-    /**
-     * check column access permissions for each table
-     * @param analysis the Analysis that needs to check ACL for
-     */
-    public void checkColumnAccessPermissions(Analysis analysis)
-    {
-        analysis.getTableColumnAndSubfieldReferencesForAccessControl(isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session))
-                .forEach((accessControlInfo, tableColumnReferences) ->
-                tableColumnReferences.forEach((tableName, columns) ->
-                        accessControlInfo.getAccessControl().checkCanSelectFromColumns(
-                                session.getRequiredTransactionId(),
-                                accessControlInfo.getIdentity(),
-                                session.getAccessControlContext(),
-                                tableName,
-                                columns)));
     }
 
     static void verifyNoAggregateWindowOrGroupingFunctions(

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -16,8 +16,6 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.ConnectorId;
-import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.analyzer.AnalyzerContext;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
@@ -28,12 +26,9 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LogicalPlanner;
-import com.facebook.presto.sql.tree.Explain;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.google.common.base.Preconditions.checkState;
@@ -91,30 +86,5 @@ public class BuiltInQueryAnalyzer
     {
         checkState(analyzerContext instanceof BuiltInAnalyzerContext, "analyzerContext should be an instance of BuiltInAnalyzerContext");
         return new LogicalPlanner(((BuiltInAnalyzerContext) analyzerContext).getSession(), analyzerContext.getIdAllocator(), metadata, analyzerContext.getVariableAllocator()).plan(((BuiltInQueryAnalysis) queryAnalysis).getAnalysis());
-    }
-
-    @Override
-    public boolean isExplainAnalyzeQuery(QueryAnalysis queryAnalysis)
-    {
-        Analysis analysis = ((BuiltInQueryAnalysis) queryAnalysis).getAnalysis();
-        return analysis.getStatement() instanceof Explain && ((Explain) analysis.getStatement()).isAnalyze();
-    }
-
-    @Override
-    public Set<ConnectorId> extractConnectors(QueryAnalysis queryAnalysis)
-    {
-        Analysis analysis = ((BuiltInQueryAnalysis) queryAnalysis).getAnalysis();
-        ImmutableSet.Builder<ConnectorId> connectors = ImmutableSet.builder();
-
-        for (TableHandle tableHandle : analysis.getTables()) {
-            connectors.add(tableHandle.getConnectorId());
-        }
-
-        if (analysis.getInsert().isPresent()) {
-            TableHandle target = analysis.getInsert().get().getTarget();
-            connectors.add(target.getConnectorId());
-        }
-
-        return connectors.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
-import static com.facebook.presto.util.AnalyzerUtil.checkAccessControlPermissions;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -92,15 +91,6 @@ public class BuiltInQueryAnalyzer
     {
         checkState(analyzerContext instanceof BuiltInAnalyzerContext, "analyzerContext should be an instance of BuiltInAnalyzerContext");
         return new LogicalPlanner(((BuiltInAnalyzerContext) analyzerContext).getSession(), analyzerContext.getIdAllocator(), metadata, analyzerContext.getVariableAllocator()).plan(((BuiltInQueryAnalysis) queryAnalysis).getAnalysis());
-    }
-
-    @Override
-    public void checkAccessPermissions(AnalyzerContext analyzerContext, QueryAnalysis queryAnalysis)
-    {
-        checkState(analyzerContext instanceof BuiltInAnalyzerContext, "analyzerContext should be an instance of BuiltInAnalyzerContext");
-        BuiltInQueryAnalysis builtInQueryAnalysis = (BuiltInQueryAnalysis) queryAnalysis;
-        Analysis analysis = builtInQueryAnalysis.getAnalysis();
-        checkAccessControlPermissions(analysis);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -35,8 +35,6 @@ import com.google.inject.Inject;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlOnUtilizedColumnsOnly;
-import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlWithSubfields;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.facebook.presto.util.AnalyzerUtil.checkAccessControlPermissions;
 import static com.google.common.base.Preconditions.checkState;
@@ -100,11 +98,9 @@ public class BuiltInQueryAnalyzer
     public void checkAccessPermissions(AnalyzerContext analyzerContext, QueryAnalysis queryAnalysis)
     {
         checkState(analyzerContext instanceof BuiltInAnalyzerContext, "analyzerContext should be an instance of BuiltInAnalyzerContext");
-        Session session = ((BuiltInAnalyzerContext) analyzerContext).getSession();
         BuiltInQueryAnalysis builtInQueryAnalysis = (BuiltInQueryAnalysis) queryAnalysis;
         Analysis analysis = builtInQueryAnalysis.getAnalysis();
-
-        checkAccessControlPermissions(analysis, isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session));
+        checkAccessControlPermissions(analysis);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlOnUtilizedColumnsOnly;
 import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlWithSubfields;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessControlPermissions;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -101,15 +102,9 @@ public class BuiltInQueryAnalyzer
         checkState(analyzerContext instanceof BuiltInAnalyzerContext, "analyzerContext should be an instance of BuiltInAnalyzerContext");
         Session session = ((BuiltInAnalyzerContext) analyzerContext).getSession();
         BuiltInQueryAnalysis builtInQueryAnalysis = (BuiltInQueryAnalysis) queryAnalysis;
-        builtInQueryAnalysis.getAnalysis().getTableColumnAndSubfieldReferencesForAccessControl(isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session))
-                .forEach((accessControlInfo, tableColumnReferences) ->
-                        tableColumnReferences.forEach((tableName, columns) ->
-                                accessControlInfo.getAccessControl().checkCanSelectFromColumns(
-                                        session.getRequiredTransactionId(),
-                                        accessControlInfo.getIdentity(),
-                                        session.getAccessControlContext(),
-                                        tableName,
-                                        columns)));
+        Analysis analysis = builtInQueryAnalysis.getAnalysis();
+
+        checkAccessControlPermissions(analysis, isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1895,7 +1895,13 @@ public class ExpressionAnalyzer
         analysis.addFunctionHandles(resolvedFunctions);
         analysis.addColumnReferences(analyzer.getColumnReferences());
         analysis.addLambdaArgumentReferences(analyzer.getLambdaArgumentReferences());
-        analysis.addTableColumnAndSubfieldReferences(accessControl, session.getIdentity(), analyzer.getTableColumnAndSubfieldReferences(), analyzer.getTableColumnAndSubfieldReferencesForAccessControl());
+        analysis.addTableColumnAndSubfieldReferences(
+                accessControl,
+                session.getIdentity(),
+                session.getTransactionId(),
+                session.getAccessControlContext(),
+                analyzer.getTableColumnAndSubfieldReferences(),
+                analyzer.getTableColumnAndSubfieldReferencesForAccessControl());
 
         return new ExpressionAnalysis(
                 expressionTypes,

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.QualifiedObjectName;
-import com.facebook.presto.sql.analyzer.Analysis.AccessControlInfo;
+import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.sql.tree.AliasedRelation;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -264,6 +264,7 @@ import static com.facebook.presto.sql.testing.TreeAssertions.assertFormattedSql;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static com.facebook.presto.util.AnalyzerUtil.createAnalyzerOptions;
 import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
 import static com.facebook.presto.util.AnalyzerUtil.getAnalyzerContext;
@@ -1065,7 +1066,7 @@ public class LocalQueryRunner
         AnalyzerContext analyzerContext = getAnalyzerContext(queryAnalyzer, metadata.getMetadataResolver(session), idAllocator, new VariableAllocator(), session);
 
         QueryAnalysis queryAnalysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
-        queryAnalyzer.checkAccessPermissions(analyzerContext, queryAnalysis);
+        checkAccessPermissions(queryAnalysis.getAccessControlReferences());
 
         PlanNode planNode = session.getRuntimeStats().profileNanos(
                 LOGICAL_PLANNER_TIME_NANOS,

--- a/presto-main/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
@@ -96,13 +96,13 @@ public class AnalyzerUtil
         return new AnalyzerContext(metadataResolver, idAllocator, variableAllocator);
     }
 
-    public static void checkAccessControlPermissions(Analysis analysis, boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)
+    public static void checkAccessControlPermissions(Analysis analysis)
     {
         // Table checks
         checkAccessControlPermissions(analysis.getAccessControlReferences());
 
         // Table Column checks
-        analysis.getTableColumnAndSubfieldReferencesForAccessControl(checkAccessControlOnUtilizedColumnsOnly, checkAccessControlWithSubfields)
+        analysis.getAccessControlReferences().getTableColumnAndSubfieldReferencesForAccessControl()
                 .forEach((accessControlInfo, tableColumnReferences) ->
                         tableColumnReferences.forEach((tableName, columns) -> {
                             Optional<TransactionId> transactionId = accessControlInfo.getTransactionId();

--- a/presto-main/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer;
 import com.facebook.presto.sql.parser.ParsingOptions;
 
@@ -96,13 +95,17 @@ public class AnalyzerUtil
         return new AnalyzerContext(metadataResolver, idAllocator, variableAllocator);
     }
 
-    public static void checkAccessControlPermissions(Analysis analysis)
+    public static void checkAccessPermissions(AccessControlReferences accessControlReferences)
     {
         // Table checks
-        checkAccessControlPermissions(analysis.getAccessControlReferences());
-
+        checkAccessPermissionsForTable(accessControlReferences);
         // Table Column checks
-        analysis.getAccessControlReferences().getTableColumnAndSubfieldReferencesForAccessControl()
+        checkAccessPermissionsForColumns(accessControlReferences);
+    }
+
+    private static void checkAccessPermissionsForColumns(AccessControlReferences accessControlReferences)
+    {
+        accessControlReferences.getTableColumnAndSubfieldReferencesForAccessControl()
                 .forEach((accessControlInfo, tableColumnReferences) ->
                         tableColumnReferences.forEach((tableName, columns) -> {
                             Optional<TransactionId> transactionId = accessControlInfo.getTransactionId();
@@ -116,7 +119,7 @@ public class AnalyzerUtil
                         }));
     }
 
-    private static void checkAccessControlPermissions(AccessControlReferences accessControlReferences)
+    private static void checkAccessPermissionsForTable(AccessControlReferences accessControlReferences)
     {
         accessControlReferences.getTableReferences().forEach((accessControlRole, accessControlInfoForTables) -> accessControlInfoForTables.forEach(accessControlInfoForTable -> {
             AccessControlInfo accessControlInfo = accessControlInfoForTable.getAccessControlInfo();

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY;
 import static com.facebook.presto.SystemSessionProperties.CHECK_ACCESS_CONTROL_WITH_SUBFIELDS;
-import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlOnUtilizedColumnsOnly;
-import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlWithSubfields;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -198,7 +196,7 @@ public class TestColumnAndSubfieldAnalyzer
                     Statement statement = SQL_PARSER.createStatement(query);
                     Analysis analysis = analyzer.analyze(statement);
                     assertEquals(
-                            analysis.getTableColumnAndSubfieldReferencesForAccessControl(isCheckAccessControlOnUtilizedColumnsOnly(session), isCheckAccessControlWithSubfields(session))
+                            analysis.getAccessControlReferences().getTableColumnAndSubfieldReferencesForAccessControl()
                                     .values().stream().findFirst().get().entrySet().stream()
                                     .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().stream().map(Subfield::toString).collect(toImmutableSet()))),
                             expected);

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -120,7 +120,7 @@ public class TestGrantRevoke
 
         // test REVOKE
         aliceExecutor.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName)))
+        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES (1, 5)", tableName)))
                 .failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
         aliceExecutor.executeQuery(format("REVOKE INSERT, SELECT ON %s FROM bob", tableName));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfo.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.analyzer;
+
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.Identity;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class AccessControlInfo
+{
+    private final AccessControl accessControl;
+    private final Identity identity;
+
+    public AccessControlInfo(AccessControl accessControl, Identity identity)
+    {
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.identity = requireNonNull(identity, "identity is null");
+    }
+
+    public AccessControl getAccessControl()
+    {
+        return accessControl;
+    }
+
+    public Identity getIdentity()
+    {
+        return identity;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AccessControlInfo that = (AccessControlInfo) o;
+        return Objects.equals(accessControl, that.accessControl) &&
+                Objects.equals(identity, that.identity);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(accessControl, identity);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("AccessControl: %s, Identity: %s", accessControl.getClass(), identity);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfo.java
@@ -13,23 +13,29 @@
  */
 package com.facebook.presto.spi.analyzer;
 
+import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.Identity;
 
 import java.util.Objects;
+import java.util.Optional;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class AccessControlInfo
 {
     private final AccessControl accessControl;
     private final Identity identity;
+    private final Optional<TransactionId> transactionId;
+    private final AccessControlContext accessControlContext;
 
-    public AccessControlInfo(AccessControl accessControl, Identity identity)
+    public AccessControlInfo(AccessControl accessControl, Identity identity, Optional<TransactionId> transactionId, AccessControlContext accessControlContext)
     {
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.identity = requireNonNull(identity, "identity is null");
+        this.transactionId = requireNonNull(transactionId, "transactionId is null");
+        this.accessControlContext = requireNonNull(accessControlContext, "accessControlContext is null");
     }
 
     public AccessControl getAccessControl()
@@ -40,6 +46,16 @@ public final class AccessControlInfo
     public Identity getIdentity()
     {
         return identity;
+    }
+
+    public Optional<TransactionId> getTransactionId()
+    {
+        return transactionId;
+    }
+
+    public AccessControlContext getAccessControlContext()
+    {
+        return accessControlContext;
     }
 
     @Override
@@ -54,18 +70,25 @@ public final class AccessControlInfo
 
         AccessControlInfo that = (AccessControlInfo) o;
         return Objects.equals(accessControl, that.accessControl) &&
-                Objects.equals(identity, that.identity);
+                Objects.equals(identity, that.identity) &&
+                Objects.equals(transactionId, that.transactionId) &&
+                Objects.equals(accessControlContext, that.accessControlContext);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(accessControl, identity);
+        return Objects.hash(accessControl, identity, transactionId, accessControlContext);
     }
 
     @Override
     public String toString()
     {
-        return format("AccessControl: %s, Identity: %s", accessControl.getClass(), identity);
+        return "AccessControlInfo{" +
+                "accessControl=" + accessControl +
+                ", identity=" + identity +
+                ", transactionId=" + transactionId +
+                ", accessControlContext=" + accessControlContext +
+                '}';
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfoForTable.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlInfoForTable.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.analyzer;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.Identity;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class AccessControlInfoForTable
+{
+    private final AccessControlInfo accessControlInfo;
+    private final QualifiedObjectName tableName;
+
+    public AccessControlInfoForTable(AccessControl accessControl, Identity identity, Optional<TransactionId> transactionId, AccessControlContext accessControlContext, QualifiedObjectName tableName)
+    {
+        this(new AccessControlInfo(accessControl, identity, transactionId, accessControlContext), tableName);
+    }
+
+    public AccessControlInfoForTable(AccessControlInfo accessControlInfo, QualifiedObjectName tableName)
+    {
+        this.accessControlInfo = requireNonNull(accessControlInfo, "accessControlInfo is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    public AccessControlInfo getAccessControlInfo()
+    {
+        return accessControlInfo;
+    }
+
+    public QualifiedObjectName getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AccessControlInfoForTable that = (AccessControlInfoForTable) o;
+        return Objects.equals(accessControlInfo, that.accessControlInfo) && Objects.equals(tableName, that.tableName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(accessControlInfo, tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AccessControlInfoForTable{" +
+                "accessControlInfo=" + accessControlInfo +
+                ", tableName=" + tableName +
+                '}';
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
@@ -13,17 +13,22 @@
  */
 package com.facebook.presto.spi.analyzer;
 
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.Subfield;
+
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
 
 // TODO: Should we migrate existing table column references to this class?
 public class AccessControlReferences
 {
     private final Map<AccessControlRole, Set<AccessControlInfoForTable>> tableReferences;
+    private Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl;
 
     public AccessControlReferences()
     {
@@ -38,5 +43,15 @@ public class AccessControlReferences
     public void addTableReference(AccessControlRole role, AccessControlInfoForTable accessControlInfoForTable)
     {
         tableReferences.computeIfAbsent(role, r -> new LinkedHashSet<>()).add(accessControlInfoForTable);
+    }
+
+    public Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> getTableColumnAndSubfieldReferencesForAccessControl()
+    {
+        return tableColumnAndSubfieldReferencesForAccessControl;
+    }
+
+    public void setTableColumnAndSubfieldReferencesForAccessControl(Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl)
+    {
+        this.tableColumnAndSubfieldReferencesForAccessControl = unmodifiableMap(requireNonNull(tableColumnAndSubfieldReferencesForAccessControl, "tableColumnAndSubfieldReferencesForAccessControl is null"));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.analyzer;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableMap;
+
+// TODO: Should we migrate existing table column references to this class?
+public class AccessControlReferences
+{
+    private final Map<AccessControlRole, Set<AccessControlInfoForTable>> tableReferences;
+
+    public AccessControlReferences()
+    {
+        tableReferences = new LinkedHashMap<>();
+    }
+
+    public Map<AccessControlRole, Set<AccessControlInfoForTable>> getTableReferences()
+    {
+        return unmodifiableMap(tableReferences);
+    }
+
+    public void addTableReference(AccessControlRole role, AccessControlInfoForTable accessControlInfoForTable)
+    {
+        tableReferences.computeIfAbsent(role, r -> new LinkedHashSet<>()).add(accessControlInfoForTable);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlRole.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlRole.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.analyzer;
+
+public enum AccessControlRole
+{
+    TABLE_CREATE,
+    TABLE_INSERT,
+    TABLE_DELETE
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AnalyzerContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AnalyzerContext.java
@@ -22,7 +22,6 @@ public class AnalyzerContext
 {
     private final MetadataResolver metadataResolver;
     private final PlanNodeIdAllocator idAllocator;
-
     private final VariableAllocator variableAllocator;
 
     public AnalyzerContext(MetadataResolver metadataResolver, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.analyzer;
 
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.function.FunctionKind;
 
 import java.util.Map;
@@ -46,4 +47,14 @@ public interface QueryAnalysis
      * Returns access control references for ACL checks
      */
     AccessControlReferences getAccessControlReferences();
+
+    /**
+     * Returns whether the QueryAnalysis represents an "EXPLAIN ANALYZE" query.
+     */
+    boolean isExplainAnalyzeQuery();
+
+    /**
+     * Extracts the set of ConnectorIds used in the QueryAnalysis.
+     */
+    Set<ConnectorId> extractConnectors();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
@@ -41,4 +41,9 @@ public interface QueryAnalysis
      * Returns function names based on the kinds (scalar, aggregate and window).
      */
     Map<FunctionKind, Set<String>> getInvokedFunctions();
+
+    /**
+     * Returns access control references for ACL checks
+     */
+    AccessControlReferences getAccessControlReferences();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalyzer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalyzer.java
@@ -14,10 +14,7 @@
 package com.facebook.presto.spi.analyzer;
 
 import com.facebook.presto.common.analyzer.PreparedQuery;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.plan.PlanNode;
-
-import java.util.Set;
 
 /**
  * The QueryAnalyzer interface should be implemented by respective analyzer to provide various analyzer related functionalities.
@@ -41,14 +38,4 @@ public interface QueryAnalyzer
      * @return root logical plan node created from the given query analysis
      */
     PlanNode plan(AnalyzerContext analyzerContext, QueryAnalysis queryAnalysis);
-
-    /**
-     * Returns whether the given QueryAnalysis represents an "EXPLAIN ANALYZE" query.
-     */
-    boolean isExplainAnalyzeQuery(QueryAnalysis queryAnalysis);
-
-    /**
-     * Extracts the set of ConnectorIds used in the given QueryAnalysis.
-     */
-    Set<ConnectorId> extractConnectors(QueryAnalysis queryAnalysis);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalyzer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalyzer.java
@@ -34,14 +34,6 @@ public interface QueryAnalyzer
     QueryAnalysis analyze(AnalyzerContext analyzerContext, PreparedQuery preparedQuery);
 
     /**
-     * Check access permission for the various tables and columns used in the query.
-     *
-     * @param analyzerContext analyzerContext analyzer context which stores various information used by analyzer
-     * @param queryAnalysis query analysis on which the access permissions needs to be checked
-     */
-    void checkAccessPermissions(AnalyzerContext analyzerContext, QueryAnalysis queryAnalysis);
-
-    /**
      * Create logical plan for a given query analysis.
      *
      * @param analyzerContext analyzerContext analyzer context which stores various information used by analyzer

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueryRunner.java
@@ -39,7 +39,7 @@ public class TestLocalQueryRunner
     public void testAnalyzeAccessControl()
     {
         assertAccessAllowed("ANALYZE nation");
-        assertAccessDenied("ANALYZE nation", "Cannot ANALYZE \\(missing insert privilege\\) table .*.nation.*", privilege("nation", INSERT_TABLE));
+        assertAccessDenied("ANALYZE nation", "Cannot insert into table .*.nation.*", privilege("nation", INSERT_TABLE));
         assertAccessDenied("ANALYZE nation", "Cannot select from columns \\[.*] in table or view .*.nation", privilege("nation", SELECT_COLUMN));
         assertAccessDenied("ANALYZE nation", "Cannot select from columns \\[.*nationkey.*] in table or view .*.nation", privilege("nationkey", SELECT_COLUMN));
     }


### PR DESCRIPTION
We've reorganized access control checks for the SQLQueryExecution flow to ensure consistency, as earlier table and column level checks were fragmented across various phases of query execution.  

We've moved table-level access control checks to occur after analysis, and also brought column-level checks under the analyzer interface. This change enables analyzers to consistently return access control-related references.

Note that ViewCreate access checks still occur during analysis, but we plan to move those after DDL statements are onboarded to the analyzer framework.


```
== RELEASE NOTES ==

General Changes
* Moved access control checks after semantic analysis.  Queries with both semantic and permission issues that previously failed with permission errors may now fail with semantic errors.
```