### PR TITLE
Add payload on the LHS of the join during payload join optimization, push down projections for computed join keys

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -162,6 +162,22 @@ public class PlannerUtils
         return Optional.of(result);
     }
 
+    public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, Map<VariableReferenceExpression, RowExpression> variableMap)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        for (VariableReferenceExpression variableReferenceExpression : source.getOutputVariables()) {
+            assignments.put(variableReferenceExpression, variableReferenceExpression);
+        }
+        variableMap.forEach(assignments::put);
+
+        return new ProjectNode(
+                source.getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                source,
+                assignments.build(),
+                LOCAL);
+    }
+
     public static PlanNode projectExpressions(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, List<? extends RowExpression> expressions, List<VariableReferenceExpression> variableMap)
     {
         Assignments.Builder assignments = Assignments.builder();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1219,7 +1219,8 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem_map) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
                 "with lm as (select quantity + 1 as q1, * from lineitem_map) SELECT l.* FROM (select * from lm) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
 
-                "SELECT l.* FROM lineitem_map l left join orders o on (cast(l.orderkey as varchar) = cast(o.orderkey as varchar)) left join part p on (l.partkey=p.partkey)"
+                "SELECT l.* FROM lineitem_map l left join orders o on (cast(l.orderkey as varchar) = cast(o.orderkey as varchar)) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem_map) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)"
         };
 
         for (String query : queries) {
@@ -1237,7 +1238,8 @@ public abstract class AbstractTestDistributedQueries
         String[] nonOptimizableQueries = {
                 "with lm as (select if (quantity > 1, quantity, 1) as q1, * from lineitem_map), lm2 as (select if (q1 > 2, q1, 1) as q2, quantity,partkey,suppkey,linenumber,m1,m2 from lm left join orders o on (lm.orderkey=o.orderkey)) SELECT l.* FROM (select q2+3 as q3,partkey,suppkey,linenumber,m1,m2 from lm2) l left join part p on (l.partkey=p.partkey)",
                 "SELECT l.* FROM (select rand(100) as pk100 from (select orderkey+1 as ok1, * from lineitem_map) l left join orders o on (l.ok1 = o.orderkey+1)) l left join part p on (l.pk100=p.partkey)",
-                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)"
+                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
+                "SELECT l.*, p.m3, p.m4 FROM (select * from lineitem_map where false) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)"
         };
 
         for (String query : nonOptimizableQueries) {


### PR DESCRIPTION
This is a refinement of the earlier commit which introduced an optimization for payload joinsL https://github.com/prestodb/presto/commit/1ac2e724c47c184541a245308e8f236ca199377b

This change swaps the sides of the joins to keep the payload on the LHS of the join for efficiency reasons.

It also implements projection push-down for cases when the join keys are not base-table columns but computed in projections such as:
```
SELECT l.* 
FROM 
  (select orderkey+1 as ok1, * from lineitem_map) l left join orders o 
      on (l.ok1 = o.orderkey+1) left join part p 
      on (l.partkey=p.partkey)
```

```
== NO RELEASE NOTE ==
```
