### PR TITLE
[native] Update TPC-H query 15 to cast `shipdate` to DATE before comparison.

### DIFF
--- a/presto-native-execution/src/test/resources/tpch/queries/q15.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q15.sql
@@ -9,8 +9,8 @@ select
 from
     lineitem
 where
-    shipdate >= date '1996-01-01'
-    and shipdate < date '1996-01-01' + interval '3' month
+    shipdate >= '1996-01-01'
+    and cast(shipdate as date) < date '1996-01-01' + interval '3' month
 group by suppkey
 )
 


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/19232 broke this test. Fixing here.

```
== NO RELEASE NOTE ==
```
