### PR TITLE
Initialize column references for access control

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -861,7 +861,7 @@ public class Analysis
 
     public void populateTableColumnAndSubfieldReferencesForAccessControl(boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)
     {
-        accessControlReferences.setTableColumnAndSubfieldReferencesForAccessControl(getTableColumnAndSubfieldReferencesForAccessControl(checkAccessControlOnUtilizedColumnsOnly, checkAccessControlWithSubfields));
+        accessControlReferences.addTableColumnAndSubfieldReferencesForAccessControl(getTableColumnAndSubfieldReferencesForAccessControl(checkAccessControlOnUtilizedColumnsOnly, checkAccessControlWithSubfields));
     }
 
     private Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> getTableColumnAndSubfieldReferencesForAccessControl(boolean checkAccessControlOnUtilizedColumnsOnly, boolean checkAccessControlWithSubfields)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
@@ -24,15 +24,15 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
-// TODO: Should we migrate existing table column references to this class?
 public class AccessControlReferences
 {
     private final Map<AccessControlRole, Set<AccessControlInfoForTable>> tableReferences;
-    private Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl;
+    private final Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl;
 
     public AccessControlReferences()
     {
         tableReferences = new LinkedHashMap<>();
+        tableColumnAndSubfieldReferencesForAccessControl = new LinkedHashMap<>();
     }
 
     public Map<AccessControlRole, Set<AccessControlInfoForTable>> getTableReferences()
@@ -50,8 +50,8 @@ public class AccessControlReferences
         return tableColumnAndSubfieldReferencesForAccessControl;
     }
 
-    public void setTableColumnAndSubfieldReferencesForAccessControl(Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl)
+    public void addTableColumnAndSubfieldReferencesForAccessControl(Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl)
     {
-        this.tableColumnAndSubfieldReferencesForAccessControl = unmodifiableMap(requireNonNull(tableColumnAndSubfieldReferencesForAccessControl, "tableColumnAndSubfieldReferencesForAccessControl is null"));
+        this.tableColumnAndSubfieldReferencesForAccessControl.putAll((requireNonNull(tableColumnAndSubfieldReferencesForAccessControl, "tableColumnAndSubfieldReferencesForAccessControl is null")));
     }
 }


### PR DESCRIPTION
Initializing column references for access control in the AccessControlReferences. Also changing the method to provide columnReferences from set to add.

```
== NO RELEASE NOTE ==
```
