### PR TITLE
[presto-native] Reuse driver instance for all scheduled splits

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -15,26 +15,16 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.predicate.TupleDomain;
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.Lifespan;
-import com.facebook.presto.execution.StateMachine;
-import com.facebook.presto.execution.buffer.BufferResult;
-import com.facebook.presto.execution.buffer.BufferState;
-import com.facebook.presto.execution.buffer.OutputBuffer;
-import com.facebook.presto.execution.buffer.OutputBufferInfo;
-import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OperatorFactory;
-import com.facebook.presto.operator.SourceOperator;
-import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TableScanOperator;
 import com.facebook.presto.operator.TaskOutputOperator;
@@ -44,7 +34,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.TableScanNode;
@@ -61,8 +50,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ListenableFuture;
-import io.airlift.units.DataSize;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -72,7 +59,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Consumer;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
@@ -231,162 +217,6 @@ public class TestLocalExecutionPlanner
                 new TestingOutputBuffer(),
                 new TestingRemoteSourceFactory(),
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
-    }
-
-    private static class TestingOutputBuffer
-            implements OutputBuffer
-    {
-        @Override
-        public OutputBufferInfo getInfo()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isFinished()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public double getUtilization()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isOverutilized()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setOutputBuffers(OutputBuffers newOutputBuffers)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ListenableFuture<BufferResult> get(OutputBuffers.OutputBufferId bufferId, long token, DataSize maxSize)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void acknowledge(OutputBuffers.OutputBufferId bufferId, long token)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void abort(OutputBuffers.OutputBufferId bufferId)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ListenableFuture<?> isFull()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void enqueue(Lifespan lifespan, List<SerializedPage> pages)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void enqueue(Lifespan lifespan, int partition, List<SerializedPage> pages)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setNoMorePages()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void destroy()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void fail()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setNoMorePagesForLifespan(Lifespan lifespan)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void registerLifespanCompletionCallback(Consumer<Lifespan> callback)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isFinishedForLifespan(Lifespan lifespan)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getPeakMemoryUsage()
-        {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    private static class TestingRemoteSourceFactory
-            implements RemoteSourceFactory
-    {
-        @Override
-        public SourceOperatorFactory createRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types)
-        {
-            return new TestingSourceOperatorFactory();
-        }
-
-        @Override
-        public SourceOperatorFactory createMergeRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types, List<Integer> outputChannels, List<Integer> sortChannels, List<SortOrder> sortOrder)
-        {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    private static class TestingSourceOperatorFactory
-            implements SourceOperatorFactory
-    {
-        @Override
-        public PlanNodeId getSourceId()
-        {
-            return new PlanNodeId("test");
-        }
-
-        @Override
-        public SourceOperator createOperator(DriverContext driverContext)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void noMoreOperators()
-        {
-            throw new UnsupportedOperationException();
-        }
     }
 
     private static class CustomNodeA

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingOutputBuffer.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.buffer.OutputBuffer;
+import com.facebook.presto.execution.buffer.OutputBufferInfo;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TestingOutputBuffer
+        implements OutputBuffer
+{
+    @Override
+    public OutputBufferInfo getInfo()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getUtilization()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOverutilized()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOutputBuffers(OutputBuffers newOutputBuffers)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListenableFuture<BufferResult> get(OutputBuffers.OutputBufferId bufferId, long token, DataSize maxSize)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acknowledge(OutputBuffers.OutputBufferId bufferId, long token)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abort(OutputBuffers.OutputBufferId bufferId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListenableFuture<?> isFull()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enqueue(Lifespan lifespan, List<SerializedPage> pages)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enqueue(Lifespan lifespan, int partition, List<SerializedPage> pages)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setNoMorePages()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void destroy()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fail()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setNoMorePagesForLifespan(Lifespan lifespan)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerLifespanCompletionCallback(Consumer<Lifespan> callback)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isFinishedForLifespan(Lifespan lifespan)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getPeakMemoryUsage()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingRemoteSourceFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingRemoteSourceFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.DriverContext;
+import com.facebook.presto.operator.SourceOperator;
+import com.facebook.presto.operator.SourceOperatorFactory;
+import com.facebook.presto.spi.plan.PlanNodeId;
+
+import java.util.List;
+
+public class TestingRemoteSourceFactory
+        implements RemoteSourceFactory
+{
+    @Override
+    public SourceOperatorFactory createRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types)
+    {
+        return new TestingSourceOperatorFactory();
+    }
+
+    @Override
+    public SourceOperatorFactory createMergeRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types, List<Integer> outputChannels, List<Integer> sortChannels, List<SortOrder> sortOrder)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private static class TestingSourceOperatorFactory
+            implements SourceOperatorFactory
+    {
+        @Override
+        public PlanNodeId getSourceId()
+        {
+            return new PlanNodeId("test");
+        }
+
+        @Override
+        public SourceOperator createOperator(DriverContext driverContext)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.task;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.ScheduledSplit;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.execution.TaskTestUtils;
+import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spark.execution.PrestoSparkTaskExecution;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.sql.planner.LocalExecutionPlanner;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.TestingOutputBuffer;
+import com.facebook.presto.sql.planner.TestingRemoteSourceFactory;
+import com.facebook.presto.testing.TestingSplit;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
+import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
+import static com.facebook.presto.execution.TaskTestUtils.createPlanFragment;
+import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestPrestoSparkTaskExecution
+{
+    Session nativeTestSession;
+    Session nonNativeTestSession;
+    LocalExecutionPlanner.LocalExecutionPlan localExecutionPlan;
+    TaskExecutor taskExecutor;
+    PlanFragment planFragment = createPlanFragment();
+    ExecutorService taskNotificationExecutor;
+    ScheduledExecutorService scheduledExecutor;
+    TaskStateMachine taskStateMachine;
+
+    Set<ScheduledSplit> splits = ImmutableSet.of(
+            new ScheduledSplit(1, TABLE_SCAN_NODE_ID, new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit())),
+            new ScheduledSplit(2, TABLE_SCAN_NODE_ID, new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit())),
+            new ScheduledSplit(3, TABLE_SCAN_NODE_ID, new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit())));
+
+    @BeforeMethod
+    public void setUp()
+    {
+        taskNotificationExecutor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
+
+        nativeTestSession = testSessionBuilder()
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+        nonNativeTestSession = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        taskStateMachine = new TaskStateMachine(new TaskId("test_query_id", 4, 4, 1), taskNotificationExecutor);
+
+        localExecutionPlan = createTestingPlanner().plan(
+                TestingTaskContext.createTaskContext(taskNotificationExecutor, scheduledExecutor, nativeTestSession),
+                planFragment,
+                new TestingOutputBuffer(),
+                new TestingRemoteSourceFactory(),
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new ArrayList<>());
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        taskStateMachine.finished();
+        taskExecutor.stop();
+        scheduledExecutor.shutdown();
+        taskNotificationExecutor.shutdown();
+    }
+
+    @Test
+    public void testNativeDriverInstanceCount()
+    {
+        testDriverCount(nativeTestSession, true, 1);
+    }
+
+    @Test
+    public void testJavaDriverInstanceCount()
+    {
+        testDriverCount(nonNativeTestSession, false, 3);
+    }
+
+    private void testDriverCount(Session session, boolean isNative, int expectedDriverCount)
+    {
+        TaskContext taskContext = TestingTaskContext.createTaskContext(taskNotificationExecutor, scheduledExecutor, session, new DataSize(2, GIGABYTE));
+        taskExecutor.start();
+        PrestoSparkTaskExecution taskExecution = new PrestoSparkTaskExecution(taskStateMachine, taskContext, localExecutionPlan, taskExecutor, TaskTestUtils.createTestSplitMonitor(), taskNotificationExecutor, scheduledExecutor, isNative);
+        taskExecution.start(ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, splits, true)));
+        assertEquals(taskContext.getPipelineContexts().get(0).getPipelineStats().getDrivers().size(), expectedDriverCount);
+    }
+}


### PR DESCRIPTION
In presto-on-spark, a new driver runner instance is created for each split scheduled to run on a worker. For presto-on-spark native, this results in each split being processed by its own cpp instance, serially, thus poor query latency.
In the proposed solution, specifically for presto-on-spark native, we schedule all the splits on a single driver runner instance and thus single cpp instance.

For non-native flow, this change is a no-op.



```
== NO RELEASE NOTE ==
```
