### PR TITLE
Add optimization to merge aggregations with and without filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -260,6 +260,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME = "optimize_join_probe_for_empty_build_runtime";
     public static final String USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS = "use_defaults_for_correlated_aggregation_pushdown_through_outer_joins";
     public static final String MERGE_DUPLICATE_AGGREGATIONS = "merge_duplicate_aggregations";
+    public static final String MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER = "merge_aggregations_with_and_without_filter";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1498,6 +1499,11 @@ public final class SystemSessionProperties
                         MERGE_DUPLICATE_AGGREGATIONS,
                         "Merge identical aggregation functions within the same aggregation node",
                         featuresConfig.isMergeDuplicateAggregationsEnabled(),
+                        false),
+                booleanProperty(
+                        MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER,
+                        "Merge aggregations that are same except for filter",
+                        featuresConfig.isMergeAggregationsWithAndWithoutFilter(),
                         false));
     }
 
@@ -2482,6 +2488,11 @@ public final class SystemSessionProperties
     public static boolean isPrefilterForGroupbyLimit(Session session)
     {
         return session.getSystemProperty(PREFILTER_FOR_GROUPBY_LIMIT, Boolean.class);
+    }
+
+    public static boolean isMergeAggregationsWithAndWithoutFilter(Session session)
+    {
+        return session.getSystemProperty(MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER, Boolean.class);
     }
 
     public static boolean isInPredicatesAsInnerJoinsEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -251,6 +251,8 @@ public class FeaturesConfig
     private boolean isOptimizeJoinProbeWithEmptyBuildRuntime;
     private boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins = true;
     private boolean mergeDuplicateAggregationsEnabled = true;
+    private boolean mergeAggregationsWithAndWithoutFilter;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2422,6 +2424,19 @@ public class FeaturesConfig
     public FeaturesConfig setMergeDuplicateAggregationsEnabled(boolean mergeDuplicateAggregationsEnabled)
     {
         this.mergeDuplicateAggregationsEnabled = mergeDuplicateAggregationsEnabled;
+        return this;
+    }
+
+    public boolean isMergeAggregationsWithAndWithoutFilter()
+    {
+        return this.mergeAggregationsWithAndWithoutFilter;
+    }
+
+    @Config("optimizer.merge-aggregations-with-and-without-filter")
+    @ConfigDescription("Enable optimization that merges the same agg with and without filter for efficiency")
+    public FeaturesConfig setMergeAggregationsWithAndWithoutFilter(boolean mergeAggregationsWithAndWithoutFilter)
+    {
+        this.mergeAggregationsWithAndWithoutFilter = mergeAggregationsWithAndWithoutFilter;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -135,6 +135,7 @@ import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
 import com.facebook.presto.sql.planner.optimizations.KeyBasedSampler;
 import com.facebook.presto.sql.planner.optimizations.LimitPushDown;
 import com.facebook.presto.sql.planner.optimizations.MergeJoinForSortedInputOptimizer;
+import com.facebook.presto.sql.planner.optimizations.MergePartialAggregationsWithFilter;
 import com.facebook.presto.sql.planner.optimizations.MetadataDeleteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MetadataQueryOptimizer;
 import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggregations;
@@ -691,8 +692,15 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.of(
                         new PushPartialAggregationThroughJoin(),
-                        new PushPartialAggregationThroughExchange(metadata.getFunctionAndTypeManager()),
-                        new PruneJoinColumns())));
+                        new PushPartialAggregationThroughExchange(metadata.getFunctionAndTypeManager()))),
+                // MergePartialAggregationsWithFilter should immediately follow PushPartialAggregationThroughExchange
+                new MergePartialAggregationsWithFilter(metadata.getFunctionAndTypeManager()),
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.of(
+                                new PruneJoinColumns())));
 
         builder.add(new IterativeOptimizer(
                 ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -180,15 +180,19 @@ public class PlannerUtils
                 LOCAL);
     }
 
-    public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, List<RowExpression> expressions)
+    public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator, List<RowExpression> expressions,
+            List<VariableReferenceExpression> variablesToUse)
     {
         Assignments.Builder assignments = Assignments.builder();
         for (VariableReferenceExpression variableReferenceExpression : source.getOutputVariables()) {
             assignments.put(variableReferenceExpression, variableReferenceExpression);
         }
 
-        for (RowExpression expression : expressions) {
-            assignments.put(variableAllocator.newVariable("expr", expression.getType()), expression);
+        checkState(variablesToUse.isEmpty() || variablesToUse.size() == expressions.size());
+        for (int i = 0; i < expressions.size(); i++) {
+            RowExpression expression = expressions.get(i);
+            VariableReferenceExpression variable = variablesToUse.isEmpty() ? variableAllocator.newVariable(expression) : variablesToUse.get(i);
+            assignments.put(variable, expression);
         }
 
         return new ProjectNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -130,10 +130,11 @@ public class Memo
         PlanNode old = getGroup(group).membership;
 
         checkArgument(new HashSet<>(old.getOutputVariables()).equals(new HashSet<>(node.getOutputVariables())),
-                "%s: transformed expression doesn't produce same outputs: %s vs %s",
+                "%s: transformed expression doesn't produce same outputs: %s vs %s for node: %s",
                 reason,
                 old.getOutputVariables(),
-                node.getOutputVariables());
+                node.getOutputVariables(),
+                node);
 
         if (node instanceof GroupReference) {
             node = getNode(((GroupReference) node).getGroupId());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
@@ -90,4 +90,21 @@ public class AggregationNodeUtils
 
         return groupbyKeys.stream().noneMatch(x -> estimate.getVariableStatistics(x).getDistinctValuesCount() >= count);
     }
+
+    public static AggregationNode.Aggregation removeFilterAndMask(AggregationNode.Aggregation aggregation)
+    {
+        Optional<RowExpression> filter = aggregation.getFilter();
+        Optional<VariableReferenceExpression> mask = aggregation.getMask();
+
+        if (filter.isPresent() || mask.isPresent()) {
+            return new AggregationNode.Aggregation(
+                    aggregation.getCall(),
+                    Optional.empty(),
+                    aggregation.getOrderBy(),
+                    aggregation.isDistinct(),
+                    Optional.empty());
+        }
+
+        return aggregation;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.isMergeAggregationsWithAndWithoutFilter;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
+import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.removeFilterAndMask;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Merge partial aggregations which have mask with the partial aggregation without mask when all other fields are the same
+ *
+ * <pre>
+ *     - Aggregation (Final)
+ *          sum_1 := sum(partial_sum_1)
+ *          sum_2 := sum(partial_sum_2)
+ *          group_by_key [gb]
+ *          - Exchange
+ *              - Aggregation (Partial)
+ *                  partial_sum_1 := sum(a)
+ *                  partial_sum_2 := sum(a) mask m
+ *                  group_by_key [gb]
+ * </pre>
+ * into
+ * <pre>
+ *     - Aggregation (Final)
+ *          sum_1 := sum(partial_sum_1)
+ *          sum_2 := sum(partial_sum_2)
+ *          group_by_key [gb]
+ *          - Project
+ *              partial_sum_2 := IF(m, partial_sum_1, null)
+ *              - Exchange
+ *                  - Aggregation (Partial)
+ *                      partial_sum_1 := sum(a)
+ *                      group_by_key [gb, m]
+ * </pre>
+ */
+public class MergePartialAggregationsWithFilter
+        implements PlanOptimizer
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public MergePartialAggregationsWithFilter(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isMergeAggregationsWithAndWithoutFilter(session)) {
+            return SimplePlanRewriter.rewriteWith(new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager), plan, new Context());
+        }
+
+        return plan;
+    }
+
+    private static class Context
+    {
+        private final Map<VariableReferenceExpression, VariableReferenceExpression> partialResultToMask;
+        private final Map<VariableReferenceExpression, VariableReferenceExpression> partialOutputMapping;
+
+        public Context()
+        {
+            partialResultToMask = new HashMap<>();
+            partialOutputMapping = new HashMap<>();
+        }
+
+        public boolean isEmpty()
+        {
+            return partialOutputMapping.isEmpty();
+        }
+
+        public void clear()
+        {
+            partialResultToMask.clear();
+            partialOutputMapping.clear();
+        }
+
+        public Map<VariableReferenceExpression, VariableReferenceExpression> getPartialOutputMapping()
+        {
+            return partialOutputMapping;
+        }
+
+        public Map<VariableReferenceExpression, VariableReferenceExpression> getPartialResultToMask()
+        {
+            return partialResultToMask;
+        }
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Context>
+    {
+        private final Session session;
+        private final VariableAllocator variableAllocator;
+        private final PlanNodeIdAllocator planNodeIdAllocator;
+        private final FunctionAndTypeManager functionAndTypeManager;
+
+        public Rewriter(Session session, VariableAllocator variableAllocator, PlanNodeIdAllocator planNodeIdAllocator, FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
+            this.planNodeIdAllocator = requireNonNull(planNodeIdAllocator, "planNodeIdAllocator is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        }
+
+        public static RowExpression ifThenElse(RowExpression... arguments)
+        {
+            return specialForm(SpecialFormExpression.Form.IF, arguments[1].getType(), arguments);
+        }
+
+        @Override
+        public PlanNode visitPlan(PlanNode node, RewriteContext<Context> context)
+        {
+            List<PlanNode> children = node.getSources().stream()
+                    .map(child -> context.rewrite(child, context.get()))
+                    .collect(toImmutableList());
+            if (!context.get().isEmpty()) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unexpected plan node between partial and final aggregation");
+            }
+            return replaceChildren(node, children);
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Context> context)
+        {
+            PlanNode rewrittenSource = context.rewrite(node.getSource(), context.get());
+            // Before optimization, for aggregations with filter, input rows will be skipped if mask is false. However, after optimization, the partial
+            // aggregation output is projected to be NULL if mask is false. We need to have the function to not calledOnNullInput to ensure correctness.
+            // Applying optimizations on global aggregations will lead to exception at
+            // https://github.com/prestodb/presto/blob/dfbf21744ccd900d1a650571ffc35915db9b9f59/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java#L627
+            boolean canOptimize = !node.getGroupingKeys().isEmpty() && node.getAggregations().values().stream()
+                    .map(x -> functionAndTypeManager.getFunctionMetadata(x.getFunctionHandle())).noneMatch(x -> x.isCalledOnNullInput());
+            if (canOptimize) {
+                checkState(node.getAggregations().values().stream().noneMatch(x -> x.getFilter().isPresent()), "All aggregation filters should already be rewritten to mask before this optimization");
+                if (node.getStep().equals(PARTIAL)) {
+                    return createPartialAggregationNode(node, rewrittenSource, context);
+                }
+                else if (node.getStep().equals(FINAL)) {
+                    return createFinalAggregationNode(node, rewrittenSource, context);
+                }
+            }
+            return node.replaceChildren(ImmutableList.of(rewrittenSource));
+        }
+
+        private AggregationNode createPartialAggregationNode(AggregationNode node, PlanNode rewrittenSource, RewriteContext<Context> context)
+        {
+            checkState(context.get().isEmpty(), "There should be no partial aggregation left unmerged for a partial aggregation node");
+            Map<AggregationNode.Aggregation, VariableReferenceExpression> aggregationsWithoutMaskToOutput = node.getAggregations().entrySet().stream()
+                    .filter(x -> !x.getValue().getMask().isPresent())
+                    .collect(toImmutableMap(x -> x.getValue(), x -> x.getKey(), (a, b) -> a));
+            Map<AggregationNode.Aggregation, VariableReferenceExpression> aggregationsToMergeOutput = node.getAggregations().entrySet().stream()
+                    .filter(x -> x.getValue().getMask().isPresent() && aggregationsWithoutMaskToOutput.containsKey(removeFilterAndMask(x.getValue())))
+                    .collect(toImmutableMap(x -> x.getValue(), x -> x.getKey()));
+
+            context.get().getPartialResultToMask().putAll(aggregationsToMergeOutput.entrySet().stream()
+                    .collect(toImmutableMap(x -> x.getValue(), x -> x.getKey().getMask().get())));
+            context.get().getPartialOutputMapping().putAll(aggregationsToMergeOutput.entrySet().stream()
+                    .collect(toImmutableMap(x -> x.getValue(), x -> aggregationsWithoutMaskToOutput.get(removeFilterAndMask(x.getKey())))));
+
+            Set<VariableReferenceExpression> maskVariables = new HashSet<>(context.get().getPartialResultToMask().values());
+            if (maskVariables.isEmpty()) {
+                return (AggregationNode) node.replaceChildren(ImmutableList.of(rewrittenSource));
+            }
+
+            ImmutableList.Builder<VariableReferenceExpression> groupingVariables = ImmutableList.builder();
+            AggregationNode.GroupingSetDescriptor groupingSetDescriptor = node.getGroupingSets();
+            groupingVariables.addAll(groupingSetDescriptor.getGroupingKeys());
+            groupingVariables.addAll(maskVariables);
+            AggregationNode.GroupingSetDescriptor partialGroupingSetDescriptor = new AggregationNode.GroupingSetDescriptor(
+                    groupingVariables.build(), groupingSetDescriptor.getGroupingSetCount(), groupingSetDescriptor.getGlobalGroupingSets());
+
+            Set<VariableReferenceExpression> partialResultToMerge = new HashSet<>(aggregationsToMergeOutput.values());
+            Map<VariableReferenceExpression, AggregationNode.Aggregation> newAggregations = node.getAggregations().entrySet().stream()
+                    .filter(x -> !partialResultToMerge.contains(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(MergePartialAggregationsWithFilter.class.getSimpleName(), true, Optional.empty()));
+
+            return new AggregationNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    rewrittenSource,
+                    newAggregations,
+                    partialGroupingSetDescriptor,
+                    node.getPreGroupedVariables(),
+                    PARTIAL,
+                    node.getHashVariable(),
+                    node.getGroupIdVariable());
+        }
+
+        private AggregationNode createFinalAggregationNode(AggregationNode node, PlanNode rewrittenSource, RewriteContext<Context> context)
+        {
+            if (context.get().isEmpty()) {
+                return (AggregationNode) node.replaceChildren(ImmutableList.of(rewrittenSource));
+            }
+            List<VariableReferenceExpression> intermediateVariables = node.getAggregations().values().stream()
+                    .map(x -> (VariableReferenceExpression) x.getArguments().get(0)).collect(Collectors.toList());
+            checkState(intermediateVariables.containsAll(context.get().partialResultToMask.keySet()));
+
+            ImmutableList.Builder<RowExpression> projectionsFromPartialAgg = ImmutableList.builder();
+            ImmutableList.Builder<VariableReferenceExpression> variablesForPartialAggResult = ImmutableList.builder();
+            ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> newFinalAggregationMap = ImmutableMap.builder();
+            for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> entry : node.getAggregations().entrySet()) {
+                AggregationNode.Aggregation aggregation = entry.getValue();
+                checkState(aggregation.getArguments().size() > 0 && aggregation.getArguments().get(0) instanceof VariableReferenceExpression);
+                VariableReferenceExpression partialInput = (VariableReferenceExpression) aggregation.getArguments().get(0);
+                if (!context.get().partialResultToMask.containsKey(partialInput)) {
+                    newFinalAggregationMap.put(entry.getKey(), entry.getValue());
+                    continue;
+                }
+                VariableReferenceExpression maskVariable = context.get().getPartialResultToMask().get(partialInput);
+                VariableReferenceExpression toMergePartialInput = context.get().getPartialOutputMapping().get(partialInput);
+                RowExpression conditionalResult = ifThenElse(maskVariable, toMergePartialInput, constantNull(toMergePartialInput.getType()));
+                projectionsFromPartialAgg.add(conditionalResult);
+                VariableReferenceExpression maskedPartialResult = variableAllocator.newVariable(toMergePartialInput);
+                variablesForPartialAggResult.add(maskedPartialResult);
+
+                CallExpression originalExpression = aggregation.getCall();
+                CallExpression newExpression = new CallExpression(originalExpression.getSourceLocation(),
+                        originalExpression.getDisplayName(),
+                        originalExpression.getFunctionHandle(),
+                        originalExpression.getType(),
+                        ImmutableList.<RowExpression>builder()
+                                .add(maskedPartialResult)
+                                .addAll(originalExpression.getArguments().subList(1, originalExpression.getArguments().size()))
+                                .build());
+
+                AggregationNode.Aggregation newFinalAggregation = new AggregationNode.Aggregation(
+                        newExpression,
+                        aggregation.getFilter(),
+                        aggregation.getOrderBy(),
+                        aggregation.isDistinct(),
+                        aggregation.getMask());
+                newFinalAggregationMap.put(entry.getKey(), newFinalAggregation);
+            }
+
+            PlanNode projectNode = addProjections(rewrittenSource, planNodeIdAllocator, variableAllocator, projectionsFromPartialAgg.build(), variablesForPartialAggResult.build());
+            context.get().clear();
+            return new AggregationNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    projectNode,
+                    newFinalAggregationMap.build(),
+                    node.getGroupingSets(),
+                    node.getPreGroupedVariables(),
+                    node.getStep(),
+                    node.getHashVariable(),
+                    node.getGroupIdVariable());
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Context> context)
+        {
+            PlanNode rewrittenSource = context.rewrite(node.getSource(), context.get());
+            if (!context.get().isEmpty()) {
+                Assignments.Builder assignments = Assignments.builder();
+                Map<VariableReferenceExpression, RowExpression> excludeMergedAssignments = node.getAssignments().getMap().entrySet().stream()
+                        .filter(x -> !(x.getValue() instanceof VariableReferenceExpression && context.get().getPartialOutputMapping().containsKey(x.getValue())))
+                        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                assignments.putAll(excludeMergedAssignments);
+                assignments.putAll(identityAssignments(context.get().getPartialResultToMask().values()));
+                return new ProjectNode(
+                        node.getSourceLocation(),
+                        node.getId(),
+                        rewrittenSource,
+                        assignments.build(),
+                        node.getLocality());
+            }
+            return node.replaceChildren(ImmutableList.of(rewrittenSource));
+        }
+
+        @Override
+        public PlanNode visitExchange(ExchangeNode node, RewriteContext<Context> context)
+        {
+            ImmutableList.Builder rewriteChildren = ImmutableList.builder();
+            for (PlanNode child : node.getSources()) {
+                context.get().clear();
+                rewriteChildren.add(context.rewrite(child, context.get()));
+            }
+            List<PlanNode> children = rewriteChildren.build();
+            if (!context.get().isEmpty()) {
+                PartitioningScheme partitioning = new PartitioningScheme(
+                        node.getPartitioningScheme().getPartitioning(),
+                        children.get(children.size() - 1).getOutputVariables(),
+                        node.getPartitioningScheme().getHashColumn(),
+                        node.getPartitioningScheme().isReplicateNullsAndAny(),
+                        node.getPartitioningScheme().getBucketToPartition());
+
+                return new ExchangeNode(
+                        node.getSourceLocation(),
+                        node.getId(),
+                        node.getType(),
+                        node.getScope(),
+                        partitioning,
+                        children,
+                        children.stream().map(x -> x.getOutputVariables()).collect(toImmutableList()),
+                        node.isEnsureSourceOrdering(),
+                        node.getOrderingScheme());
+            }
+            return node.replaceChildren(children);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -210,7 +210,7 @@ public class PrefilterForLimitingAggregation
 
             VariableReferenceExpression mapAggVariable = variableAllocator.newVariable("expr", mapType);
             PlanNode crossJoinRhs = addAggregation(rightProjectNode, functionAndTypeManager, idAllocator, variableAllocator, "MAP_AGG", mapType, ImmutableList.of(), mapAggVariable, rightProjectNode.getOutputVariables().get(0), rightProjectNode.getOutputVariables().get(1));
-            PlanNode crossJoinLhs = addProjections(originalSource, idAllocator, variableAllocator, ImmutableList.of(leftHashExpression));
+            PlanNode crossJoinLhs = addProjections(originalSource, idAllocator, variableAllocator, ImmutableList.of(leftHashExpression), ImmutableList.of());
             ImmutableList.Builder<VariableReferenceExpression> crossJoinOutput = ImmutableList.builder();
 
             crossJoinOutput.addAll(crossJoinLhs.getOutputVariables());

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -221,7 +221,8 @@ public class TestFeaturesConfig
                 .setPrefilterForGroupbyLimit(false)
                 .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(false)
                 .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(true)
-                .setMergeDuplicateAggregationsEnabled(true));
+                .setMergeDuplicateAggregationsEnabled(true)
+                .setMergeAggregationsWithAndWithoutFilter(false));
     }
 
     @Test
@@ -393,6 +394,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-probe-for-empty-build-runtime", "true")
                 .put("optimizer.use-defaults-for-correlated-aggregation-pushdown-through-outer-joins", "false")
                 .put("optimizer.merge-duplicate-aggregations", "false")
+                .put("optimizer.merge-aggregations-with-and-without-filter", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -561,7 +563,8 @@ public class TestFeaturesConfig
                 .setPrefilterForGroupbyLimit(true)
                 .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(true)
                 .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(false)
-                .setMergeDuplicateAggregationsEnabled(false);
+                .setMergeDuplicateAggregationsEnabled(false)
+                .setMergeAggregationsWithAndWithoutFilter(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationFunctionMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationFunctionMatcher.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.OrderBy;
@@ -42,10 +43,18 @@ public class AggregationFunctionMatcher
         implements RvalueMatcher
 {
     private final ExpectedValueProvider<FunctionCall> callMaker;
+    private final Optional<Symbol> mask;
 
     public AggregationFunctionMatcher(ExpectedValueProvider<FunctionCall> callMaker)
     {
         this.callMaker = requireNonNull(callMaker, "functionCall is null");
+        this.mask = Optional.empty();
+    }
+
+    public AggregationFunctionMatcher(ExpectedValueProvider<FunctionCall> callMaker, Symbol mask)
+    {
+        this.callMaker = requireNonNull(callMaker, "functionCall is null");
+        this.mask = Optional.of(requireNonNull(mask, "mask is null"));
     }
 
     @Override
@@ -60,7 +69,7 @@ public class AggregationFunctionMatcher
 
         FunctionCall expectedCall = callMaker.getExpectedValue(symbolAliases);
         for (Map.Entry<VariableReferenceExpression, Aggregation> assignment : aggregationNode.getAggregations().entrySet()) {
-            if (verifyAggregation(metadata.getFunctionAndTypeManager(), assignment.getValue(), expectedCall)) {
+            if (verifyAggregation(metadata.getFunctionAndTypeManager(), assignment.getValue(), expectedCall, mask.map(x -> new Symbol(symbolAliases.get(x.getName()).getName())))) {
                 checkState(!result.isPresent(), "Ambiguous function calls in %s", aggregationNode);
                 result = Optional.of(assignment.getKey());
             }
@@ -69,7 +78,7 @@ public class AggregationFunctionMatcher
         return result;
     }
 
-    private static boolean verifyAggregation(FunctionAndTypeManager functionAndTypeManager, Aggregation aggregation, FunctionCall expectedCall)
+    private static boolean verifyAggregation(FunctionAndTypeManager functionAndTypeManager, Aggregation aggregation, FunctionCall expectedCall, Optional<Symbol> mask)
     {
         return functionAndTypeManager.getFunctionMetadata(aggregation.getFunctionHandle()).getName().getObjectName().equalsIgnoreCase(expectedCall.getName().getSuffix()) &&
                 aggregation.getArguments().size() == expectedCall.getArguments().size() &&
@@ -79,7 +88,8 @@ public class AggregationFunctionMatcher
                         (actualArgument, expectedArgument) -> isEquivalent(Optional.of(expectedArgument), Optional.of(actualArgument))).allMatch(Boolean::booleanValue) &&
                 isEquivalent(expectedCall.getFilter(), aggregation.getFilter()) &&
                 expectedCall.isDistinct() == aggregation.isDistinct() &&
-                verifyAggregationOrderBy(aggregation.getOrderBy(), expectedCall.getOrderBy());
+                verifyAggregationOrderBy(aggregation.getOrderBy(), expectedCall.getOrderBy()) &&
+                maskMatch(mask, aggregation.getMask());
     }
 
     private static boolean verifyAggregationOrderBy(Optional<OrderingScheme> orderingScheme, Optional<OrderBy> expectedSortOrder)
@@ -117,6 +127,14 @@ public class AggregationFunctionMatcher
             return expression.get().equals(createSymbolReference(((VariableReferenceExpression) rowExpression.get())));
         }
         return rowExpression.isPresent() == expression.isPresent();
+    }
+
+    private static boolean maskMatch(Optional<Symbol> symbol, Optional<VariableReferenceExpression> mask)
+    {
+        if (symbol.isPresent() && mask.isPresent()) {
+            return symbol.get().getName().equals(mask.get().getName());
+        }
+        return symbol.isPresent() == mask.isPresent();
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -93,8 +93,10 @@ public class AggregationMatcher
             return NO_MATCH;
         }
 
+        Set<Symbol> maskToAlias = masks.keySet().stream().map(x -> new Symbol(symbolAliases.get(x.getName()).getName())).collect(Collectors.toSet());
+
         for (VariableReferenceExpression variable : aggregationsWithMask) {
-            if (!masks.keySet().contains(new Symbol(variable.getName()))) {
+            if (!masks.keySet().contains(new Symbol(variable.getName())) && !maskToAlias.contains(new Symbol(variable.getName()))) {
                 return NO_MATCH;
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionMatcher.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
@@ -117,6 +118,10 @@ public class ExpressionMatcher
         else if (node instanceof ApplyNode) {
             ApplyNode applyNode = (ApplyNode) node;
             return applyNode.getSubqueryAssignments().getMap();
+        }
+        else if (node instanceof GroupIdNode) {
+            GroupIdNode groupIdNode = (GroupIdNode) node;
+            return groupIdNode.getGroupingColumns().entrySet().stream().collect(Collectors.toMap(x -> x.getKey(), x -> (RowExpression) x.getValue()));
         }
         else {
             return null;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergePartialAggregationsWithFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergePartialAggregationsWithFilter.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER;
+import static com.facebook.presto.SystemSessionProperties.PARTIAL_AGGREGATION_STRATEGY;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.GroupingSetDescriptor;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.globalAggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.groupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+
+public class TestMergePartialAggregationsWithFilter
+        extends BasePlanTest
+{
+    private Session enableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER, "true")
+                .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
+                .build();
+    }
+
+    private Session disableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER, "false")
+                .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
+                .build();
+    }
+
+    @Test
+    public void testOptimizationApplied()
+    {
+        assertPlan("SELECT partkey, sum(quantity), sum(quantity) filter (where orderkey > 0) from lineitem group by partkey",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                project(
+                                        ImmutableMap.of("maskPartialSum", expression("IF(expr, partialSum, null)")),
+                                        anyTree(
+                                                aggregation(
+                                                        singleGroupingSet("partkey", "expr"),
+                                                        ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        AggregationNode.Step.PARTIAL,
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "quantity", "quantity"))))))))),
+                false);
+    }
+
+    @Test
+    public void testOptimizationDisabled()
+    {
+        assertPlan("SELECT partkey, sum(quantity), sum(quantity) filter (where orderkey > 0) from lineitem group by partkey",
+                disableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                anyTree(
+                                        aggregation(
+                                                singleGroupingSet("partkey"),
+                                                ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity")), Optional.of("maskPartialSum"), functionCall("sum", ImmutableList.of("quantity"))),
+                                                ImmutableMap.of(new Symbol("maskPartialSum"), new Symbol("expr")),
+                                                Optional.empty(),
+                                                AggregationNode.Step.PARTIAL,
+                                                project(
+                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "quantity", "quantity"))))))),
+                false);
+    }
+
+    @Test
+    public void testMultipleAggregations()
+    {
+        assertPlan("SELECT partkey, sum(quantity), sum(quantity) filter (where orderkey > 0), avg(quantity), avg(quantity) filter (where orderkey > 0) from lineitem group by partkey",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum")),
+                                        Optional.of("finalAvg"), functionCall("avg", ImmutableList.of("partialAvg")), Optional.of("maskFinalAvg"), functionCall("avg", ImmutableList.of("maskPartialAvg"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                project(
+                                        ImmutableMap.of("maskPartialSum", expression("IF(expr, partialSum, null)"), "maskPartialAvg", expression("IF(expr, partialAvg, null)")),
+                                        anyTree(
+                                                aggregation(
+                                                        singleGroupingSet("partkey", "expr"),
+                                                        ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity")), Optional.of("partialAvg"), functionCall("avg", ImmutableList.of("quantity"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        AggregationNode.Step.PARTIAL,
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "quantity", "quantity"))))))))),
+                false);
+    }
+
+    @Test
+    public void testAggregationsMultipleLevel()
+    {
+        assertPlan("select partkey, avg(sum), avg(sum) filter (where suppkey > 0), avg(filtersum) from (select partkey, suppkey, sum(quantity) sum, sum(quantity) filter (where orderkey > 0) filtersum from lineitem group by partkey, suppkey) t group by partkey",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("finalAvg"), functionCall("avg", ImmutableList.of("partialAvg")), Optional.of("maskFinalAvg"), functionCall("avg", ImmutableList.of("maskPartialAvg")),
+                                        Optional.of("finalFilterAvg"), functionCall("avg", ImmutableList.of("partialFilterAvg"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                project(
+                                        ImmutableMap.of("maskPartialAvg", expression("IF(expr_2, partialAvg, null)")),
+                                        anyTree(
+                                                aggregation(
+                                                        singleGroupingSet("partkey", "expr_2"),
+                                                        ImmutableMap.of(Optional.of("partialAvg"), functionCall("avg", ImmutableList.of("finalSum")), Optional.of("partialFilterAvg"), functionCall("avg", ImmutableList.of("maskFinalSum"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        AggregationNode.Step.PARTIAL,
+                                                        anyTree(
+                                                                project(
+                                                                        ImmutableMap.of("expr_2", expression("suppkey > 0")),
+                                                                        aggregation(
+                                                                                singleGroupingSet("partkey", "suppkey"),
+                                                                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum"))),
+                                                                                ImmutableMap.of(),
+                                                                                Optional.empty(),
+                                                                                AggregationNode.Step.FINAL,
+                                                                                project(
+                                                                                        ImmutableMap.of("maskPartialSum", expression("IF(expr, partialSum, null)")),
+                                                                                        anyTree(
+                                                                                                aggregation(
+                                                                                                        singleGroupingSet("partkey", "suppkey", "expr"),
+                                                                                                        ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity"))),
+                                                                                                        ImmutableMap.of(),
+                                                                                                        Optional.empty(),
+                                                                                                        AggregationNode.Step.PARTIAL,
+                                                                                                        anyTree(
+                                                                                                                project(
+                                                                                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                                                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "quantity", "quantity", "suppkey", "suppkey"))))))))))))))),
+                false);
+    }
+
+    @Test
+    public void testGlobalOptimization()
+    {
+        assertPlan("SELECT sum(quantity), sum(quantity) filter (where orderkey > 0) from lineitem",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                anyTree(
+                                        aggregation(
+                                                globalAggregation(),
+                                                ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity")), Optional.of("maskPartialSum"), functionCall("sum", ImmutableList.of("quantity"))),
+                                                ImmutableMap.of(new Symbol("maskPartialSum"), new Symbol("expr")),
+                                                Optional.empty(),
+                                                AggregationNode.Step.PARTIAL,
+                                                project(
+                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "quantity", "quantity"))))))),
+                false);
+    }
+
+    @Test
+    public void testHasOrderBy()
+    {
+        assertPlan("select partkey, array_agg(suppkey order by suppkey), array_agg(suppkey order by suppkey) filter (where orderkey > 0) from lineitem group by partkey",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("array_agg"), functionCall("array_agg", ImmutableList.of("suppkey"), ImmutableList.of(sort("suppkey", ASCENDING, LAST))),
+                                        Optional.of("array_agg_filter"), functionCall("array_agg", ImmutableList.of("suppkey"), ImmutableList.of(sort("suppkey", ASCENDING, LAST)))),
+                                ImmutableMap.of(new Symbol("array_agg_filter"), new Symbol("expr")),
+                                Optional.empty(),
+                                AggregationNode.Step.SINGLE,
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "suppkey", "suppkey")))))),
+                false);
+    }
+
+    @Test
+    public void testGroupingSets()
+    {
+        assertPlan("SELECT partkey, sum(quantity), sum(quantity) filter (where orderkey > 0) from lineitem group by grouping sets((), (partkey))",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                new GroupingSetDescriptor(ImmutableList.of("partkey$gid", "groupid"), 2, ImmutableSet.of(0)),
+                                ImmutableMap.of(Optional.of("finalSum"), functionCall("sum", ImmutableList.of("partialSum")), Optional.of("maskFinalSum"), functionCall("sum", ImmutableList.of("maskPartialSum"))),
+                                ImmutableMap.of(),
+                                Optional.of(new Symbol("groupid")),
+                                AggregationNode.Step.FINAL,
+                                project(
+                                        ImmutableMap.of("maskPartialSum", expression("IF(expr, partialSum, null)")),
+                                        anyTree(
+                                                aggregation(
+                                                        new GroupingSetDescriptor(ImmutableList.of("partkey$gid", "groupid", "expr"), 2, ImmutableSet.of(0)),
+                                                        ImmutableMap.of(Optional.of("partialSum"), functionCall("sum", ImmutableList.of("quantity"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.of(new Symbol("groupid")),
+                                                        AggregationNode.Step.PARTIAL,
+                                                        anyTree(
+                                                                groupingSet(
+                                                                        ImmutableList.of(ImmutableList.of(), ImmutableList.of("partkey")),
+                                                                        ImmutableMap.of("quantity", "quantity", "expr", "expr"),
+                                                                        "groupid",
+                                                                        ImmutableMap.of("partkey$gid", expression("partkey")),
+                                                                        project(
+                                                                                ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                                                tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey", "quantity", "quantity")))))))))),
+                false);
+    }
+
+    @Test
+    public void testCalledOnNull()
+    {
+        assertPlan("SELECT partkey, count(*), count(*) filter (where orderkey > 0) from lineitem group by partkey",
+                enableOptimization(),
+                anyTree(
+                        aggregation(
+                                singleGroupingSet("partkey"),
+                                ImmutableMap.of(Optional.of("finalCnt"), functionCall("count", ImmutableList.of("partialCnt")), Optional.of("maskFinalCnt"), functionCall("count", ImmutableList.of("maskPartialCnt"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                anyTree(
+                                        aggregation(
+                                                singleGroupingSet("partkey"),
+                                                ImmutableMap.of(Optional.of("partialCnt"), functionCall("count", ImmutableList.of()), Optional.of("maskPartialCnt"), functionCall("count", ImmutableList.of())),
+                                                ImmutableMap.of(new Symbol("maskPartialCnt"), new Symbol("expr")),
+                                                Optional.empty(),
+                                                AggregationNode.Step.PARTIAL,
+                                                project(
+                                                        ImmutableMap.of("expr", expression("orderkey > 0")),
+                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "partkey", "partkey"))))))),
+                false);
+    }
+}


### PR DESCRIPTION
Supersede https://github.com/prestodb/presto/pull/19078

When two aggregations are the same, except that one has mask field while the other one does not have, we can combine the partial aggregations of these two, and has a conditional expression based on the mask as the input for the final aggregation.

### Test plan - (Please fill in how you tested your changes)

Add unit tests

Co-authored-by: Sreeni Viswanadha <kaikalur@users.noreply.github.com>

```
== RELEASE NOTES ==

General Changes
* Add an optimization rule for queries which have multiple similar aggregations, with and without filters. The optimization is controlled by session parameter `merge_aggs_with_and_without_filter `.
```

