### PR TITLE
Refactor Presto-native and Presto-on-Spark native unit tests infrastructure

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -49,6 +49,17 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-metastore</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive</artifactId>

--- a/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/hive/HiveExternalWorkerQueryRunner.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.log.Logging;
+import com.facebook.presto.nativeworker.AbstractNativeRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 
 public class HiveExternalWorkerQueryRunner
+        extends AbstractNativeRunner
 {
     private HiveExternalWorkerQueryRunner() {}
 
@@ -78,6 +80,12 @@ public class HiveExternalWorkerQueryRunner
     public static QueryRunner createJavaQueryRunner(Optional<Path> dataDirectory)
             throws Exception
     {
+        return createJavaQueryRunner(dataDirectory, "sql-standard");
+    }
+
+    public static QueryRunner createJavaQueryRunner(Optional<Path> dataDirectory, String security)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner =
                 HiveQueryRunner.createQueryRunner(
                         ImmutableList.of(),
@@ -85,7 +93,7 @@ public class HiveExternalWorkerQueryRunner
                                 "parse-decimal-literals-as-double", "true",
                                 "regex-library", "RE2J",
                                 "offset-clause-enabled", "true"),
-                        "sql-standard",
+                        security,
                         ImmutableMap.of(
                                 "hive.storage-format", "DWRF",
                                 "hive.pushdown-filter-enabled", "true"),
@@ -124,23 +132,13 @@ public class HiveExternalWorkerQueryRunner
                 ImmutableList.of(),
                 ImmutableList.of(),
                 ImmutableMap.<String, String>builder()
-                        .put("optimizer.optimize-hash-generation", "false")
-                        .put("parse-decimal-literals-as-double", "true")
                         .put("http-server.http.port", "8080")
                         .put("experimental.internal-communication.thrift-transport-enabled", String.valueOf(useThrift))
-                        .put("regex-library", "RE2J")
-                        .put("offset-clause-enabled", "true")
-                        // By default, Presto will expand some functions into its SQL equivalent (e.g. array_duplicates()).
-                        // With Velox, we do not want Presto to replace the function with its SQL equivalent.
-                        // To achieve that, we set inline-sql-functions to false.
-                        .put("inline-sql-functions", "false")
-                        .put("use-alternative-function-signatures", "true")
+                        .putAll(getNativeWorkerSystemProperties())
                         .build(),
                 ImmutableMap.of(),
                 "legacy",
-                ImmutableMap.of(
-                        "hive.storage-format", "DWRF",
-                        "hive.pushdown-filter-enabled", "true"),
+                getNativeWorkerHiveProperties(),
                 workerCount,
                 Optional.of(Paths.get(dataDirectory)),
                 Optional.of((workerIndex, discoveryUri) -> {
@@ -197,267 +195,6 @@ public class HiveExternalWorkerQueryRunner
                         throw new UncheckedIOException(e);
                     }
                 }));
-    }
-
-    private static void createLineitem(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem")) {
-            queryRunner.execute("CREATE TABLE lineitem AS " +
-                    "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
-                    "   returnflag, linestatus, cast(shipdate as varchar) as shipdate, cast(commitdate as varchar) as commitdate, " +
-                    "   cast(receiptdate as varchar) as receiptdate, shipinstruct, shipmode, comment, " +
-                    "   linestatus = 'O' as is_open, returnflag = 'R' as is_returned, " +
-                    "   cast(tax as real) as tax_as_real, cast(discount as real) as discount_as_real, " +
-                    "   cast(linenumber as smallint) as linenumber_as_smallint, " +
-                    "   cast(linenumber as tinyint) as linenumber_as_tinyint " +
-                    "FROM tpch.tiny.lineitem");
-        }
-    }
-
-    private static void createOrders(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders")) {
-            queryRunner.execute("CREATE TABLE orders AS " +
-                    "SELECT orderkey, custkey, orderstatus, totalprice, cast(orderdate as varchar) as orderdate, " +
-                    "   orderpriority, clerk, shippriority, comment " +
-                    "FROM tpch.tiny.orders");
-        }
-    }
-
-    private static void createOrdersEx(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_ex")) {
-            queryRunner.execute("CREATE TABLE orders_ex AS " +
-                    "SELECT orderkey, array_agg(quantity) as quantities, map_agg(linenumber, quantity) as quantity_by_linenumber " +
-                    "FROM tpch.tiny.lineitem " +
-                    "GROUP BY 1");
-        }
-    }
-
-    private static void createOrdersHll(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_hll")) {
-            queryRunner.execute("CREATE TABLE orders_hll AS " +
-                    "SELECT orderkey % 23 as key, cast(approx_set(cast(orderdate as varchar)) as varbinary) as hll " +
-                    "FROM tpch.tiny.orders " +
-                    "GROUP BY 1");
-        }
-    }
-
-    private static void createNation(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation")) {
-            queryRunner.execute("CREATE TABLE nation AS SELECT * FROM tpch.tiny.nation");
-        }
-    }
-
-    private static void createPartitionedNation(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation_partitioned")) {
-            queryRunner.execute("CREATE TABLE nation_partitioned(nationkey BIGINT, name VARCHAR, comment VARCHAR, regionkey VARCHAR) WITH (partitioned_by = ARRAY['regionkey'])");
-            queryRunner.execute("INSERT INTO nation_partitioned SELECT nationkey, name, comment, cast(regionkey as VARCHAR) FROM tpch.tiny.nation");
-        }
-
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation_partitioned_ds")) {
-            queryRunner.execute("CREATE TABLE nation_partitioned_ds(nationkey BIGINT, name VARCHAR, comment VARCHAR, regionkey VARCHAR, ds VARCHAR) WITH (partitioned_by = ARRAY['ds'])");
-            queryRunner.execute("INSERT INTO nation_partitioned_ds SELECT nationkey, name, comment, cast(regionkey as VARCHAR), '2022-04-09' FROM tpch.tiny.nation");
-            queryRunner.execute("INSERT INTO nation_partitioned_ds SELECT nationkey, name, comment, cast(regionkey as VARCHAR), '2022-03-18' FROM tpch.tiny.nation");
-        }
-    }
-
-    private static void createBucketedCustomer(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "customer_bucketed")) {
-            queryRunner.execute("CREATE TABLE customer_bucketed(acctbal DOUBLE, custkey BIGINT, name VARCHAR, ds VARCHAR) WITH (bucket_count = 10, bucketed_by = ARRAY['name'], partitioned_by = ARRAY['ds'])");
-            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-01' FROM tpch.tiny.customer limit 10");
-            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-02' FROM tpch.tiny.customer limit 20");
-            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-03' FROM tpch.tiny.customer limit 30");
-        }
-    }
-
-    // Create PrestoBench tables that can be useful for Velox testing. PrestoBench leverages TPC-H data generator but it is
-    // more representative of modern data warehouses workloads than TPC-H. Main highlights:
-    // - It is based on 4 tables which are a denormalized version of the 7 tables in TPC-H.
-    // - It supports complex types like arrays and maps which is not covered by TPC-H.
-    // - TPC-H data model does not have nulls and this gap is covered by PrestoBench.
-    // - Add partitioning and bucketing to some of the tables in PrestoBench.
-    private static void createPrestoBenchTables(QueryRunner queryRunner)
-    {
-        // Create PrestoBench 4 tables
-        createPrestoBenchNation(queryRunner);
-        createPrestoBenchPart(queryRunner);
-        createPrestoBenchCustomer(queryRunner);
-        createPrestoBenchOrders(queryRunner);
-    }
-
-    private static void createCustomer(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "customer")) {
-            queryRunner.execute("CREATE TABLE customer AS " +
-                    "SELECT custkey, name, address, nationkey, phone, acctbal, comment, mktsegment " +
-                    "FROM tpch.tiny.customer");
-        }
-    }
-
-    // prestobench_nation: TPC-H Nation and region tables are consolidated into the nation table adding the region name as a new field.
-    // This table is not bucketed or partitioned.
-    private static void createPrestoBenchNation(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_nation")) {
-            queryRunner.execute("CREATE TABLE prestobench_nation as SELECT nation.nationkey, nation.name, region.name as regionname,nation.comment " +
-                                "FROM tpch.tiny.nation, tpch.tiny.region  WHERE nation.regionkey = region.regionkey");
-        }
-    }
-
-    // prestobench_part: TPC-H part, supplier and part supplier are consolidated into the part table.
-    // - Complex types:
-    //   * The list of suppliers of each part is captured into an array of JSON objects(about 4 suppliers for each part).
-    //     Each JSON has a key and a value corresponding to a supplier.
-    //        - The key is the supplier key (suppkey)
-    //        - The value is simply the original supplier columns in tpc-h which are: suppkey, name, address, nationkey, phone, acctbal, comment
-    // - Partitioning: p_size (50 values)
-    // - Bucketing:none to exercise non bucketed joins
-    private static void createPrestoBenchPart(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_part")) {
-            queryRunner.execute("CREATE TABLE prestobench_part " +
-                    "with (partitioned_by = array['size']) " +
-                    "as WITH part_suppliers as (SELECT part.partkey, supplier.suppkey, " +
-                    "                                  array_agg(cast(row(supplier.suppkey, supplier.name, availqty, supplycost, address, nationkey, phone, acctbal) as " +
-                    "                                                 row(suppkey integer, suppname varchar(25), availqty double, suppcost double, address varchar(40), " +
-                    "                                                     nationkey integer, phone varchar(15), acctbal double))) suppliers " +
-                    "                            FROM tpch.tiny.part part, tpch.tiny.supplier supplier, tpch.tiny.partsupp partsupp " +
-                    "                            WHERE supplier.suppkey = partsupp.suppkey and partsupp.partkey = part.partkey GROUP BY 1, 2 " +
-                    "                          ), " +
-                    "                          part_agg_suppliers as (SELECT partkey, map_agg(suppkey, suppliers) suppliers FROM part_suppliers GROUP BY partkey) " +
-                    "SELECT part.partkey, part.name, part.mfgr, part.brand, part.type, part.container, part.retailprice, part.comment, suppliers, part.size " +
-                    "FROM tpch.tiny.part part, part_agg_suppliers " +
-                    "WHERE part_agg_suppliers.partkey = part.partkey");
-        }
-    }
-
-    // prestobench_orders: orders and line items are merged to form orders tables.
-    // Complex types: The new orders table has all the line items as a map of
-    //      * key = line item numbers
-    //      * value  = ROW of partkey, suppkey, linenumber, quantity, extendedprice, discount, tax,
-    //                        returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct, shipmode
-    // Bucketing: The new order table is bucketed by customer key to help joins with customer table
-    // Partitioning: Order date is used commonly in the workload below and is a good candidate for partitioning field.
-    //               However, that will produce too many partitions. An alternative is to partition by
-    //               year of order date (7 values) and this means we need a field for that since Presto only allows partitioning  by fields.
-    // Nulls: Make 10% of custkey as nulls. This is useful for join keys with nulls.
-    // Skew: There are already columns with few values like order status that can be used for skewed (hot task) aggregations.
-    //       There are three values with these distributions:  ‘F’ with 49%, ‘O’ with 49% and ‘P’ with 2%
-    private static void createPrestoBenchOrders(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_orders")) {
-            queryRunner.execute("CREATE TABLE prestobench_orders " +
-                     "with (partitioned_by = array['orderdate_year'], bucketed_by = array['custkey'], bucket_count = 16) " +
-                     "as WITH order_lineitems as (SELECT o.orderkey, l.linenumber, " +
-                     "                                   array_agg(cast(row(partkey, suppkey, quantity, extendedprice, discount, tax, returnflag, linestatus, " +
-                     "                                                      shipdate, commitdate, receiptdate, shipinstruct, shipmode ) as " +
-                     "                                                  row(partkey integer, suppkey integer, quantity integer, extendedprice double, discount double, " +
-                     "                                                      tax double , returnflag varchar(1), linestatus varchar(1), " +
-                     "                                                      shipdate varchar, commitdate varchar, receiptdate varchar, shipinstruct varchar(25) , shipmode varchar(10)) " +
-                     "                                             ) " +
-                     "                                            ) lineitems " +
-                     "                            FROM orders o, lineitem l " +
-                     "                            WHERE o.orderkey = l.orderkey " +
-                     "                            GROUP BY 1, 2 " +
-                     "                           ), " +
-                     "        order_lineitems_agg as (SELECT orderkey, map_agg(linenumber, lineitems) lineitems_map FROM order_lineitems GROUP BY orderkey) " +
-                     "SELECT o.orderkey, if(custkey % 10 = 0,null,custkey) as custkey,cast(orderstatus as varchar(1)) as orderstatus," +
-                     "       totalprice,cast(orderpriority as varchar(15)) as orderpriority," +
-                     "       cast(clerk as varchar(15)) as clerk,shippriority,cast(comment as varchar(79)) as comment,lineitems_map, " +
-                     "       cast(orderdate as varchar) orderdate, cast(substr(cast(orderdate as varchar),1,4) as integer) orderdate_year " +
-                     "FROM orders o, order_lineitems_agg " +
-                     "WHERE order_lineitems_agg.orderkey = o.orderkey");
-        }
-    }
-
-    // prestobench_customer represents the original tpc-h customer table with additional fields with complex types.
-    // Complex Types: Add two fields as map
-    //  * key=year of ship date and value is an array of parts info for the customer orders in the year
-    //  * key=year of ship date and values is total spending by the customer on orders for the year
-    // Bucketing: customer key
-    // Partitioning: mktsegment (150 values)
-    private static void createPrestoBenchCustomer(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_customer")) {
-            queryRunner.execute("CREATE TABLE prestobench_customer " +
-                     "with (partitioned_by = array['mktsegment'], bucketed_by = array['custkey'], bucket_count = 64) " +
-                     "as WITH customer_yearly_summary as (SELECT custkey, map_agg(y, parts) AS year_parts, map_agg(y, total_cost) AS year_cost " +
-                     "                                    FROM (SELECT c.custkey,  cast(substr(cast(shipdate as varchar),1,4) as integer) y, " +
-                     "                                                 ARRAY_AGG( CAST(ROW (partkey, extendedprice, quantity) AS " +
-                     "                                                                 ROW (pk BIGINT, ep DOUBLE, qt DOUBLE))) AS parts, " +
-                     "                                                 SUM(extendedprice) AS total_cost " +
-                     "                                          FROM customer c LEFT OUTER JOIN orders o ON o.custkey = c.custkey " +
-                     "                                               LEFT OUTER JOIN lineitem l " +
-                     "                                               ON l.orderkey = o.orderkey " +
-                     "                                               GROUP BY c.custkey, cast(substr(cast(shipdate as varchar),1,4) as integer) " +
-                     "                                         ) GROUP BY custkey" +
-                     "                                   ) " +
-                     "SELECT customer.custkey, cast(name as varchar) as name, " +
-                     "       cast(address as varchar) as address, nationkey, " +
-                     "       cast(phone as varchar) as phone, acctbal, " +
-                     "       cast(comment as varchar) as comment, year_parts, year_cost, " +
-                     "       cast(mktsegment as varchar) as mktsegment " +
-                     "FROM customer, customer_yearly_summary " +
-                     "WHERE customer_yearly_summary.custkey=customer.custkey");
-        }
-    }
-
-    private static void createPart(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "part")) {
-            queryRunner.execute("CREATE TABLE part AS SELECT * FROM tpch.tiny.part");
-        }
-    }
-
-    private static void createPartSupp(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "partsupp")) {
-            queryRunner.execute("CREATE TABLE partsupp AS SELECT * FROM tpch.tiny.partsupp");
-        }
-    }
-
-    private static void createRegion(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "region")) {
-            queryRunner.execute("CREATE TABLE region AS SELECT * FROM tpch.tiny.region");
-        }
-    }
-
-    private static void createSupplier(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "supplier")) {
-            queryRunner.execute("CREATE TABLE supplier AS SELECT * FROM tpch.tiny.supplier");
-        }
-    }
-
-    private static void createEmptyTable(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "empty_table")) {
-            queryRunner.execute("CREATE TABLE empty_table (orderkey BIGINT, shipmodes array(varchar))");
-        }
-    }
-
-    // Create two bucketed by 'orderkey' tables to be able to run bucketed execution join query on them.
-    private static void createBucketedLineitemAndOrders(QueryRunner queryRunner)
-    {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem_bucketed")) {
-            queryRunner.execute("CREATE TABLE lineitem_bucketed(orderkey BIGINT, partkey BIGINT, suppkey BIGINT, linenumber INTEGER, quantity DOUBLE, ds VARCHAR) " +
-                    "WITH (bucket_count = 10, bucketed_by = ARRAY['orderkey'], sorted_by = ARRAY['orderkey'], partitioned_by = ARRAY['ds'])");
-            queryRunner.execute("INSERT INTO lineitem_bucketed SELECT orderkey, partkey, suppkey, linenumber, quantity, '2021-12-20' FROM tpch.tiny.lineitem");
-            queryRunner.execute("INSERT INTO lineitem_bucketed SELECT orderkey, partkey, suppkey, linenumber, quantity+10, '2021-12-21' FROM tpch.tiny.lineitem");
-        }
-
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_bucketed")) {
-            queryRunner.execute("CREATE TABLE orders_bucketed (orderkey BIGINT, custkey BIGINT, orderstatus VARCHAR, ds VARCHAR) " +
-                    "WITH (bucket_count = 10, bucketed_by = ARRAY['orderkey'], sorted_by = ARRAY['orderkey'], partitioned_by = ARRAY['ds'])");
-            queryRunner.execute("INSERT INTO orders_bucketed SELECT orderkey, custkey, orderstatus, '2021-12-20' FROM tpch.tiny.orders");
-            queryRunner.execute("INSERT INTO orders_bucketed SELECT orderkey, custkey, orderstatus, '2021-12-21' FROM tpch.tiny.orders");
-        }
     }
 
     public static void main(String[] args)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractNativeRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractNativeRunner.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public abstract class AbstractNativeRunner
+{
+    protected static Map<String, String> getNativeWorkerHiveProperties()
+    {
+        return ImmutableMap.of("hive.storage-format", "DWRF", "hive.pushdown-filter-enabled", "true");
+    }
+
+    protected static Map<String, String> getNativeWorkerSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("optimizer.optimize-hash-generation", "false")
+                .put("parse-decimal-literals-as-double", "true")
+                .put("regex-library", "RE2J")
+                .put("offset-clause-enabled", "true")
+                // By default, Presto will expand some functions into its SQL equivalent (e.g. array_duplicates()).
+                // With Velox, we do not want Presto to replace the function with its SQL equivalent.
+                // To achieve that, we set inline-sql-functions to false.
+                .put("inline-sql-functions", "false")
+                .put("use-alternative-function-signatures", "true")
+                .build();
+    }
+
+    protected static void createLineitem(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem")) {
+            queryRunner.execute("CREATE TABLE lineitem AS " +
+                    "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
+                    "   returnflag, linestatus, cast(shipdate as varchar) as shipdate, cast(commitdate as varchar) as commitdate, " +
+                    "   cast(receiptdate as varchar) as receiptdate, shipinstruct, shipmode, comment, " +
+                    "   linestatus = 'O' as is_open, returnflag = 'R' as is_returned, " +
+                    "   cast(tax as real) as tax_as_real, cast(discount as real) as discount_as_real, " +
+                    "   cast(linenumber as smallint) as linenumber_as_smallint, " +
+                    "   cast(linenumber as tinyint) as linenumber_as_tinyint " +
+                    "FROM tpch.tiny.lineitem");
+        }
+    }
+
+    protected static void createOrders(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders")) {
+            queryRunner.execute("CREATE TABLE orders AS " +
+                    "SELECT orderkey, custkey, orderstatus, totalprice, cast(orderdate as varchar) as orderdate, " +
+                    "   orderpriority, clerk, shippriority, comment " +
+                    "FROM tpch.tiny.orders");
+        }
+    }
+
+    protected static void createOrdersEx(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_ex")) {
+            queryRunner.execute("CREATE TABLE orders_ex AS " +
+                    "SELECT orderkey, array_agg(quantity) as quantities, map_agg(linenumber, quantity) as quantity_by_linenumber " +
+                    "FROM tpch.tiny.lineitem " +
+                    "GROUP BY 1");
+        }
+    }
+
+    protected static void createOrdersHll(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_hll")) {
+            queryRunner.execute("CREATE TABLE orders_hll AS " +
+                    "SELECT orderkey % 23 as key, cast(approx_set(cast(orderdate as varchar)) as varbinary) as hll " +
+                    "FROM tpch.tiny.orders " +
+                    "GROUP BY 1");
+        }
+    }
+
+    protected static void createNation(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation")) {
+            queryRunner.execute("CREATE TABLE nation AS SELECT * FROM tpch.tiny.nation");
+        }
+    }
+
+    protected static void createPartitionedNation(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation_partitioned")) {
+            queryRunner.execute("CREATE TABLE nation_partitioned(nationkey BIGINT, name VARCHAR, comment VARCHAR, regionkey VARCHAR) WITH (partitioned_by = ARRAY['regionkey'])");
+            queryRunner.execute("INSERT INTO nation_partitioned SELECT nationkey, name, comment, cast(regionkey as VARCHAR) FROM tpch.tiny.nation");
+        }
+
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "nation_partitioned_ds")) {
+            queryRunner.execute("CREATE TABLE nation_partitioned_ds(nationkey BIGINT, name VARCHAR, comment VARCHAR, regionkey VARCHAR, ds VARCHAR) WITH (partitioned_by = ARRAY['ds'])");
+            queryRunner.execute("INSERT INTO nation_partitioned_ds SELECT nationkey, name, comment, cast(regionkey as VARCHAR), '2022-04-09' FROM tpch.tiny.nation");
+            queryRunner.execute("INSERT INTO nation_partitioned_ds SELECT nationkey, name, comment, cast(regionkey as VARCHAR), '2022-03-18' FROM tpch.tiny.nation");
+        }
+    }
+
+    protected static void createBucketedCustomer(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "customer_bucketed")) {
+            queryRunner.execute("CREATE TABLE customer_bucketed(acctbal DOUBLE, custkey BIGINT, name VARCHAR, ds VARCHAR) WITH (bucket_count = 10, bucketed_by = ARRAY['name'], partitioned_by = ARRAY['ds'])");
+            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-01' FROM tpch.tiny.customer limit 10");
+            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-02' FROM tpch.tiny.customer limit 20");
+            queryRunner.execute("INSERT INTO customer_bucketed SELECT acctbal, custkey, cast(name as VARCHAR), '2021-01-03' FROM tpch.tiny.customer limit 30");
+        }
+    }
+
+    // Create PrestoBench tables that can be useful for Velox testing. PrestoBench leverages TPC-H data generator but it is
+    // more representative of modern data warehouses workloads than TPC-H. Main highlights:
+    // - It is based on 4 tables which are a denormalized version of the 7 tables in TPC-H.
+    // - It supports complex types like arrays and maps which is not covered by TPC-H.
+    // - TPC-H data model does not have nulls and this gap is covered by PrestoBench.
+    // - Add partitioning and bucketing to some of the tables in PrestoBench.
+    protected static void createPrestoBenchTables(QueryRunner queryRunner)
+    {
+        // Create PrestoBench 4 tables
+        createPrestoBenchNation(queryRunner);
+        createPrestoBenchPart(queryRunner);
+        createPrestoBenchCustomer(queryRunner);
+        createPrestoBenchOrders(queryRunner);
+    }
+
+    protected static void createCustomer(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "customer")) {
+            queryRunner.execute("CREATE TABLE customer AS " +
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, comment, mktsegment " +
+                    "FROM tpch.tiny.customer");
+        }
+    }
+
+    // prestobench_nation: TPC-H Nation and region tables are consolidated into the nation table adding the region name as a new field.
+    // This table is not bucketed or partitioned.
+    protected static void createPrestoBenchNation(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_nation")) {
+            queryRunner.execute("CREATE TABLE prestobench_nation as SELECT nation.nationkey, nation.name, region.name as regionname,nation.comment " +
+                    "FROM tpch.tiny.nation, tpch.tiny.region  WHERE nation.regionkey = region.regionkey");
+        }
+    }
+
+    // prestobench_part: TPC-H part, supplier and part supplier are consolidated into the part table.
+    // - Complex types:
+    //   * The list of suppliers of each part is captured into an array of JSON objects(about 4 suppliers for each part).
+    //     Each JSON has a key and a value corresponding to a supplier.
+    //        - The key is the supplier key (suppkey)
+    //        - The value is simply the original supplier columns in tpc-h which are: suppkey, name, address, nationkey, phone, acctbal, comment
+    // - Partitioning: p_size (50 values)
+    // - Bucketing:none to exercise non bucketed joins
+    protected static void createPrestoBenchPart(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_part")) {
+            queryRunner.execute("CREATE TABLE prestobench_part " +
+                    "with (partitioned_by = array['size']) " +
+                    "as WITH part_suppliers as (SELECT part.partkey, supplier.suppkey, " +
+                    "                                  array_agg(cast(row(supplier.suppkey, supplier.name, availqty, supplycost, address, nationkey, phone, acctbal) as " +
+                    "                                                 row(suppkey integer, suppname varchar(25), availqty double, suppcost double, address varchar(40), " +
+                    "                                                     nationkey integer, phone varchar(15), acctbal double))) suppliers " +
+                    "                            FROM tpch.tiny.part part, tpch.tiny.supplier supplier, tpch.tiny.partsupp partsupp " +
+                    "                            WHERE supplier.suppkey = partsupp.suppkey and partsupp.partkey = part.partkey GROUP BY 1, 2 " +
+                    "                          ), " +
+                    "                          part_agg_suppliers as (SELECT partkey, map_agg(suppkey, suppliers) suppliers FROM part_suppliers GROUP BY partkey) " +
+                    "SELECT part.partkey, part.name, part.mfgr, part.brand, part.type, part.container, part.retailprice, part.comment, suppliers, part.size " +
+                    "FROM tpch.tiny.part part, part_agg_suppliers " +
+                    "WHERE part_agg_suppliers.partkey = part.partkey");
+        }
+    }
+
+    // prestobench_orders: orders and line items are merged to form orders tables.
+    // Complex types: The new orders table has all the line items as a map of
+    //      * key = line item numbers
+    //      * value  = ROW of partkey, suppkey, linenumber, quantity, extendedprice, discount, tax,
+    //                        returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct, shipmode
+    // Bucketing: The new order table is bucketed by customer key to help joins with customer table
+    // Partitioning: Order date is used commonly in the workload below and is a good candidate for partitioning field.
+    //               However, that will produce too many partitions. An alternative is to partition by
+    //               year of order date (7 values) and this means we need a field for that since Presto only allows partitioning  by fields.
+    // Nulls: Make 10% of custkey as nulls. This is useful for join keys with nulls.
+    // Skew: There are already columns with few values like order status that can be used for skewed (hot task) aggregations.
+    //       There are three values with these distributions:  ‘F’ with 49%, ‘O’ with 49% and ‘P’ with 2%
+    protected static void createPrestoBenchOrders(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_orders")) {
+            queryRunner.execute("CREATE TABLE prestobench_orders " +
+                    "with (partitioned_by = array['orderdate_year'], bucketed_by = array['custkey'], bucket_count = 16) " +
+                    "as WITH order_lineitems as (SELECT o.orderkey, l.linenumber, " +
+                    "                                   array_agg(cast(row(partkey, suppkey, quantity, extendedprice, discount, tax, returnflag, linestatus, " +
+                    "                                                      shipdate, commitdate, receiptdate, shipinstruct, shipmode ) as " +
+                    "                                                  row(partkey integer, suppkey integer, quantity integer, extendedprice double, discount double, " +
+                    "                                                      tax double , returnflag varchar(1), linestatus varchar(1), " +
+                    "                                                      shipdate varchar, commitdate varchar, receiptdate varchar, shipinstruct varchar(25) , shipmode varchar(10)) " +
+                    "                                             ) " +
+                    "                                            ) lineitems " +
+                    "                            FROM orders o, lineitem l " +
+                    "                            WHERE o.orderkey = l.orderkey " +
+                    "                            GROUP BY 1, 2 " +
+                    "                           ), " +
+                    "        order_lineitems_agg as (SELECT orderkey, map_agg(linenumber, lineitems) lineitems_map FROM order_lineitems GROUP BY orderkey) " +
+                    "SELECT o.orderkey, if(custkey % 10 = 0,null,custkey) as custkey,cast(orderstatus as varchar(1)) as orderstatus," +
+                    "       totalprice,cast(orderpriority as varchar(15)) as orderpriority," +
+                    "       cast(clerk as varchar(15)) as clerk,shippriority,cast(comment as varchar(79)) as comment,lineitems_map, " +
+                    "       cast(orderdate as varchar) orderdate, cast(substr(cast(orderdate as varchar),1,4) as integer) orderdate_year " +
+                    "FROM orders o, order_lineitems_agg " +
+                    "WHERE order_lineitems_agg.orderkey = o.orderkey");
+        }
+    }
+
+    // prestobench_customer represents the original tpc-h customer table with additional fields with complex types.
+    // Complex Types: Add two fields as map
+    //  * key=year of ship date and value is an array of parts info for the customer orders in the year
+    //  * key=year of ship date and values is total spending by the customer on orders for the year
+    // Bucketing: customer key
+    // Partitioning: mktsegment (150 values)
+    protected static void createPrestoBenchCustomer(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "prestobench_customer")) {
+            queryRunner.execute("CREATE TABLE prestobench_customer " +
+                    "with (partitioned_by = array['mktsegment'], bucketed_by = array['custkey'], bucket_count = 64) " +
+                    "as WITH customer_yearly_summary as (SELECT custkey, map_agg(y, parts) AS year_parts, map_agg(y, total_cost) AS year_cost " +
+                    "                                    FROM (SELECT c.custkey,  cast(substr(cast(shipdate as varchar),1,4) as integer) y, " +
+                    "                                                 ARRAY_AGG( CAST(ROW (partkey, extendedprice, quantity) AS " +
+                    "                                                                 ROW (pk BIGINT, ep DOUBLE, qt DOUBLE))) AS parts, " +
+                    "                                                 SUM(extendedprice) AS total_cost " +
+                    "                                          FROM customer c LEFT OUTER JOIN orders o ON o.custkey = c.custkey " +
+                    "                                               LEFT OUTER JOIN lineitem l " +
+                    "                                               ON l.orderkey = o.orderkey " +
+                    "                                               GROUP BY c.custkey, cast(substr(cast(shipdate as varchar),1,4) as integer) " +
+                    "                                         ) GROUP BY custkey" +
+                    "                                   ) " +
+                    "SELECT customer.custkey, cast(name as varchar) as name, " +
+                    "       cast(address as varchar) as address, nationkey, " +
+                    "       cast(phone as varchar) as phone, acctbal, " +
+                    "       cast(comment as varchar) as comment, year_parts, year_cost, " +
+                    "       cast(mktsegment as varchar) as mktsegment " +
+                    "FROM customer, customer_yearly_summary " +
+                    "WHERE customer_yearly_summary.custkey=customer.custkey");
+        }
+    }
+
+    protected static void createPart(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "part")) {
+            queryRunner.execute("CREATE TABLE part AS SELECT * FROM tpch.tiny.part");
+        }
+    }
+
+    protected static void createPartSupp(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "partsupp")) {
+            queryRunner.execute("CREATE TABLE partsupp AS SELECT * FROM tpch.tiny.partsupp");
+        }
+    }
+
+    protected static void createRegion(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "region")) {
+            queryRunner.execute("CREATE TABLE region AS SELECT * FROM tpch.tiny.region");
+        }
+    }
+
+    protected static void createSupplier(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "supplier")) {
+            queryRunner.execute("CREATE TABLE supplier AS SELECT * FROM tpch.tiny.supplier");
+        }
+    }
+
+    protected static void createEmptyTable(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "empty_table")) {
+            queryRunner.execute("CREATE TABLE empty_table (orderkey BIGINT, shipmodes array(varchar))");
+        }
+    }
+
+    // Create two bucketed by 'orderkey' tables to be able to run bucketed execution join query on them.
+    protected static void createBucketedLineitemAndOrders(QueryRunner queryRunner)
+    {
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem_bucketed")) {
+            queryRunner.execute("CREATE TABLE lineitem_bucketed(orderkey BIGINT, partkey BIGINT, suppkey BIGINT, linenumber INTEGER, quantity DOUBLE, ds VARCHAR) " +
+                    "WITH (bucket_count = 10, bucketed_by = ARRAY['orderkey'], sorted_by = ARRAY['orderkey'], partitioned_by = ARRAY['ds'])");
+            queryRunner.execute("INSERT INTO lineitem_bucketed SELECT orderkey, partkey, suppkey, linenumber, quantity, '2021-12-20' FROM tpch.tiny.lineitem");
+            queryRunner.execute("INSERT INTO lineitem_bucketed SELECT orderkey, partkey, suppkey, linenumber, quantity+10, '2021-12-21' FROM tpch.tiny.lineitem");
+        }
+
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders_bucketed")) {
+            queryRunner.execute("CREATE TABLE orders_bucketed (orderkey BIGINT, custkey BIGINT, orderstatus VARCHAR, ds VARCHAR) " +
+                    "WITH (bucket_count = 10, bucketed_by = ARRAY['orderkey'], sorted_by = ARRAY['orderkey'], partitioned_by = ARRAY['ds'])");
+            queryRunner.execute("INSERT INTO orders_bucketed SELECT orderkey, custkey, orderstatus, '2021-12-20' FROM tpch.tiny.orders");
+            queryRunner.execute("INSERT INTO orders_bucketed SELECT orderkey, custkey, orderstatus, '2021-12-21' FROM tpch.tiny.orders");
+        }
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/AbstractTestPrestoSparkQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/AbstractTestPrestoSparkQueries.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.hive.HiveExternalWorkerQueryRunner;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_EXECUTABLE_PATH;
+import static com.facebook.presto.SystemSessionProperties.TABLE_WRITER_MERGE_OPERATOR_ENABLED;
+import static com.facebook.presto.hive.HiveSessionProperties.COLLECT_COLUMN_STATISTICS_ON_WRITE;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_INITIAL_PARTITION_COUNT;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED;
+import static java.util.Objects.requireNonNull;
+
+public class AbstractTestPrestoSparkQueries
+        extends AbstractTestQueryFramework
+{
+    private static final String SPARK_SHUFFLE_MANAGER = "spark.shuffle.manager";
+    private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
+
+    protected Session getNativeSession()
+    {
+        Session.SessionBuilder sessionBuilder = Session.builder(getSession())
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .setSystemProperty(TABLE_WRITER_MERGE_OPERATOR_ENABLED, "false")
+                .setSystemProperty(SPARK_INITIAL_PARTITION_COUNT, "1")
+                .setSystemProperty(SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED, "false")
+                .setCatalogSessionProperty("hive", COLLECT_COLUMN_STATISTICS_ON_WRITE, "false");
+
+        if (System.getProperty("NATIVE_PORT") == null) {
+            sessionBuilder.setSystemProperty(NATIVE_EXECUTION_EXECUTABLE_PATH, requireNonNull(System.getProperty("PRESTO_SERVER"), "Native worker binary path is missing. Add -DPRESTO_SERVER=/path/to/native/process/bin to your JVM arguments."));
+        }
+        return sessionBuilder.build();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        // prevent to use the default Prestissimo config files since the Presto-Spark will generate the configs on-the-fly.
+        return PrestoSparkNativeQueryRunner.createPrestoSparkNativeQueryRunner(
+                ImmutableMap.of("catalog.config-dir", "/"), getNativeExecutionShuffleConfigs());
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        String dataDirectory = System.getProperty("DATA_DIR");
+        return HiveExternalWorkerQueryRunner.createJavaQueryRunner(Optional.ofNullable(dataDirectory).map(Paths::get), "legacy");
+    }
+
+    protected void assertQuery(String sql)
+    {
+        assertQuery(getNativeSession(), sql, getQueryRunner().getDefaultSession(), sql);
+    }
+
+    protected void assertQuerySucceeds(String sql)
+    {
+        assertQuerySucceeds(getNativeSession(), sql);
+    }
+
+    protected void assertQueryFails(String sql, String expectedMessageRegExp)
+    {
+        assertQueryFails(getNativeSession(), sql, expectedMessageRegExp);
+    }
+
+    protected Map<String, String> getNativeExecutionShuffleConfigs()
+    {
+        ImmutableMap.Builder<String, String> sparkConfigs = ImmutableMap.builder();
+        sparkConfigs.put(SPARK_SHUFFLE_MANAGER, "com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager");
+        sparkConfigs.put(FALLBACK_SPARK_SHUFFLE_MANAGER, "org.apache.spark.shuffle.sort.SortShuffleManager");
+        return sparkConfigs.build();
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.nativeworker.AbstractNativeRunner;
+import com.facebook.presto.spi.security.PrincipalType;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spark.PrestoSparkQueryRunner.METASTORE_CONTEXT;
+
+public class PrestoSparkNativeQueryRunner
+        extends AbstractNativeRunner
+{
+    private static final int AVAILABLE_CPU_COUNT = 4;
+
+    public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner(Map<String, String> additionalConfigProperties, Map<String, String> additionalSparkProperties)
+    {
+        String dataDirectory = System.getProperty("DATA_DIR");
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        PrestoSparkQueryRunner queryRunner = new PrestoSparkQueryRunner(
+                "hive",
+                builder.putAll(getNativeWorkerSystemProperties()).putAll(additionalConfigProperties).build(),
+                getNativeWorkerHiveProperties(),
+                additionalSparkProperties,
+                Optional.ofNullable(dataDirectory).map(Paths::get),
+                AVAILABLE_CPU_COUNT);
+
+        ExtendedHiveMetastore metastore = queryRunner.getMetastore();
+        if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {
+            metastore.createDatabase(METASTORE_CONTEXT, createDatabaseMetastoreObject("tpch"));
+        }
+        return queryRunner;
+    }
+
+    private static Database createDatabaseMetastoreObject(String name)
+    {
+        return Database.builder()
+                .setDatabaseName(name)
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build();
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -13,136 +13,66 @@
  */
 package com.facebook.presto.spark;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager;
-import com.facebook.presto.testing.QueryRunner;
-import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.google.common.collect.ImmutableMap;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.shuffle.ShuffleHandle;
 import org.apache.spark.shuffle.sort.BypassMergeSortShuffleHandle;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
-import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_EXECUTABLE_PATH;
-import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
-import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
  * Following JVM argument is needed to run Spark native tests.
- *
+ * <p>
  * - PRESTO_SERVER
- *   - This tells Spark where to find the Presto native binary to launch the process.
- *      Example: -DPRESTO_SERVER=/path/to/native/process/bin
- *
+ * - This tells Spark where to find the Presto native binary to launch the process.
+ * Example: -DPRESTO_SERVER=/path/to/native/process/bin
+ * <p>
  * - DATA_DIR
- *   - Optional path to store TPC-H tables used in the test. If this directory is empty, it will be
- *     populated. If tables already exists, they will be reused.
- *
+ * - Optional path to store TPC-H tables used in the test. If this directory is empty, it will be
+ * populated. If tables already exists, they will be reused.
+ * <p>
  * Tests can be running in Interactive Debugging Mode that allows for easier debugging
  * experience. Instead of launching its own native process, the test will connect to an existing
  * native process. This gives developers flexibility to connect IDEA and debuggers to the native process.
  * Enable this mode by setting NATIVE_PORT JVM argument.
- *
+ * <p>
  * - NATIVE_PORT
- *   - This is the port your externally launched native process listens to. It is used to tell Spark where to send
- *     requests. This port number has to be the same as to which your externally launched process listens.
- *     Example: -DNATIVE_PORT=7777.
- *     When NATIVE_PORT is specified, PRESTO_SERVER argument is not requires and is ignored if specified.
+ * - This is the port your externally launched native process listens to. It is used to tell Spark where to send
+ * requests. This port number has to be the same as to which your externally launched process listens.
+ * Example: -DNATIVE_PORT=7777.
+ * When NATIVE_PORT is specified, PRESTO_SERVER argument is not requires and is ignored if specified.
  */
 public class TestPrestoSparkNativeExecution
-        extends AbstractTestQueryFramework
+        extends AbstractTestPrestoSparkQueries
 {
-    private static final String SPARK_SHUFFLE_MANAGER = "spark.shuffle.manager";
-    private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
-    private static final int AVAILABLE_CPU_COUNT = 16;
-
-    protected Session getNativeSession()
-    {
-        Session.SessionBuilder sessionBuilder = Session.builder(getSession())
-                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true");
-        if (System.getProperty("NATIVE_PORT") == null) {
-            sessionBuilder.setSystemProperty(NATIVE_EXECUTION_EXECUTABLE_PATH, requireNonNull(System.getProperty("PRESTO_SERVER"), "Native worker binary path is missing. Add -DPRESTO_SERVER=/path/to/native/process/bin to your JVM arguments."));
-        }
-        return sessionBuilder.build();
-    }
-
-    @Override
-    protected QueryRunner createQueryRunner()
-    {
-        Map<String, String> configs = new HashMap<>();
-        // prevent to use the default Prestissimo config files since the Presto-Spark will generate the configs on-the-fly.
-        configs.put("catalog.config-dir", "/");
-
-        String dataDirectory = System.getProperty("DATA_DIR");
-
-        return PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner(configs, Optional.ofNullable(dataDirectory).map(Paths::get), AVAILABLE_CPU_COUNT);
-    }
-
     @Test
-    public void testNativeExecutionWithProjection()
+    public void testMapOnlyQueries()
     {
-        assertQuerySucceeds("DROP TABLE IF EXISTS test_order");
-        assertUpdate("CREATE TABLE test_order WITH (format = 'DWRF') as SELECT orderkey, custkey FROM orders", 15_000);
-
-        Session session = Session.builder(getNativeSession())
-                .setSystemProperty("table_writer_merge_operator_enabled", "false")
-                .setSystemProperty("spark_partition_count_auto_tune_enabled", "false")
-                .setSystemProperty("spark_initial_partition_count", "1")
-                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
-                .setCatalogSessionProperty("hive", PUSHDOWN_FILTER_ENABLED, "true")
-                .build();
-
-        // Reset the spark context to register the native execution shuffle manager. We want to let the query runner use the default spark shuffle
-        // manager to generate the test tables and only test the new native execution shuffle manager on the test below test cases.
-        PrestoSparkQueryRunner queryRunner = (PrestoSparkQueryRunner) getQueryRunner();
-        queryRunner.resetSparkContext(getNativeExecutionShuffleConfigs(), AVAILABLE_CPU_COUNT);
-        try {
-            assertQuerySucceeds("SELECT * FROM test_order");
-            assertQueryFails(session, "SELECT sequence(1, orderkey) FROM test_order",
-                    ".*Scalar function name not registered: presto.default.sequence.*");
-            assertQueryFails(session, "SELECT orderkey / 0 FROM test_order", ".*division by zero.*");
-        }
-        finally {
-            queryRunner.resetSparkContext();
-        }
-
-        queryRunner.resetSparkContext(getNativeExecutionShuffleConfigs(), AVAILABLE_CPU_COUNT);
-        try {
-            assertQueryFails(session, "SELECT * FROM test_order LIMIT 4",
-                    ".*Failure in LocalWriteFile: path .* already exists.*");
-        }
-        finally {
-            queryRunner.resetSparkContext();
-        }
+        assertQuery("SELECT orderkey, custkey FROM orders WHERE orderkey <= 200");
+        assertQuerySucceeds("SELECT * FROM orders");
+        assertQueryFails("SELECT sequence(1, orderkey) FROM orders",
+                ".*Scalar function name not registered: presto.default.sequence.*");
+        assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
+        assertQueryFails("SELECT orderkey, custkey FROM orders LIMIT 4", ".*Failure in LocalWriteFile: path .* already exists.*");
     }
 
     // TODO: re-enable the test once the shuffle integration is ready.
     @Ignore
-    @Test(priority = 2, dependsOnMethods = "testNativeExecutionWithProjection")
+    @Test(priority = 2, dependsOnMethods = "testMapOnlyQueries")
     public void testNativeExecutionShuffleManager()
     {
-        Session session = Session.builder(getNativeSession())
-                .setSystemProperty("table_writer_merge_operator_enabled", "false")
-                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
-                .build();
-
         PrestoSparkQueryRunner queryRunner = (PrestoSparkQueryRunner) getQueryRunner();
 
         // Reset the spark context to register the native execution shuffle manager. We want to let the query runner use the default spark shuffle
         // manager to generate the test tables and only test the new native execution shuffle manager on the test below test cases.
-        queryRunner.resetSparkContext(getNativeExecutionShuffleConfigs(), AVAILABLE_CPU_COUNT);
         // Expecting 0 row updated since currently the NativeExecutionOperator is dummy.
-        queryRunner.execute(session, "CREATE TABLE test_aggregate as SELECT  partkey, count(*) c FROM lineitem WHERE partkey % 10 = 1 GROUP BY partkey");
+        queryRunner.execute("CREATE TABLE test_aggregate as SELECT  partkey, count(*) c FROM lineitem WHERE partkey % 10 = 1 GROUP BY partkey");
 
         assertNotNull(SparkEnv.get());
         assertTrue(SparkEnv.get().shuffleManager() instanceof PrestoSparkNativeExecutionShuffleManager);
@@ -154,13 +84,5 @@ public class TestPrestoSparkNativeExecution
         int shuffleId = shuffleHandle.get().shuffleId();
         assertEquals(0, shuffleId);
         assertEquals(shuffleManager.getNumOfPartitions(shuffleId), bypassMergeSortShuffleHandle.numMaps());
-    }
-
-    private Map<String, String> getNativeExecutionShuffleConfigs()
-    {
-        ImmutableMap.Builder<String, String> sparkConfigs = ImmutableMap.builder();
-        sparkConfigs.put(SPARK_SHUFFLE_MANAGER, "com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager");
-        sparkConfigs.put(FALLBACK_SPARK_SHUFFLE_MANAGER, "org.apache.spark.shuffle.sort.SortShuffleManager");
-        return sparkConfigs.build();
     }
 }


### PR DESCRIPTION
In this PR, we:
1. Refactor Prestissimo and Sapphire unit tests to allow them to share common functionalities (properties, util functions etc).
2. Simplified the TestPrestoSparkNativeExecution to allow adding new test query by one line.
3. Add test query results verification compared with the results from vanilla Presto
```
== NO RELEASE NOTE ==
```
