### PR TITLE
[native] Prestissimo 3-stages Dockerfile

### DIFF
--- a/presto-native-execution/Dockerfile.0.buildtime
+++ b/presto-native-execution/Dockerfile.0.buildtime
@@ -1,0 +1,51 @@
+# prestodb/avx/centos8-prestissimo-buildtime
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG IMAGE_CACHE_REGISTRY=quay.io/centos
+FROM --platform=linux/amd64 ${IMAGE_CACHE_REGISTRY}/centos:stream8
+
+LABEL org.opencontainers.image.title="centos8-prestissimo-buildtime"
+LABEL org.opencontainers.image.description="Centos-Stream-8 based Prestissimo base image for buildtime container."
+LABEL org.opencontainers.image.vendor="Ahana, Intel and Meta Corporations collaboration"
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.authors="milosz.linkiewicz@intel.com"
+
+ARG CPU_TARGET=avx
+
+SHELL ["/bin/bash", "-eEuo", "pipefail", "-c"]
+WORKDIR /opt/dependency
+
+ENV CPU_TARGET=${CPU_TARGET}
+ENV PROMPT_ALWAYS_RESPOND=n
+ENV PRESTO_HOME="/opt/presto/"
+ENV CMAKE_PREFIX_PATH="/usr/local"
+ENV DEPENDENCY_DIR="/opt/dependency"
+ENV INSTALL_PREFIX="/usr/local"
+ENV CC=/opt/rh/gcc-toolset-9/root/bin/gcc
+ENV CXX=/opt/rh/gcc-toolset-9/root/bin/g++
+ENV TZ="Europe/Warsaw"
+
+ADD velox/scripts /opt/dependency/_build/velox/scripts/
+ADD scripts /opt/dependency/_build/scripts/
+
+RUN dnf -y install make python3-devel && \
+    python3 -m pip install antlr4-tools antlr4-python3-runtime && \
+    cd _build && \
+    sed -i 's/\(.*folly.*\)/# \1/g' "/opt/dependency/_build/velox/scripts/setup-circleci.sh" && \
+    CPU_TARGET="$CPU_TARGET" bash "/opt/dependency/_build/velox/scripts/setup-circleci.sh" && \
+    CPU_TARGET="$CPU_TARGET" bash '/opt/dependency/_build/scripts/setup-centos.sh' && \
+    mkdir -p "/opt/dependency/install/bin" && \
+    cd /opt/dependency && \
+    CPU_TARGET="$CPU_TARGET" bash '/opt/dependency/_build/velox/scripts/setup-adapters.sh' && \
+    dnf clean all && \
+    rm -rf '/opt/dependency/_build' '/opt/dependency/aws-sdk-cpp'

--- a/presto-native-execution/Dockerfile.0.runtime
+++ b/presto-native-execution/Dockerfile.0.runtime
@@ -1,0 +1,42 @@
+# prestodb/avx/centos8-prestissimo-runtime
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG IMAGE_CACHE_REGISTRY=quay.io/centos
+FROM --platform=linux/amd64 ${IMAGE_CACHE_REGISTRY}/centos:stream8
+
+LABEL org.opencontainers.image.title="centos8-prestissimo-runtime"
+LABEL org.opencontainers.image.description="Centos-Stream-8 based Prestissimo base image for runtime container."
+LABEL org.opencontainers.image.vendor="Ahana, Intel and Meta Corporations collaboration"
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.authors="milosz.linkiewicz@intel.com"
+
+SHELL ["/bin/bash", "-c"]
+WORKDIR /opt/presto/
+
+ENV PROMPT_ALWAYS_RESPOND=n
+ENV PRESTO_HOME="/opt/presto/"
+ENV TZ="Europe/Warsaw"
+
+ADD --chown=186:186 --chmod=0755 scripts/release-centos-dockerfile/etc/ /opt/presto/etc/
+ADD --chown=186:186 --chmod=0755 scripts/release-centos-dockerfile/opt/ /opt/
+
+RUN set -exu && \
+    dnf -y install uuid hostname vim && \
+    useradd -r -U --uid=186 -d /opt presto && \
+    chgrp 186 /etc/passwd && \
+    chown -R 186 /opt && \
+    chmod -R ug+rw /etc/passwd /opt && \
+    chmod ug+x /opt/*.sh && \
+    rm -rf /root/.cache /tmp && \
+    dnf clean all
+

--- a/presto-native-execution/Dockerfile.1.prestissimo
+++ b/presto-native-execution/Dockerfile.1.prestissimo
@@ -1,0 +1,54 @@
+# prestodb/prestissimo
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG CPU_TARGET=avx
+ARG IMAGE_TAG=latest
+ARG IMAGE_REGISTRY=prestodb
+ARG BUILDTIME_IMAGE=${CPU_TARGET}/centos8-prestissimo-buildtime
+ARG RUNTIME_IMAGE=${CPU_TARGET}/centos8-prestissimo-runtime
+FROM --platform=linux/amd64 ${IMAGE_REGISTRY}/${BUILDTIME_IMAGE}:${IMAGE_TAG} as build-stage
+
+ENV PATH=/opt/dependency/install/bin:/opt/dependency/install/bin/hadoop-2.10.1/bin:$PATH
+
+ADD ./ /opt/presto/_build/
+
+WORKDIR /opt/presto
+RUN NO_SYNCH=True make --directory="/opt/presto/_build/" release \
+        PRESTO_ENABLE_PARQUET=ON \
+        PRESTO_ENABLE_S3=ON \
+        PRESTO_ENABLE_HDFS=ON \
+        PRESTO_ENABLE_TESTING=ON \
+        TREAT_WARNINGS_AS_ERRORS=OFF && \
+    mv "$(find $(pwd) | grep 'presto_server$')" /opt/presto/ && \
+    chmod uga+x "/opt/presto/presto_server"
+
+#/////////////////////////////////////////////
+#          centos8-prestissimo-runtime
+#//////////////////////////////////////////////
+FROM --platform=linux/amd64 ${IMAGE_REGISTRY}/${RUNTIME_IMAGE}:${IMAGE_TAG}
+
+LABEL org.opencontainers.image.title="prestissimo"
+LABEL org.opencontainers.image.description="Prestissimo, a presto-native-execution Velox based query engine worker container for use in datalakes and benchmarking."
+LABEL org.opencontainers.image.vendor="Ahana, Intel and Meta Corporations collaboration"
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.authors="milosz.linkiewicz@intel.com"
+
+COPY --chown=186:186 --chmod=0755 --from=build-stage /opt/presto/presto_server /opt/presto/presto_server
+COPY --chown=186:186 --chmod=0755 --from=build-stage /usr/local/lib64/lib* /usr/lib64/lib* /usr/local/lib64/
+COPY --chown=186:186 --chmod=0755 --from=build-stage /usr/local/lib/lib* /usr/local/lib/
+
+USER presto
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
+
+VOLUME [ "/tmp/prestissimo-worker" ]
+EXPOSE 22/tcp 8080/tcp

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -61,18 +61,21 @@ velox-submodule:		#: Check out code for velox submodule
 
 submodules: velox-submodule
 
-cmake: submodules		#: Use CMake to create a Makefile build system
+cmake: 					#: Use CMake to create a Makefile build system. Call submodules only if NO_SYNCH is empty
+ifeq ($(strip $(NO_SYNCH)),)
+	$(MAKE) submodules
+endif
 	cmake -B "$(BUILD_BASE_DIR)/$(BUILD_DIR)" $(FORCE_COLOR) $(CMAKE_FLAGS) $(EXTRA_CMAKE_FLAGS)
 
 build:					#: Build the software based in BUILD_DIR and BUILD_TYPE variables
 	cmake --build $(BUILD_BASE_DIR)/$(BUILD_DIR) -j $(NUM_THREADS)
 
 debug:					#: Build with debugging symbols
-	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug
+	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug NO_SYNCH=$(NO_SYNCH)
 	$(MAKE) build BUILD_DIR=debug
 
 release:				#: Build the release version
-	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=Release && \
+	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=Release NO_SYNCH=$(NO_SYNCH)
 	$(MAKE) build BUILD_DIR=release
 
 unittest: debug			#: Build with debugging and run unit tests
@@ -112,6 +115,18 @@ linux-container:
 	cp scripts/setup-$(CONTAINER_NAME).sh scripts/$(CONTAINER_NAME)-container.dockfile velox/scripts/setup-helper-functions.sh /tmp/docker && \
 	cd /tmp/docker && \
 	docker build --build-arg cpu_target=$(CPU_TARGET) --tag "prestocpp/prestocpp-$(CPU_TARGET)-$(CONTAINER_NAME):$(USER)-$(shell date +%Y%m%d)" -f $(CONTAINER_NAME)-container.dockfile .
+
+centos-staging: submodules
+	rm -rf /tmp/centos-staging && \
+	mkdir -p /tmp/centos-staging && \
+	cp -a ./. /tmp/centos-staging && \
+	IMAGE_TAG="$${IMAGE_TAG:-$(USER)-$(shell date +%Y%m%d)}" && \
+	IMAGE_REGISTRY="$${IMAGE_REGISTRY:-prestodb}" && \
+	IMAGE_NAME_BUILDTIME="$${IMAGE_NAME_BUILDTIME$(CPU_TARGET)/centos8-prestissimo-buildtime}"
+	IMAGE_NAME_RUNTIME="$${IMAGE_NAME_RUNTIME:-$(CPU_TARGET)/centos8-prestissimo-runtime}"
+	docker build --build-arg CPU_TARGET=$(CPU_TARGET) --tag "$${IMAGE_REGISTRY}/$${IMAGE_NAME_BUILDTIME}:$${IMAGE_TAG}" -f Dockerfile.0.buildtime .
+	docker build --build-arg CPU_TARGET=$(CPU_TARGET) --tag "$${IMAGE_REGISTRY}/$${IMAGE_NAME_RUNTIME}:$${IMAGE_TAG}" -f Dockerfile.0.runtime .
+	docker build --build-arg CPU_TARGET=$(CPU_TARGET) --build-arg IMAGE_REGISTRY=$${IMAGE_REGISTRY} --build-arg BUILDTIME_IMAGE=$${IMAGE_NAME_BUILDTIME} --build-arg RUNTIME_IMAGE=$${IMAGE_NAME_RUNTIME} --build-arg IMAGE_TAG=$${IMAGE_TAG} --tag "$${IMAGE_REGISTRY}/$(CPU_TARGET)/prestissimo:$${IMAGE_TAG}" -f Dockerfile.1.prestissimo .
 
 runtime-container:
 	rm -rf /tmp/release-centos-dockerfile && \


### PR DESCRIPTION
[Dockerfile Prestissimo runtime container](https://github.com/prestodb/presto/commit/8fefcbfa91f8d573e0715051f494f6597d1e1b04)

Dockerfile Prestissimo runtime container base.
Container include automated entrypoint with memory management.
Presto user account named 'presto' with fixed UID=186
Basic configuration parameters included.

[Dockerfile Prestissimo buildtime container](https://github.com/prestodb/presto/commit/7744a9fef8606e1d6becca0fa725ce2a4335beff)

Dockerfile Prestissimo buildtime container base.
Container includes both Velox and Prestissimo dependencies
All dependencies are pre-build and included inside.
Minimalistic and basic configuration parameters included.

[Dockerfile for building Prestissimo](https://github.com/prestodb/presto/commit/0582d83de914899ec6c14f872b44bea405d7de8d)

Dockerfile for building Prestissimo

Fixes the issue: https://github.com/prestodb/presto/issues/19211

## Appendix A

### Keeping track of direct dependencies

Running ldd on build result as follows:
```
ldd /opt/presto/presto_server
```

Would produce the bellow list of dependencies that are mandatory and should be present in `/usr/local/lib` and `/usr/local/lib64` or `/usr/lib` `/usr/lib64` inside the runtime container:
```
libhdfs3.so.1
libproxygenhttpserver.so
libproxygen.so
libwangle.so.1.0.0
libfizz.so.1.0.0
libantlr4-runtime.so.4.9.3
libthriftcpp2.so.1.0.0
libthriftprotocol.so.1.0.0
libthriftmetadata.so.1.0.0
libthrift-core.so.1.0.0
libtransport.so.1.0.0
libre2.so.10
libprotobuf.so.32
libfolly.so.0.58.0-dev
libglog.so.0
libgflags.so.2.2
libdwarf.so.1
libsodium.so.23
libdouble-conversion.so.3
libevent-2.1.so.6
libboost_context.so.1.72.0
libboost_filesystem.so.1.72.0
libboost_program_options.so.1.72.0
libboost_regex.so.1.72.0
libboost_system.so.1.72.0
libboost_thread.so.1.72.0
```

```
== NO RELEASE NOTE ==
```