### PR TITLE
Increase default key limit in DWRF flat map writer to 25k keys

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -43,7 +43,7 @@ public class OrcWriterOptions
     public static final DataSize DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE = new DataSize(8, MEGABYTE);
     public static final DwrfStripeCacheMode DEFAULT_DWRF_STRIPE_CACHE_MODE = INDEX_AND_FOOTER;
     public static final int DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT = 0;
-    public static final int DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT = 20000;
+    public static final int DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT = 25000;
     public static final boolean DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED = false;
     public static final boolean DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED = true;
     public static final boolean DEFAULT_STRING_DICTIONARY_SORTING_ENABLED = true;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -66,7 +66,7 @@ public class TestOrcWriterOptions
 
         assertEquals(options.getFlattenedColumns(), ImmutableSet.of());
         assertFalse(options.isMapStatisticsEnabled());
-        assertEquals(options.getMaxFlattenedMapKeyCount(), 20000);
+        assertEquals(options.getMaxFlattenedMapKeyCount(), 25000);
     }
 
     @Test


### PR DESCRIPTION
It appears that a new norm is not 20k keys, but 25k. I'll follow up with a PR consuming the limit 
from the Metastore's SerDe.params.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
