### PR TITLE
[native] BenchmarkQueryRunner getTotalCpuTime()

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -266,7 +266,12 @@ public class BenchmarkQueryRunner
         for (URI server : nodes) {
             URI addressUri = uriBuilderFrom(server).replacePath("/v1/jmx/mbean/java.lang:type=OperatingSystem/ProcessCpuTime").build();
             String data = httpClient.execute(prepareGet().setUri(addressUri).build(), createStringResponseHandler()).getBody();
-            totalCpuTime += parseLong(data.trim());
+            if (!data.trim().isEmpty()) {
+                totalCpuTime += parseLong(data.trim());
+            }
+            else {
+                totalCpuTime += System.nanoTime();
+            }
         }
         return TimeUnit.NANOSECONDS.toNanos(totalCpuTime);
     }

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -266,11 +266,11 @@ public class BenchmarkQueryRunner
         for (URI server : nodes) {
             URI addressUri = uriBuilderFrom(server).replacePath("/v1/jmx/mbean/java.lang:type=OperatingSystem/ProcessCpuTime").build();
             String data = httpClient.execute(prepareGet().setUri(addressUri).build(), createStringResponseHandler()).getBody();
-            if (!data.trim().isEmpty()) {
-                totalCpuTime += parseLong(data.trim());
+            if (data.trim().isEmpty()) {
+                throw new IllegalStateException("Node server returned empty response. Get CPU time failed");
             }
             else {
-                totalCpuTime += System.nanoTime();
+                totalCpuTime += parseLong(data.trim());
             }
         }
         return TimeUnit.NANOSECONDS.toNanos(totalCpuTime);

--- a/presto-native-execution/presto_cpp/main/TaskResource.h
+++ b/presto-native-execution/presto_cpp/main/TaskResource.h
@@ -95,6 +95,10 @@ class TaskResource {
       proxygen::HTTPMessage* message,
       const std::vector<std::string>& pathMatch);
 
+  proxygen::RequestHandler* mockJmxMbeanInfo(
+      proxygen::HTTPMessage* message,
+      const std::vector<std::string>& pathMatch);
+
   TaskManager& taskManager_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };


### PR DESCRIPTION
**[native] BenchmarkQueryRunner getTotalCpuTime()**

[native] Mock '/v1/jmv/mbean/' implementation.
Registered path for `mockJmxMbeanInfo`:
`R"(/v1/jmx/mbean/(.+):(.+)=(.+))"`

for utilizing REST call for `/v1/jmx/mbean/java.lang:type=OperatingSystem/ProcessCpuTime` when using benchmark query engine for running queries.

Presto-native-execution as a C++ project, it does not introduce JMX implementation. Benchmark driver is failing due to that. Simple check allows it to not fail when got empty response - like in case of 404 - from a node, also simple mock REST was added to prestissimo workers code. This allows to fetch data from C++ workers about cpu utilization and in case of unexpected behavior ignore this statistic without throwing exception to whole run.

```
== NO RELEASE NOTE ==
```
