### PR TITLE
Upgrade Hudi to 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>0.12.0</dep.hudi.version>
+        <dep.hudi.version>0.13.0</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.jayway.version>2.6.0</dep.jayway.version>
@@ -2240,6 +2240,7 @@
                                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                                     <exclude>com.google.guava:guava</exclude>
                                     <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                                    <exclude>org.objenesis:objenesis</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>
                         </rules>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -166,6 +166,7 @@
                             <ignoredResourcePatterns>
                                 <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
                                 <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                                <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                             </ignoredResourcePatterns>
                             <ignoredClassPatterns>
                                 <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -462,6 +462,7 @@
                     <ignoredResourcePatterns>
                         <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
                         <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                        <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                     </ignoredResourcePatterns>
                     <ignoredClassPatterns>
                         <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -522,6 +522,7 @@
                             <ignoredClassPattern>module-info</ignoredClassPattern>
                             <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
                             <ignoredClassPattern>org.apache.parquet.*</ignoredClassPattern>
+                            <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Upgraded Hudi to 0.13.0, which applies to presto-hive, presto-hudi, presto-server. 

Ran a couple of unit tests for basic test such as `TestHudiDirectoryLister`, `TestHudiConfig` without issue.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Hudi Upgrade

Hive Changes
* N/A
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
