### PR TITLE
[native] Add config for durable SSD checkpoint size

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -404,7 +404,8 @@ void PrestoServer::initializeAsyncCache() {
         systemConfig->asyncCacheSsdPath(),
         asyncCacheSsdGb << 30,
         kNumSsdShards,
-        cacheExecutor_.get());
+        cacheExecutor_.get(),
+        systemConfig->asyncCacheSsdCheckpointGb() << 30);
   }
   const auto memoryBytes = memoryGb << 30;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -109,6 +109,12 @@ uint64_t SystemConfig::asyncCacheSsdGb() const {
   return opt.value_or(kAsyncCacheSsdGbDefault);
 }
 
+uint64_t SystemConfig::asyncCacheSsdCheckpointGb() const {
+  auto opt =
+      optionalProperty<uint64_t>(std::string(kAsyncCacheSsdCheckpointGb));
+  return opt.value_or(kAsyncCacheSsdCheckpointGbDefault);
+}
+
 uint64_t SystemConfig::localShuffleMaxPartitionBytes() const {
   auto opt =
       optionalProperty<uint32_t>(std::string(kLocalShuffleMaxPartitionBytes));

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -96,6 +96,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
   static constexpr std::string_view kSystemMemoryGb{"system-memory-gb"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
+  static constexpr std::string_view kAsyncCacheSsdCheckpointGb{
+      "async-cache-ssd-checkpoint-gb"};
   static constexpr std::string_view kAsyncCacheSsdPath{"async-cache-ssd-path"};
   static constexpr std::string_view kEnableSerializedPageChecksum{
       "enable-serialized-page-checksum"};
@@ -125,6 +127,7 @@ class SystemConfig : public ConfigBase {
   static constexpr int32_t kMmapArenaCapacityRatioDefault = 10;
   static constexpr uint64_t kLocalShuffleMaxPartitionBytesDefault = 1 << 15;
   static constexpr uint64_t kAsyncCacheSsdGbDefault = 0;
+  static constexpr uint64_t kAsyncCacheSsdCheckpointGbDefault = 0;
   static constexpr std::string_view kAsyncCacheSsdPathDefault{
       "/mnt/flash/async_cache."};
   static constexpr std::string_view kShuffleNameDefault{""};
@@ -165,6 +168,8 @@ class SystemConfig : public ConfigBase {
   int32_t systemMemoryGb() const;
 
   uint64_t asyncCacheSsdGb() const;
+
+  uint64_t asyncCacheSsdCheckpointGb() const;
 
   uint64_t localShuffleMaxPartitionBytes() const;
 


### PR DESCRIPTION
Add config async-cache-ssd-checkpoint-gb for SSD checkpoint size.
When the value is positive, durable SSD is enabled.

```
== NO RELEASE NOTE ==
```
