### PR TITLE
Fix PrestoSparkHttpTaskClient#abortResults

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -149,7 +149,11 @@ public class PrestoSparkHttpTaskClient
     public ListenableFuture<?> abortResults()
     {
         return httpClient.executeAsync(
-                prepareDelete().setUri(taskUri).build(),
+                prepareDelete().setUri(
+                        uriBuilderFrom(taskUri)
+                                .appendPath("/results/0")
+                                .build())
+                        .build(),
                 createStatusResponseHandler());
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
@@ -169,7 +169,9 @@ public class NativeExecutionOperator
                     return processResult(page.get());
                 }
                 else {
-                    finished = true;
+                    if (taskInfo.isPresent() && taskInfo.get().getTaskStatus().getState().isDone()) {
+                        finished = true;
+                    }
                     return null;
                 }
             }
@@ -222,10 +224,7 @@ public class NativeExecutionOperator
     }
 
     @Override
-    public void finish()
-    {
-        finished = true;
-    }
+    public void finish() {}
 
     @Override
     public boolean isFinished()

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -893,6 +893,18 @@ public class TestPrestoSparkHttpClient
                         }
                         else if (method.equalsIgnoreCase("DELETE")) {
                             // DELETE /v1/task/{taskId}
+                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\/results\\/[0-9]+\\z").matcher(path).find()) {
+                                try {
+                                    future.complete(responseHandler.handle(request, responseManager.createDummyResultResponse()));
+                                }
+                                catch (Exception e) {
+                                    e.printStackTrace();
+                                    future.completeExceptionally(e);
+                                }
+                            }
+                        }
+                        else if (method.equalsIgnoreCase("DELETE")) {
+                            // DELETE /v1/task/{taskId}/results/{bufferId}
                             if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\z").matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createDummyResultResponse()));


### PR DESCRIPTION
To signal that results have are not longer needed (have been received and processed), we need to send DELETE <taskUri>/results/0.

Before this change, we were sending DELETE <taskUri>, which was aborting the task and causing VeloxRuntimeError:  Aborted for external error.

See https://prestodb.io/docs/current/develop/worker-protocol.html

Also, wait for native task to finish before finishing NativeExecutionOperator.java.

```
== NO RELEASE NOTE ==
```
