### PR TITLE
Quantize exchange allocation size

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -160,7 +160,7 @@ void PrestoExchangeSource::processDataResponse(
           folly::IOBuf* start = &iobuf;
           auto curr = start;
           do {
-            allocator->freeBytes(curr->writableData(), curr->length());
+            allocator->freeBytes(curr->writableData(), curr->capacity());
             curr = curr->next();
           } while (curr != start);
         });

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -60,6 +60,9 @@ class HttpResponse {
   velox::memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   std::vector<std::unique_ptr<folly::IOBuf>> bodyChain_;
+
+  // Allocated capacity of IOBufs in 'bodyChain'.
+  int64_t bodyChainBytes_{0};
 };
 
 // HttpClient uses proxygen::SessionPool which must be destructed on the


### PR DESCRIPTION
Quantizes allocation sizes of IOBufs for PrestoExchangeClient. The minimum size is 4K and the maximum is 64K. The allocations for exchange IOBufs will be chains of 64K chunks or larger if individual chunks produced by Proxygen are larger.

The benefit is that allocation is tracked by MemoryPool and for mmap backed memory will always come from MmapAllocator and not malloc. This means no fragmentation and no rise in resident set size. Cache will be evicted to make space for exchange and RSS will not go up because of alternating demand between malloc and MmapAllocator.

Also, the frequency of allocation drops for receiving long messages which saves some CPU.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
