### PR TITLE
[native]Catch memory allocation exception in http response processing

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -147,6 +147,8 @@ void Announcer::makeAnnouncement() {
           LOG(WARNING) << "Announcement failed: HTTP "
                        << message->getStatusCode() << " - "
                        << response->dumpBodyChain();
+        } else if (response->hasError()) {
+          LOG(ERROR) << "Announcement failed: " << response->error();
         } else {
           LOG(INFO) << "Announcement succeeded: " << message->getStatusCode();
         }


### PR DESCRIPTION
Record the memory pool allocation failure (exception) of http response data in
HttpResponse and process the failure in driver execution context to fail the query
instead of causing the presto server process die
Avoid the http request get retry if the error is caused by the http response data
memory allocation failure.
Add unit tests to cover these new behavior changes.
```
== NO RELEASE NOTE ==
```
