### PR TITLE
Refactor Spark native interactive debugging to be more developer friendly

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -255,7 +255,7 @@ public class PrestoSparkQueryRunner
 
         ImmutableList.Builder<Module> additionalModules = ImmutableList.builder();
         additionalModules.add(new PrestoSparkLocalMetadataStorageModule());
-        if (Boolean.valueOf(System.getProperty("NATIVE_INTERACTIVE_DEBUG"))) {
+        if (System.getProperty("NATIVE_PORT") != null) {
             additionalModules.add(new TestNativeExecutionModule());
         }
         else {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
@@ -27,6 +27,8 @@ import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * This is a testing class that essentially does nothing. Its mere purpose is to disable the launching and killing of
  * native process by native execution. Instead it allows the native execution to reuse the same externally launched
@@ -36,7 +38,6 @@ public class DetachedNativeExecutionProcess
         extends NativeExecutionProcess
 {
     private static final Logger log = Logger.get(DetachedNativeExecutionProcess.class);
-    private static final int DEFAULT_PORT = 7777;
 
     public DetachedNativeExecutionProcess(
             Session session,
@@ -76,10 +77,7 @@ public class DetachedNativeExecutionProcess
     @Override
     public int getPort()
     {
-        String configuredPort = System.getProperty("NATIVE_PORT");
-        if (configuredPort != null) {
-            return Integer.valueOf(configuredPort);
-        }
-        return DEFAULT_PORT;
+        String configuredPort = requireNonNull(System.getProperty("NATIVE_PORT"), "NATIVE_PORT not set for interactive debugging");
+        return Integer.valueOf(configuredPort);
     }
 }


### PR DESCRIPTION
Refactor Presto-on-Spark test to remove unnecessary configurations

- Remove NATIVE_INTERACTIVE_DEBUG property and rely solely on NATIVE_PORT. If NATIVE_PORT is set system will adopt interactive mode automatically.
- Do not require PRESTO_SERVER property when NATIVE_PORT is set. 
- Remove default value for NATIVE_PORT.

```
== NO RELEASE NOTE ==
```
