### PR TITLE
[native] Pass required subfields to Velox HiveColumnHandle

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -90,6 +90,16 @@ connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
   }
 }
 
+std::vector<common::Subfield> toRequiredSubfields(
+    const protocol::List<protocol::Subfield>& subfields) {
+  std::vector<common::Subfield> result;
+  result.reserve(subfields.size());
+  for (auto& subfield : subfields) {
+    result.emplace_back(subfield);
+  }
+  return result;
+}
+
 std::shared_ptr<connector::ColumnHandle> toColumnHandle(
     const protocol::ColumnHandle* column) {
   if (auto hiveColumn =
@@ -97,7 +107,8 @@ std::shared_ptr<connector::ColumnHandle> toColumnHandle(
     return std::make_shared<connector::hive::HiveColumnHandle>(
         hiveColumn->name,
         toHiveColumnType(hiveColumn->columnType),
-        stringToType(hiveColumn->typeSignature));
+        stringToType(hiveColumn->typeSignature),
+        toRequiredSubfields(hiveColumn->requiredSubfields));
   }
 
   if (auto tpchColumn =

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -24,6 +24,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 namespace fs = boost::filesystem;
@@ -93,7 +94,17 @@ class PlanConverterTest : public ::testing::Test {};
 // Scan + Partial Agg + Repartitioning
 TEST_F(PlanConverterTest, scanAgg) {
   protocol::registerConnector("hive", "hive");
-  assertToVeloxQueryPlan("ScanAgg.json");
+  auto partitionedOutput = assertToVeloxQueryPlan("ScanAgg.json");
+  auto* tableScan = dynamic_cast<const core::TableScanNode*>(
+      partitionedOutput->sources()[0]->sources()[0]->sources()[0].get());
+  ASSERT_TRUE(tableScan != nullptr);
+  auto* columnHandle = dynamic_cast<const connector::hive::HiveColumnHandle*>(
+      tableScan->assignments().at("complex_type").get());
+  ASSERT_TRUE(columnHandle != nullptr);
+  auto& requiredSubfields = columnHandle->requiredSubfields();
+  ASSERT_EQ(requiredSubfields.size(), 2);
+  ASSERT_EQ(requiredSubfields[0].toString(), "complex_type[1][\"foo\"].id");
+  ASSERT_EQ(requiredSubfields[1].toString(), "complex_type[2][\"bar\"].id");
 
   protocol::registerConnector("hive-plus", "hive");
   assertToVeloxQueryPlan("ScanAggCustomConnectorId.json");

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
@@ -44,6 +44,10 @@
                 "type":"bigint"
               },
               {
+                "name":"complex_type",
+                "type":"array(map(varchar, row(id bigint, description varchar)))"
+              },
+              {
                 "name":"comment",
                 "type":"varchar(152)"
               }
@@ -132,6 +136,11 @@
             "@type":"variable",
             "name":"regionkey",
             "type":"bigint"
+          },
+          {
+            "@type":"variable",
+            "name":"complex_type",
+            "type":"array(map(varchar, row(id bigint, description varchar)))"
           }
         ],
         "assignments":{
@@ -144,6 +153,18 @@
             "columnType":"REGULAR",
             "requiredSubfields":[
 
+            ]
+          },
+          "complex_type<array(map(varchar, row(id bigint, description varchar)))>":{
+            "@type":"hive",
+            "name":"complex_type",
+            "hiveType":"array<map<string, struct<id:bigint, description:string>>>",
+            "typeSignature":"array(map(varchar, row(id bigint, description varchar)))",
+            "hiveColumnIndex":3,
+            "columnType":"REGULAR",
+            "requiredSubfields":[
+              "complex_type[1][\"foo\"].id",
+              "complex_type[2][\"bar\"].id"
             ]
           }
         }


### PR DESCRIPTION
Differential Revision: D44342800

The values were currently not passed as Velox did not have support for it.  Now the support for subfields pruning is completed in Velox, we can pass the values and benefit from it.
