### PR TITLE
[native] Silence 'pointer is missing a nullability type specifier' 

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -28,15 +28,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 if("${TREAT_WARNINGS_AS_ERRORS}")
-  set(KNOWN_WARNINGS "-Wno-nullability-completeness")
-
-  # known warnings for MacOS
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(KNOWN_WARNINGS "${KNOWN_WARNINGS} -Wno-deprecated-declarations")
-  endif()
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror ${KNOWN_WARNINGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
+
+set(KNOWN_WARNINGS "-Wno-nullability-completeness")
+
+# known warnings for MacOS
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(KNOWN_WARNINGS "${KNOWN_WARNINGS} -Wno-deprecated-declarations")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
 
 # Add all Presto options below
 option(PRESTO_ENABLE_S3 "Build S3 connector" OFF)


### PR DESCRIPTION
These warnings are not very useful, but they pollute the build logs.

```
== NO RELEASE NOTE ==
```
