### PR TITLE
Add snapshot to presto-verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
@@ -22,9 +22,11 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
+import com.facebook.presto.verifier.source.SnapshotQueryConsumer;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -54,9 +56,11 @@ public class CreateTableVerification
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
-            ListeningExecutorService executor)
+            ListeningExecutorService executor,
+            SnapshotQueryConsumer snapshotQueryConsumer,
+            Map<String, SnapshotQuery> snapshotQueries)
     {
-        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_TABLE_CONVERTER, executor);
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_TABLE_CONVERTER, executor, snapshotQueryConsumer, snapshotQueries);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
@@ -22,9 +22,11 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
+import com.facebook.presto.verifier.source.SnapshotQueryConsumer;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -54,9 +56,11 @@ public class CreateViewVerification
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
-            ListeningExecutorService executor)
+            ListeningExecutorService executor,
+            SnapshotQueryConsumer snapshotQueryConsumer,
+            Map<String, SnapshotQuery> snapshotQueries)
     {
-        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_VIEW_CONVERTER, executor);
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_VIEW_CONVERTER, executor, snapshotQueryConsumer, snapshotQueries);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.C
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.MATCH;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.ROW_COUNT_MISMATCH;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.SCHEMA_MISMATCH;
+import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.SNAPSHOT_DOES_NOT_EXIST;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -38,6 +39,7 @@ public class DataMatchResult
         SCHEMA_MISMATCH,
         ROW_COUNT_MISMATCH,
         COLUMN_MISMATCH,
+        SNAPSHOT_DOES_NOT_EXIST,
     }
 
     private final MatchType matchType;
@@ -99,7 +101,7 @@ public class DataMatchResult
         StringBuilder message = new StringBuilder()
                 .append(matchType.name().replace("_", " "))
                 .append('\n');
-        if (matchType == SCHEMA_MISMATCH) {
+        if (matchType == SCHEMA_MISMATCH || matchType == SNAPSHOT_DOES_NOT_EXIST) {
             return message.toString();
         }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.verifier.framework.QueryStage.DESCRIBE;
 import static com.facebook.presto.verifier.framework.QueryStage.forTeardown;
 import static com.facebook.presto.verifier.framework.VerifierUtil.runAndConsume;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class DataVerificationUtil
 {
@@ -77,6 +78,7 @@ public class DataVerificationUtil
             ChecksumResult controlChecksum,
             ChecksumResult testChecksum)
     {
+        requireNonNull(controlColumns, "controlColumns is null.");
         if (!controlColumns.equals(testColumns)) {
             return new DataMatchResult(
                     SCHEMA_MISMATCH,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
@@ -30,6 +30,7 @@ public class DdlMatchResult
         MISMATCH,
         CONTROL_NOT_PARSABLE,
         TEST_NOT_PARSABLE,
+        SNAPSHOT_DOES_NOT_EXIST,
     }
 
     private final MatchType matchType;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
@@ -23,6 +23,7 @@ public class ExplainMatchResult
         MATCH,
         STRUCTURE_MISMATCH,
         DETAILS_MISMATCH,
+        SNAPSHOT_DOES_NOT_EXIST,
     }
 
     private final MatchType matchType;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SnapshotQuery.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SnapshotQuery.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class SnapshotQuery
+{
+    private final String suite;
+    private final String name;
+    private final boolean explain;
+    private final String snapshot;
+
+    @JdbiConstructor
+    public SnapshotQuery(
+            @ColumnName("suite") String suite,
+            @ColumnName("name") String name,
+            @ColumnName("is_explain") boolean explain,
+            @ColumnName("snapshot") String snapshot)
+    {
+        this.suite = requireNonNull(suite, "suite is null");
+        this.name = requireNonNull(name, "name is null");
+        this.explain = requireNonNull(explain, "explain is null");
+        this.snapshot = requireNonNull(snapshot, "snapshot is null");
+    }
+
+    public String getSuite()
+    {
+        return suite;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public boolean isExplain()
+    {
+        return explain;
+    }
+
+    public String getSnapshot()
+    {
+        return snapshot;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        SnapshotQuery o = (SnapshotQuery) obj;
+        return Objects.equals(suite, o.suite) &&
+                Objects.equals(name, o.name) &&
+                Objects.equals(snapshot, o.snapshot);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(suite, name, snapshot);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("suite", suite)
+                .add("name", name)
+                .add("snapshot", snapshot)
+                .toString();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -25,9 +25,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.verifier.source.MySqlSourceQuerySupplier.MYSQL_SOURCE_QUERY_SUPPLIER;
+import static java.util.Locale.ENGLISH;
 
 public class VerifierConfig
 {
+    public static final String CONTROL_TEST_MODE = "control-test";
+    public static final String QUERY_BANK_MODE = "query-bank";
     private Optional<Set<String>> whitelist = Optional.empty();
     private Optional<Set<String>> blacklist = Optional.empty();
 
@@ -55,6 +58,8 @@ public class VerifierConfig
     private boolean concurrentControlAndTest;
 
     private boolean explain;
+    private boolean saveSnapshot;
+    private String runningMode = CONTROL_TEST_MODE;
 
     @NotNull
     public Optional<Set<String>> getWhitelist()
@@ -343,6 +348,34 @@ public class VerifierConfig
     public VerifierConfig setConcurrentControlAndTest(boolean concurrentControlAndTest)
     {
         this.concurrentControlAndTest = concurrentControlAndTest;
+        return this;
+    }
+
+    public boolean isSaveSnapshot()
+    {
+        return saveSnapshot;
+    }
+    @ConfigDescription("Save control query results to database as snapshots.")
+    @Config("save-snapshot")
+    public VerifierConfig setSaveSnapshot(boolean saveSnapshot)
+    {
+        this.saveSnapshot = saveSnapshot;
+        return this;
+    }
+
+    public String getRunningMode()
+    {
+        return runningMode;
+    }
+
+    @ConfigDescription("Set running mode to 'control-test' or 'query-bank'.")
+    @Config("running-mode")
+    public VerifierConfig setRunningMode(String runningMode)
+    {
+        this.runningMode = runningMode;
+        if (QUERY_BANK_MODE.toLowerCase(ENGLISH).equals(runningMode)) {
+            skipControl = true;
+        }
         return this;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/AbstractJdbiSnapshotQueryConsumer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/AbstractJdbiSnapshotQueryConsumer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.presto.verifier.framework.SnapshotQuery;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import javax.inject.Provider;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractJdbiSnapshotQueryConsumer
+        implements SnapshotQueryConsumer
+{
+    private final Provider<Jdbi> jdbiProvider;
+    private final String tableName;
+
+    public AbstractJdbiSnapshotQueryConsumer(Provider<Jdbi> jdbiProvider, String tableName)
+    {
+        this.jdbiProvider = requireNonNull(jdbiProvider, "jdbiProvider is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    @Override
+    public void accept(SnapshotQuery snapshot)
+    {
+        try (Handle handle = jdbiProvider.get().open()) {
+            VerifierDao verifierDao = handle.attach(VerifierDao.class);
+            verifierDao.saveSnapShot(tableName, snapshot.getSuite(), snapshot.getName(), snapshot.isExplain(), snapshot.getSnapshot());
+        }
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/AbstractJdbiSnapshotQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/AbstractJdbiSnapshotQuerySupplier.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.presto.verifier.framework.SnapshotQuery;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractJdbiSnapshotQuerySupplier
+        implements SnapshotQuerySupplier
+{
+    public static final String VERIFIER_SNAPSHOT_KEY_PATTERN = "SUITE_%s_@TEST_%s_@EXPLAIN_%s";
+    private final Provider<Jdbi> jdbiProvider;
+    private final String tableName;
+    private final List<String> suites;
+    private final int maxQueriesPerSuite;
+    public AbstractJdbiSnapshotQuerySupplier(Provider<Jdbi> jdbiProvider, String tableName, List<String> suites, int maxQueriesPerSuite)
+    {
+        this.jdbiProvider = requireNonNull(jdbiProvider, "jdbiProvider is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.suites = ImmutableList.copyOf(suites);
+        this.maxQueriesPerSuite = maxQueriesPerSuite;
+    }
+
+    @Override
+    public Map<String, SnapshotQuery> get()
+    {
+        ImmutableMap.Builder<String, SnapshotQuery> snapshotQueriesMap = ImmutableMap.builder();
+        try (Handle handle = jdbiProvider.get().open()) {
+            VerifierDao verifierDao = handle.attach(VerifierDao.class);
+            for (String suite : suites) {
+                for (SnapshotQuery snapshotQuery : verifierDao.getSnapshotQueries(tableName, suite, maxQueriesPerSuite)) {
+                    String key = format(VERIFIER_SNAPSHOT_KEY_PATTERN, snapshotQuery.getSuite(), snapshotQuery.getName(), snapshotQuery.isExplain());
+                    snapshotQueriesMap.put(key, snapshotQuery);
+                }
+            }
+        }
+        return snapshotQueriesMap.build();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MySqlSourceQueryConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MySqlSourceQueryConfig.java
@@ -26,6 +26,7 @@ public class MySqlSourceQueryConfig
 {
     private String database;
     private String tableName = "verifier_queries";
+    private String snapshotTableName = "verifier_snapshots";
     private List<String> suites = ImmutableList.of();
     private int maxQueriesPerSuite = 100_000;
 
@@ -52,6 +53,19 @@ public class MySqlSourceQueryConfig
     public MySqlSourceQueryConfig setTableName(String tableName)
     {
         this.tableName = tableName;
+        return this;
+    }
+
+    @NotNull
+    public String getSnapshotTableName()
+    {
+        return snapshotTableName;
+    }
+
+    @Config("snapshot-table-name")
+    public MySqlSourceQueryConfig setSnapshotTableName(String snapshotTabaleName)
+    {
+        this.snapshotTableName = snapshotTabaleName;
         return this;
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MysqlSnapshotQueryConsumer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MysqlSnapshotQueryConsumer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import javax.inject.Inject;
+
+import java.sql.DriverManager;
+
+public class MysqlSnapshotQueryConsumer
+        extends AbstractJdbiSnapshotQueryConsumer
+{
+    @Inject
+    public MysqlSnapshotQueryConsumer(MySqlSourceQueryConfig config)
+    {
+        super(() -> Jdbi.create(() -> DriverManager.getConnection(config.getDatabase())).installPlugin(new SqlObjectPlugin()),
+                config.getSnapshotTableName());
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MysqlSnapshotQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MysqlSnapshotQuerySupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import javax.inject.Inject;
+
+import java.sql.DriverManager;
+
+public class MysqlSnapshotQuerySupplier
+        extends AbstractJdbiSnapshotQuerySupplier
+{
+    @Inject
+    public MysqlSnapshotQuerySupplier(MySqlSourceQueryConfig config)
+    {
+        super(() -> Jdbi.create(() -> DriverManager.getConnection(config.getDatabase())).installPlugin(new SqlObjectPlugin()),
+                config.getSnapshotTableName(),
+                config.getSuites(),
+                config.getMaxQueriesPerSuite());
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SnapshotQueryConsumer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SnapshotQueryConsumer.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.presto.verifier.framework.SnapshotQuery;
+
+import java.util.function.Consumer;
+
+public interface SnapshotQueryConsumer
+        extends Consumer<SnapshotQuery>
+{
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SnapshotQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SnapshotQuerySupplier.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.presto.verifier.framework.SnapshotQuery;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public interface SnapshotQuerySupplier
+        extends Supplier<Map<String, SnapshotQuery>>
+{
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
@@ -50,6 +50,8 @@ public class SourceQueryModule
         if (MYSQL_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {
             configBinder(binder).bindConfig(MySqlSourceQueryConfig.class, SOURCE_QUERY_CONFIG_PREFIX);
             binder.bind(SourceQuerySupplier.class).to(MySqlSourceQuerySupplier.class).in(SINGLETON);
+            binder.bind(SnapshotQuerySupplier.class).to(MysqlSnapshotQuerySupplier.class).in(SINGLETON);
+            binder.bind(SnapshotQueryConsumer.class).to(MysqlSnapshotQueryConsumer.class).in(SINGLETON);
         }
 
         if (PRESTO_QUERY_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -95,7 +95,10 @@ public class VerifierTestUtil
     {
         TestingMySqlServer mySqlServer = new TestingMySqlServer("testuser", "testpass", ImmutableList.of(XDB), MY_SQL_OPTIONS);
         try (Handle handle = getHandle(mySqlServer)) {
-            handle.attach(VerifierDao.class).createVerifierQueriesTable(new MySqlSourceQueryConfig().getTableName());
+            MySqlSourceQueryConfig config = new MySqlSourceQueryConfig();
+            VerifierDao verifierDao = handle.attach(VerifierDao.class);
+            verifierDao.createVerifierQueriesTable(config.getTableName());
+            verifierDao.createVerifierSnapshotsTable(config.getSnapshotTableName());
         }
         return mySqlServer;
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateTableVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateTableVerification.java
@@ -26,6 +26,7 @@ import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.CO
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MISMATCH;
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.TEST_NOT_PARSABLE;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -124,5 +125,29 @@ public class TestCreateTableVerification
                 "CREATE TABLE failed (LIKE non_existing)");
         assertTrue(event.isPresent());
         assertEvent(event.get(), FAILED, Optional.empty(), false);
+    }
+
+    @Test
+    public void testRunningInQueryBankMode()
+    {
+        String query = "CREATE TABLE succeeded (x int, ds varchar) COMMENT 'test table'";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query, saveSnapshotSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+
+        event = runVerification(query, query, queryBankModeSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+    }
+
+    private void assertEvent(
+            VerifierQueryEvent event,
+            VerifierQueryEvent.EventStatus expectedStatus)
+    {
+        assertEquals(event.getSuite(), SUITE);
+        assertEquals(event.getTestId(), TEST_ID);
+        assertEquals(event.getName(), NAME);
+        assertEquals(event.getStatus(), expectedStatus.name());
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.CO
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MISMATCH;
 import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.TEST_NOT_PARSABLE;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -135,5 +136,29 @@ public class TestCreateViewVerification
         assertEvent(event.get(), FAILED, Optional.empty(), true);
 
         getQueryRunner().execute("DROP VIEW failed");
+    }
+
+    @Test
+    public void testRunningInQueryBankMode()
+    {
+        String query = "CREATE VIEW succeeded_not_exists AS SELECT * FROM tpch.tiny.nation";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query, saveSnapshotSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+
+        event = runVerification(query, query, queryBankModeSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+    }
+
+    private void assertEvent(
+            VerifierQueryEvent event,
+            VerifierQueryEvent.EventStatus expectedStatus)
+    {
+        assertEquals(event.getSuite(), SUITE);
+        assertEquals(event.getTestId(), TEST_ID);
+        assertEquals(event.getName(), NAME);
+        assertEquals(event.getStatus(), expectedStatus.name());
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -19,7 +19,6 @@ import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -52,21 +51,9 @@ import static org.testng.Assert.assertTrue;
 public class TestDataVerification
         extends AbstractVerificationTest
 {
-    private static VerificationSettings concurrentControlAndTestSettings;
-    private static VerificationSettings skipControlSettings;
-
     public TestDataVerification()
             throws Exception
     {
-    }
-
-    @BeforeClass
-    public static void beforeClass()
-    {
-        concurrentControlAndTestSettings = new VerificationSettings();
-        concurrentControlAndTestSettings.concurrentControlAndTest = Optional.of(true);
-        skipControlSettings = new VerificationSettings();
-        skipControlSettings.skipControl = Optional.of(true);
     }
 
     @Test
@@ -355,6 +342,18 @@ public class TestDataVerification
         Optional<VerifierQueryEvent> event = verify(sourceQuery, false);
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    public void testRunningInQueryBankMode()
+    {
+        Optional<VerifierQueryEvent> event = runVerification("SELECT ARRAY[ROW(1, 'a'), ROW(2, 'b')]", "SELECT ARRAY[ROW(1, 'a'), ROW(2, 'b')]", saveSnapshotSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty(), false);
+
+        event = runVerification("SELECT ARRAY[ROW(1, 'a'), ROW(2, 'b')]", "SELECT ARRAY[ROW(1, 'a'), ROW(2, 'b')]", queryBankModeSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty(), false);
     }
 
     private void assertEvent(

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
@@ -105,4 +105,16 @@ public class TestExplainVerification
         assertEquals(event.getName(), NAME);
         assertEquals(event.getStatus(), expectedStatus.name());
     }
+
+    @Test
+    public void testRunningInQueryBankMode()
+    {
+        Optional<VerifierQueryEvent> event = runExplain("SELECT 1", "SELECT 2", saveSnapshotSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+
+        event = runExplain("SELECT 1", "SELECT 2", queryBankModeSettings);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED);
+    }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -33,6 +33,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -210,6 +211,8 @@ public class TestVerificationManager
     {
         return new VerificationManager(
                 () -> sourceQueries,
+                (snapshot) -> {},
+                () -> Collections.emptyMap(),
                 new VerificationFactory(
                         SQL_PARSER,
                         (sourceQuery, verificationContext) -> new QueryActions(prestoAction, prestoAction, prestoAction),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -48,7 +48,9 @@ public class TestVerifierConfig
                 .setSkipControl(false)
                 .setSkipChecksum(false)
                 .setExplain(false)
-                .setConcurrentControlAndTest(false));
+                .setConcurrentControlAndTest(false)
+                .setRunningMode("control-test")
+                .setSaveSnapshot(false));
     }
 
     @Test
@@ -76,6 +78,8 @@ public class TestVerifierConfig
                 .put("skip-checksum", "true")
                 .put("explain", "true")
                 .put("concurrent-control-and-test", "true")
+                .put("running-mode", "query-bank")
+                .put("save-snapshot", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -98,7 +102,9 @@ public class TestVerifierConfig
                 .setSkipControl(true)
                 .setSkipChecksum(true)
                 .setExplain(true)
-                .setConcurrentControlAndTest(true);
+                .setConcurrentControlAndTest(true)
+                .setRunningMode("query-bank")
+                .setSaveSnapshot(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestMySqlSourceQueryConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestMySqlSourceQueryConfig.java
@@ -30,6 +30,7 @@ public class TestMySqlSourceQueryConfig
         assertRecordedDefaults(recordDefaults(MySqlSourceQueryConfig.class)
                 .setDatabase(null)
                 .setTableName("verifier_queries")
+                .setSnapshotTableName("verifier_snapshots")
                 .setSuites("")
                 .setMaxQueriesPerSuite(100_000));
     }
@@ -40,12 +41,14 @@ public class TestMySqlSourceQueryConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("database", "jdbc://127.0.0.1:8001")
                 .put("table-name", "query_source")
+                .put("snapshot-table-name", "verifier_snaphots")
                 .put("suites", "test1,test2")
                 .put("max-queries-per-suite", "50")
                 .build();
         MySqlSourceQueryConfig expected = new MySqlSourceQueryConfig()
                 .setDatabase("jdbc://127.0.0.1:8001")
                 .setTableName("query_source")
+                .setSnapshotTableName("verifier_snaphots")
                 .setSuites("test1,test2")
                 .setMaxQueriesPerSuite(50);
 


### PR DESCRIPTION
Verifier runs Control and Test queries and matches the results for verification.
This PR improves the Verifier and allows it run in query-bank mode, that is, save the result in database as a snapshot, and subsequent runs only need to re-run the Test queries and match the Test result with the saved snapshot.

Test plan - Added unit tests.


```
== RELEASE NOTES ==

Presto-Verifier Changes
* Add support for Verifier to run in query-bank mode and save query results as a snapshot.

