### PR TITLE
Use LocalPartitionNode::gather

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2223,17 +2223,13 @@ velox::core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
       partitionedOutputNode->sources().back(),
       partitionedOutputNode->partitionFunctionFactory());
 
-  auto localPartitionNode = std::make_shared<core::LocalPartitionNode>(
-      "shuffle-gather",
-      core::LocalPartitionNode::Type::kGather,
-      nullptr,
-      std::vector<core::PlanNodePtr>{partitionAndSerializeNode});
-
   auto shuffleWriteNode = std::make_shared<operators::ShuffleWriteNode>(
       "root",
       shuffleName_,
       std::move(*serializedShuffleWriteInfo_),
-      std::move(localPartitionNode));
+      core::LocalPartitionNode::gather(
+          "shuffle-gather",
+          std::vector<core::PlanNodePtr>{partitionAndSerializeNode}));
 
   // For presto_cpp, the last node must be the PartitionedOutputNode in order to
   // get the output (e.g actual data or metadata) and send back to coordinator.


### PR DESCRIPTION
Use LocalPartitionNode::gather static method instead of LocalPartitionNode's constructor. This makes code easier to read and avoids passing nullptr for PartitionFunctionFactory, which is not expected, but currently not enforced.

```
== NO RELEASE NOTE ==
```
