### PR TITLE
[native] Fix HttpParser$IllegalCharacterException: 400: Illegal character SPACE=' '

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -61,8 +61,17 @@ void sendErrorResponse(
     uint16_t status) {
   static const size_t kMaxStatusSize = 1024;
 
+  // Use a prefix of the 'error' as status message. Make sure it doesn't include
+  // new lines. See https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
+
+  size_t statusSize = kMaxStatusSize;
+  auto pos = error.find('\n');
+  if (pos != std::string::npos && pos < statusSize) {
+    statusSize = pos;
+  }
+
   proxygen::ResponseBuilder(downstream)
-      .status(status, error.substr(0, kMaxStatusSize))
+      .status(status, error.substr(0, statusSize))
       .body(error)
       .sendWithEOM();
 }


### PR DESCRIPTION
Native worker used to generate invalid HTTP 500 response that contained new lines in the HTTP status message. These are not allowed and resulted in cryptic failures.

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html

These failures could be observed by runninng a LIMIT query or a query that uses unsupported function (from_utf8).

The fix is to make sure status message doesn't include new lines.

Here is the error from the LIMIT query after the fix:

```
    Caused by: com.facebook.presto.operator.PageTransportErrorException: Expected response code to be 200, but was 500 Exception: VeloxUserError:
    Exception: VeloxUserError
    Error Source: USER
    Error Code: INVALID_ARGUMENT
    Reason: Calling getResult() on a failed PrestoTask: 20230330_025016_00002_ex4fx.1.0.0. PrestoTask failure reason: Exception: VeloxUserError
    Error Source: USER
    Error Code: INVALID_ARGUMENT
    Reason: Shuffle name not provided from 'shuffle.name' property in config.properties
    Retriable: False
    Expression: !shuffleName.empty()
    Function: operator()
    File: /Users/mbasmanova/java/presto/presto-native-execution/presto_cpp/main/TaskResource.cpp
    Line: 276
```

```
== NO RELEASE NOTE ==
```
