### PR TITLE
[native] Register Presto functions with "presto.default." prefix.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -231,9 +231,11 @@ void PrestoServer::run() {
             .sendWithEOM();
       });
 
-  velox::functions::prestosql::registerAllScalarFunctions();
-  velox::aggregate::prestosql::registerAllAggregateFunctions();
-  velox::window::prestosql::registerAllWindowFunctions();
+  static const std::string kPrestoDefaultPrefix{"presto.default."};
+  velox::functions::prestosql::registerAllScalarFunctions(kPrestoDefaultPrefix);
+  velox::aggregate::prestosql::registerAllAggregateFunctions(
+      kPrestoDefaultPrefix);
+  velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
   registerVectorSerdes();
 
   facebook::velox::exec::ExchangeSource::registerFactory(

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -32,39 +32,30 @@ std::string toJsonString(const T& value) {
   return ((json)value).dump();
 }
 
-std::optional<std::string> mapDefaultFunctionName(
-    const std::string& lowerCaseName) {
-  static const char* kPrestoDefaultPrefix = "presto.default.";
-  static const uint32_t kPrestoDefaultPrefixLength =
-      strlen(kPrestoDefaultPrefix);
-
-  if (lowerCaseName.compare(
-          0, kPrestoDefaultPrefixLength, kPrestoDefaultPrefix) == 0) {
-    return lowerCaseName.substr(kPrestoDefaultPrefixLength);
-  }
-
-  return std::nullopt;
-}
-
 std::string mapScalarFunction(const std::string& name) {
   static const std::unordered_map<std::string, std::string> kFunctionNames = {
-      // see com.facebook.presto.common.function.OperatorType
-      {"presto.default.$operator$add", "plus"},
-      {"presto.default.$operator$between", "between"},
-      {"presto.default.$operator$divide", "divide"},
-      {"presto.default.$operator$equal", "eq"},
-      {"presto.default.$operator$greater_than", "gt"},
-      {"presto.default.$operator$greater_than_or_equal", "gte"},
-      {"presto.default.$operator$is_distinct_from", "distinct_from"},
-      {"presto.default.$operator$less_than", "lt"},
-      {"presto.default.$operator$less_than_or_equal", "lte"},
-      {"presto.default.$operator$modulus", "mod"},
-      {"presto.default.$operator$multiply", "multiply"},
-      {"presto.default.$operator$negation", "negate"},
-      {"presto.default.$operator$not_equal", "neq"},
-      {"presto.default.$operator$subtract", "minus"},
-      {"presto.default.$operator$subscript", "subscript"},
-      {"presto.default.random", "rand"}};
+      // Operator overrides: com.facebook.presto.common.function.OperatorType
+      {"presto.default.$operator$add", "presto.default.plus"},
+      {"presto.default.$operator$between", "presto.default.between"},
+      {"presto.default.$operator$divide", "presto.default.divide"},
+      {"presto.default.$operator$equal", "presto.default.eq"},
+      {"presto.default.$operator$greater_than", "presto.default.gt"},
+      {"presto.default.$operator$greater_than_or_equal", "presto.default.gte"},
+      {"presto.default.$operator$is_distinct_from",
+       "presto.default.distinct_from"},
+      {"presto.default.$operator$less_than", "presto.default.lt"},
+      {"presto.default.$operator$less_than_or_equal", "presto.default.lte"},
+      {"presto.default.$operator$modulus", "presto.default.mod"},
+      {"presto.default.$operator$multiply", "presto.default.multiply"},
+      {"presto.default.$operator$negation", "presto.default.negate"},
+      {"presto.default.$operator$not_equal", "presto.default.neq"},
+      {"presto.default.$operator$subtract", "presto.default.minus"},
+      {"presto.default.$operator$subscript", "presto.default.subscript"},
+      // Special form function overrides.
+      {"presto.default.in", "in"},
+      {"presto.default.row_constructor", "in"},
+      {"presto.default.in", "is_null"},
+  };
 
   std::string lowerCaseName = boost::to_lower_copy(name);
 
@@ -73,23 +64,11 @@ std::string mapScalarFunction(const std::string& name) {
     return it->second;
   }
 
-  auto mappedName = mapDefaultFunctionName(lowerCaseName);
-  if (mappedName.has_value()) {
-    return mappedName.value();
-  }
-
   return lowerCaseName;
 }
 
 std::string mapAggregateOrWindowFunction(const std::string& name) {
-  std::string lowerCaseName = boost::to_lower_copy(name);
-
-  auto mappedName = mapDefaultFunctionName(lowerCaseName);
-  if (mappedName.has_value()) {
-    return mappedName.value();
-  }
-
-  return lowerCaseName;
+  return boost::to_lower_copy(name);
 }
 
 std::string getFunctionName(const protocol::Signature& signature) {
@@ -231,7 +210,7 @@ std::optional<TypedExprPtr> tryConvertLiteralArray(
     const std::vector<TypedExprPtr>& args,
     velox::memory::MemoryPool* pool) {
   static const char* kLiteralArray = "presto.default.$literal$array";
-  static const char* kFromBase64 = "from_base64";
+  static const char* kFromBase64 = "presto.default.from_base64";
 
   if (signature.kind != protocol::FunctionKind::SCALAR) {
     return std::nullopt;
@@ -435,7 +414,7 @@ std::shared_ptr<const CallTypedExpr> makeEqualsExpr(
     const TypedExprPtr& b) {
   std::vector<TypedExprPtr> inputs{a, b};
   return std::make_shared<CallTypedExpr>(
-      velox::BOOLEAN(), std::move(inputs), "eq");
+      velox::BOOLEAN(), std::move(inputs), "presto.default.eq");
 }
 
 std::shared_ptr<const CastTypedExpr> makeCastExpr(

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -434,7 +434,7 @@ TEST_F(RowExpressionTest, call) {
       std::static_pointer_cast<const CallTypedExpr>(converter_->toVeloxExpr(p));
 
   // Check some values ...
-  ASSERT_EQ(callexpr->name(), "eq");
+  ASSERT_EQ(callexpr->name(), "presto.default.eq");
 
   auto iexpr = callexpr->inputs();
 
@@ -542,7 +542,7 @@ TEST_F(RowExpressionTest, special) {
         std::static_pointer_cast<const CallTypedExpr>(callexpr->inputs()[0]);
 
     ASSERT_EQ(arg0expr->type()->toString(), "BOOLEAN");
-    ASSERT_EQ(arg0expr->name(), "eq");
+    ASSERT_EQ(arg0expr->name(), "presto.default.eq");
     {
       auto cexpr = std::static_pointer_cast<const FieldAccessTypedExpr>(
           arg0expr->inputs()[0]);
@@ -562,7 +562,7 @@ TEST_F(RowExpressionTest, special) {
         std::static_pointer_cast<const CallTypedExpr>(callexpr->inputs()[1]);
 
     ASSERT_EQ(arg1expr->type()->toString(), "BOOLEAN");
-    ASSERT_EQ(arg1expr->name(), "eq");
+    ASSERT_EQ(arg1expr->name(), "presto.default.eq");
     {
       auto cexpr = std::static_pointer_cast<const FieldAccessTypedExpr>(
           arg1expr->inputs()[0]);
@@ -734,7 +734,7 @@ TEST_F(RowExpressionTest, likeSimple) {
   ASSERT_NE(callExpr, nullptr);
 
   auto callExprToString = callExpr->toString();
-  ASSERT_EQ(callExprToString, "like(\"type\",\"%BRASS\")");
+  ASSERT_EQ(callExprToString, "presto.default.like(\"type\",\"%BRASS\")");
 }
 
 TEST_F(RowExpressionTest, likeWithEscape) {
@@ -797,7 +797,8 @@ TEST_F(RowExpressionTest, likeWithEscape) {
   ASSERT_NE(callExpr, nullptr);
 
   auto callExprToString = callExpr->toString();
-  ASSERT_EQ(callExpr->toString(), "like(\"type\",\"%BRASS\",\"#\")");
+  ASSERT_EQ(
+      callExpr->toString(), "presto.default.like(\"type\",\"%BRASS\",\"#\")");
 }
 
 TEST_F(RowExpressionTest, dereference) {


### PR DESCRIPTION
Remove the hard-coded trimming of presto function prefix.
Advance Velox version.

Test plan - existing integration tests.

```
== NO RELEASE NOTE ==
```
