### PR TITLE
Quantize size memory allocation in http response

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -15,6 +15,7 @@
 #include "presto_cpp/main/PeriodicTaskManager.h"
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/stop_watch.h>
+#include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/TaskManager.h"
 #include "presto_cpp/main/common/Counters.h"
 #include "velox/common/base/StatsReporter.h"
@@ -33,6 +34,9 @@ namespace facebook::presto {
 static constexpr size_t kTaskPeriodGlobalCounters{2'000'000}; // 2 seconds.
 // Every two seconds we export memory counters.
 static constexpr size_t kMemoryPeriodGlobalCounters{2'000'000}; // 2 seconds.
+// Every two seconds we export exchange source counters.
+static constexpr size_t kExchangeSourcePeriodGlobalCounters{
+    2'000'000}; // 2 seconds.
 // Every 1 minute we clean old tasks.
 static constexpr size_t kTaskPeriodCleanOldTasks{60'000'000}; // 60 seconds.
 // Every 1 minute we export cache counters.
@@ -143,6 +147,21 @@ void PeriodicTaskManager::start() {
         std::chrono::microseconds{kMemoryPeriodGlobalCounters},
         "mmap_memory_counters");
   }
+
+  // Presto exchange source memory usage update.
+  scheduler_.addFunction(
+      []() {
+        int64_t currQueuedMemoryBytes{0};
+        int64_t peakQueuedMemoryBytes{0};
+        PrestoExchangeSource::getMemoryUsage(
+            currQueuedMemoryBytes, peakQueuedMemoryBytes);
+        REPORT_ADD_STAT_VALUE(
+            kCounterExchangeSourceQueuedBytes, currQueuedMemoryBytes);
+        REPORT_ADD_STAT_VALUE(
+            kCounterExchangeSourcePeakQueuedBytes, peakQueuedMemoryBytes);
+      },
+      std::chrono::microseconds{kExchangeSourcePeriodGlobalCounters},
+      "exchange_source_counters");
 
   if (auto* asyncDataCache = dynamic_cast<velox::cache::AsyncDataCache*>(
           velox::memory::MemoryAllocator::getInstance())) {
@@ -303,9 +322,9 @@ void PeriodicTaskManager::start() {
             (int64_t)usage.ru_stime.tv_sec * 1'000'000 +
                 (int64_t)usage.ru_stime.tv_usec);
         REPORT_ADD_STAT_VALUE(
-            kCounterNumCumulativeSoftPageFaults, usage.ru_minflt)
+            kCounterNumCumulativeSoftPageFaults, usage.ru_minflt);
         REPORT_ADD_STAT_VALUE(
-            kCounterNumCumulativeHardPageFaults, usage.ru_majflt)
+            kCounterNumCumulativeHardPageFaults, usage.ru_majflt);
       },
       std::chrono::microseconds{kOsPeriodGlobalCounters},
       "os_counters");

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -171,6 +171,11 @@ bool SystemConfig::enableHttpStatsFilter() const {
   return opt.value_or(kHttpEnableStatsFilterDefault);
 }
 
+uint64_t SystemConfig::httpMaxAllocateBytes() const {
+  auto opt = optionalProperty<uint64_t>(std::string(kHttpMaxAllocateBytes));
+  return opt.value_or(kHttpMaxAllocateBytesDefault);
+}
+
 NodeConfig* NodeConfig::instance() {
   static std::unique_ptr<NodeConfig> instance = std::make_unique<NodeConfig>();
   return instance.get();

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -116,6 +116,10 @@ class SystemConfig : public ConfigBase {
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatFilter{
       "http-server.enable-stats-filter"};
+  /// The options to configure the max quantized memory allocation size to store
+  /// the received http response data.
+  static constexpr std::string_view kHttpMaxAllocateBytes{
+      "http-server.max-response-allocate-bytes"};
   // Most server nodes today (May 2022) have at least 16 cores.
   // Setting the default maximum drivers per task to this value will
   // provide a better off-shelf experience.
@@ -140,6 +144,7 @@ class SystemConfig : public ConfigBase {
   static constexpr bool kUseMmapAllocatorDefault{true};
   static constexpr bool kHttpEnableAccessLogDefault = false;
   static constexpr bool kHttpEnableStatsFilterDefault = false;
+  static constexpr uint64_t kHttpMaxAllocateBytesDefault = 64 << 10;
 
   static SystemConfig* instance();
 
@@ -195,6 +200,8 @@ class SystemConfig : public ConfigBase {
   bool enableHttpAccessLog() const;
 
   bool enableHttpStatsFilter() const;
+
+  uint64_t httpMaxAllocateBytes() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -76,6 +76,10 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMappedMemoryRawAllocBytesLarge, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterExchangeSourceQueuedBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterExchangeSourcePeakQueuedBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumEmptyEntries, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -114,6 +114,13 @@ constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesSizeClass{
 // largest SizeClass cannot accommodate, are counted towards this counter.
 constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesLarge{
     "presto_cpp.mapped_memory_raw_alloc_bytes_large"};
+/// Number of bytes currently queued in PrestoExchangeSource waiting for
+/// consume.
+constexpr folly::StringPiece kCounterExchangeSourceQueuedBytes{
+    "presto_cpp.exchange_source_queued_bytes"};
+/// Peak number of bytes queued in PrestoExchangeSource waiting for consume.
+constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
+    "presto_cpp.exchange_source_peak_queued_bytes"};
 
 // ================== Cache Counters ==================
 

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -83,7 +83,7 @@ std::string bodyAsString(http::HttpResponse& response, MemoryPool* pool) {
   auto iobufs = response.consumeBody();
   for (auto& body : iobufs) {
     oss << std::string((const char*)body->data(), body->length());
-    pool->free(body->writableData(), body->length());
+    pool->free(body->writableData(), body->capacity());
   }
   EXPECT_EQ(pool->getCurrentBytes(), 0);
   return oss.str();


### PR DESCRIPTION
Add two system configs to configure the buffer allocation size
to store the data received from http server: httpMinAllocateBytes
and httpMaxAllocateBytes. This is to ensure the data copy to
velox memory use mapped buffer pool which is sufficient large to
handle the memory usage peak from http server. The mapped buffer
pool is also used for async data cache which the memory allocator
will shrink on-demand.

Also add to track the currently queued memory bytes in presto exchange
source and its peak and reports through stats by presto periodic task
manager.

```
== NO RELEASE NOTE ==
```
