### PR TITLE
Fix docs formatting for new array and map functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -154,7 +154,7 @@ Array Functions
 .. function:: array_sort_desc(x) -> array
 
     Returns the ``array`` sorted in the descending order. Elements of the ``array`` must be orderable.
-    Null elements will be placed at the end of the returned array.
+    Null elements will be placed at the end of the returned array. ::
 
         SELECT array_sort_desc(ARRAY [100, 1, 10, 50]); -- [100, 50, 10, 1]
         SELECT array_sort_desc(ARRAY [null, 100, null, 1, 10, 50]); -- [100, 50, 10, 1, null, null]

--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -89,7 +89,7 @@ Map Functions
 
     Returns top n keys in the map ``x``.
     ``n`` must be a non-negative integer
-    For bottom ``n`` keys, use the function with lambda operator to perform custom sorting
+    For bottom ``n`` keys, use the function with lambda operator to perform custom sorting. ::
 
         SELECT map_top_n_keys(map(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]), 2) --- ['c', 'b']
 
@@ -105,7 +105,7 @@ Map Functions
 .. function:: map_top_n(x(K,V), n) -> map(K, V)
 
     Truncates map items. Keeps only the top N elements by value.
-    ``n`` must be a non-negative integer
+    ``n`` must be a non-negative integer. ::
 
         SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[2, 3, 1]), 2) --- {'b' -> 3, 'a' -> 2}
 


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
mvn clean install -DskipTests -T1C
Once built I checked the built documentation, loading it up in the browser:
http://localhost:63342/presto-root/presto-docs/target/html/functions/array.html
http://localhost:63342/presto-root/presto-docs/target/html/functions/map.html

```
== NO RELEASE NOTE ==
```