### PR TITLE
Add http-access-log system config to presto-on-spark native

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -29,16 +29,21 @@ public class NativeExecutionSystemConfig
     private static final String ENABLE_SERIALIZED_PAGE_CHECKSUM = "enable-serialized-page-checksum";
     private static final String ENABLE_VELOX_EXPRESSION_LOGGING = "enable_velox_expression_logging";
     private static final String ENABLE_VELOX_TASK_LOGGING = "enable_velox_task_logging";
+    // Port on which presto-native http server should run
     private static final String HTTP_SERVER_HTTP_PORT = "http-server.http.port";
     private static final String HTTP_SERVER_REUSE_PORT = "http-server.reuse-port";
+    // Number of I/O thread to use for serving http request on presto-native (proxygen server)
+    // this excludes worker thread used by velox
     private static final String HTTP_EXEC_THREADS = "http_exec_threads";
     private static final String NUM_IO_THREADS = "num-io-threads";
     private static final String PRESTO_VERSION = "presto.version";
     private static final String SHUTDOWN_ONSET_SEC = "shutdown-onset-sec";
     private static final String SYSTEM_MEMORY_GB = "system-memory-gb";
     private static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
+    // Name of exchange client to use
     private static final String SHUFFLE_NAME = "shuffle.name";
-
+    // Feature flag for access log on presto-native http server
+    private static final String HTTP_SERVER_ACCESS_LOGS = "http-server.enable-access-log";
     private boolean enableSerializedPageChecksum = true;
     private boolean enableVeloxExpressionLogging;
     private boolean enableVeloxTaskLogging = true;
@@ -52,6 +57,7 @@ public class NativeExecutionSystemConfig
     private int maxDriversPerTask = 15;
     private String prestoVersion = "dummy.presto.version";
     private String shuffleName = "local";
+    private boolean enableHttpServerAccessLog = true;
 
     public Map<String, String> getAllProperties()
     {
@@ -69,6 +75,7 @@ public class NativeExecutionSystemConfig
                 .put(SYSTEM_MEMORY_GB, String.valueOf(getSystemMemoryGb()))
                 .put(TASK_MAX_DRIVERS_PER_TASK, String.valueOf(getMaxDriversPerTask()))
                 .put(SHUFFLE_NAME, getShuffleName())
+                .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
                 .build();
     }
 
@@ -226,5 +233,17 @@ public class NativeExecutionSystemConfig
     public String getPrestoVersion()
     {
         return prestoVersion;
+    }
+
+    @Config(HTTP_SERVER_ACCESS_LOGS)
+    public NativeExecutionSystemConfig setEnableHttpServerAccessLog(boolean enableHttpServerAccessLog)
+    {
+        this.enableHttpServerAccessLog = enableHttpServerAccessLog;
+        return this;
+    }
+
+    public boolean isEnableHttpServerAccessLog()
+    {
+        return enableHttpServerAccessLog;
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestProperties.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestProperties.java
@@ -50,7 +50,8 @@ public class TestProperties
                 .setConcurrentLifespansPerTask(5)
                 .setMaxDriversPerTask(15)
                 .setPrestoVersion("dummy.presto.version")
-                .setShuffleName("local"));
+                .setShuffleName("local")
+                .setEnableHttpServerAccessLog(true));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionSystemConfig expected = new NativeExecutionSystemConfig()
@@ -66,7 +67,8 @@ public class TestProperties
                 .setShutdownOnsetSec(30)
                 .setSystemMemoryGb(40)
                 .setMaxDriversPerTask(30)
-                .setShuffleName("custom");
+                .setShuffleName("custom")
+                .setEnableHttpServerAccessLog(false);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Accesslog was introduced in #19165 to presto-native. 
Enable access log in [Apache Combined Log Format](https://httpd.apache.org/docs/2.4/logs.html) via system config with a default value of true for presto-on-spark.
Example: 
`I0406 12:47:52.321221  2873 AccessLogFilter.cpp:74] 127.0.0.1 - - [2023-04-06 12:47:52] "DELETE /v1/task/20230406_191303_00000_n66nx.1.0.113/results/0 HTTP/1.1" 200 0   0`

```
== RELEASE NOTES ==

General Changes
* Add system config to enable access log on presto-on-spark native, the logs are in Apache's Combined Log Format. This can be enabled with the system config ``http-server.enable-access-log``. Default value is ``true``.

```
