### PR TITLE
Add test for native execution of functions registered via a json file

### DIFF
--- a/presto-native-execution/etc/config.properties
+++ b/presto-native-execution/etc/config.properties
@@ -2,3 +2,4 @@ discovery.uri=http://127.0.0.1:58215
 presto.version=testversion
 http-server.http.port=7777
 shutdown-onset-sec=1
+register-test-functions=true

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -45,6 +45,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tpcds</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -283,6 +283,10 @@ void PrestoServer::run() {
   velox::aggregate::prestosql::registerAllAggregateFunctions(
       kPrestoDefaultPrefix);
   velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
+  if (SystemConfig::instance()->registerTestFunctions()) {
+    velox::functions::prestosql::registerComparisonFunctions(
+        "json.test_schema.");
+  }
   registerVectorSerdes();
   registerPrestoPlanNodeSerDe();
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -171,6 +171,11 @@ bool SystemConfig::enableHttpStatsFilter() const {
   return opt.value_or(kHttpEnableStatsFilterDefault);
 }
 
+bool SystemConfig::registerTestFunctions() const {
+  auto opt = optionalProperty<bool>(std::string(kRegisterTestFunctions));
+  return opt.value_or(kRegisterTestFunctionsDefault);
+}
+
 uint64_t SystemConfig::httpMaxAllocateBytes() const {
   auto opt = optionalProperty<uint64_t>(std::string(kHttpMaxAllocateBytes));
   return opt.value_or(kHttpMaxAllocateBytesDefault);

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -116,6 +116,8 @@ class SystemConfig : public ConfigBase {
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatFilter{
       "http-server.enable-stats-filter"};
+  static constexpr std::string_view kRegisterTestFunctions{
+      "register-test-functions"};
   /// The options to configure the max quantized memory allocation size to store
   /// the received http response data.
   static constexpr std::string_view kHttpMaxAllocateBytes{
@@ -144,6 +146,7 @@ class SystemConfig : public ConfigBase {
   static constexpr bool kUseMmapAllocatorDefault{true};
   static constexpr bool kHttpEnableAccessLogDefault = false;
   static constexpr bool kHttpEnableStatsFilterDefault = false;
+  static constexpr bool kRegisterTestFunctionsDefault = false;
   static constexpr uint64_t kHttpMaxAllocateBytesDefault = 64 << 10;
 
   static SystemConfig* instance();
@@ -200,6 +203,8 @@ class SystemConfig : public ConfigBase {
   bool enableHttpAccessLog() const;
 
   bool enableHttpStatsFilter() const;
+
+  bool registerTestFunctions() const;
 
   uint64_t httpMaxAllocateBytes() const;
 };

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -70,4 +70,14 @@ public class TestPrestoSparkNativeExecution
                 ".*Scalar function name not registered: presto.default.sequence.*");
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
     }
+
+    /**
+     * Test native execution of a cpp function declared via json file, with sample function eq() defined
+     * in src/test/resources/eq.json
+     */
+    @Test
+    public void testJsonFileBasedFunction()
+    {
+        assertQuery("SELECT json.test_schema.eq(1, linenumber) FROM lineitem", "SELECT 1 = linenumber FROM lineitem");
+    }
 }

--- a/presto-native-execution/src/test/resources/eq.json
+++ b/presto-native-execution/src/test/resources/eq.json
@@ -1,0 +1,21 @@
+{
+  "udfSignatureMap": {
+    "eq":[
+      {
+        "docString":"function to check equivalence of the two values",
+        "functionKind": "SCALAR",
+        "outputType": "BOOLEAN",
+        "paramTypes":[
+          "INTEGER",
+          "INTEGER"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionTask.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spark.execution;
 
 import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpStatus;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
@@ -175,7 +176,10 @@ public class NativeExecutionTask
                 return response.getValue();
             }
             else {
-                throw new IllegalStateException("Create-or-update task request didn't return a result");
+                String message = String.format("Create-or-update task request didn't return a result. %s: %s",
+                        HttpStatus.fromStatusCode(response.getStatusCode()),
+                        response.getStatusMessage());
+                throw new IllegalStateException(message);
             }
         }
         catch (InterruptedException | ExecutionException e) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -32,6 +32,7 @@ public class NativeExecutionSystemConfig
     // Port on which presto-native http server should run
     private static final String HTTP_SERVER_HTTP_PORT = "http-server.http.port";
     private static final String HTTP_SERVER_REUSE_PORT = "http-server.reuse-port";
+    private static final String REGISTER_TEST_FUNCTIONS = "register-test-functions";
     // Number of I/O thread to use for serving http request on presto-native (proxygen server)
     // this excludes worker thread used by velox
     private static final String HTTP_EXEC_THREADS = "http_exec_threads";
@@ -57,6 +58,7 @@ public class NativeExecutionSystemConfig
     private int maxDriversPerTask = 15;
     private String prestoVersion = "dummy.presto.version";
     private String shuffleName = "local";
+    private boolean registerTestFunctions;
     private boolean enableHttpServerAccessLog = true;
 
     public Map<String, String> getAllProperties()
@@ -68,6 +70,7 @@ public class NativeExecutionSystemConfig
                 .put(ENABLE_VELOX_TASK_LOGGING, String.valueOf(isEnableVeloxTaskLogging()))
                 .put(HTTP_SERVER_HTTP_PORT, String.valueOf(getHttpServerPort()))
                 .put(HTTP_SERVER_REUSE_PORT, String.valueOf(isHttpServerReusePort()))
+                .put(REGISTER_TEST_FUNCTIONS, String.valueOf(isRegisterTestFunctions()))
                 .put(HTTP_EXEC_THREADS, String.valueOf(getHttpExecThreads()))
                 .put(NUM_IO_THREADS, String.valueOf(getNumIoThreads()))
                 .put(PRESTO_VERSION, getPrestoVersion())
@@ -149,6 +152,18 @@ public class NativeExecutionSystemConfig
     public boolean isHttpServerReusePort()
     {
         return httpServerReusePort;
+    }
+
+    @Config(REGISTER_TEST_FUNCTIONS)
+    public NativeExecutionSystemConfig setRegisterTestFunctions(boolean registerTestFunctions)
+    {
+        this.registerTestFunctions = registerTestFunctions;
+        return this;
+    }
+
+    public boolean isRegisterTestFunctions()
+    {
+        return registerTestFunctions;
     }
 
     @Config(HTTP_EXEC_THREADS)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestProperties.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestProperties.java
@@ -51,6 +51,7 @@ public class TestProperties
                 .setMaxDriversPerTask(15)
                 .setPrestoVersion("dummy.presto.version")
                 .setShuffleName("local")
+                .setRegisterTestFunctions(false)
                 .setEnableHttpServerAccessLog(true));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
@@ -68,6 +69,7 @@ public class TestProperties
                 .setSystemMemoryGb(40)
                 .setMaxDriversPerTask(30)
                 .setShuffleName("custom")
+                .setRegisterTestFunctions(true)
                 .setEnableHttpServerAccessLog(false);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);


### PR DESCRIPTION
Add test for native execution of external functions that are registered via json file. The support for this feature was added via `JsonFileBasedFunctionNamespaceManager` in #18630.

The introduced test fires a query `SELECT json.test_schema.eq(...) ...` and asserts successful registration of the external function in presto function register as well as successful registration+execution of the function in presto native(velox). On native side, the function is conditionally registered via the introduced config flag `register-test-functions` that's only true for testing.

```
== NO RELEASE NOTE ==
```