### PR TITLE
Support parquet dereference pushdown for Iceberg Connector.

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -457,6 +457,13 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -13,19 +13,27 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.iceberg.ColumnIdentity.createColumnIdentity;
 import static com.facebook.presto.iceberg.ColumnIdentity.primitiveColumnIdentity;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergColumnHandle
@@ -34,16 +42,27 @@ public class IcebergColumnHandle
     private final ColumnIdentity columnIdentity;
     private final Type type;
     private final Optional<String> comment;
+    private final ColumnType columnType;
+    private final List<Subfield> requiredSubfields;
 
     @JsonCreator
     public IcebergColumnHandle(
             @JsonProperty("columnIdentity") ColumnIdentity columnIdentity,
             @JsonProperty("type") Type type,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("columnType") ColumnType columnType,
+            @JsonProperty("requiredSubfields") List<Subfield> requiredSubfields)
     {
         this.columnIdentity = requireNonNull(columnIdentity, "columnIdentity is null");
         this.type = requireNonNull(type, "type is null");
         this.comment = requireNonNull(comment, "comment is null");
+        this.columnType = requireNonNull(columnType, "columnType is null");
+        this.requiredSubfields = requireNonNull(requiredSubfields, "requiredSubfields is null");
+    }
+
+    public IcebergColumnHandle(ColumnIdentity columnIdentity, Type type, Optional<String> comment)
+    {
+        this(columnIdentity, type, comment, REGULAR, ImmutableList.of());
     }
 
     @JsonProperty
@@ -76,10 +95,33 @@ public class IcebergColumnHandle
         return comment;
     }
 
+    @JsonProperty
+    public ColumnType getColumnType()
+    {
+        return columnType;
+    }
+
+    @JsonProperty
+    public List<Subfield> getRequiredSubfields()
+    {
+        return requiredSubfields;
+    }
+
+    @Override
+    public ColumnHandle withRequiredSubfields(List<Subfield> subfields)
+    {
+        if (isPushedDownSubfield(this)) {
+            // This column is already a pushed down subfield column
+            return this;
+        }
+
+        return new IcebergColumnHandle(columnIdentity, type, comment, columnType, subfields);
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(columnIdentity, type, comment);
+        return Objects.hash(columnIdentity, type, comment, columnType, requiredSubfields);
     }
 
     @Override
@@ -94,13 +136,19 @@ public class IcebergColumnHandle
         IcebergColumnHandle other = (IcebergColumnHandle) obj;
         return Objects.equals(this.columnIdentity, other.columnIdentity) &&
                 Objects.equals(this.type, other.type) &&
-                Objects.equals(this.comment, other.comment);
+                Objects.equals(this.comment, other.comment) &&
+                Objects.equals(this.columnType, other.columnType) &&
+                Objects.equals(this.requiredSubfields, other.requiredSubfields);
     }
 
     @Override
     public String toString()
     {
-        return getId() + ":" + getName() + ":" + type.getDisplayName();
+        if (requiredSubfields.isEmpty()) {
+            return getId() + ":" + getName() + ":" + type.getDisplayName();
+        }
+
+        return getId() + ":" + getName() + ":" + type.getDisplayName() + ":" + columnType + ":" + requiredSubfields;
     }
 
     public static IcebergColumnHandle primitiveIcebergColumnHandle(int id, String name, Type type, Optional<String> comment)
@@ -114,5 +162,37 @@ public class IcebergColumnHandle
                 createColumnIdentity(column),
                 toPrestoType(column.type(), typeManager),
                 Optional.ofNullable(column.doc()));
+    }
+
+    public enum ColumnType
+    {
+        REGULAR,
+        SYNTHESIZED
+    }
+
+    public static Subfield getPushedDownSubfield(IcebergColumnHandle column)
+    {
+        checkArgument(isPushedDownSubfield(column), format("not a valid pushed down subfield: type=%s, subfields=%s", column.getColumnType(), column.getRequiredSubfields()));
+        return getOnlyElement(column.getRequiredSubfields());
+    }
+
+    public static boolean isPushedDownSubfield(IcebergColumnHandle column)
+    {
+        return column.getColumnType() == SYNTHESIZED && column.getRequiredSubfields().size() == 1;
+    }
+
+    public static IcebergColumnHandle getSynthesizedIcebergColumnHandle(String pushdownColumnName, Type pushdownColumnType, Subfield requiredSubfields)
+    {
+        return getSynthesizedIcebergColumnHandle(pushdownColumnName, pushdownColumnType, ImmutableList.of(requiredSubfields));
+    }
+
+    public static IcebergColumnHandle getSynthesizedIcebergColumnHandle(String pushdownColumnName, Type pushdownColumnType, List<Subfield> requiredSubfields)
+    {
+        return new IcebergColumnHandle(
+                primitiveColumnIdentity(-1, pushdownColumnName),
+                pushdownColumnType,
+                Optional.of("nested column pushdown"),
+                SYNTHESIZED,
+                requiredSubfields);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -41,6 +41,7 @@ public class IcebergConfig
     private int maxPartitionsPerWriter = 100;
     private List<String> hadoopConfigResources = ImmutableList.of();
     private double minimumAssignedSplitWeight = 0.05;
+    private boolean parquetDereferencePushdownEnabled;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -151,5 +152,18 @@ public class IcebergConfig
     public double getMinimumAssignedSplitWeight()
     {
         return minimumAssignedSplitWeight;
+    }
+
+    @Config("iceberg.enable-parquet-dereference-pushdown")
+    @ConfigDescription("enable parquet dereference pushdown")
+    public IcebergConfig setParquetDereferencePushdownEnabled(boolean parquetDereferencePushdownEnabled)
+    {
+        this.parquetDereferencePushdownEnabled = parquetDereferencePushdownEnabled;
+        return this;
+    }
+
+    public boolean isParquetDereferencePushdownEnabled()
+    {
+        return this.parquetDereferencePushdownEnabled;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -63,7 +63,7 @@ public class IcebergConnector
     private final List<PropertyMetadata<?>> tableProperties;
     private final ConnectorAccessControl accessControl;
     private final Set<Procedure> procedures;
-    private final ConnectorPlanOptimizer planOptimizer;
+    private final Set<ConnectorPlanOptimizer> planOptimizers;
 
     public IcebergConnector(
             LifeCycleManager lifeCycleManager,
@@ -79,7 +79,7 @@ public class IcebergConnector
             List<PropertyMetadata<?>> tableProperties,
             ConnectorAccessControl accessControl,
             Set<Procedure> procedures,
-            ConnectorPlanOptimizer planOptimizer)
+            Set<ConnectorPlanOptimizer> planOptimizers)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -94,7 +94,7 @@ public class IcebergConnector
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
-        this.planOptimizer = requireNonNull(planOptimizer, "planOptimizer is null");
+        this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
     }
 
     @Override
@@ -209,6 +209,6 @@ public class IcebergConnector
     @Override
     public ConnectorPlanOptimizerProvider getConnectorPlanOptimizerProvider()
     {
-        return new IcebergPlanOptimizerProvider(planOptimizer);
+        return new IcebergPlanOptimizerProvider(planOptimizers);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -45,6 +45,7 @@ import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.facebook.presto.iceberg.nessie.NessieConfig;
+import com.facebook.presto.iceberg.optimizer.IcebergParquetDereferencePushDown;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizer;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
 import com.facebook.presto.orc.DwrfAwareStripeMetadataSourceFactory;
@@ -167,6 +168,7 @@ public class IcebergModule
         configBinder(binder).bindConfig(OrcFileWriterConfig.class);
 
         binder.bind(IcebergPlanOptimizer.class).in(Scopes.SINGLETON);
+        binder.bind(IcebergParquetDereferencePushDown.class).in(Scopes.SINGLETON);
     }
 
     @ForCachingHiveMetastore

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.StandardTypes;
@@ -80,6 +81,7 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
+import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.MessageType;
 
@@ -89,7 +91,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Function;
@@ -97,10 +98,13 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReaderVerificationEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createDecryptor;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.getPushedDownSubfield;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.isPushedDownSubfield;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_DATA;
@@ -123,10 +127,14 @@ import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getSubfieldType;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.nestedColumnPath;
 import static com.facebook.presto.parquet.cache.MetadataReader.findFirstNonHiddenColumnId;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatches;
 import static com.facebook.presto.parquet.reader.ColumnIndexFilterUtils.getColumnIndexStore;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -135,8 +143,8 @@ import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static org.apache.parquet.io.ColumnIOConverter.constructField;
+import static org.apache.parquet.io.ColumnIOConverter.findNestedColumnIO;
 
 public class IcebergPageSourceProvider
         implements ConnectorPageSourceProvider
@@ -214,18 +222,14 @@ public class IcebergPageSourceProvider
                     .filter(field -> field.getId() != null)
                     .collect(toImmutableMap(field -> field.getId().intValue(), Function.identity()));
 
-            List<org.apache.parquet.schema.Type> parquetFields = regularColumns.stream()
-                    .map(column -> {
-                        if (parquetIdToField.isEmpty()) {
-                            // This is a migrated table
-                            return getParquetTypeByName(column.getName(), fileSchema);
-                        }
-                        return parquetIdToField.get(column.getId());
-                    })
-                    .collect(toList());
+            Optional<MessageType> messageType = regularColumns.stream()
+                    .map(column -> getColumnType(parquetIdToField, fileSchema, column))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(type -> new MessageType(fileSchema.getName(), type))
+                    .reduce(MessageType::union);
 
-            // TODO: support subfield pushdown
-            MessageType requestedSchema = new MessageType(fileSchema.getName(), parquetFields.stream().filter(Objects::nonNull).collect(toImmutableList()));
+            MessageType requestedSchema = messageType.orElse(new MessageType(fileSchema.getName(), ImmutableList.of()));
             Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, requestedSchema);
             TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(descriptorsByPath, effectivePredicate);
             Predicate parquetPredicate = buildPredicate(requestedSchema, parquetTupleDomain, descriptorsByPath);
@@ -266,17 +270,30 @@ public class IcebergPageSourceProvider
             for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
                 IcebergColumnHandle column = regularColumns.get(columnIndex);
                 namesBuilder.add(column.getName());
-                org.apache.parquet.schema.Type parquetField = parquetFields.get(columnIndex);
 
                 Type prestoType = column.getType();
 
                 prestoTypes.add(prestoType);
 
-                if (parquetField == null) {
-                    internalFields.add(Optional.empty());
+                if (column.getColumnType() == IcebergColumnHandle.ColumnType.SYNTHESIZED) {
+                    Subfield pushedDownSubfield = getPushedDownSubfield(column);
+                    List<String> nestedColumnPath = nestedColumnPath(pushedDownSubfield);
+                    Optional<ColumnIO> columnIO = findNestedColumnIO(lookupColumnByName(messageColumnIO, pushedDownSubfield.getRootName()), nestedColumnPath);
+                    if (columnIO.isPresent()) {
+                        internalFields.add(constructField(prestoType, columnIO.get()));
+                    }
+                    else {
+                        internalFields.add(Optional.empty());
+                    }
                 }
                 else {
-                    internalFields.add(constructField(column.getType(), messageColumnIO.getChild(parquetField.getName())));
+                    Optional<org.apache.parquet.schema.Type> parquetField = getColumnType(parquetIdToField, fileSchema, column);
+                    if (!parquetField.isPresent()) {
+                        internalFields.add(Optional.empty());
+                    }
+                    else {
+                        internalFields.add(constructField(column.getType(), messageColumnIO.getChild(parquetField.get().getName())));
+                    }
                 }
             }
 
@@ -304,6 +321,35 @@ public class IcebergPageSourceProvider
             }
             throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, message, e);
         }
+    }
+
+    public static Optional<org.apache.parquet.schema.Type> getColumnType(
+            Map<Integer, org.apache.parquet.schema.Type> parquetIdToField,
+            MessageType messageType,
+            IcebergColumnHandle column)
+    {
+        if (isPushedDownSubfield(column)) {
+            Subfield pushedDownSubfield = getPushedDownSubfield(column);
+            return getSubfieldType(messageType, pushedDownSubfield.getRootName(), nestedColumnPath(pushedDownSubfield));
+        }
+
+        if (parquetIdToField.isEmpty()) {
+            // This is a migrated table
+            return Optional.ofNullable(getParquetTypeByName(column.getName(), messageType));
+        }
+        return Optional.ofNullable(parquetIdToField.get(column.getId()));
+    }
+
+    private static HiveColumnHandle.ColumnType getHiveColumnHandleColumnType(IcebergColumnHandle.ColumnType columnType)
+    {
+        switch (columnType) {
+            case REGULAR:
+                return REGULAR;
+            case SYNTHESIZED:
+                return SYNTHESIZED;
+        }
+
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unknown ColumnType: " + columnType);
     }
 
     private static TupleDomain<ColumnDescriptor> getParquetTupleDomain(Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<IcebergColumnHandle> effectivePredicate)
@@ -448,8 +494,9 @@ public class IcebergPageSourceProvider
                             toHiveType(column.getType()),
                             column.getType().getTypeSignature(),
                             nextMissingColumnIndex++,
-                            REGULAR,
-                            Optional.empty(),
+                            getHiveColumnHandleColumnType(column.getColumnType()),
+                            column.getComment(),
+                            column.getRequiredSubfields(),
                             Optional.empty()));
                 }
             }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -77,6 +77,7 @@ public final class IcebergSessionProperties
     private static final String NESSIE_REFERENCE_NAME = "nessie_reference_name";
     private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
+    public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -267,6 +268,11 @@ public final class IcebergSessionProperties
                         READ_MASKED_VALUE_ENABLED,
                         "Return null when access is denied for an encrypted parquet column",
                         hiveClientConfig.getReadNullMaskedParquetEncryptedValue(),
+                        false),
+                booleanProperty(
+                        PARQUET_DEREFERENCE_PUSHDOWN_ENABLED,
+                        "Is dereference pushdown expression pushdown into Parquet reader enabled?",
+                        icebergConfig.isParquetDereferencePushdownEnabled(),
                         false));
     }
 
@@ -433,5 +439,10 @@ public final class IcebergSessionProperties
     public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
     {
         return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isParquetDereferencePushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_DEREFERENCE_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -24,6 +24,7 @@ import com.facebook.presto.hive.authentication.HiveAuthenticationModule;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
 import com.facebook.presto.hive.s3.HiveS3Module;
+import com.facebook.presto.iceberg.optimizer.IcebergParquetDereferencePushDown;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizer;
 import com.facebook.presto.plugin.base.security.AllowAllAccessControl;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
@@ -96,6 +97,7 @@ public final class InternalIcebergConnectorFactory
             IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
             Set<Procedure> procedures = injector.getInstance((Key<Set<Procedure>>) Key.get(Types.setOf(Procedure.class)));
             ConnectorPlanOptimizer planOptimizer = injector.getInstance(IcebergPlanOptimizer.class);
+            ConnectorPlanOptimizer parquetDereferencePushDown = injector.getInstance(IcebergParquetDereferencePushDown.class);
 
             return new IcebergConnector(
                     lifeCycleManager,
@@ -111,7 +113,7 @@ public final class InternalIcebergConnectorFactory
                     icebergTableProperties.getTableProperties(),
                     new AllowAllAccessControl(),
                     procedures,
-                    planOptimizer);
+                    ImmutableSet.of(planOptimizer, parquetDereferencePushDown));
         }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.optimizer;
+
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.iceberg.IcebergAbstractMetadata;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.iceberg.IcebergTableHandle;
+import com.facebook.presto.iceberg.IcebergTransactionManager;
+import com.facebook.presto.parquet.rule.ParquetDereferencePushDown;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import org.apache.iceberg.FileFormat;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.iceberg.IcebergColumnHandle.getSynthesizedIcebergColumnHandle;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isParquetDereferencePushdownEnabled;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
+import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergParquetDereferencePushDown
+        extends ParquetDereferencePushDown
+{
+    private final IcebergTransactionManager transactionManager;
+    private final TypeManager typeManager;
+
+    @Inject
+    public IcebergParquetDereferencePushDown(
+            IcebergTransactionManager transactionManager,
+            RowExpressionService rowExpressionService,
+            TypeManager typeManager)
+    {
+        super(rowExpressionService);
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    protected boolean isParquetDereferenceEnabled(ConnectorSession session, TableHandle tableHandle)
+    {
+        checkArgument(tableHandle.getConnectorHandle() instanceof IcebergTableHandle,
+                "Dereference pushdown into reader is not supported on a non-iceberg TableHandle");
+
+        if (!isParquetDereferencePushdownEnabled(session)) {
+            return false;
+        }
+
+        ConnectorMetadata metadata = transactionManager.get(tableHandle.getTransaction());
+        checkState(metadata instanceof IcebergAbstractMetadata, "metadata must be IcebergAbstractMetadata");
+
+        return FileFormat.PARQUET == getFileFormat(metadata.getTableMetadata(session, tableHandle.getConnectorHandle()).getProperties());
+    }
+
+    @Override
+    protected String getColumnName(ColumnHandle columnHandle)
+    {
+        checkArgument(columnHandle instanceof IcebergColumnHandle,
+                "Expected Iceberg column handle, instead got: " + columnHandle.getClass());
+        return ((IcebergColumnHandle) columnHandle).getName();
+    }
+
+    @Override
+    protected ColumnHandle createSubfieldColumnHandle(
+            ColumnHandle baseColumnHandle,
+            Subfield subfield,
+            Type subfieldDataType,
+            String subfieldColumnName)
+    {
+        checkArgument(baseColumnHandle instanceof IcebergColumnHandle,
+                "Expected Iceberg column handle, instead got: " + baseColumnHandle.getClass());
+
+        IcebergColumnHandle icebergBaseColumnHandle = (IcebergColumnHandle) baseColumnHandle;
+        Type type = icebergBaseColumnHandle.getType();
+        checkArgument(type instanceof RowType, "%s must be type of RowType", subfield.getRootName());
+
+        Optional<HiveType> nestedColumnHiveType = toHiveType(type)
+                .findChildType(subfield.getPath()
+                        .stream()
+                        .map(p -> ((Subfield.NestedField) p).getName())
+                        .collect(Collectors.toList()));
+
+        if (!nestedColumnHiveType.isPresent()) {
+            throw new IllegalArgumentException("nested column [" + subfield + "] type is not present in Hive column type");
+        }
+
+        Type pushdownColumnType = nestedColumnHiveType.get().getType(typeManager);
+
+        return getSynthesizedIcebergColumnHandle(subfieldColumnName, pushdownColumnType, ImmutableList.of(subfield));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -25,19 +25,19 @@ import static java.util.Objects.requireNonNull;
 public class IcebergPlanOptimizerProvider
         implements ConnectorPlanOptimizerProvider
 {
-    private final ConnectorPlanOptimizer planOptimizer;
+    private final Set<ConnectorPlanOptimizer> planOptimizers;
 
     @Inject
     public IcebergPlanOptimizerProvider(
-            ConnectorPlanOptimizer planOptimizer)
+            Set<ConnectorPlanOptimizer> planOptimizers)
     {
-        this.planOptimizer = requireNonNull(planOptimizer, "planOptimizer is null");
+        this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
     }
 
     @Override
     public Set<ConnectorPlanOptimizer> getLogicalPlanOptimizers()
     {
-        return ImmutableSet.of(planOptimizer);
+        return planOptimizers;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -41,7 +41,8 @@ public class TestIcebergConfig
                 .setCatalogCacheSize(10)
                 .setHadoopConfigResources(null)
                 .setMaxPartitionsPerWriter(100)
-                .setMinimumAssignedSplitWeight(0.05));
+                .setMinimumAssignedSplitWeight(0.05)
+                .setParquetDereferencePushdownEnabled(false));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestIcebergConfig
                 .put("iceberg.hadoop.config.resources", "/etc/hadoop/conf/core-site.xml")
                 .put("iceberg.max-partitions-per-writer", "222")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
+                .put("iceberg.enable-parquet-dereference-pushdown", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -66,7 +68,8 @@ public class TestIcebergConfig
                 .setCatalogCacheSize(6)
                 .setHadoopConfigResources("/etc/hadoop/conf/core-site.xml")
                 .setMaxPartitionsPerWriter(222)
-                .setMinimumAssignedSplitWeight(0.01);
+                .setMinimumAssignedSplitWeight(0.01)
+                .setParquetDereferencePushdownEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.assertions.MatchResult;
+import com.facebook.presto.sql.planner.assertions.Matcher;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_DEREFERENCE_ENABLED;
+import static com.facebook.presto.common.predicate.Domain.create;
+import static com.facebook.presto.common.predicate.Domain.singleValue;
+import static com.facebook.presto.common.predicate.Range.greaterThan;
+import static com.facebook.presto.common.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.common.predicate.ValueSet.ofRanges;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ColumnType.SYNTHESIZED;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.getSynthesizedIcebergColumnHandle;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.isPushedDownSubfield;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PARQUET_DEREFERENCE_PUSHDOWN_ENABLED;
+import static com.facebook.presto.parquet.ParquetTypeUtils.pushdownColumnNameForSubfield;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class TestIcebergLogicalPlanner
+        extends AbstractTestQueryFramework
+{
+    protected TestIcebergLogicalPlanner() {}
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createIcebergQueryRunner(ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"), ImmutableMap.of());
+    }
+
+    @Test
+    public void testParquetDereferencePushDown()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_nestedcolumn_parquet(" +
+                "id bigint, " +
+                "x row(a bigint, b varchar, c double, d row(d1 bigint, d2 double))," +
+                "y array(row(a bigint, b varchar, c double, d row(d1 bigint, d2 double)))) " +
+                "with (format = 'PARQUET')");
+
+        assertParquetDereferencePushDown("SELECT x.a FROM test_pushdown_nestedcolumn_parquet",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown("SELECT x.a, mod(x.d.d1, 2) FROM test_pushdown_nestedcolumn_parquet",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.d.d1"));
+
+        assertParquetDereferencePushDown("SELECT x.d, mod(x.d.d1, 2), x.d.d2 FROM test_pushdown_nestedcolumn_parquet",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d"));
+
+        assertParquetDereferencePushDown("SELECT x.a FROM test_pushdown_nestedcolumn_parquet WHERE x.b LIKE 'abc%'",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.b"));
+
+        Subfield nestedColumn1 = nestedColumn("x.a");
+        String pushdownColumnName1 = pushdownColumnNameForSubfield(nestedColumn1);
+        assertParquetDereferencePushDown("SELECT x.a FROM test_pushdown_nestedcolumn_parquet WHERE x.a > 10 AND x.b LIKE 'abc%'",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.b"),
+                ImmutableSet.of(pushdownColumnNameForSubfield(nestedColumn("x.a"))),
+                withColumnDomains(ImmutableMap.of(getSynthesizedIcebergColumnHandle(pushdownColumnName1, BIGINT, nestedColumn1), create(ofRanges(greaterThan(BIGINT, 10L)), false))));
+
+        // Join
+        assertPlan(withParquetDereferencePushDownEnabled(), "SELECT l.orderkey, x.a, mod(x.d.d1, 2) FROM lineitem l, test_pushdown_nestedcolumn_parquet a WHERE l.linenumber = a.id",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x.a", "x.d.d1"))))));
+
+        assertPlan(withParquetDereferencePushDownEnabled(), "SELECT l.orderkey, x.a, mod(x.d.d1, 2) FROM lineitem l, test_pushdown_nestedcolumn_parquet a WHERE l.linenumber = a.id AND x.a > 10",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScanParquetDeferencePushDowns(
+                                        "test_pushdown_nestedcolumn_parquet",
+                                        nestedColumnMap("x.a", "x.d.d1"),
+                                        ImmutableSet.of(pushdownColumnNameForSubfield(nestedColumn("x.a"))),
+                                        withColumnDomains(ImmutableMap.of(getSynthesizedIcebergColumnHandle(pushdownColumnName1, BIGINT, nestedColumn1), create(ofRanges(greaterThan(BIGINT, 10L)), false))))))));
+        // Aggregation
+        assertParquetDereferencePushDown("SELECT id, min(x.a) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown("SELECT id, min(mod(x.a, 3)) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown("SELECT id, min(x.a) FILTER (WHERE x.b LIKE 'abc%') FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.b"));
+
+        assertParquetDereferencePushDown("SELECT id, min(x.a + 1) * avg(x.d.d1) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.d.d1"));
+
+        assertParquetDereferencePushDown("SELECT id, arbitrary(x.a) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        // Dereference can't be pushed down, but the subfield pushdown will help in pruning the number of columns to read
+        assertPushdownSubfields("SELECT id, arbitrary(x.a) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
+        // Dereference can't be pushed down, but the subfield pushdown will help in pruning the number of columns to read
+        assertPushdownSubfields("SELECT id, arbitrary(x).d.d1 FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                ImmutableMap.of("x", toSubfields("x.d.d1")));
+
+        assertParquetDereferencePushDown("SELECT id, arbitrary(x.d).d1 FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d"));
+
+        assertParquetDereferencePushDown("SELECT id, arbitrary(x.d.d2) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d.d2"));
+
+        // Unnest
+        assertParquetDereferencePushDown("SELECT t.a, t.d.d1, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(a, b, c, d)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown("SELECT t.*, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(a, b, c, d)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown("SELECT id, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(a, b, c, d)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        // Legacy unnest
+        Session legacyUnnest = Session.builder(withParquetDereferencePushDownEnabled())
+                .setSystemProperty("legacy_unnest", "true")
+                .build();
+        assertParquetDereferencePushDown(legacyUnnest, "SELECT t.y.a, t.y.d.d1, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(y)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown(legacyUnnest, "SELECT t.*, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(y)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        assertParquetDereferencePushDown(legacyUnnest, "SELECT id, x.a FROM test_pushdown_nestedcolumn_parquet CROSS JOIN UNNEST(y) as t(y)",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a"));
+
+        // Case sensitivity
+        assertParquetDereferencePushDown("SELECT x.a, x.b, x.A + 2 FROM test_pushdown_nestedcolumn_parquet WHERE x.B LIKE 'abc%'",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.a", "x.b"));
+
+        // No pass-through nested column pruning
+        assertParquetDereferencePushDown("SELECT id, min(x.d).d1 FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d"));
+
+        assertParquetDereferencePushDown("SELECT id, min(x.d).d1, min(x.d.d2) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d"));
+
+        // Test pushdown of filters on dereference columns
+        nestedColumn1 = nestedColumn("x.d.d1");
+        pushdownColumnName1 = pushdownColumnNameForSubfield(nestedColumn1);
+        assertParquetDereferencePushDown("SELECT id, x.d.d1 FROM test_pushdown_nestedcolumn_parquet WHERE x.d.d1 = 1",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d.d1"),
+                ImmutableSet.of(pushdownColumnNameForSubfield(nestedColumn("x.d.d1"))),
+                withColumnDomains(ImmutableMap.of(
+                        getSynthesizedIcebergColumnHandle(pushdownColumnName1, BIGINT, nestedColumn1), singleValue(BIGINT, 1L))));
+
+        Subfield nestedColumn2 = nestedColumn("x.d.d2");
+        String pushdownColumnName2 = pushdownColumnNameForSubfield(nestedColumn2);
+        assertParquetDereferencePushDown("SELECT id, x.d.d1 FROM test_pushdown_nestedcolumn_parquet WHERE x.d.d1 = 1 and x.d.d2 = 5.0",
+                "test_pushdown_nestedcolumn_parquet",
+                nestedColumnMap("x.d.d1", "x.d.d2"),
+                ImmutableSet.of(
+                        pushdownColumnNameForSubfield(nestedColumn("x.d.d1")),
+                        pushdownColumnNameForSubfield(nestedColumn("x.d.d2"))),
+                withColumnDomains(ImmutableMap.of(
+                        getSynthesizedIcebergColumnHandle(pushdownColumnName1, BIGINT, nestedColumn1), singleValue(BIGINT, 1L),
+                        getSynthesizedIcebergColumnHandle(pushdownColumnName2, DOUBLE, nestedColumn2), singleValue(DOUBLE, 5.0))));
+
+        assertUpdate("DROP TABLE test_pushdown_nestedcolumn_parquet");
+    }
+
+    private static PlanMatchPattern tableScanParquetDeferencePushDowns(String expectedTableName, Map<String, Subfield> expectedDeferencePushDowns)
+    {
+        return PlanMatchPattern.tableScan(expectedTableName).with(new IcebergParquetDereferencePushdownMatcher(expectedDeferencePushDowns, ImmutableSet.of(), TupleDomain.all()));
+    }
+
+    private static PlanMatchPattern tableScanParquetDeferencePushDowns(
+            String expectedTableName,
+            Map<String, Subfield> expectedDeferencePushDowns,
+            Set<String> predicateColumns,
+            TupleDomain<IcebergColumnHandle> predicate)
+    {
+        return PlanMatchPattern.tableScan(expectedTableName).with(new IcebergParquetDereferencePushdownMatcher(expectedDeferencePushDowns, predicateColumns, predicate));
+    }
+
+    private void assertParquetDereferencePushDown(@Language("SQL") String query, String tableName, Map<String, Subfield> expectedDeferencePushDowns)
+    {
+        assertParquetDereferencePushDown(withParquetDereferencePushDownEnabled(), query, tableName, expectedDeferencePushDowns);
+    }
+
+    private void assertParquetDereferencePushDown(@Language("SQL") String query, String tableName, Map<String, Subfield> expectedDeferencePushDowns,
+            Set<String> predicateColumns,
+            TupleDomain<IcebergColumnHandle> predicate)
+    {
+        assertPlan(withParquetDereferencePushDownEnabled(), query,
+                anyTree(tableScanParquetDeferencePushDowns(tableName, expectedDeferencePushDowns, predicateColumns, predicate)));
+    }
+
+    private void assertParquetDereferencePushDown(Session session, @Language("SQL") String query, String tableName, Map<String, Subfield> expectedDeferencePushDowns)
+    {
+        assertPlan(session, query, anyTree(tableScanParquetDeferencePushDowns(tableName, expectedDeferencePushDowns)));
+    }
+
+    private Session withParquetDereferencePushDownEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(PUSHDOWN_DEREFERENCE_ENABLED, "true")
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PARQUET_DEREFERENCE_PUSHDOWN_ENABLED, "true")
+                .build();
+    }
+
+    private static Set<Subfield> toSubfields(String... subfieldPaths)
+    {
+        return Arrays.stream(subfieldPaths)
+                .map(Subfield::new)
+                .collect(toImmutableSet());
+    }
+
+    private void assertPushdownSubfields(@Language("SQL") String query, String tableName, Map<String, Set<Subfield>> requiredSubfields)
+    {
+        assertPlan(query, anyTree(tableScan(tableName, requiredSubfields)));
+    }
+
+    private static PlanMatchPattern tableScan(String expectedTableName, Map<String, Set<Subfield>> expectedRequiredSubfields)
+    {
+        return PlanMatchPattern.tableScan(expectedTableName).with(new IcebergTableScanMatcher(expectedRequiredSubfields));
+    }
+
+    private static final class IcebergTableScanMatcher
+            implements Matcher
+    {
+        private final Map<String, Set<Subfield>> requiredSubfields;
+
+        private IcebergTableScanMatcher(Map<String, Set<Subfield>> requiredSubfields)
+        {
+            this.requiredSubfields = requireNonNull(requiredSubfields, "requiredSubfields is null");
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof TableScanNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            TableScanNode tableScan = (TableScanNode) node;
+            for (ColumnHandle column : tableScan.getAssignments().values()) {
+                IcebergColumnHandle icebergColumn = (IcebergColumnHandle) column;
+                String columnName = icebergColumn.getName();
+                if (requiredSubfields.containsKey(columnName)) {
+                    if (!requiredSubfields.get(columnName).equals(ImmutableSet.copyOf(icebergColumn.getRequiredSubfields()))) {
+                        return NO_MATCH;
+                    }
+                }
+                else {
+                    if (!icebergColumn.getRequiredSubfields().isEmpty()) {
+                        return NO_MATCH;
+                    }
+                }
+            }
+
+            return match();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("requiredSubfields", requiredSubfields)
+                    .toString();
+        }
+    }
+
+    private static final class IcebergParquetDereferencePushdownMatcher
+            implements Matcher
+    {
+        private final Map<String, Subfield> dereferenceColumns;
+        private final Set<String> predicateColumns;
+        private final TupleDomain<IcebergColumnHandle> predicate;
+
+        private IcebergParquetDereferencePushdownMatcher(
+                Map<String, Subfield> dereferenceColumns,
+                Set<String> predicateColumns,
+                TupleDomain<IcebergColumnHandle> predicate)
+        {
+            this.dereferenceColumns = requireNonNull(dereferenceColumns, "dereferenceColumns is null");
+            this.predicateColumns = requireNonNull(predicateColumns, "predicateColumns is null");
+            this.predicate = requireNonNull(predicate, "predicate is null");
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof TableScanNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            TableScanNode tableScan = (TableScanNode) node;
+            for (ColumnHandle column : tableScan.getAssignments().values()) {
+                IcebergColumnHandle icebergColumn = (IcebergColumnHandle) column;
+                String columnName = icebergColumn.getName();
+                if (dereferenceColumns.containsKey(columnName)) {
+                    if (icebergColumn.getColumnType() != SYNTHESIZED ||
+                            icebergColumn.getRequiredSubfields().size() != 1 ||
+                            !icebergColumn.getRequiredSubfields().get(0).equals(dereferenceColumns.get(columnName))) {
+                        return NO_MATCH;
+                    }
+                    dereferenceColumns.remove(columnName);
+                }
+                else {
+                    if (isPushedDownSubfield(icebergColumn)) {
+                        return NO_MATCH;
+                    }
+                }
+            }
+
+            if (!dereferenceColumns.isEmpty()) {
+                return NO_MATCH;
+            }
+
+            Optional<ConnectorTableLayoutHandle> layout = tableScan.getTable().getLayout();
+
+            if (!layout.isPresent()) {
+                return NO_MATCH;
+            }
+
+            IcebergTableLayoutHandle layoutHandle = (IcebergTableLayoutHandle) layout.get();
+
+            Optional<List<TupleDomain.ColumnDomain<ColumnHandle>>> columnDomains = layoutHandle.getTupleDomain().getColumnDomains();
+            Set<String> actualPredicateColumns = ImmutableSet.of();
+            if (columnDomains.isPresent()) {
+                actualPredicateColumns = columnDomains.get().stream()
+                        .map(TupleDomain.ColumnDomain::getColumn)
+                        .filter(c -> c instanceof IcebergColumnHandle)
+                        .map(c -> ((IcebergColumnHandle) c).getName())
+                        .collect(Collectors.toSet());
+            }
+
+            if (!Objects.equals(actualPredicateColumns, predicateColumns)
+                    || !Objects.equals(layoutHandle.getTupleDomain(), predicate)) {
+                return NO_MATCH;
+            }
+
+            return match();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("dereferenceColumns", dereferenceColumns)
+                    .add("predicateColumns", predicateColumns)
+                    .add("predicate", predicate)
+                    .toString();
+        }
+    }
+
+    private static Map<String, Subfield> nestedColumnMap(String... columns)
+    {
+        return Arrays.stream(columns).collect(Collectors.toMap(
+                column -> pushdownColumnNameForSubfield(nestedColumn(column)),
+                TestIcebergLogicalPlanner::nestedColumn));
+    }
+
+    private static Subfield nestedColumn(String column)
+    {
+        return new Subfield(column);
+    }
+}


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Iceberg Changes

* Support parquet dereference pushdown for Iceberg Connector.
```

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/5170878/225658807-806c70a2-4f8c-4aa0-8aa8-4ad0cfeffe6f.png">
