### PR TITLE
[native] Add operational endpoints for connector cache cleanup

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   PrestoServer.cpp
   PrestoTask.cpp
   QueryContextManager.cpp
+  ServerOperation.cpp
   SignalHandler.cpp
   TaskManager.cpp
   TaskResource.cpp)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/main/Announcer.h"
 #include "presto_cpp/main/PeriodicTaskManager.h"
 #include "presto_cpp/main/PrestoExchangeSource.h"
+#include "presto_cpp/main/ServerOperation.h"
 #include "presto_cpp/main/SignalHandler.h"
 #include "presto_cpp/main/TaskResource.h"
 #include "presto_cpp/main/common/ConfigReader.h"
@@ -39,6 +40,7 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/Context.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
@@ -74,15 +76,6 @@ protocol::NodeState convertNodeState(presto::NodeState nodeState) {
   return protocol::NodeState::ACTIVE; // For gcc build.
 }
 
-void sendOkResponse(proxygen::ResponseHandler* downstream, const json& body) {
-  proxygen::ResponseBuilder(downstream)
-      .status(http::kHttpOk, "OK")
-      .header(
-          proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
-      .body(body.dump())
-      .sendWithEOM();
-}
-
 std::string getLocalIp() {
   using boost::asio::ip::tcp;
   boost::asio::io_service io_service;
@@ -107,6 +100,42 @@ void enableChecksum() {
         return std::make_unique<
             serializer::presto::PrestoOutputStreamListener>();
       });
+}
+
+std::string clearConnectorCache(proxygen::HTTPMessage* message) {
+  const auto name = message->getQueryParam("name");
+  const auto id = message->getQueryParam("id");
+  if (name == "hive") {
+    // ======== HiveConnector Operations ========
+    auto hiveConnector =
+        std::dynamic_pointer_cast<velox::connector::hive::HiveConnector>(
+            velox::connector::getConnector(id));
+    VELOX_USER_CHECK_NOT_NULL(
+        hiveConnector,
+        "No '{}' connector found for connector id '{}'",
+        name,
+        id);
+    return hiveConnector->clearFileHandleCache().toString();
+  }
+  VELOX_USER_FAIL("connector '{}' operation is not supported", name);
+}
+
+std::string getConnectorCacheStats(proxygen::HTTPMessage* message) {
+  const auto name = message->getQueryParam("name");
+  const auto id = message->getQueryParam("id");
+  if (name == "hive") {
+    // ======== HiveConnector Operations ========
+    auto hiveConnector =
+        std::dynamic_pointer_cast<velox::connector::hive::HiveConnector>(
+            velox::connector::getConnector(id));
+    VELOX_USER_CHECK_NOT_NULL(
+        hiveConnector,
+        "No '{}' connector found for connector id '{}'",
+        name,
+        id);
+    return hiveConnector->fileHandleCacheStats().toString();
+  }
+  VELOX_USER_FAIL("connector '{}' operation is not supported", name);
 }
 
 } // namespace
@@ -209,7 +238,7 @@ void PrestoServer::run() {
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream) {
         json infoStateJson = convertNodeState(server->nodeState());
-        sendOkResponse(downstream, infoStateJson);
+        http::sendOkResponse(downstream, infoStateJson);
       });
   httpServer_->registerGet(
       "/v1/status",
@@ -221,16 +250,25 @@ void PrestoServer::run() {
       });
   httpServer_->registerHead(
       "/v1/status",
-      [server = this](
-          proxygen::HTTPMessage* /*message*/,
-          const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
-          proxygen::ResponseHandler* downstream) {
+      [](proxygen::HTTPMessage* /*message*/,
+         const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
+         proxygen::ResponseHandler* downstream) {
         proxygen::ResponseBuilder(downstream)
             .status(http::kHttpOk, "OK")
             .header(
                 proxygen::HTTP_HEADER_CONTENT_TYPE,
                 http::kMimeTypeApplicationJson)
             .sendWithEOM();
+      });
+
+  // The endpoint used by operation in production.
+  httpServer_->registerGet(
+      "/v1/operation/.*",
+      [server = this](
+          proxygen::HTTPMessage* message,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
+          proxygen::ResponseHandler* downstream) {
+        server->runOperation(message, downstream);
       });
 
   static const std::string kPrestoDefaultPrefix{"presto.default."};
@@ -563,6 +601,39 @@ void PrestoServer::populateMemAndCPUInfo() {
   **memoryInfo_.wlock() = std::move(memoryInfo);
 }
 
+void PrestoServer::runOperation(
+    proxygen::HTTPMessage* message,
+    proxygen::ResponseHandler* downstream) {
+  try {
+    ServerOperation op = buildServerOpFromHttpRequest(message);
+    switch (op.target) {
+      case ServerOperation::Target::kConnector:
+        http::sendOkResponse(downstream, connectorOperation(op, message));
+        break;
+    }
+  } catch (const VeloxUserError& ex) {
+    http::sendErrorResponse(downstream, ex.what());
+  } catch (const VeloxException& ex) {
+    http::sendErrorResponse(downstream, ex.what());
+  }
+}
+
+std::string PrestoServer::connectorOperation(
+    const ServerOperation& op,
+    proxygen::HTTPMessage* message) {
+  switch (op.action) {
+    case ServerOperation::Action::kClearCache:
+      return clearConnectorCache(message);
+    case ServerOperation::Action::kGetCacheStats:
+      return getConnectorCacheStats(message);
+    default:
+      VELOX_USER_FAIL(
+          "Target '{}' does not support action '{}'",
+          ServerOperation::targetString(op.target),
+          ServerOperation::actionString(op.action));
+  }
+}
+
 static protocol::Duration getUptime(
     std::chrono::steady_clock::time_point& start) {
   auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
@@ -582,7 +653,7 @@ static protocol::Duration getUptime(
 }
 
 void PrestoServer::reportMemoryInfo(proxygen::ResponseHandler* downstream) {
-  sendOkResponse(downstream, json(**memoryInfo_.rlock()));
+  http::sendOkResponse(downstream, json(**memoryInfo_.rlock()));
 }
 
 void PrestoServer::reportServerInfo(proxygen::ResponseHandler* downstream) {
@@ -592,7 +663,7 @@ void PrestoServer::reportServerInfo(proxygen::ResponseHandler* downstream) {
       false,
       false,
       std::make_shared<protocol::Duration>(getUptime(start_))};
-  sendOkResponse(downstream, json(serverInfo));
+  http::sendOkResponse(downstream, json(serverInfo));
 }
 
 void PrestoServer::reportNodeStatus(proxygen::ResponseHandler* downstream) {
@@ -621,7 +692,7 @@ void PrestoServer::reportNodeStatus(proxygen::ResponseHandler* downstream) {
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed};
 
-  sendOkResponse(downstream, json(nodeStatus));
+  http::sendOkResponse(downstream, json(nodeStatus));
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -42,6 +42,7 @@ class HttpServer;
 }
 
 namespace proxygen {
+class HTTPMessage;
 class ResponseHandler;
 }
 
@@ -54,6 +55,7 @@ namespace facebook::presto {
 // Three states our server can be in.
 enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };
 
+struct ServerOperation;
 class SignalHandler;
 class TaskManager;
 class TaskResource;
@@ -109,6 +111,15 @@ class PrestoServer {
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
   void populateMemAndCPUInfo();
+
+  /// Invoked to run operation on this server per http request.
+  void runOperation(
+      proxygen::HTTPMessage* message,
+      proxygen::ResponseHandler* downstream);
+
+  std::string connectorOperation(
+      const ServerOperation& op,
+      proxygen::HTTPMessage* message);
 
   const std::string configDirectoryPath_;
 

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/ServerOperation.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::presto {
+
+const std::unordered_map<std::string, ServerOperation::Action>
+    ServerOperation::kActionLookup = {
+        {"clearCache", ServerOperation::Action::kClearCache},
+        {"getCacheStats", ServerOperation::Action::kGetCacheStats}};
+
+const std::unordered_map<ServerOperation::Action, std::string>
+    ServerOperation::kReverseActionLookup = {
+        {ServerOperation::Action::kClearCache, "clearCache"},
+        {ServerOperation::Action::kGetCacheStats, "getCacheStats"}};
+
+const std::unordered_map<std::string, ServerOperation::Target>
+    ServerOperation::kTargetLookup = {
+        {"connector", ServerOperation::Target::kConnector}};
+
+const std::unordered_map<ServerOperation::Target, std::string>
+    ServerOperation::kReverseTargetLookup = {
+        {ServerOperation::Target::kConnector, "connector"}};
+
+ServerOperation::Target ServerOperation::targetFromString(
+    const std::string& str) {
+  auto it = kTargetLookup.find(str);
+  if (it == kTargetLookup.end()) {
+    VELOX_USER_FAIL("Unsupported server operation target '{}'", str);
+  }
+  return it->second;
+}
+
+std::string ServerOperation::targetString(ServerOperation::Target target) {
+  auto it = kReverseTargetLookup.find(target);
+  if (it == kReverseTargetLookup.end()) {
+    VELOX_FAIL();
+  }
+  return it->second;
+}
+
+ServerOperation::Action ServerOperation::actionFromString(
+    const std::string& str) {
+  auto it = kActionLookup.find(str);
+  if (it == kActionLookup.end()) {
+    VELOX_USER_FAIL("Unsupported server operation action '{}'", str);
+  }
+  return it->second;
+}
+
+std::string ServerOperation::actionString(Action action) {
+  auto it = kReverseActionLookup.find(action);
+  if (it == kReverseActionLookup.end()) {
+    VELOX_FAIL();
+  }
+  return it->second;
+}
+
+ServerOperation buildServerOpFromHttpRequest(
+    const proxygen::HTTPMessage* message) {
+  const auto& path = message->getPath();
+  const auto targetPos = std::string("/v1/operation/").length();
+  auto actionPos = path.find('/', targetPos);
+  VELOX_USER_CHECK_NE(actionPos, std::string::npos);
+  // Go beyond '/' to point to the first letter of action
+  actionPos += 1;
+  VELOX_USER_CHECK_LT(targetPos, actionPos);
+  auto target = path.substr(targetPos, actionPos - 1 - targetPos);
+  auto action = path.substr(actionPos);
+
+  ServerOperation op;
+  op.target = ServerOperation::targetFromString(target);
+  op.action = ServerOperation::actionFromString(action);
+  return op;
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <proxygen/lib/http/HTTPMessage.h>
+#include <string>
+
+namespace facebook::presto {
+
+/// Defines a server operation.
+struct ServerOperation {
+  /// The target this operation is operating upon
+  enum class Target {
+    kConnector,
+  };
+
+  /// The action this operation is trying to take
+  enum class Action { kClearCache, kGetCacheStats };
+
+  static const std::unordered_map<std::string, Target> kTargetLookup;
+  static const std::unordered_map<Target, std::string> kReverseTargetLookup;
+  static const std::unordered_map<std::string, Action> kActionLookup;
+  static const std::unordered_map<Action, std::string> kReverseActionLookup;
+
+  static Target targetFromString(const std::string& str);
+  static std::string targetString(Target target);
+  static Action actionFromString(const std::string& str);
+  static std::string actionString(Action action);
+
+  Target target;
+  Action action;
+};
+
+/// Builds a server operation from an HTTP request. Throws upon build failure.
+ServerOperation buildServerOpFromHttpRequest(
+    const proxygen::HTTPMessage* httpMsg);
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/http/HttpConstants.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpConstants.h
@@ -14,11 +14,11 @@
 #pragma once
 namespace facebook::presto::http {
 
-const int kHttpOk = 200;
-const int kHttpAccepted = 202;
-const int kHttpNoContent = 204;
-const int kHttpNotFound = 404;
-const int kHttpInternalServerError = 500;
+const uint16_t kHttpOk = 200;
+const uint16_t kHttpAccepted = 202;
+const uint16_t kHttpNoContent = 204;
+const uint16_t kHttpNotFound = 404;
+const uint16_t kHttpInternalServerError = 500;
 
 const char kMimeTypeApplicationJson[] = "application/json";
 const char kMimeTypeApplicationThrift[] = "application/x-thrift+binary";

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -18,6 +18,55 @@
 
 namespace facebook::presto::http {
 
+void sendOkResponse(proxygen::ResponseHandler* downstream) {
+  proxygen::ResponseBuilder(downstream)
+      .status(http::kHttpOk, "OK")
+      .sendWithEOM();
+}
+
+void sendOkResponse(proxygen::ResponseHandler* downstream, const json& body) {
+  proxygen::ResponseBuilder(downstream)
+      .status(http::kHttpOk, "OK")
+      .header(
+          proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
+      .body(body.dump())
+      .sendWithEOM();
+}
+
+void sendOkResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body) {
+  proxygen::ResponseBuilder(downstream)
+      .status(http::kHttpOk, "OK")
+      .header(
+          proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
+      .body(body)
+      .sendWithEOM();
+}
+
+void sendOkThriftResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body) {
+  proxygen::ResponseBuilder(downstream)
+      .status(http::kHttpOk, "OK")
+      .header(
+          proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationThrift)
+      .body(body)
+      .sendWithEOM();
+}
+
+void sendErrorResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& error,
+    uint16_t status) {
+  static const size_t kMaxStatusSize = 1024;
+
+  proxygen::ResponseBuilder(downstream)
+      .status(status, error.substr(0, kMaxStatusSize))
+      .body(error)
+      .sendWithEOM();
+}
+
 HttpServer::HttpServer(
     const folly::SocketAddress& httpAddress,
     int httpExecThreads)

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -17,12 +17,32 @@
 #include <proxygen/httpserver/RequestHandlerFactory.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <re2/re2.h>
+#include "presto_cpp/external/json/json.hpp"
 #include "presto_cpp/main/common/Counters.h"
 #include "presto_cpp/main/http/HttpConstants.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/time/Timer.h"
 
 namespace facebook::presto::http {
+
+using json = nlohmann::json;
+
+void sendOkResponse(proxygen::ResponseHandler* downstream);
+
+void sendOkResponse(proxygen::ResponseHandler* downstream, const json& body);
+
+void sendOkResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body);
+
+void sendOkThriftResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body);
+
+void sendErrorResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& error = "",
+    uint16_t status = http::kHttpInternalServerError);
 
 class AbstractRequestHandler : public proxygen::RequestHandler {
  public:

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -11,8 +11,13 @@
 # limitations under the License.
 add_executable(
   presto_server_test
-  PrestoExchangeSourceTest.cpp TaskManagerTest.cpp HttpServerWrapper.cpp
-  PrestoTaskTest.cpp AnnouncerTest.cpp QueryContextCacheTest.cpp)
+  PrestoExchangeSourceTest.cpp
+  TaskManagerTest.cpp
+  HttpServerWrapper.cpp
+  PrestoTaskTest.cpp
+  AnnouncerTest.cpp
+  QueryContextCacheTest.cpp
+  ServerOperationTest.cpp)
 
 add_test(presto_server_test presto_server_test)
 

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/ServerOperation.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::presto {
+
+class ServerOperationTest : public testing::Test {};
+
+TEST_F(ServerOperationTest, targetActionLookup) {
+  {
+    auto size = ServerOperation::kTargetLookup.size();
+    // Targets lookup verification
+    EXPECT_EQ(
+        ServerOperation::kTargetLookup.size(),
+        ServerOperation::kReverseTargetLookup.size());
+    const auto endReverseIt = ServerOperation::kReverseTargetLookup.end();
+    for (auto lookupIt = ServerOperation::kTargetLookup.begin();
+         lookupIt != ServerOperation::kTargetLookup.end();
+         lookupIt++) {
+      EXPECT_NE(
+          ServerOperation::kReverseTargetLookup.find(lookupIt->second),
+          endReverseIt);
+    }
+    const auto endLookupIt = ServerOperation::kTargetLookup.end();
+    for (auto reverseIt = ServerOperation::kReverseTargetLookup.begin();
+         reverseIt != ServerOperation::kReverseTargetLookup.end();
+         reverseIt++) {
+      EXPECT_NE(
+          ServerOperation::kTargetLookup.find(reverseIt->second), endLookupIt);
+    }
+  }
+
+  {
+    // Actions lookup verification
+    EXPECT_EQ(
+        ServerOperation::kActionLookup.size(),
+        ServerOperation::kReverseActionLookup.size());
+    const auto endReverseIt = ServerOperation::kReverseActionLookup.end();
+    for (auto lookupIt = ServerOperation::kActionLookup.begin();
+         lookupIt != ServerOperation::kActionLookup.end();
+         lookupIt++) {
+      EXPECT_NE(
+          ServerOperation::kReverseActionLookup.find(lookupIt->second),
+          endReverseIt);
+    }
+    const auto endLookupIt = ServerOperation::kActionLookup.end();
+    for (auto reverseIt = ServerOperation::kReverseActionLookup.begin();
+         reverseIt != ServerOperation::kReverseActionLookup.end();
+         reverseIt++) {
+      EXPECT_NE(
+          ServerOperation::kActionLookup.find(reverseIt->second), endLookupIt);
+    }
+  }
+}
+
+TEST_F(ServerOperationTest, stringEnumConversion) {
+  for (auto lookupIt = ServerOperation::kTargetLookup.begin();
+       lookupIt != ServerOperation::kTargetLookup.end();
+       lookupIt++) {
+    EXPECT_EQ(
+        ServerOperation::targetFromString(lookupIt->first), lookupIt->second);
+    EXPECT_EQ(ServerOperation::targetString(lookupIt->second), lookupIt->first);
+  }
+  EXPECT_THROW(
+      ServerOperation::targetFromString("UNKNOWN_TARGET"),
+      velox::VeloxUserError);
+
+  for (auto lookupIt = ServerOperation::kActionLookup.begin();
+       lookupIt != ServerOperation::kActionLookup.end();
+       lookupIt++) {
+    EXPECT_EQ(
+        ServerOperation::actionFromString(lookupIt->first), lookupIt->second);
+    EXPECT_EQ(ServerOperation::actionString(lookupIt->second), lookupIt->first);
+  }
+  EXPECT_THROW(
+      ServerOperation::actionFromString("UNKNOWN_ACTION"),
+      velox::VeloxUserError);
+}
+
+} // namespace facebook::presto


### PR DESCRIPTION
Adding HTTP operational endpoints for native server for debugging/maintenance purposes.
Currently added:
* HiveConnector file handle cache stats get
* HiveConnector file handle cache clearing

```
== NO RELEASE NOTE ==
```
