### PR TITLE
Fix a compile issue in presto-tests

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1249,7 +1249,7 @@ public abstract class AbstractTestDistributedQueries
         }
 
         MaterializedResult countStarQuery = computeActual(session, "select count(t.m1) from (SELECT l.* FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)) t");
-        assertEquals((Long) countStarQuery.getOnlyValue(), 60175);
+        assertEquals((Long) countStarQuery.getOnlyValue(), Long.valueOf(60175L));
     }
 
     private String sanitizePlan(String explain)


### PR DESCRIPTION
Summary:
Fix a compile issue "reference to assertEquals is ambiguous" in presto-tests when build the code with buck:

```
github/presto-trunk/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java:1252: error: reference to assertEquals is ambiguous
        assertEquals((Long) countStarQuery.getOnlyValue(), 60175);
        ^
  both method assertEquals(long,long) in Assert and method assertEquals(Object,Object) in Assert match
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
```
I'm not sure what's the difference in maven and it looks like we don't have the same issue with maven.

Test Plan:
Make sure all CI runs are green.

Reviewers:

Subscribers:

Tasks:

Tags:

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
