### PR TITLE
[native] Re-factor filter attachment in http server.

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -167,16 +167,12 @@ void HttpServer::start(
   options.idleTimeout = std::chrono::milliseconds(60'000);
   options.enableContentCompression = false;
 
+  proxygen::RequestHandlerChain handlerFactories;
   if (SystemConfig::instance()->enableHttpAccessLog()) {
-    options.handlerFactories = proxygen::RequestHandlerChain()
-                                   .addThen<filters::AccessLogFilterFactory>()
-                                   .addThen(std::move(handlerFactory_))
-                                   .build();
-  } else {
-    options.handlerFactories = proxygen::RequestHandlerChain()
-                                   .addThen(std::move(handlerFactory_))
-                                   .build();
+    handlerFactories.addThen<filters::AccessLogFilterFactory>();
   }
+  handlerFactories.addThen(std::move(handlerFactory_));
+  options.handlerFactories = handlerFactories.build();
 
   // Increase the default flow control to 1MB/10MB
   options.initialReceiveWindow = uint32_t(1 << 20);


### PR DESCRIPTION
Proxygen http server allows to build filter chains to intercept incoming and outgoing calls. We added accesslogfilter based on an option. Re-factoring the code so that we can add many filters without duplicating the whole chain.

```
== NO RELEASE NOTE ==
```
