### PR TITLE
Set memory usage tracker on constructor (#3677)

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -84,9 +84,8 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
 
   const int64_t maxQueryMemoryPerNode =
       getMaxMemoryPerNode(kQueryMaxMemoryPerNode, kDefaultMaxMemoryPerNode);
-  auto pool = memory::getProcessDefaultMemoryManager().getPool(queryId);
-  pool->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(maxQueryMemoryPerNode));
+  auto pool = memory::getProcessDefaultMemoryManager().getPool(
+      queryId, memory::MemoryPool::Kind::kAggregate, maxQueryMemoryPerNode);
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       executor().get(),


### PR DESCRIPTION
Summary:
Set memory usage tracker in memory pool constructor and deprecate
set memory usage tracker API to enforce setting the memory usage tracker.
This paves way for the followup merge the memory usage tracker into the
memory pool. Also set the default memory pool with unlimited quota as it is
used for critical system purpose such as disk spilling. Note the physical OOM
prevention is enforced by the memory manager which has tracked all the
memory allocations go through the memory pools.

X-link: https://github.com/facebookincubator/velox/pull/3677

Differential Revision: D42446278

Pulled By: xiaoxmeng

