### PR TITLE
Produce less GC garbage in PrioritizedSplitRunner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
@@ -172,12 +172,11 @@ public class PrioritizedSplitRunner
             priority.set(taskHandle.addScheduledNanos(quantaScheduledNanos));
             lastRun.set(endNanos);
 
-            Duration wallDuration = new Duration(quantaScheduledNanos, NANOSECONDS);
             if (blocked == NOT_BLOCKED) {
-                unblockedQuantaWallTime.add(wallDuration);
+                unblockedQuantaWallTime.add(quantaScheduledNanos, NANOSECONDS);
             }
             else {
-                blockedQuantaWallTime.add(wallDuration);
+                blockedQuantaWallTime.add(quantaScheduledNanos, NANOSECONDS);
             }
 
             cpuTimeNanos.addAndGet(quantaCpuNanos);


### PR DESCRIPTION
A small change to avoid creating an unnecessary Duration object that immediately gets unwrapped.
 
Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
