### PR TITLE
[native] Use new Velox VectorFuzzer API for timestamp generation

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsaferowShuffleTest.cpp
@@ -610,7 +610,8 @@ TEST_F(UnsafeRowShuffleTest, persistentShuffleFuzz) {
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   // UnsafeRows use microseconds to store timestamp.
-  opts.useMicrosecondPrecisionTimestamp = true;
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   opts.stringLength = 100;
   opts.containerLength = 10;
 


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
