### PR TITLE
Increase Jenkins agent resource allocation

### DIFF
--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -13,13 +13,13 @@ spec:
       image: maven:3.8.6-openjdk-8-slim
       env:
       - name: MAVEN_OPTS
-        value: "-Xmx6000m -Xms6000m"
+        value: "-Xmx8000m -Xms8000m"
       resources:
         requests:
-          memory: "8Gi"
+          memory: "10Gi"
           cpu: "4000m"
         limits:
-          memory: "8Gi"
+          memory: "10Gi"
           cpu: "4000m"
       tty: true
       command:


### PR DESCRIPTION
Maven build has been failing most of the time because there is not enough memory allocation. This update increases memory to "-Xmx8000m -Xms8000m".

```
== NO RELEASE NOTE ==
```
