### PR TITLE
[native] Allow to skip the announcer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -200,17 +200,20 @@ void PrestoServer::run() {
       servicePort,
       address_);
 
-  Announcer announcer(
-      address_,
-      servicePort,
-      discoveryAddressLookup(),
-      nodeVersion_,
-      environment_,
-      nodeId_,
-      nodeLocation_,
-      catalogNames,
-      30'000 /*milliseconds*/);
-  announcer.start();
+  std::unique_ptr<Announcer> announcer;
+  if (auto discoveryAddressLookupFunc = discoveryAddressLookup()) {
+    announcer = std::make_unique<Announcer>(
+        address_,
+        servicePort,
+        discoveryAddressLookupFunc,
+        nodeVersion_,
+        environment_,
+        nodeId_,
+        nodeLocation_,
+        catalogNames,
+        30'000 /*milliseconds*/);
+    announcer->start();
+  }
 
   httpServer_ =
       std::make_unique<http::HttpServer>(socketAddress, httpExecThreads);
@@ -458,8 +461,16 @@ void PrestoServer::stop() {
 }
 
 std::function<folly::SocketAddress()> PrestoServer::discoveryAddressLookup() {
+  // Check if discovery URI is specified. Presto-on-Spark doesn't specify it.
+  auto discoveryUri = SystemConfig::instance()->discoveryUri();
+  if (!discoveryUri.has_value()) {
+    LOG(INFO)
+        << "STARTUP: Discovery URI is not specified - will not run Announcer.";
+    return nullptr;
+  }
+
   try {
-    auto uri = folly::Uri(SystemConfig::instance()->discoveryUri());
+    auto uri = folly::Uri(discoveryUri.value());
 
     return [uri]() {
       return folly::SocketAddress(uri.hostname(), uri.port(), true);

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -44,7 +44,7 @@ class HttpServer;
 namespace proxygen {
 class HTTPMessage;
 class ResponseHandler;
-}
+} // namespace proxygen
 
 namespace facebook::presto::protocol {
 struct MemoryInfo;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -53,8 +53,9 @@ std::string SystemConfig::prestoVersion() const {
   return requiredProperty(std::string(kPrestoVersion));
 }
 
-std::string SystemConfig::discoveryUri() const {
-  return requiredProperty(std::string(kDiscoveryUri));
+std::optional<std::string> SystemConfig::discoveryUri() const {
+  return static_cast<std::optional<std::string>>(
+      optionalProperty<std::string>(std::string(kDiscoveryUri)));
 }
 
 int32_t SystemConfig::maxDriversPerTask() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -143,7 +143,7 @@ class SystemConfig : public ConfigBase {
 
   std::string prestoVersion() const;
 
-  std::string discoveryUri() const;
+  std::optional<std::string> discoveryUri() const;
 
   int32_t maxDriversPerTask() const;
 


### PR DESCRIPTION
Presto-on-Spark doesn't need announcer logic. This change allows to skip running the Announcer if discovery.uri is not specified in config.properties.

```
== NO RELEASE NOTE ==
```
