### PR TITLE
Add ConnectorIdentity to HiveDirectoryContext class

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -23,12 +24,18 @@ public class HiveDirectoryContext
 {
     private final NestedDirectoryPolicy nestedDirectoryPolicy;
     private final boolean cacheable;
+    private final ConnectorIdentity connectorIdentity;
     private final Map<String, String> additionalProperties;
 
-    public HiveDirectoryContext(NestedDirectoryPolicy nestedDirectoryPolicy, boolean cacheable, Map<String, String> additionalProperties)
+    public HiveDirectoryContext(
+            NestedDirectoryPolicy nestedDirectoryPolicy,
+            boolean cacheable,
+            ConnectorIdentity connectorIdentity,
+            Map<String, String> additionalProperties)
     {
         this.nestedDirectoryPolicy = requireNonNull(nestedDirectoryPolicy, "nestedDirectoryPolicy is null");
         this.cacheable = cacheable;
+        this.connectorIdentity = requireNonNull(connectorIdentity, "connectorIdentity is null");
         this.additionalProperties = ImmutableMap.copyOf(requireNonNull(additionalProperties, "additionalProperties is null"));
     }
 
@@ -40,6 +47,11 @@ public class HiveDirectoryContext
     public boolean isCacheable()
     {
         return cacheable;
+    }
+
+    public ConnectorIdentity getConnectorIdentity()
+    {
+        return connectorIdentity;
     }
 
     public Map<String, String> getAdditionalProperties()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -187,7 +187,11 @@ public class ManifestPartitionLoader
             throws IOException
     {
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, false, buildDirectoryContextProperties(session));
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
+                recursiveDirWalkerEnabled ? RECURSE : IGNORED,
+                false,
+                hdfsContext.getIdentity(),
+                buildDirectoryContextProperties(session));
 
         Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fileSystem, table, path, partition.getPartition(), namenodeStats, hiveDirectoryContext);
         int fileCount = 0;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -17,6 +17,7 @@ import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
@@ -117,7 +118,11 @@ public class TestHudiDirectoryLister
             assertEquals(metaClient.getBasePath(), mockTable.getStorage().getLocation());
             Path path = new Path(mockTable.getStorage().getLocation());
             ExtendedFileSystem fs = (ExtendedFileSystem) path.getFileSystem(hadoopConf);
-            Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(IGNORED, false, ImmutableMap.of()));
+            Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(
+                    IGNORED,
+                    false,
+                    new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
+                    ImmutableMap.of()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
             assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
@@ -139,7 +144,11 @@ public class TestHudiDirectoryLister
             assertEquals(metaClient.getBasePath(), mockTable.getStorage().getLocation());
             Path path = new Path(mockTable.getStorage().getLocation());
             ExtendedFileSystem fs = (ExtendedFileSystem) path.getFileSystem(hadoopConf);
-            Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(IGNORED, false, ImmutableMap.of()));
+            Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(
+                    IGNORED,
+                    false,
+                    new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
+                    ImmutableMap.of()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
             assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");


### PR DESCRIPTION
Add `ConnectorIdentity` to be accessible through `HiveDirectoryContext`. Useful for internal FB integrations.