### PR TITLE
[native] Track and export the get data latency of OutputBuffer

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -143,12 +143,13 @@ void getData(
     return;
   }
 
+  int64_t startMs = getCurrentTimeMs();
   auto bufferFound = bufferManager.getData(
       taskId,
       bufferId,
       maxSize.getValue(protocol::DataUnit::BYTE),
       token,
-      [taskId = taskId, bufferId = bufferId, promiseHolder](
+      [taskId = taskId, bufferId = bufferId, promiseHolder, startMs](
           std::vector<std::unique_ptr<folly::IOBuf>> pages,
           int64_t sequence) mutable {
         bool complete = pages.empty();
@@ -184,6 +185,10 @@ void getData(
         result->data = std::move(iobuf);
 
         promiseHolder->promise.setValue(std::move(result));
+
+        REPORT_ADD_STAT_VALUE(
+            kCounterPartitionedOutputBufferGetDataLatencyMs,
+            getCurrentTimeMs() - startMs);
       });
 
   if (!bufferFound) {

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -58,6 +58,9 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterTotalPartitionedOutputBuffer, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterPartitionedOutputBufferGetDataLatencyMs,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterCumulativeUserCpuTimeMicros, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterCumulativeSystemCpuTimeMicros, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -63,6 +63,10 @@ constexpr folly::StringPiece kCounterNumBlockedDrivers{
 // PartitionedOutputBufferManager
 constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{
     "presto_cpp.num_partitioned_output_buffer"};
+// Latency in millisecond of the get data call of a
+// PartitionedOutputBufferManager.
+constexpr folly::StringPiece kCounterPartitionedOutputBufferGetDataLatencyMs{
+    "presto_cpp.partitioned_output_buffer_get_data_latency_ms"};
 
 // ================== OS Counters =================
 


### PR DESCRIPTION
The metric measures the latency of the critical path of a task serving the result request.

```
== NO RELEASE NOTE ==
```
