### PR TITLE
[native] Centralize http filter registration.

### DIFF
--- a/presto-native-execution/etc/config.properties
+++ b/presto-native-execution/etc/config.properties
@@ -1,3 +1,4 @@
 discovery.uri=http://127.0.0.1:58215
 presto.version=testversion
 http-server.http.port=7777
+shutdown-onset-sec=1

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -86,9 +86,8 @@ class PrestoServer {
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
 
-  /// Invoked to get the list of filters passed to the http server.
-  virtual std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
-  getHttpServerFilters();
+  /// Returns statistics based http filter.
+  virtual std::unique_ptr<proxygen::RequestHandlerFactory> getHttpStatsFilter();
 
   virtual std::vector<std::string> registerConnectors(
       const fs::path& configDirectoryPath);
@@ -102,6 +101,10 @@ class PrestoServer {
   virtual void registerFileSystems();
 
   virtual void registerStatsCounters();
+
+  /// Invoked to get the list of filters passed to the http server.
+  std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
+  getHttpServerFilters();
 
   void initializeAsyncCache();
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -166,6 +166,11 @@ bool SystemConfig::enableHttpAccessLog() const {
   return opt.value_or(kHttpEnableAccessLogDefault);
 }
 
+bool SystemConfig::enableHttpStatsFilter() const {
+  auto opt = optionalProperty<bool>(std::string(kHttpEnableStatFilter));
+  return opt.value_or(kHttpEnableStatsFilterDefault);
+}
+
 NodeConfig* NodeConfig::instance() {
   static std::unique_ptr<NodeConfig> instance = std::make_unique<NodeConfig>();
   return instance.get();

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -114,6 +114,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kShuffleName{"shuffle.name"};
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
+  static constexpr std::string_view kHttpEnableStatFilter{
+      "http-server.enable-stats-filter"};
   // Most server nodes today (May 2022) have at least 16 cores.
   // Setting the default maximum drivers per task to this value will
   // provide a better off-shelf experience.
@@ -137,6 +139,7 @@ class SystemConfig : public ConfigBase {
   static constexpr bool kUseMmapArenaDefault = false;
   static constexpr bool kUseMmapAllocatorDefault{true};
   static constexpr bool kHttpEnableAccessLogDefault = false;
+  static constexpr bool kHttpEnableStatsFilterDefault = false;
 
   static SystemConfig* instance();
 
@@ -190,6 +193,8 @@ class SystemConfig : public ConfigBase {
   bool useMmapAllocator() const;
 
   bool enableHttpAccessLog() const;
+
+  bool enableHttpStatsFilter() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/http/HttpClient.h"
-#include <velox/common/base/Exceptions.h>
 
 namespace facebook::presto::http {
 HttpClient::HttpClient(

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -14,7 +14,6 @@
 
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/common/Configs.h"
-#include "presto_cpp/main/http/filters/AccessLogFilter.h"
 
 namespace facebook::presto::http {
 
@@ -179,11 +178,6 @@ void HttpServer::start(
   options.enableContentCompression = false;
 
   proxygen::RequestHandlerChain handlerFactories;
-
-  // Register all built in filters
-  if (SystemConfig::instance()->enableHttpAccessLog()) {
-    handlerFactories.addThen<filters::AccessLogFilterFactory>();
-  }
 
   // Register all filters passed to the http server.
   for (size_t i = 0; i < filters.size(); ++i) {


### PR DESCRIPTION
- Centralize all filter registration inside Presto server
- Add config to enable/disable statistics based filter
- Provide a default `getHttpStatsFilter` implementation just returning null filter
- Update config.properties to give 1 sec shutdown wait time to speed up local development and tests. 

```
== NO RELEASE NOTE ==
```
