### PR TITLE
[Not for review] Decouple NativeExecutionProcess and NativeExecutionOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -51,7 +51,6 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.MetadataDeleteNode;
-import com.facebook.presto.sql.planner.plan.NativeExecutionNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
@@ -78,7 +77,6 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isForceSingleNodeOutput;
-import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isTableWriterMergeOperatorEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -180,10 +178,10 @@ public abstract class BasePlanFragmenter
         }
 
         // Only delegate non-coordinatorOnly plan fragment to native engine
-        if (isNativeExecutionEnabled(session) && !properties.getPartitioningHandle().isCoordinatorOnly()) {
-            root = new NativeExecutionNode(root);
-            schedulingOrder = scheduleOrder(root);
-        }
+//        if (isNativeExecutionEnabled(session) && !properties.getPartitioningHandle().isCoordinatorOnly()) {
+//            root = new NativeExecutionNode(root);
+//            schedulingOrder = scheduleOrder(root);
+//        }
 
         PlanFragment fragment = new PlanFragment(
                 fragmentId,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkService.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkService.java
@@ -57,5 +57,6 @@ public class PrestoSparkService
     public void close()
     {
         lifeCycleManager.stop();
+        taskExecutorFactory.stop();
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -478,9 +478,11 @@ public abstract class AbstractPrestoSparkQueryExecution
             long currentFragmentOutputUncompressedSizeInBytes = 0;
             for (Tuple2<MutablePartitionId, PrestoSparkSerializedPage> tuple : tuples) {
                 PrestoSparkSerializedPage page = tuple._2;
-                currentFragmentOutputCompressedSizeInBytes += page.getSize();
-                currentFragmentOutputUncompressedSizeInBytes += page.getUncompressedSizeInBytes();
-                pages.add(page);
+                if (page != null) {
+                    currentFragmentOutputCompressedSizeInBytes += page.getSize();
+                    currentFragmentOutputUncompressedSizeInBytes += page.getUncompressedSizeInBytes();
+                    pages.add(page);
+                }
             }
             log.info(
                     "Received %s pages from fragment %s. Compressed size: %s. Uncompressed size: %s.",

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -115,13 +115,13 @@ public class NativeExecutionProcess
             throws ExecutionException, InterruptedException, IOException
     {
         String configPath = Paths.get(getProcessWorkingPath("./"), String.valueOf(port)).toAbsolutePath().toString();
-
+        String executableFullPath = getProcessWorkingPath(executablePath);
         populateConfigurationFiles(configPath, catalog);
-        ProcessBuilder processBuilder = new ProcessBuilder(executablePath, "--v", "1", "--etc_dir", configPath);
+        ProcessBuilder processBuilder = new ProcessBuilder(executableFullPath, "--v", "1", "--etc_dir", configPath);
         processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
         processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
         try {
-            log.info("Launching %s \nConfig path: %s\n", executablePath, configPath);
+            log.info("Launching %s \nConfig path: %s\n", executableFullPath, configPath);
             process = processBuilder.start();
         }
         catch (IOException e) {
@@ -145,7 +145,7 @@ public class NativeExecutionProcess
     @Override
     public void close()
     {
-        if (process != null && process.isAlive()) {
+        if (isAlive()) {
             process.destroy();
             try {
                 // For native process it takes 10s to initiate SHUTDOWN. The task cleanup interval is 60s. To be sure task cleanup is run at least once we just roughly double the
@@ -162,6 +162,11 @@ public class NativeExecutionProcess
                 }
             }
         }
+    }
+
+    public boolean isAlive()
+    {
+        return process != null && process.isAlive();
     }
 
     public int getPort()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
@@ -36,10 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 public class NativeExecutionProcessFactory
 {
-    // TODO add config
-    private static final int MAX_THREADS = 1000;
     private static final Duration MAX_ERROR_DURATION = new Duration(2, TimeUnit.MINUTES);
-
     private final HttpClient httpClient;
     private final ExecutorService coreExecutor;
     private final ScheduledExecutorService errorRetryScheduledExecutor;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -127,6 +127,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -181,7 +182,8 @@ public class PrestoSparkTaskExecutorFactory
         implements IPrestoSparkTaskExecutorFactory
 {
     private static final Logger log = Logger.get(PrestoSparkTaskExecutorFactory.class);
-
+    private static final String NATIVE_EXECUTION_SERVER_URI = "http://127.0.0.1";
+    private static final String NATIVE_EXECUTION_EXECUTABLE_PATH = "./sapphire_cpp";
     private final SessionPropertyManager sessionPropertyManager;
     private final BlockEncodingManager blockEncodingManager;
     private final FunctionAndTypeManager functionAndTypeManager;
@@ -222,6 +224,8 @@ public class PrestoSparkTaskExecutorFactory
     private final NativeExecutionProcessFactory processFactory;
     private final NativeExecutionTaskFactory taskFactory;
     private final PrestoSparkShuffleInfoTranslator shuffleInfoTranslator;
+    private final NativeExecutionProcessFactory nativeExecutionProcessFactory;
+    private NativeExecutionProcess nativeExecutionProcess;
 
     @Inject
     public PrestoSparkTaskExecutorFactory(
@@ -250,7 +254,8 @@ public class PrestoSparkTaskExecutorFactory
             BlockEncodingSerde blockEncodingSerde,
             NativeExecutionProcessFactory processFactory,
             NativeExecutionTaskFactory taskFactory,
-            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator)
+            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator,
+            NativeExecutionProcessFactory nativeExecutionProcessFactory)
     {
         this(
                 sessionPropertyManager,
@@ -282,7 +287,8 @@ public class PrestoSparkTaskExecutorFactory
                 blockEncodingSerde,
                 processFactory,
                 taskFactory,
-                shuffleInfoTranslator);
+                shuffleInfoTranslator,
+                nativeExecutionProcessFactory);
     }
 
     public PrestoSparkTaskExecutorFactory(
@@ -315,7 +321,8 @@ public class PrestoSparkTaskExecutorFactory
             BlockEncodingSerde blockEncodingSerde,
             NativeExecutionProcessFactory processFactory,
             NativeExecutionTaskFactory taskFactory,
-            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator)
+            PrestoSparkShuffleInfoTranslator shuffleInfoTranslator,
+            NativeExecutionProcessFactory nativeExecutionProcessFactory)
     {
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
@@ -348,6 +355,32 @@ public class PrestoSparkTaskExecutorFactory
         this.processFactory = requireNonNull(processFactory, "processFactory is null");
         this.taskFactory = requireNonNull(taskFactory, "taskFactory is null");
         this.shuffleInfoTranslator = requireNonNull(shuffleInfoTranslator, "shuffleInfoFactory is null");
+        this.nativeExecutionProcessFactory = nativeExecutionProcessFactory;
+    }
+
+    private void createAndStartNativeExecutionProcess()
+    {
+        if (nativeExecutionProcess != null) {
+            log.info("NativeExecutionProcess already exists");
+            return;
+        }
+
+        if (nativeExecutionProcessFactory == null) {
+            throw new RuntimeException("NativeExecutionProcessFactory is null but native execution is enabled ");
+        }
+
+        try {
+            // create the CPP sidecar process if it doesn't exist.
+            // We create this when the first task is scheduled
+            nativeExecutionProcess = nativeExecutionProcessFactory.createNativeExecutionProcess(
+                NATIVE_EXECUTION_EXECUTABLE_PATH,
+                "",
+                URI.create(NATIVE_EXECUTION_SERVER_URI));
+            nativeExecutionProcess.start();
+        }
+        catch (ExecutionException | InterruptedException | IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -397,6 +430,10 @@ public class PrestoSparkTaskExecutorFactory
                 extraAuthenticators.build());
         PlanFragment fragment = taskDescriptor.getFragment();
         StageId stageId = new StageId(session.getQueryId(), fragment.getId().getId());
+
+        if (isNativeExecutionEnabled(session)) {
+            createAndStartNativeExecutionProcess();
+        }
 
         // Clear the cache if the cache does not have broadcast table for current stageId.
         // We will only cache 1 HT at any time. If the stageId changes, we will drop the old cached HT
@@ -638,6 +675,14 @@ public class PrestoSparkTaskExecutorFactory
                 outputBuffer,
                 tempStorage,
                 tempDataOperationContext);
+    }
+
+    @Override
+    public void stop()
+    {
+        if (nativeExecutionProcess != null) {
+            nativeExecutionProcess.close();
+        }
     }
 
     public boolean isMemoryRevokePending(TaskContext taskContext)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
@@ -178,15 +178,16 @@ public class NativeExecutionOperator
 
     private void createTask()
     {
-        checkState(taskSource != null, "taskSource is null");
-        checkState(taskStatusFuture == null, "taskStatusFuture has already been set");
-        checkState(task == null, "task has already been set");
+//        checkState(taskSource != null, "taskSource is null");
+//        checkState(taskStatusFuture == null, "taskStatusFuture has already been set");
+//        checkState(task == null, "task has already been set");
+        log.info("Creating task with taskSource =%s", taskSource);
         this.task = taskFactory.createNativeExecutionTask(
                 operatorContext.getSession(),
                 uriBuilderFrom(URI.create(NATIVE_EXECUTION_SERVER_URI)).port(processFactory.getNativeExecutionProcess().getPort()).build(),
                 operatorContext.getDriverContext().getTaskId(),
                 planFragment,
-                ImmutableList.of(taskSource),
+                    ImmutableList.of(taskSource),
                 tableWriteInfo,
                 shuffleWriteInfo);
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -771,7 +771,8 @@ public class TestPrestoSparkHttpClient
                 workerProperty);
         List<TaskSource> sources = new ArrayList<>();
         return factory.createNativeExecutionProcess(
-                testSessionBuilder().build(),
+                "",
+                "",
                 BASE_URI,
                 maxErrorDuration);
     }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
@@ -27,4 +27,8 @@ public interface IPrestoSparkTaskExecutorFactory
             CollectionAccumulator<SerializedTaskInfo> taskInfoCollector,
             CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
             Class<T> outputType);
+
+    default void stop()
+    {
+    }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Currently the lifecycle of NativeProcess is tied to the NativeOperator. This is bad because It is not inline with the Native Execution design where we want the lifecycle to be couple with the executor. This could manifest as various issues. 
The one that we have encountered is the case where we are creating a CPP process for every split, causing exponentially large wall query execution time due to the cpp process startup and shutdown.


```
== NO RELEASE NOTE ==
```
