### PR TITLE
[native] Setup-centos.sh simplification and defragmentation.

### DIFF
--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -1,0 +1,46 @@
+ARG PRESTO_VERSION
+
+FROM prestocpp/prestocpp-avx-centos:kpai-20221018 as Builder
+
+WORKDIR  /app
+COPY . .
+RUN cd presto-native-execution && \
+    make velox-submodule && \
+    source /opt/rh/gcc-toolset-9/enable && \
+    source velox/scripts/setup-helper-functions.sh && \
+    (mkdir -p third_party && cd third_party && github_checkout aws/aws-sdk-cpp 1.9.96 --depth 1 --recurse-submodules --config advice.detachedHead=false && \
+    cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management") && \
+    TREAT_WARNINGS_AS_ERRORS=0 PRESTO_ENABLE_PARQUET=ON PRESTO_ENABLE_S3=ON make release NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8 && \
+    mkdir -p prestissimo && \
+    cp _build/release/presto_cpp/main/presto_server prestissimo && \
+    tar cvf prestissimo.tar entrypoint.sh prestissimo
+
+##
+
+FROM prestocpp/prestocpp-avx-centos:kpai-20221018
+ENV PRESTO_HOME="/opt/presto-server"
+
+RUN dnf update -y && dnf install -y \
+        awscli \
+        gperf \
+        iproute \
+        lsof \
+        procps \
+        python3 \
+        sysstat \
+        tar \
+        vim \
+        wget \
+        which \
+        && \
+    mkdir -p $PRESTO_HOME/etc/catalog && \
+    mkdir -p /var/lib/presto/data
+
+WORKDIR  /app
+COPY --from=Builder /app/presto-native-execution/prestissimo.tar .
+RUN tar xvf prestissimo.tar && \
+    mv prestissimo/presto_server /usr/local/bin/ && \
+    mv entrypoint.sh /opt/ && \
+    touch /opt/presto-native-execution-${PRESTO_VERSION}
+
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/jenkins/agent-dind.yaml
+++ b/jenkins/agent-dind.yaml
@@ -16,8 +16,8 @@ spec:
       tty: true
       resources:
         requests:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "16Gi"
+          cpu: "4000m"
         limits:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "16Gi"
+          cpu: "4000m"

--- a/presto-native-execution/entrypoint.sh
+++ b/presto-native-execution/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GLOG_logtostderr=1 presto_server -etc-dir=/opt/presto-server/etc

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -11,37 +11,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
+export SCRIPT_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 
-export FB_OS_VERSION=v2022.11.14.00
-export nproc=$(getconf _NPROCESSORS_ONLN)
+source "${SCRIPT_DIR}/../velox/scripts/setup-helper-functions.sh" || \
+source "${SCRIPT_DIR}/setup-helper-functions.sh"
 
-dnf install -y maven
-dnf install -y java
+dnf install -y tar jq wget git
+dnf install -y maven java
 dnf install -y python3
 dnf install -y clang-tools-extra
-dnf install -y jq
 dnf install -y perl-XML-XPath
+dnf install -y libuuid-devel
 
 python3 -m pip install regex pyyaml chevron black six
 
-# Required for Antlr4
-dnf install -y libuuid-devel
-
-export CC=/opt/rh/gcc-toolset-9/root/bin/gcc
-export CXX=/opt/rh/gcc-toolset-9/root/bin/g++
-
-CPU_TARGET="${CPU_TARGET:-avx}"
-SCRIPT_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-if [ -f "${SCRIPT_DIR}/setup-helper-functions.sh" ]
-then
-  source "${SCRIPT_DIR}/setup-helper-functions.sh"
-else
-  source "${SCRIPT_DIR}/../velox/scripts/setup-helper-functions.sh"
-fi
-
-export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
+export FB_OS_VERSION=${FB_OS_VERSION:-'v2022.11.14.00'}
+export nproc=${nproc:-"$(getconf _NPROCESSORS_ONLN)"}
+export CC=${CC:-/opt/rh/gcc-toolset-9/root/bin/gcc}
+export CXX=${CXX:-/opt/rh/gcc-toolset-9/root/bin/g++}
+export CPU_TARGET="${CPU_TARGET:-avx}"
+export COMPILER_FLAGS=${COMPILER_FLAGS:-"$(echo -n $(get_cxx_flags $CPU_TARGET))"}
 
 (
   wget --max-redirect 3 https://download.libsodium.org/libsodium/releases/LATEST.tar.gz &&
@@ -63,30 +53,26 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
 )
 
 (
-  git clone https://github.com/facebook/folly &&
+  git clone --branch $FB_OS_VERSION https://github.com/facebook/folly &&
   cd folly &&
-  git checkout $FB_OS_VERSION &&
   cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
 )
 
 (
-  git clone https://github.com/facebookincubator/fizz &&
+  git clone --branch $FB_OS_VERSION https://github.com/facebookincubator/fizz &&
   cd fizz &&
-  git checkout $FB_OS_VERSION &&
   cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON fizz
 )
 
 (
-  git clone https://github.com/facebook/wangle &&
+  git clone --branch $FB_OS_VERSION https://github.com/facebook/wangle &&
   cd wangle &&
-  git checkout $FB_OS_VERSION &&
   cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON wangle
 )
 
 (
-  git clone https://github.com/facebook/proxygen &&
+  git clone --branch $FB_OS_VERSION https://github.com/facebook/proxygen &&
   cd proxygen &&
-  git checkout $FB_OS_VERSION &&
   cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
 )
 
@@ -106,9 +92,8 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
 )
 
 (
-  git clone https://github.com/facebook/fbthrift &&
+  git clone --branch $FB_OS_VERSION https://github.com/facebook/fbthrift &&
   cd fbthrift &&
-  git checkout $FB_OS_VERSION &&
   cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
 )
 


### PR DESCRIPTION
`Setup-centos.sh` script simplification and defragmentation.

From functional point of view nothing changes at all, but from practical point of view:

Using default value notation `VARIABLE=${VARIABLE:-DEFAULT}` instead of overwrite variable `VARIABLE=$DEFAULT` all bellow parameters can be easily overwritten by developer but if nothing is done the right-side default value is sed:

```bash
export FB_OS_VERSION="${FB_OS_VERSION:-'v2022.11.14.00'}"
export nproc="${nproc:-"$(getconf _NPROCESSORS_ONLN)"}"
export CC="${CC:-/opt/rh/gcc-toolset-9/root/bin/gcc}"
export CXX="${CXX:-/opt/rh/gcc-toolset-9/root/bin/g++}"
export CPU_TARGET="${CPU_TARGET:-avx}"
export COMPILER_FLAGS="${COMPILER_FLAGS:-"$(echo -n $(get_cxx_flags $CPU_TARGET))"}"
```
This should be preferred in generic repositories as single change in workflow not always require any changes in the point of interest scripts as they are flexible.

Added `git`, `wget` and `tar` as those may not be yet installed inside the container as we are planning to change the Docker workflow

```
== NO RELEASE NOTE ==
```
