### PR TITLE
Add interactive debugging experience to Spark native tests

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -28,7 +28,9 @@
 #include "presto_cpp/main/connectors/hive/storage_adapters/FileSystems.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/operators/LocalPersistentShuffle.h"
+#include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleInterface.h"
+#include "presto_cpp/main/operators/ShuffleRead.h"
 #include "presto_cpp/main/operators/UnsafeRowExchangeSource.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
@@ -492,6 +494,15 @@ void PrestoServer::registerShuffleInterfaceFactories() {
   operators::ShuffleInterfaceFactory::registerFactory(
       operators::LocalPersistentShuffleFactory::kShuffleName.toString(),
       std::make_unique<operators::LocalPersistentShuffleFactory>());
+}
+
+void PrestoServer::registerCustomOperators() {
+  facebook::velox::exec::Operator::registerOperator(
+      std::make_unique<operators::PartitionAndSerializeTranslator>());
+  facebook::velox::exec::Operator::registerOperator(
+      std::make_unique<facebook::presto::operators::ShuffleWriteTranslator>());
+  facebook::velox::exec::Operator::registerOperator(
+      std::make_unique<operators::ShuffleReadTranslator>());
 }
 
 void PrestoServer::registerVectorSerdes() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -88,7 +88,7 @@ class PrestoServer {
 
   virtual void registerShuffleInterfaceFactories();
 
-  virtual void registerCustomOperators(){};
+  virtual void registerCustomOperators();
 
   virtual void registerVectorSerdes();
 

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
                    UnsafeRowExchangeSource.cpp LocalPersistentShuffle.cpp)
 
 target_link_libraries(presto_operators presto_common velox_core velox_exec
-                      velox_vector)
+                      velox_presto_serializer velox_vector)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -35,6 +35,19 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * Tests can be running in Interactive Debugging Mode. Interactive Debugging Mode allows you to have an easier debugging
+ * experience by allowing Spark side not launching its own native process, but instead communicating with an already
+ * launched native process. This gives developers flexibility to hookup any IDEs or debuggers with the native process.
+ * Following environment variables are needed in order to enable this mode:
+ *
+ * - NATIVE_INTERACTIVE_DEBUG
+ *   - Setting this to "true" will enable interactive debugging session. This means Spark will talk to an already
+ *     launched native process instead of launching its own.
+ * - NATIVE_PORT
+ *   - This is the port your externally launched native process listens to. It is used to tell Spark where to send
+ *     requests. If not set it is by default 7777.
+ */
 public class TestPrestoSparkNativeExecution
         extends AbstractTestQueryFramework
 {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -107,9 +107,6 @@ import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spark.execution.BatchTaskUpdateRequest;
-import com.facebook.presto.spark.execution.ForNativeExecutionTask;
-import com.facebook.presto.spark.execution.NativeExecutionProcessFactory;
-import com.facebook.presto.spark.execution.NativeExecutionTaskFactory;
 import com.facebook.presto.spark.execution.PrestoSparkBroadcastTableCacheManager;
 import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.PrestoSparkLocalShuffleReadInfo;
@@ -118,10 +115,6 @@ import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
-import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
-import com.facebook.presto.spark.execution.property.WorkerProperty;
-import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleInfoTranslator;
-import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
 import com.facebook.presto.spark.node.PrestoSparkInternalNodeManager;
 import com.facebook.presto.spark.node.PrestoSparkNodePartitioningManager;
 import com.facebook.presto.spark.node.PrestoSparkQueryManager;
@@ -199,7 +192,6 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-import io.airlift.units.Duration;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
@@ -213,7 +205,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
-import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.airlift.json.smile.SmileCodecBinder.smileCodecBinder;
@@ -223,7 +214,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class PrestoSparkModule
@@ -504,17 +494,6 @@ public class PrestoSparkModule
 
         binder.bind(RemoteTaskStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RemoteTaskStats.class).withGeneratedName();
-        binder.bind(NativeExecutionProcessFactory.class).in(Scopes.SINGLETON);
-        binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
-        binder.bind(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder, new TypeLiteral<PrestoSparkShuffleInfoTranslator>() {}).setDefault().to(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
-        binder.bind(NativeExecutionTaskFactory.class).in(Scopes.SINGLETON);
-        httpClientBinder(binder).bindHttpClient("nativeExecution", ForNativeExecutionTask.class)
-                .withConfigDefaults(config -> {
-                    config.setRequestTimeout(new Duration(10, SECONDS));
-                    config.setMaxConnectionsPerServer(250);
-                });
 
         // spark specific
         binder.bind(SparkProcessType.class).toInstance(sparkProcessType);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spark.classloader_interface.IPrestoSparkService;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkServiceFactory;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.facebook.presto.spark.execution.NativeExecutionModule;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,7 +63,10 @@ public class PrestoSparkServiceFactory
     protected List<Module> getAdditionalModules(PrestoSparkConfiguration configuration)
     {
         checkArgument(METADATA_STORAGE_TYPE_LOCAL.equalsIgnoreCase(configuration.getMetadataStorageType()), "only local metadata storage is supported");
-        return ImmutableList.of(new PrestoSparkLocalMetadataStorageModule());
+        return ImmutableList.of(
+                new PrestoSparkLocalMetadataStorageModule(),
+                // TODO: Need to let NativeExecutionModule addition be controlled by configuration as well.
+                new NativeExecutionModule());
     }
 
     protected SqlParserOptions getSqlParserOptions()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
+import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleInfoTranslator;
+import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import io.airlift.units.Duration;
+
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class NativeExecutionModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<PrestoSparkShuffleInfoTranslator>() {}).setDefault().to(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
+        binder.bind(NativeExecutionTaskFactory.class).in(Scopes.SINGLETON);
+        httpClientBinder(binder)
+                .bindHttpClient("nativeExecution", ForNativeExecutionTask.class)
+                .withConfigDefaults(config -> {
+                    config.setRequestTimeout(new Duration(10, SECONDS));
+                    config.setMaxConnectionsPerServer(250);
+                });
+        binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        binder.bind(NativeExecutionProcessFactory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -90,7 +90,7 @@ public class NativeExecutionProcess
     {
         this.port = getAvailableTcpPort();
         this.session = requireNonNull(session, "session is null");
-        this.location = getBaseUriWithPort(requireNonNull(uri, "uri is null"), port);
+        this.location = getBaseUriWithPort(requireNonNull(uri, "uri is null"), getPort());
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.serverClient = new PrestoSparkHttpServerClient(
                 this.httpClient,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -53,6 +53,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFa
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
 import com.facebook.presto.spark.execution.NativeExecutionModule;
+import com.facebook.presto.spark.execution.TestNativeExecutionModule;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.function.FunctionImplementationType;
@@ -74,6 +75,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Module;
 import io.airlift.tpch.TpchTable;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -251,6 +253,14 @@ public class PrestoSparkQueryRunner
         configProperties.put("task.concurrency", Integer.toString(TASK_CONCURRENCY));
         configProperties.putAll(additionalConfigProperties);
 
+        ImmutableList.Builder<Module> additionalModules = ImmutableList.builder();
+        additionalModules.add(new PrestoSparkLocalMetadataStorageModule());
+        if (Boolean.valueOf(System.getProperty("NATIVE_INTERACTIVE_DEBUG"))) {
+            additionalModules.add(new TestNativeExecutionModule());
+        }
+        else {
+            additionalModules.add(new NativeExecutionModule());
+        }
         PrestoSparkInjectorFactory injectorFactory = new PrestoSparkInjectorFactory(
                 DRIVER,
                 configProperties.build(),
@@ -261,7 +271,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 new SqlParserOptions(),
-                ImmutableList.of(new PrestoSparkLocalMetadataStorageModule(), new NativeExecutionModule()),
+                additionalModules.build(),
                 true);
 
         Injector injector = injectorFactory.create();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
+import com.facebook.presto.spark.execution.NativeExecutionModule;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.function.FunctionImplementationType;
@@ -260,7 +261,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 new SqlParserOptions(),
-                ImmutableList.of(new PrestoSparkLocalMetadataStorageModule()),
+                ImmutableList.of(new PrestoSparkLocalMetadataStorageModule(), new NativeExecutionModule()),
                 true);
 
         Injector injector = injectorFactory.create();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
+import io.airlift.units.Duration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * This is a testing class that essentially does nothing. Its mere purpose is to disable the launching and killing of
+ * native process by native execution. Instead it allows the native execution to reuse the same externally launched
+ * process over and over again.
+ */
+public class DetachedNativeExecutionProcess
+        extends NativeExecutionProcess
+{
+    private static final Logger log = Logger.get(DetachedNativeExecutionProcess.class);
+    private static final int DEFAULT_PORT = 7777;
+
+    public DetachedNativeExecutionProcess(
+            Session session,
+            URI uri,
+            HttpClient httpClient,
+            ScheduledExecutorService errorRetryScheduledExecutor,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            Duration maxErrorDuration,
+            TaskManagerConfig taskManagerConfig,
+            WorkerProperty<?, ?, ?> workerProperty) throws IOException
+    {
+        super(session,
+                uri,
+                httpClient,
+                errorRetryScheduledExecutor,
+                serverInfoCodec,
+                maxErrorDuration,
+                taskManagerConfig,
+                workerProperty);
+    }
+
+    @Override
+    public void start() throws ExecutionException, InterruptedException
+    {
+        log.info("Please use port " + getPort() + " for detached native process launching.");
+        // getServerInfoWithRetry will return a Future on the getting the ServerInfo from the native process, we
+        // intentionally block on the Future till the native process successfully response the ServerInfo to ensure the
+        // process has been launched and initialized correctly.
+        getServerInfoWithRetry().get();
+    }
+
+    /**
+     * The port Spark native is going to use instead of dynamically generate. Since this class is for local debugging
+     * only, there is no need to make this port configurable.
+     * @return a fixed port.
+     */
+    @Override
+    public int getPort()
+    {
+        String configuredPort = System.getProperty("NATIVE_PORT");
+        if (configuredPort != null) {
+            return Integer.valueOf(configuredPort);
+        }
+        return DEFAULT_PORT;
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.Session;
+import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
+import com.facebook.presto.spi.PrestoException;
+import com.google.inject.Inject;
+import io.airlift.units.Duration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class DetachedNativeExecutionProcessFactory
+        extends NativeExecutionProcessFactory
+{
+    private final HttpClient httpClient;
+    private final ScheduledExecutorService errorRetryScheduledExecutor;
+    private final JsonCodec<ServerInfo> serverInfoCodec;
+    private final TaskManagerConfig taskManagerConfig;
+    private final WorkerProperty<?, ?, ?> workerProperty;
+
+    @Inject
+    public DetachedNativeExecutionProcessFactory(
+            @ForNativeExecutionTask HttpClient httpClient,
+            ExecutorService coreExecutor,
+            ScheduledExecutorService errorRetryScheduledExecutor,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            TaskManagerConfig taskManagerConfig,
+            WorkerProperty<?, ?, ?> workerProperty)
+    {
+        super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, taskManagerConfig, workerProperty);
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
+        this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
+        this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
+    }
+
+    @Override
+    public NativeExecutionProcess createNativeExecutionProcess(
+            Session session,
+            URI location)
+    {
+        return createNativeExecutionProcess(session, location, new Duration(2, TimeUnit.MINUTES));
+    }
+
+    @Override
+    public NativeExecutionProcess createNativeExecutionProcess(
+            Session session,
+            URI location,
+            Duration maxErrorDuration)
+    {
+        try {
+            return new DetachedNativeExecutionProcess(
+                    session,
+                    location,
+                    httpClient,
+                    errorRetryScheduledExecutor,
+                    serverInfoCodec,
+                    maxErrorDuration,
+                    taskManagerConfig,
+                    workerProperty);
+        }
+        catch (IOException e) {
+            throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start native process: %s", e.getMessage()), e);
+        }
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionModule.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionModule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
+import com.facebook.presto.spark.execution.property.WorkerProperty;
+import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleInfoTranslator;
+import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import io.airlift.units.Duration;
+
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestNativeExecutionModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<PrestoSparkShuffleInfoTranslator>() {}).setDefault().to(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
+        binder.bind(NativeExecutionTaskFactory.class).in(Scopes.SINGLETON);
+        httpClientBinder(binder)
+                .bindHttpClient("nativeExecution", ForNativeExecutionTask.class)
+                .withConfigDefaults(config -> {
+                    config.setRequestTimeout(new Duration(10, SECONDS));
+                    config.setMaxConnectionsPerServer(250);
+                });
+        binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        binder.bind(NativeExecutionProcessFactory.class).to(DetachedNativeExecutionProcessFactory.class).in(Scopes.SINGLETON);
+    }
+}


### PR DESCRIPTION
Interactive Debugging Mode allows you to have an easier debugging experience by allowing Spark side not launching its own native process, but instead communicating with an already launched native process. This gives developers flexibility to hookup any IDEs or debuggers with the native process. 

This PR also: 
1. Extracted native related bindings to an individual module.
2. Added custom needed operators to native execution engine.

```
== NO RELEASE NOTE ==
```
