### PR TITLE
[Presto-on-Spark] Move out session object from NativeProcess

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -16,8 +16,6 @@ package com.facebook.presto.spark.execution;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
-import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.server.RequestErrorTracker;
@@ -50,7 +48,6 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_BINARY_NOT_EXIST;
 import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_TASK_ERROR;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.String.format;
@@ -65,7 +62,8 @@ public class NativeExecutionProcess
     private static final String WORKER_NODE_CONFIG_FILE = "/node.properties";
     private static final String WORKER_CONNECTOR_CONFIG_FILE = "/catalog/";
 
-    private final Session session;
+    private final String executablePath;
+    private final String catalogName;
     private final PrestoSparkHttpServerClient serverClient;
     private final URI location;
     private final int port;
@@ -78,8 +76,9 @@ public class NativeExecutionProcess
     private Process process;
 
     public NativeExecutionProcess(
-            Session session,
+            String executablePath,
             URI uri,
+            String catalogName,
             HttpClient httpClient,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
@@ -89,8 +88,9 @@ public class NativeExecutionProcess
             throws IOException
     {
         this.port = getAvailableTcpPort();
-        this.session = requireNonNull(session, "session is null");
+        this.executablePath = requireNonNull(executablePath, "executablePath is null");
         this.location = getBaseUriWithPort(requireNonNull(uri, "uri is null"), getPort());
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.serverClient = new PrestoSparkHttpServerClient(
                 this.httpClient,
@@ -115,7 +115,6 @@ public class NativeExecutionProcess
     public void start()
             throws ExecutionException, InterruptedException, IOException
     {
-        String executablePath = getProcessWorkingPath(SystemSessionProperties.getNativeExecutionExecutablePath(session));
         String configPath = Paths.get(getProcessWorkingPath("./"), String.valueOf(port)).toAbsolutePath().toString();
 
         populateConfigurationFiles(configPath);
@@ -187,12 +186,6 @@ public class NativeExecutionProcess
         return port;
     }
 
-    private String getNativeExecutionCatalogName(Session session)
-    {
-        checkArgument(session.getCatalog().isPresent(), "Catalog isn't set in the session.");
-        return session.getCatalog().get();
-    }
-
     private void populateConfigurationFiles(String configBasePath)
             throws IOException
     {
@@ -204,7 +197,7 @@ public class NativeExecutionProcess
         workerProperty.populateAllProperties(
                 Paths.get(configBasePath, WORKER_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_NODE_CONFIG_FILE),
-                Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE, getNativeExecutionCatalogName(session))));
+                Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE, catalogName)));
     }
 
     private void doGetServerInfo(SettableFuture<ServerInfo> future)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spark.execution;
 
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
@@ -67,21 +66,24 @@ public class NativeExecutionProcessFactory
     }
 
     public NativeExecutionProcess createNativeExecutionProcess(
-            Session session,
-            URI location)
+            String executablePath,
+            URI location,
+            String catalogName)
     {
-        return createNativeExecutionProcess(session, location, MAX_ERROR_DURATION);
+        return createNativeExecutionProcess(executablePath, location, catalogName, MAX_ERROR_DURATION);
     }
 
     public NativeExecutionProcess createNativeExecutionProcess(
-            Session session,
+            String executablePath,
             URI location,
+            String catalogName,
             Duration maxErrorDuration)
     {
         try {
             return new NativeExecutionProcess(
-                    session,
+                    executablePath,
                     location,
+                    catalogName,
                     httpClient,
                     errorRetryScheduledExecutor,
                     serverInfoCodec,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark.execution;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
-import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
@@ -28,8 +27,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * This is a testing class that essentially does nothing. Its mere purpose is to disable the launching and killing of
- * native process by native execution. Instead it allows the native execution to reuse the same externally launched
+ * This is a testing class that essentially does nothing. Its mere, purpose is to disable the launching and killing of
+ * native process by native execution. Instead, it allows the native execution to reuse the same externally launched
  * process over and over again.
  */
 public class DetachedNativeExecutionProcess
@@ -39,8 +38,9 @@ public class DetachedNativeExecutionProcess
     private static final int DEFAULT_PORT = 7777;
 
     public DetachedNativeExecutionProcess(
-            Session session,
+            String executablePath,
             URI uri,
+            String catalogName,
             HttpClient httpClient,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
@@ -48,8 +48,9 @@ public class DetachedNativeExecutionProcess
             TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?> workerProperty) throws IOException
     {
-        super(session,
+        super(executablePath,
                 uri,
+                catalogName,
                 httpClient,
                 errorRetryScheduledExecutor,
                 serverInfoCodec,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spark.execution;
 
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
@@ -61,22 +60,25 @@ public class DetachedNativeExecutionProcessFactory
 
     @Override
     public NativeExecutionProcess createNativeExecutionProcess(
-            Session session,
-            URI location)
+            String executablePath,
+            URI location,
+            String catalogName)
     {
-        return createNativeExecutionProcess(session, location, new Duration(2, TimeUnit.MINUTES));
+        return createNativeExecutionProcess(executablePath, location, catalogName, new Duration(2, TimeUnit.MINUTES));
     }
 
     @Override
     public NativeExecutionProcess createNativeExecutionProcess(
-            Session session,
+            String executablePath,
             URI location,
+            String catalogName,
             Duration maxErrorDuration)
     {
         try {
             return new DetachedNativeExecutionProcess(
-                    session,
+                    executablePath,
                     location,
+                    catalogName,
                     httpClient,
                     errorRetryScheduledExecutor,
                     serverInfoCodec,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -771,8 +771,9 @@ public class TestPrestoSparkHttpClient
                 workerProperty);
         List<TaskSource> sources = new ArrayList<>();
         return factory.createNativeExecutionProcess(
-                testSessionBuilder().build(),
+                "",
                 BASE_URI,
+                "",
                 maxErrorDuration);
     }
 


### PR DESCRIPTION
Currently the NativeProcess expects Session object to be passed in to be instantiated. Internally it only needs an executable path and catalogName. Directly passing these as arguments help instantiate NativeProcess outside of a session

```
== NO RELEASE NOTE ==
```
