### PR TITLE
Add optimization to merge duplicate aggregations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -259,6 +259,7 @@ public final class SystemSessionProperties
     public static final String PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS = "prefilter_for_groupby_limit_timeout_ms";
     public static final String OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME = "optimize_join_probe_for_empty_build_runtime";
     public static final String USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS = "use_defaults_for_correlated_aggregation_pushdown_through_outer_joins";
+    public static final String MERGE_DUPLICATE_AGGREGATIONS = "merge_duplicate_aggregations";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1476,6 +1477,11 @@ public final class SystemSessionProperties
                         USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS,
                         "Coalesce with defaults for correlated aggregations",
                         featuresConfig.isUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(),
+                        false),
+                booleanProperty(
+                        MERGE_DUPLICATE_AGGREGATIONS,
+                        "Merge identical aggregation functions within the same aggregation node",
+                        featuresConfig.isMergeDuplicateAggregationsEnabled(),
                         false));
     }
 
@@ -2480,5 +2486,10 @@ public final class SystemSessionProperties
     public static boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(Session session)
     {
         return session.getSystemProperty(USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS, Boolean.class);
+    }
+
+    public static boolean isMergeDuplicateAggregationsEnabled(Session session)
+    {
+        return session.getSystemProperty(MERGE_DUPLICATE_AGGREGATIONS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -249,6 +249,7 @@ public class FeaturesConfig
     private boolean prefilterForGroupbyLimit;
     private boolean isOptimizeJoinProbeWithEmptyBuildRuntime;
     private boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins = true;
+    private boolean mergeDuplicateAggregationsEnabled = true;
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2394,6 +2395,19 @@ public class FeaturesConfig
     public FeaturesConfig setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(boolean useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins)
     {
         this.useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins = useDefaultsForCorrelatedAggregationPushdownThroughOuterJoins;
+        return this;
+    }
+
+    public boolean isMergeDuplicateAggregationsEnabled()
+    {
+        return mergeDuplicateAggregationsEnabled;
+    }
+
+    @Config("optimizer.merge-duplicate-aggregations")
+    @ConfigDescription("Merge identical aggregation functions within the same aggregation node")
+    public FeaturesConfig setMergeDuplicateAggregationsEnabled(boolean mergeDuplicateAggregationsEnabled)
+    {
+        this.mergeDuplicateAggregationsEnabled = mergeDuplicateAggregationsEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -47,6 +47,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregati
 import com.facebook.presto.sql.planner.iterative.rule.ImplementOffset;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.InlineSqlFunctions;
+import com.facebook.presto.sql.planner.iterative.rule.MergeDuplicateAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.MergeFilters;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
@@ -341,6 +342,7 @@ public class PlanOptimizers
                                 .addAll(predicatePushDownRules)
                                 .addAll(columnPruningRules)
                                 .addAll(ImmutableSet.of(
+                                        new MergeDuplicateAggregation(metadata.getFunctionAndTypeManager()),
                                         new RemoveRedundantIdentityProjections(),
                                         new RemoveFullSample(),
                                         new EvaluateZeroSample(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeDuplicateAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeDuplicateAggregation.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.isMergeDuplicateAggregationsEnabled;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class MergeDuplicateAggregation
+        implements Rule<AggregationNode>
+{
+    private static final Pattern<AggregationNode> PATTERN = aggregation();
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public MergeDuplicateAggregation(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        if (!isMergeDuplicateAggregationsEnabled(context.getSession())) {
+            return Result.empty();
+        }
+        Map<AggregationNode.Aggregation, List<VariableReferenceExpression>> aggregationToVariableList = node.getAggregations().entrySet().stream()
+                .collect(Collectors.groupingBy(Map.Entry::getValue, Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
+        ImmutableMap.Builder<VariableReferenceExpression, VariableReferenceExpression> variablesToMergeBuilder = ImmutableMap.builder();
+        for (Map.Entry<AggregationNode.Aggregation, List<VariableReferenceExpression>> entry : aggregationToVariableList.entrySet()) {
+            List<VariableReferenceExpression> variableToSameAggregation = entry.getValue();
+            if (variableToSameAggregation.size() <= 1 || !functionAndTypeManager.getFunctionMetadata(entry.getKey().getFunctionHandle()).isDeterministic()) {
+                continue;
+            }
+            for (int i = 1; i < variableToSameAggregation.size(); ++i) {
+                variablesToMergeBuilder.put(variableToSameAggregation.get(i), variableToSameAggregation.get(0));
+            }
+        }
+        ImmutableMap<VariableReferenceExpression, VariableReferenceExpression> variablesToMerge = variablesToMergeBuilder.build();
+        if (variablesToMerge.isEmpty()) {
+            return Result.empty();
+        }
+        Map<VariableReferenceExpression, AggregationNode.Aggregation> aggregations = node.getAggregations().entrySet().stream()
+                .filter(x -> !variablesToMerge.containsKey(x.getKey()))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        Assignments.Builder assignments = Assignments.builder();
+        assignments.putAll(identityAssignments(node.getOutputVariables().stream().filter(x -> !variablesToMerge.containsKey(x)).collect(toImmutableList())));
+        assignments.putAll(variablesToMerge.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        return Result.ofPlanNode(
+                new ProjectNode(
+                        node.getSourceLocation(),
+                        context.getIdAllocator().getNextId(),
+                        new AggregationNode(
+                                node.getSourceLocation(),
+                                node.getId(),
+                                node.getSource(),
+                                aggregations,
+                                node.getGroupingSets(),
+                                node.getPreGroupedVariables(),
+                                node.getStep(),
+                                node.getHashVariable(),
+                                node.getGroupIdVariable()),
+                        assignments.build(),
+                        LOCAL));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -219,7 +219,8 @@ public class TestFeaturesConfig
                 .setPushAggregationBelowJoinByteReductionThreshold(1)
                 .setPrefilterForGroupbyLimit(false)
                 .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(false)
-                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(true));
+                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(true)
+                .setMergeDuplicateAggregationsEnabled(true));
     }
 
     @Test
@@ -389,6 +390,7 @@ public class TestFeaturesConfig
                 .put("optimizer.prefilter-for-groupby-limit", "true")
                 .put("optimizer.optimize-probe-for-empty-build-runtime", "true")
                 .put("optimizer.use-defaults-for-correlated-aggregation-pushdown-through-outer-joins", "false")
+                .put("optimizer.merge-duplicate-aggregations", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -555,7 +557,8 @@ public class TestFeaturesConfig
                 .setPushAggregationBelowJoinByteReductionThreshold(0.9)
                 .setPrefilterForGroupbyLimit(true)
                 .setOptimizeJoinProbeForEmptyBuildRuntimeEnabled(true)
-                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(false);
+                .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(false)
+                .setMergeDuplicateAggregationsEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionMatcher.java
@@ -25,9 +25,10 @@ import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
@@ -101,7 +102,7 @@ public class ExpressionMatcher
             }
         }
 
-        List<Object> matches = matchesBuilder.build();
+        Set<Object> matches = new HashSet<>(matchesBuilder.build());
         checkState(matches.size() < 2, "Ambiguous expression %s matches multiple assignments", expression,
                 (matches.stream().map(Object::toString).collect(Collectors.joining(", "))));
         return result;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeDuplicateAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeDuplicateAggregation.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.MERGE_DUPLICATE_AGGREGATIONS;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestMergeDuplicateAggregation
+        extends BaseRuleTest
+{
+    @Test
+    public void testMergeIdenticalAggregations()
+    {
+        tester().assertThat(new MergeDuplicateAggregation(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(MERGE_DUPLICATE_AGGREGATIONS, "true")
+                .on(p -> p.aggregation(af -> {
+                    p.variable("col", BIGINT);
+                    af.globalGrouping()
+                            .addAggregation(p.variable("sum_1"), p.rowExpression("sum(col)"))
+                            .addAggregation(p.variable("sum_2"), p.rowExpression("sum(col)"))
+                            .source(p.values(p.variable("col")));
+                }))
+                .matches(
+                        project(
+                                ImmutableMap.of("sum_2", expression("sum_1")),
+                                aggregation(
+                                        ImmutableMap.of("sum_1", PlanMatchPattern.functionCall("sum", ImmutableList.of("col"))),
+                                        values("col"))));
+    }
+
+    @Test
+    public void testNotMergeAggregationsDifferentColumn()
+    {
+        tester().assertThat(new MergeDuplicateAggregation(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(MERGE_DUPLICATE_AGGREGATIONS, "true")
+                .on(p -> p.aggregation(af -> {
+                    p.variable("col1", BIGINT);
+                    p.variable("col2", BIGINT);
+                    af.globalGrouping()
+                            .addAggregation(p.variable("sum_1"), p.rowExpression("sum(col1)"))
+                            .addAggregation(p.variable("sum_2"), p.rowExpression("sum(col2)"))
+                            .source(p.values(p.variable("col1"), p.variable("col2")));
+                }))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNotMergeAggregationsDifferentFunction()
+    {
+        tester().assertThat(new MergeDuplicateAggregation(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(MERGE_DUPLICATE_AGGREGATIONS, "true")
+                .on(p -> p.aggregation(af -> {
+                    p.variable("col", BIGINT);
+                    af.globalGrouping()
+                            .addAggregation(p.variable("sum"), p.rowExpression("sum(col)"))
+                            .addAggregation(p.variable("count"), p.rowExpression("count(col)"))
+                            .source(p.values(p.variable("col")));
+                }))
+                .doesNotFire();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.SystemSessionProperties.KEY_BASED_SAMPLING_ENA
 import static com.facebook.presto.SystemSessionProperties.KEY_BASED_SAMPLING_FUNCTION;
 import static com.facebook.presto.SystemSessionProperties.KEY_BASED_SAMPLING_PERCENTAGE;
 import static com.facebook.presto.SystemSessionProperties.LEGACY_UNNEST;
+import static com.facebook.presto.SystemSessionProperties.MERGE_DUPLICATE_AGGREGATIONS;
 import static com.facebook.presto.SystemSessionProperties.OFFSET_CLAUSE_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_CASE_EXPRESSION_PREDICATE;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_JOINS_WITH_EMPTY_SOURCES;
@@ -6465,5 +6466,17 @@ public abstract class AbstractTestQueries
         assertQuery(session,
                 "select count(*) from nation n where (select max_by(custkey, c.name) from customer c where n.nationkey=c.nationkey)>2000",
                 "select 0");
+    }
+
+    @Test
+    public void testMergeDuplicateAggregations()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(MERGE_DUPLICATE_AGGREGATIONS, "true")
+                .build();
+        assertQuery(session, "SELECT linenumber, min(orderkey) " +
+                "FROM lineitem " +
+                "GROUP BY linenumber " +
+                "HAVING min(orderkey) < (SELECT avg(orderkey) FROM orders WHERE orderkey < 7)");
     }
 }


### PR DESCRIPTION
Add a rule to merge aggregations when there are multiple duplicate aggregations in the aggregation node.

### Test plan - (Please fill in how you tested your changes)

Add unit tests.

Tested with query `SELECT linenumber, min(orderkey) FROM lineitem GROUP BY linenumber HAVING min(orderkey) < (SELECT avg(orderkey) FROM orders WHERE orderkey < 7)`, without optimization where there are two duplicate aggregations in final query plan.

```
 Fragment 2 [SOURCE]                                                                                                                                                       >
     Output layout: [linenumber, min_25, min_24, $hashvalue_28]                                                                                                            >
     Output partitioning: HASH [linenumber][$hashvalue_28]                                                                                                                 >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                         >
     - Aggregate(PARTIAL)[linenumber][$hashvalue_28] => [linenumber:integer, $hashvalue_28:bigint, min_25:bigint, min_24:bigint]                                           >
             min_25 := "presto.default.min"((orderkey)) (1:102)                                                                                                            >
             min_24 := "presto.default.min"((orderkey)) (1:47)                                                                                                             >
         - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty>
                 Estimates: {rows: 60175 (1.84MB), cpu: 842450.00, memory: 0.00, network: 0.00}/{rows: 60175 (1.84MB), cpu: 2226475.00, memory: 0.00, network: 0.00}       >
                 $hashvalue_28 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(linenumber), BIGINT'0')) (1:84)                                                     >
                 LAYOUT: tpch.lineitem{}                                                                                                                                   >
                 linenumber := linenumber:int:3:REGULAR (1:66)                                                                                                             >
                 orderkey := orderkey:bigint:0:REGULAR (1:66)
```
The rule added will merge the aggregations, query plan after optimization:
```
 Fragment 2 [SOURCE]                                                                                                                                                       >
     Output layout: [linenumber, min_24, $hashvalue_27]                                                                                                                    >
     Output partitioning: HASH [linenumber][$hashvalue_27]                                                                                                                 >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                         >
     - Aggregate(PARTIAL)[linenumber][$hashvalue_27] => [linenumber:integer, $hashvalue_27:bigint, min_24:bigint]                                                          >
             min_24 := "presto.default.min"((orderkey)) (1:47)                                                                                                             >
         - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty>
                 Estimates: {rows: 60175 (1.32MB), cpu: 842450.00, memory: 0.00, network: 0.00}/{rows: 60175 (1.32MB), cpu: 2226475.00, memory: 0.00, network: 0.00}       >
                 $hashvalue_27 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(linenumber), BIGINT'0')) (1:84)                                                     >
                 LAYOUT: tpch.lineitem{}                                                                                                                                   >
                 linenumber := linenumber:int:3:REGULAR (1:66)                                                                                                             >
                 orderkey := orderkey:bigint:0:REGULAR (1:66)              
```

```
== RELEASE NOTES ==

General Changes
* Add an optimization rule to merge aggregations when there are multiple duplicate aggregations in the aggregation node.
   The optimization is controlled by session property `merge_duplicate_aggregations`
```

