### PR TITLE
[Presto-on-Spark] Extract NativeExecutionProcess to Executor lifecycle

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkService.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkService.java
@@ -57,5 +57,6 @@ public class PrestoSparkService
     public void close()
     {
         lifeCycleManager.stop();
+        taskExecutorFactory.stop();
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/HttpNativeExecutionTaskInfoFetcher.java
@@ -76,7 +76,9 @@ public class HttpNativeExecutionTaskInfoFetcher
                             @Override
                             public void onSuccess(BaseResponse<TaskInfo> result)
                             {
-                                log.debug("TaskInfoCallback success %s", result.getValue().getTaskId());
+                                TaskInfo taskInfoResult = result.getValue();
+                                log.info("TaskInfoCallback success taskId=%s, taskStatus=%s, bufferState=%s",
+                                        taskInfoResult.getTaskId(), taskInfoResult.getTaskStatus(), taskInfoResult.getOutputBuffers().getState());
                                 taskInfo.set(result.getValue());
                             }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
@@ -16,9 +16,7 @@ package com.facebook.presto.spark.execution;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
-import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import io.airlift.units.Duration;
 
@@ -30,8 +28,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import static java.util.Objects.requireNonNull;
 
 /**
- * This is a testing class that essentially does nothing. Its mere purpose is to disable the launching and killing of
- * native process by native execution. Instead it allows the native execution to reuse the same externally launched
+ * This is a testing class that essentially does nothing. Its mere, purpose is to disable the launching and killing of
+ * native process by native execution. Instead, it allows the native execution to reuse the same externally launched
  * process over and over again.
  */
 public class DetachedNativeExecutionProcess
@@ -40,22 +38,22 @@ public class DetachedNativeExecutionProcess
     private static final Logger log = Logger.get(DetachedNativeExecutionProcess.class);
 
     public DetachedNativeExecutionProcess(
-            Session session,
+            String executablePath,
             URI uri,
+            String catalogName,
             HttpClient httpClient,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
-            TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?> workerProperty) throws IOException
     {
-        super(session,
+        super(executablePath,
                 uri,
+                catalogName,
                 httpClient,
                 errorRetryScheduledExecutor,
                 serverInfoCodec,
                 maxErrorDuration,
-                taskManagerConfig,
                 workerProperty);
     }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -767,12 +767,12 @@ public class TestPrestoSparkHttpClient
                 newSingleThreadExecutor(),
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,
-                config,
                 workerProperty);
         List<TaskSource> sources = new ArrayList<>();
         return factory.createNativeExecutionProcess(
-                testSessionBuilder().build(),
+                "",
                 BASE_URI,
+                "",
                 maxErrorDuration);
     }
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
@@ -27,4 +27,8 @@ public interface IPrestoSparkTaskExecutorFactory
             CollectionAccumulator<SerializedTaskInfo> taskInfoCollector,
             CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
             Class<T> outputType);
+
+    default void stop()
+    {
+    }
 }


### PR DESCRIPTION
Currently the lifecycle of a CPP process is tied to the NativeExecutionOperator. This is incorrect and it needs to be tied to the executor itself so that the CPP process can be re-used.
```
== NO RELEASE NOTE ==
```
