### PR TITLE
[native] Build mechanism to provide external fitler to http server.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -341,7 +341,7 @@ void PrestoServer::run() {
 
   // Start everything. After the return from the following call we are shutting
   // down.
-  httpServer_->start();
+  httpServer_->start(getHttpServerFilters());
 
   LOG(INFO) << "SHUTDOWN: Stopping all periodic tasks...";
   periodicTaskManager.stop();
@@ -492,6 +492,11 @@ std::shared_ptr<velox::exec::TaskListener> PrestoServer::getTaskListener() {
 std::shared_ptr<velox::exec::ExprSetListener>
 PrestoServer::getExprSetListener() {
   return nullptr;
+}
+
+std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
+PrestoServer::getHttpServerFilters() {
+  return {};
 }
 
 std::vector<std::string> PrestoServer::registerConnectors(

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -16,6 +16,7 @@
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
 #include <velox/exec/Task.h>
 #include <velox/expression/Expr.h>
 #include "presto_cpp/main/CPUMon.h"
@@ -84,6 +85,10 @@ class PrestoServer {
   virtual std::shared_ptr<velox::exec::TaskListener> getTaskListener();
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
+
+  /// Invoked to get the list of filters passed to the http server.
+  virtual std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
+  getHttpServerFilters();
 
   virtual std::vector<std::string> registerConnectors(
       const fs::path& configDirectoryPath);

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -237,6 +237,8 @@ class HttpServer {
       int httpExecThreads = 8);
 
   void start(
+      std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters =
+          {},
       std::function<void(proxygen::HTTPServer* /*server*/)> onSuccess = nullptr,
       std::function<void(std::exception_ptr)> onError = nullptr);
 
@@ -316,8 +318,7 @@ class HttpServer {
  private:
   const folly::SocketAddress httpAddress_;
   int httpExecThreads_;
-  std::unique_ptr<DispatchingRequestHandlerFactory> handlerFactory_ =
-      std::make_unique<DispatchingRequestHandlerFactory>();
+  std::unique_ptr<DispatchingRequestHandlerFactory> handlerFactory_;
   std::unique_ptr<proxygen::HTTPServer> server_;
   std::shared_ptr<folly::IOThreadPoolExecutor> httpExecutor_;
 

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -42,7 +42,7 @@ class HttpServerWrapper {
     auto [promise, future] = folly::makePromiseContract<folly::SocketAddress>();
     promise_ = std::move(promise);
     serverThread_ = std::make_unique<std::thread>([this]() {
-      server_->start([&](proxygen::HTTPServer* httpServer) {
+      server_->start({}, [&](proxygen::HTTPServer* httpServer) {
         ASSERT_EQ(httpServer->addresses().size(), 1);
         promise_.setValue(httpServer->addresses()[0].address);
       });

--- a/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
@@ -20,7 +20,7 @@ folly::SemiFuture<folly::SocketAddress> HttpServerWrapper::start() {
   auto [promise, future] = folly::makePromiseContract<folly::SocketAddress>();
   promise_ = std::move(promise);
   serverThread_ = std::make_unique<std::thread>([this]() {
-    server_->start([&](proxygen::HTTPServer* httpServer) {
+    server_->start({}, [&](proxygen::HTTPServer* httpServer) {
       ASSERT_EQ(httpServer->addresses().size(), 1);
       promise_.setValue(httpServer->addresses()[0].address);
     });


### PR DESCRIPTION
Http server supports filtering mechanism to intercept http calls. PrestoServer can provide application specific filters to http server to add different monitoring capabilities. This PR develops a mechanism that can pass a list of external filters to http server.