### PR TITLE
Fix bug in LogicalRowExpressions

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
@@ -661,7 +661,7 @@ public final class LogicalRowExpressions
 
     private int numOfClauses(RowExpression expression)
     {
-        if (expression instanceof SpecialFormExpression) {
+        if (isConjunctionOrDisjunction(expression)) {
             return getGroupedClauses((SpecialFormExpression) expression).stream().mapToInt(List::size).sum();
         }
         return 1;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -77,6 +77,14 @@ public class TestSimplifyRowExpressions
     }
 
     @Test
+    public void testNestedExpressions()
+    {
+        assertSimplifies(
+                "(true and coalesce(X, true) IN (true, false)) IN (true, false)",
+                "(coalesce(X, true) IN (true, false)) IN (true, false)");
+    }
+
+    @Test
     public void testExtractCommonPredicates()
     {
         assertSimplifies("TRUE", "TRUE");
@@ -85,6 +93,7 @@ public class TestSimplifyRowExpressions
         assertSimplifies("X AND Y", "X AND Y");
         assertSimplifies("X OR Y", "X OR Y");
         assertSimplifies("X AND X", "X");
+        assertSimplifies("true AND X", "X");
         assertSimplifies("X OR X", "X");
         assertSimplifies("(X OR Y) AND (X OR Y)", "X OR Y");
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6410,6 +6410,14 @@ public abstract class AbstractTestQueries
         assertTrue(((String) plan.getOnlyValue()).toUpperCase().indexOf("MAP_AGG") == -1);
     }
 
+    @Test
+    public void testNestedExpressions()
+    {
+        assertQuery(
+                "SELECT (true and coalesce(X, true) IN (true, false)) IN (true, false) FROM (VALUES true) T(X)",
+                "SELECT true");
+    }
+
     @DataProvider(name = "use_default_literal_coalesce")
     public static Object[][] useDefaultLiteralCoalesce()
     {


### PR DESCRIPTION
Noticed a failure in nightly verifier: 20230321_134745_09817_3c7b5

We moved from using SimplifyExpressions -> SimplifyRowExpressions recently. Apparently, SimplifyRowExpressions has a bug which did not surface before.

Issue is with nested expressions, we incorrectly assume that special form expression is and/or. Replaced with current check. Added unit tests and query test as well.

```
== NO RELEASE NOTE ==
```
