### PR TITLE
Infer inequality predicates in joins

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedJoinQueriesWithInequalityInference.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedJoinQueriesWithInequalityInference.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestJoinQueries;
+
+import static com.facebook.presto.SystemSessionProperties.INFER_INEQUALITY_PREDICATES;
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestHiveDistributedJoinQueriesWithInequalityInference
+        extends AbstractTestJoinQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(getTables());
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(INFER_INEQUALITY_PREDICATES, Boolean.toString(true))
+                .build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -285,6 +285,7 @@ public final class SystemSessionProperties
     public static final String FIELD_NAMES_IN_JSON_CAST_ENABLED = "field_names_in_json_cast_enabled";
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
+    public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1661,6 +1662,11 @@ public final class SystemSessionProperties
                         REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION,
                         "Rewrite contant array contains to IN expression",
                         true,
+                        false),
+                booleanProperty(
+                        INFER_INEQUALITY_PREDICATES,
+                        "Infer nonequality predicates for joins",
+                        featuresConfig.getInferInequalityPredicates(),
                         false));
     }
 
@@ -2798,5 +2804,10 @@ public final class SystemSessionProperties
     public static boolean isRwriteConstantArrayContainsToInExpressionEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, Boolean.class);
+    }
+
+    public static boolean shouldInferInequalityPredicates(Session session)
+    {
+        return session.getSystemProperty(INFER_INEQUALITY_PREDICATES, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -273,6 +273,7 @@ public class FeaturesConfig
     private boolean broadcastJoinWithSmallBuildUnknownProbe;
     private boolean addPartialNodeForRowNumberWithLimit = true;
     private boolean pullUpExpressionFromLambda = true;
+    private boolean inferInequalityPredicates;
 
     private boolean preProcessMetadataCalls;
 
@@ -2707,6 +2708,19 @@ public class FeaturesConfig
     public FeaturesConfig setPullUpExpressionFromLambdaEnabled(boolean pullUpExpressionFromLambda)
     {
         this.pullUpExpressionFromLambda = pullUpExpressionFromLambda;
+        return this;
+    }
+
+    public boolean getInferInequalityPredicates()
+    {
+        return inferInequalityPredicates;
+    }
+
+    @Config("optimizer.infer-inequality-predicates")
+    @ConfigDescription("Enabled inference of inequality predicates for joins")
+    public FeaturesConfig setInferInequalityPredicates(boolean inferInequalityPredicates)
+    {
+        this.inferInequalityPredicates = inferInequalityPredicates;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -329,7 +329,7 @@ public class EqualityInference
         {
             return expression -> {
                 expression = normalizeInPredicateToEquality(expression);
-                if (isOperation(expression, EQUAL) &&
+                if (isOperation(expression, EQUAL, functionAndTypeManager) &&
                         determinismEvaluator.isDeterministic(expression) &&
                         !nullabilityAnalyzer.mayReturnNullOnNonNullInput(expression)) {
                     // We should only consider equalities that have distinct left and right components
@@ -450,30 +450,30 @@ public class EqualityInference
             generateMoreEquivalences();
             return new EqualityInference(equalities.getEquivalentClasses(), derivedExpressions, determinismEvaluator, functionAndTypeManager);
         }
-
-        private boolean isOperation(RowExpression expression, OperatorType type)
-        {
-            if (expression instanceof CallExpression) {
-                CallExpression call = (CallExpression) expression;
-                Optional<OperatorType> expressionOperatorType = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle()).getOperatorType();
-                if (expressionOperatorType.isPresent()) {
-                    return expressionOperatorType.get() == type;
-                }
-            }
-            return false;
-        }
     }
 
-    private static RowExpression getLeft(RowExpression expression)
+    protected static RowExpression getLeft(RowExpression expression)
     {
         checkArgument(expression instanceof CallExpression && ((CallExpression) expression).getArguments().size() == 2, "must be binary call expression");
         return ((CallExpression) expression).getArguments().get(0);
     }
 
-    private static RowExpression getRight(RowExpression expression)
+    protected static RowExpression getRight(RowExpression expression)
     {
         checkArgument(expression instanceof CallExpression && ((CallExpression) expression).getArguments().size() == 2, "must be binary call expression");
         return ((CallExpression) expression).getArguments().get(1);
+    }
+
+    protected static boolean isOperation(RowExpression expression, OperatorType type, FunctionAndTypeManager functionAndTypeManager)
+    {
+        if (expression instanceof CallExpression) {
+            CallExpression call = (CallExpression) expression;
+            Optional<OperatorType> expressionOperatorType = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle()).getOperatorType();
+            if (expressionOperatorType.isPresent()) {
+                return expressionOperatorType.get() == type;
+            }
+        }
+        return false;
     }
 
     private static boolean isInPredicate(RowExpression expression)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InequalityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InequalityInference.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.optimizations.ExpressionEquivalence;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.EqualityInference.getLeft;
+import static com.facebook.presto.sql.planner.EqualityInference.getRight;
+import static com.facebook.presto.sql.planner.EqualityInference.isOperation;
+import static com.facebook.presto.sql.planner.optimizations.ExpressionEquivalence.swapPair;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.filter;
+import static java.util.Objects.requireNonNull;
+
+public class InequalityInference
+{
+    // inequalityExpressions include the inequalities from the current join predicate
+    // and those inherited from the join's parent
+    private final Set<RowExpression> inequalityExpressions;
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final ExpressionEquivalence expressionEquivalence;
+    // 'outerVariables' is the variable set projected from the outer input for left or right join,
+    // or EMPTY if the join is an inner join
+    private final Optional<Collection<VariableReferenceExpression>> outerVariables;
+
+    public InequalityInference(Set<RowExpression> inequalityExpressions, FunctionAndTypeManager functionAndTypeManager, ExpressionEquivalence expressionEquivalence, Optional<Collection<VariableReferenceExpression>> outerVariables)
+    {
+        if (inequalityExpressions.stream()
+                .anyMatch(e -> !isOperation(e, LESS_THAN, functionAndTypeManager) && !isOperation(e, LESS_THAN_OR_EQUAL, functionAndTypeManager))) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "all inequality expressions for inference must be < or <=");
+        }
+        this.inequalityExpressions = requireNonNull(inequalityExpressions, "inequalityExpressions is null");
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.expressionEquivalence = requireNonNull(expressionEquivalence, "expressionEquivalence is null");
+        this.outerVariables = requireNonNull(outerVariables, "outerVariables is null");
+    }
+
+    // Basic idea is to pairwise compare each predicate with all other predicates.
+    // Since any inferred predicates may trigger other inferences, keep comparing until no new predicates are generated
+    public Set<RowExpression> inferInequalities()
+    {
+        if (inequalityExpressions.size() < 2) {
+            return ImmutableSet.of();
+        }
+
+        Set<RowExpression> allInferredInequalities = new HashSet<>();
+        Set<RowExpression> inequalitiesInferredInCurrentTraversal = new HashSet<>(inequalityExpressions);
+        Set<Set<RowExpression>> exploredCombinations = new HashSet();
+
+        while (!allInferredInequalities.containsAll(inequalitiesInferredInCurrentTraversal)) {
+            allInferredInequalities.addAll(inequalitiesInferredInCurrentTraversal);
+            Set<Set<RowExpression>> newCombinations = Sets.combinations(allInferredInequalities, 2).stream()
+                    .filter(subset -> !exploredCombinations.contains(subset))
+                    .collect(toImmutableSet());
+
+            inequalitiesInferredInCurrentTraversal = newCombinations.stream()
+                    .map(pair -> {
+                        Iterator<RowExpression> it = pair.iterator();
+                        return compareAndExtractInequalities(it.next(), it.next());
+                    })
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(toImmutableSet());
+
+            exploredCombinations.addAll(newCombinations);
+        }
+
+        // we want to exclude all the original inequalities we passed in from the set we return
+        allInferredInequalities.removeAll(inequalityExpressions);
+        return ImmutableSet.copyOf(allInferredInequalities);
+    }
+
+    // If the join is an outer join, we need to make sure any inferred predicate is on the inner side only
+    // (i.e. does not reference any 'outerVariables').
+    private Optional<RowExpression> compareAndExtractInequalities(RowExpression expression1, RowExpression expression2)
+    {
+        CallExpression firstConjunct = (CallExpression) expression1;
+        OperatorType firstOperatorType = functionAndTypeManager.getFunctionMetadata(firstConjunct.getFunctionHandle()).getOperatorType().get();
+
+        CallExpression secondConjunct = (CallExpression) expression2;
+        OperatorType secondOperatorType = functionAndTypeManager.getFunctionMetadata(secondConjunct.getFunctionHandle()).getOperatorType().get();
+
+        // Get the inference operator, or empty if no inference possible.
+        Optional<OperatorType> inferenceOperatorType = getComparisonInferenceOperatorType(secondOperatorType, firstOperatorType);
+        if (!inferenceOperatorType.isPresent()) {
+            return Optional.empty();
+        }
+
+        // For two inequalities "a < b" and "b < 5" we want to infer "a < 5"
+        // Compare the call expressions' arguments to determine equivalence
+        // Make sure one input has no column/variable references since we only want to infer predicates with constants
+        // LHS : Left hand side
+        // RHS : Right hand side
+        RowExpression firstConjunctLHS = firstConjunct.getArguments().get(0);
+        RowExpression firstConjunctRHS = firstConjunct.getArguments().get(1);
+        RowExpression secondConjunctLHS = secondConjunct.getArguments().get(0);
+        RowExpression secondConjunctRHS = secondConjunct.getArguments().get(1);
+
+        Optional<RowExpression> inferredFirstArgument = Optional.empty();
+        Optional<RowExpression> inferredSecondArgument = Optional.empty();
+        Set<VariableReferenceExpression> variablesReferencedInInferredPredicate = ImmutableSet.of();
+        if (expressionEquivalence.areExpressionsEquivalent(firstConjunctRHS, secondConjunctLHS)) {
+            variablesReferencedInInferredPredicate = getVariablesReferencedInInferredPredicate(firstConjunctLHS, secondConjunctRHS);
+            if (!variablesReferencedInInferredPredicate.isEmpty()) {
+                inferredFirstArgument = Optional.of(firstConjunctLHS);
+                inferredSecondArgument = Optional.of(secondConjunctRHS);
+            }
+        }
+        else if (expressionEquivalence.areExpressionsEquivalent(firstConjunctLHS, secondConjunctRHS)) {
+            variablesReferencedInInferredPredicate = getVariablesReferencedInInferredPredicate(firstConjunctRHS, secondConjunctLHS);
+            if (!variablesReferencedInInferredPredicate.isEmpty()) {
+                inferredFirstArgument = Optional.of(secondConjunctLHS);
+                inferredSecondArgument = Optional.of(firstConjunctRHS);
+            }
+        }
+
+        if (!inferredFirstArgument.isPresent() ||
+                !inferredSecondArgument.isPresent() ||
+                (outerVariables.isPresent() && Iterables.any(variablesReferencedInInferredPredicate, in(outerVariables.get())))) {
+            return Optional.empty();
+        }
+
+        // Build and return the new predicate
+        FunctionHandle inferredComparatorFunctionHandle = functionAndTypeManager.resolveOperator(inferenceOperatorType.get(), fromTypes(inferredFirstArgument.get().getType(), inferredSecondArgument.get().getType()));
+        return Optional.of(new CallExpression(inferenceOperatorType.toString(), inferredComparatorFunctionHandle, BOOLEAN, ImmutableList.of(inferredFirstArgument.get(), inferredSecondArgument.get())));
+    }
+
+    // Get comparison operator for inferring comparison predicates given operators from
+    // two comparison predicates. E.g., '1<=a1 AND a1<a2' will return '<' as the operator.
+    // NULL is returned if no inference is possible.
+    private Optional<OperatorType> getComparisonInferenceOperatorType(OperatorType operator1, OperatorType operator2)
+    {
+        Optional<OperatorType> inferenceType = Optional.empty();
+        if (operator1.equals(LESS_THAN)) {
+            if (operator2.equals(LESS_THAN) || operator2.equals(LESS_THAN_OR_EQUAL)) {
+                inferenceType = Optional.of(LESS_THAN);
+            }
+        }
+        else if (operator1.equals(LESS_THAN_OR_EQUAL)) {
+            if (operator2.equals(LESS_THAN)) {
+                inferenceType = Optional.of(LESS_THAN);
+            }
+            else if (operator2.equals(LESS_THAN_OR_EQUAL)) {
+                inferenceType = Optional.of(LESS_THAN_OR_EQUAL);
+            }
+        }
+
+        return inferenceType;
+    }
+
+    private static Set<VariableReferenceExpression> getVariablesReferencedInInferredPredicate(RowExpression firstConjunct, RowExpression secondConjunct)
+    {
+        Set<VariableReferenceExpression> firstConjunctReferencedVariables = VariablesExtractor.extractUnique(firstConjunct);
+        if (firstConjunctReferencedVariables.isEmpty()) {
+            return VariablesExtractor.extractUnique(secondConjunct);
+        }
+        Set<VariableReferenceExpression> secondConjunctReferencedVariables = VariablesExtractor.extractUnique(secondConjunct);
+        if (secondConjunctReferencedVariables.isEmpty()) {
+            return firstConjunctReferencedVariables;
+        }
+        // inferred predicates cannot reference variables from both expressions
+        // return empty to indicate that there is no valid inferred predicate
+        return ImmutableSet.of();
+    }
+
+    public static class Builder
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final NullabilityAnalyzer nullabilityAnalyzer;
+        private final RowExpressionDeterminismEvaluator determinismEvaluator;
+        private final ExpressionEquivalence expressionEquivalence;
+        private final Set<RowExpression> inequalityExpressions = new HashSet<>();
+        private final Optional<Collection<VariableReferenceExpression>> outerVariables;
+
+        public Builder(FunctionAndTypeManager functionAndTypeManager, ExpressionEquivalence expressionEquivalence, Optional<Collection<VariableReferenceExpression>> outerVariables)
+        {
+            this.functionAndTypeManager = functionAndTypeManager;
+            this.determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
+            this.expressionEquivalence = expressionEquivalence;
+            this.nullabilityAnalyzer = new NullabilityAnalyzer(functionAndTypeManager);
+            this.outerVariables = outerVariables;
+        }
+
+        public InequalityInference build()
+        {
+            return new InequalityInference(inequalityExpressions, functionAndTypeManager, expressionEquivalence, outerVariables);
+        }
+
+        public Builder addInequalityInferences(RowExpression... expressions)
+        {
+            for (RowExpression expression : expressions) {
+                extractInequalityInferenceCandidates(expression);
+            }
+            return this;
+        }
+
+        private Builder extractInequalityInferenceCandidates(RowExpression expression)
+        {
+            Iterable<RowExpression> candidates = filter(extractConjuncts(expression), isInequalityInferenceCandidate());
+            for (RowExpression conjunct : candidates) {
+                addInequalityInferenceCandidate(conjunct);
+            }
+            return this;
+        }
+
+        private InequalityInference.Builder addInequalityInferenceCandidate(RowExpression expression)
+        {
+            checkArgument(isInequalityInferenceCandidate().apply(expression), "RowExpression: " + expression + " is not an inequality inference candidate");
+            inequalityExpressions.add(canonicalizeInequality(expression));
+            return this;
+        }
+
+        // Convert all inequalities to LESS_THAN or LESS_THAN_OR_EQUAL
+        RowExpression canonicalizeInequality(RowExpression expression)
+        {
+            if (isOperation(expression, GREATER_THAN, functionAndTypeManager) ||
+                    isOperation(expression, GREATER_THAN_OR_EQUAL, functionAndTypeManager)) {
+                CallExpression callExpression = (CallExpression) expression;
+                OperatorType operatorType = functionAndTypeManager.getFunctionMetadata(callExpression.getFunctionHandle()).getOperatorType().get();
+                operatorType = OperatorType.flip(operatorType);
+                FunctionHandle functionHandle = functionAndTypeManager.resolveOperator(operatorType, swapPair(fromTypes(callExpression.getArguments().stream().map(RowExpression::getType).collect(toImmutableList()))));
+                expression = new CallExpression(operatorType.getOperator(), functionHandle, BOOLEAN, swapPair(callExpression.getArguments()));
+            }
+            return expression;
+        }
+
+        private Predicate<RowExpression> isInequalityInferenceCandidate()
+        {
+            return expression -> (isOperation(expression, GREATER_THAN_OR_EQUAL, functionAndTypeManager) ||
+                    isOperation(expression, GREATER_THAN, functionAndTypeManager) ||
+                    isOperation(expression, LESS_THAN_OR_EQUAL, functionAndTypeManager) ||
+                    isOperation(expression, LESS_THAN, functionAndTypeManager)) &&
+                    determinismEvaluator.isDeterministic(expression) &&
+                    !nullabilityAnalyzer.mayReturnNullOnNonNullInput(expression) &&
+                    !getLeft(expression).equals(getRight(expression));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -46,12 +46,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.MULTIPLY;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
@@ -146,7 +148,7 @@ public class ExpressionEquivalence
 
             QualifiedObjectName callName = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle()).getName();
 
-            if (callName.equals(EQUAL.getFunctionName()) || callName.equals(NOT_EQUAL.getFunctionName()) || callName.equals(IS_DISTINCT_FROM.getFunctionName())) {
+            if (callName.equals(EQUAL.getFunctionName()) || callName.equals(NOT_EQUAL.getFunctionName()) || callName.equals(IS_DISTINCT_FROM.getFunctionName()) || callName.equals(ADD.getFunctionName()) || callName.equals(MULTIPLY.getFunctionName())) {
                 // sort arguments
                 return new CallExpression(
                         call.getSourceLocation(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -383,7 +383,7 @@ public class ExpressionEquivalence
         }
     }
 
-    private static <T> List<T> swapPair(List<T> pair)
+    public static <T> List<T> swapPair(List<T> pair)
     {
         requireNonNull(pair, "pair is null");
         checkArgument(pair.size() == 2, "Expected pair to have two elements");

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -240,7 +240,8 @@ public class TestFeaturesConfig
                 .setLeftJoinNullFilterToSemiJoin(true)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(false)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(true)
-                .setPullUpExpressionFromLambdaEnabled(true));
+                .setPullUpExpressionFromLambdaEnabled(true)
+                .setInferInequalityPredicates(false));
     }
 
     @Test
@@ -429,6 +430,7 @@ public class TestFeaturesConfig
                 .put("experimental.optimizer.broadcast-join-with-small-build-unknown-probe", "true")
                 .put("optimizer.add-partial-node-for-row-number-with-limit", "false")
                 .put("optimizer.pull-up-expression-from-lambda", "false")
+                .put("optimizer.infer-inequality-predicates", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -614,7 +616,8 @@ public class TestFeaturesConfig
                 .setLeftJoinNullFilterToSemiJoin(false)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(true)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(false)
-                .setPullUpExpressionFromLambdaEnabled(false);
+                .setPullUpExpressionFromLambdaEnabled(false)
+                .setInferInequalityPredicates(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
@@ -382,7 +382,7 @@ public class TestEqualityInference
         return compare(OperatorType.GREATER_THAN, expression1, expression2);
     }
 
-    private static RowExpression add(String symbol1, String symbol2)
+    static RowExpression add(String symbol1, String symbol2)
     {
         return arithmeticOperation(ADD, variable(symbol1), variable(symbol2));
     }
@@ -392,12 +392,12 @@ public class TestEqualityInference
         return arithmeticOperation(ADD, expression1, expression2);
     }
 
-    private static RowExpression multiply(String symbol1, String symbol2)
+    static RowExpression multiply(String symbol1, String symbol2)
     {
         return arithmeticOperation(MULTIPLY, variable(symbol1), variable(symbol2));
     }
 
-    private static RowExpression multiply(RowExpression expression1, RowExpression expression2)
+    static RowExpression multiply(RowExpression expression1, RowExpression expression2)
     {
         return arithmeticOperation(MULTIPLY, expression1, expression2);
     }
@@ -412,12 +412,12 @@ public class TestEqualityInference
         return compare(OperatorType.EQUAL, expression1, expression2);
     }
 
-    private static VariableReferenceExpression variable(String name)
+    static VariableReferenceExpression variable(String name)
     {
         return Expressions.variable(name, BIGINT);
     }
 
-    private static RowExpression number(long number)
+    static RowExpression number(long number)
     {
         return constant(number, BIGINT);
     }
@@ -478,7 +478,7 @@ public class TestEqualityInference
         return ImmutableSet.copyOf(elements);
     }
 
-    private static CallExpression compare(OperatorType type, RowExpression left, RowExpression right)
+    static CallExpression compare(OperatorType type, RowExpression left, RowExpression right)
     {
         return call(
                 type.getFunctionName().getObjectName(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInequalityInference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInequalityInference.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.optimizations.ExpressionEquivalence;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.sql.planner.TestEqualityInference.add;
+import static com.facebook.presto.sql.planner.TestEqualityInference.compare;
+import static com.facebook.presto.sql.planner.TestEqualityInference.multiply;
+import static com.facebook.presto.sql.planner.TestEqualityInference.number;
+import static com.facebook.presto.sql.planner.TestEqualityInference.variable;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestInequalityInference
+{
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = createTestFunctionAndTypeManager();
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
+    private static final ExpressionEquivalence EXPRESSION_EQUIVALENCE = new ExpressionEquivalence(METADATA, SQL_PARSER);
+
+    @Test
+    public void testCanonicalization()
+    {
+        InequalityInference.Builder builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        RowExpression canonicalExpression = compare(LESS_THAN, variable("a1"), variable("a2"));
+        RowExpression expression = compare(GREATER_THAN, variable("a2"), variable("a1"));
+        assertEquals(builder.canonicalizeInequality(expression), canonicalExpression);
+
+        canonicalExpression = compare(LESS_THAN_OR_EQUAL, variable("a1"), variable("a2"));
+        expression = compare(GREATER_THAN_OR_EQUAL, variable("a2"), variable("a1"));
+        assertEquals(builder.canonicalizeInequality(expression), canonicalExpression);
+
+        canonicalExpression = compare(LESS_THAN, add("a1", "a2"), variable("a3"));
+        expression = compare(GREATER_THAN, variable("a3"), add("a1", "a2"));
+        assertEquals(builder.canonicalizeInequality(expression), canonicalExpression);
+
+        canonicalExpression = compare(LESS_THAN, multiply("a1", "a2"), variable("a3"));
+        expression = compare(GREATER_THAN, variable("a3"), multiply("a1", "a2"));
+        assertEquals(builder.canonicalizeInequality(expression), canonicalExpression);
+
+        // a1+a2 != a2+a1 wrt this function. Expression equivalence matching happens in compareAndExtractInequalities()
+        canonicalExpression = compare(LESS_THAN, add("a1", "a2"), variable("a3"));
+        expression = compare(GREATER_THAN, variable("a3"), add("a2", "a1"));
+        assertNotEquals(builder.canonicalizeInequality(expression), canonicalExpression);
+    }
+
+    @Test
+    public void testSimpleTransitivity()
+    {
+        InequalityInference.Builder builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        RowExpression exp1 = compare(LESS_THAN, variable("a1"), number(5));
+        RowExpression exp2 = compare(LESS_THAN, variable("a2"), variable("a1"));
+        ImmutableSet<RowExpression> toBeInferred = ImmutableSet.of(compare(LESS_THAN, variable("a2"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(GREATER_THAN, variable("a1"), number(5));
+        exp2 = compare(GREATER_THAN, variable("a2"), variable("a1"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, number(5), variable("a2")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN_OR_EQUAL, variable("a1"), number(5));
+        exp2 = compare(LESS_THAN_OR_EQUAL, variable("a2"), variable("a1"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN_OR_EQUAL, variable("a2"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), number(5));
+        exp2 = compare(GREATER_THAN_OR_EQUAL, variable("a2"), variable("a1"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN_OR_EQUAL, number(5), variable("a2")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        // Simple transitivity after canonicalization
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN, variable("a1"), number(5));
+        exp2 = compare(GREATER_THAN, variable("a1"), variable("a2"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, variable("a2"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(GREATER_THAN, variable("a1"), number(5));
+        exp2 = compare(LESS_THAN, variable("a1"), variable("a2"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, number(5), variable("a2")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), number(5));
+        exp2 = compare(LESS_THAN, variable("a1"), variable("a2"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, number(5), variable("a2")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN, variable("a1"), number(5));
+        exp2 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), variable("a2"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, variable("a2"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.of(ImmutableList.of(variable("a2"))));
+        exp1 = compare(LESS_THAN, variable("a1"), number(5));
+        exp2 = compare(LESS_THAN, variable("a2"), variable("a1"));
+        toBeInferred = ImmutableSet.of();
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+    }
+
+    @Test
+    public void testChainOfTransitivity()
+    {
+        InequalityInference.Builder builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        RowExpression exp1 = compare(LESS_THAN, variable("a1"), number(5));
+        RowExpression exp2 = compare(LESS_THAN, variable("a2"), variable("a1"));
+        RowExpression exp3 = compare(LESS_THAN, variable("a3"), variable("a2"));
+        RowExpression exp4 = compare(LESS_THAN, variable("a4"), variable("a3"));
+        ImmutableSet<RowExpression> toBeInferred = ImmutableSet.of(
+                compare(LESS_THAN, variable("a2"), number(5)),
+                compare(LESS_THAN, variable("a3"), number(5)),
+                compare(LESS_THAN, variable("a4"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2, exp3, exp4);
+
+        // Break inference chain with an equality
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN, variable("a1"), number(10));
+        exp2 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), variable("a2"));
+        exp3 = compare(EQUAL, variable("a3"), variable("a2"));
+        exp4 = compare(LESS_THAN, variable("a4"), variable("a3"));
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, variable("a2"), number(10)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2, exp3, exp4);
+
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN, variable("a1"), number(10));
+        exp2 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), variable("a2"));
+        exp3 = compare(LESS_THAN_OR_EQUAL, variable("a3"), variable("a2"));
+        exp4 = compare(LESS_THAN, variable("a4"), variable("a3"));
+        RowExpression exp5 = compare(GREATER_THAN, variable("a4"), number(1));
+        RowExpression exp6 = compare(GREATER_THAN_OR_EQUAL, variable("a5"), variable("a4"));
+        RowExpression exp7 = compare(LESS_THAN_OR_EQUAL, variable("a5"), variable("a6"));
+        toBeInferred = ImmutableSet.of(
+                compare(LESS_THAN, variable("a2"), number(10)),
+                compare(LESS_THAN, variable("a3"), number(10)),
+                compare(LESS_THAN, variable("a4"), number(10)),
+                compare(LESS_THAN, number(1), variable("a5")),
+                compare(LESS_THAN, number(1), variable("a6")),
+                compare(LESS_THAN, number(1), variable("a3")),
+                compare(LESS_THAN, number(1), variable("a2")),
+                compare(LESS_THAN, number(1), variable("a1")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2, exp3, exp4, exp5, exp6, exp7);
+
+        // Same as previous, but with a4 & a5 as outer variables. Only infer inequalities on the other variables
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.of(ImmutableList.of(variable("a5"), variable("a4"))));
+        exp1 = compare(LESS_THAN, variable("a1"), number(10));
+        exp2 = compare(GREATER_THAN_OR_EQUAL, variable("a1"), variable("a2"));
+        exp3 = compare(LESS_THAN_OR_EQUAL, variable("a3"), variable("a2"));
+        exp4 = compare(LESS_THAN, variable("a4"), variable("a3"));
+        exp5 = compare(GREATER_THAN, variable("a4"), number(1));
+        exp6 = compare(GREATER_THAN_OR_EQUAL, variable("a5"), variable("a4"));
+        exp7 = compare(LESS_THAN_OR_EQUAL, variable("a5"), variable("a6"));
+        toBeInferred = ImmutableSet.of(
+                compare(LESS_THAN, variable("a2"), number(10)),
+                compare(LESS_THAN, variable("a3"), number(10)),
+                compare(LESS_THAN, number(1), variable("a3")),
+                compare(LESS_THAN, number(1), variable("a2")),
+                compare(LESS_THAN, number(1), variable("a1")));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2, exp3, exp4, exp5, exp6, exp7);
+    }
+
+    @Test
+    public void testTransitivityWithExpressions()
+    {
+        RowExpression a1Plusa2 = add("a1", "a2");
+        RowExpression a2Plusa1 = add("a2", "a1");
+        RowExpression a3Multiplya4 = multiply("a3", "a4");
+        RowExpression a4Multiplya3 = multiply("a4", "a3");
+        InequalityInference.Builder builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        RowExpression exp1 = compare(LESS_THAN, a1Plusa2, number(5));
+        RowExpression exp2 = compare(LESS_THAN, variable("a5"), a2Plusa1);
+        RowExpression exp3 = compare(LESS_THAN, a3Multiplya4, number(100));
+        RowExpression exp4 = compare(LESS_THAN, variable("a6"), a4Multiplya3);
+        ImmutableSet<RowExpression> toBeInferred = ImmutableSet.of(
+                compare(LESS_THAN, variable("a5"), number(5)),
+                compare(LESS_THAN, variable("a6"), number(100)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2, exp3, exp4);
+
+        RowExpression a1Plusa2Multiplya3 = multiply(add("a1", "a2"), variable("a3"));
+        RowExpression a3Multiplya2Plusa1 = multiply(variable("a3"), add("a1", "a2"));
+        builder = new InequalityInference.Builder(FUNCTION_AND_TYPE_MANAGER, EXPRESSION_EQUIVALENCE, Optional.empty());
+        exp1 = compare(LESS_THAN, a1Plusa2Multiplya3, number(5));
+        exp2 = compare(LESS_THAN, variable("a5"), a3Multiplya2Plusa1);
+        toBeInferred = ImmutableSet.of(compare(LESS_THAN, variable("a5"), number(5)));
+        assertInferredInequalites(toBeInferred, builder, exp1, exp2);
+    }
+
+    private void assertInferredInequalites(ImmutableSet<RowExpression> expectedInequalities, InequalityInference.Builder builder, RowExpression... expressions)
+    {
+        assertEquals(builder.addInequalityInferences(expressions).build().inferInequalities(), expectedInequalities);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInequalityInferenceInJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInequalityInferenceInJoins.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.INFER_INEQUALITY_PREDICATES;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestInequalityInferenceInJoins
+        extends BasePlanTest
+{
+    public TestInequalityInferenceInJoins()
+    {
+        super(ImmutableMap.of(INFER_INEQUALITY_PREDICATES, Boolean.toString(true)));
+    }
+
+    @Test
+    public void testSimpleInequalityInferencesForInnerJoins()
+    {
+        // Infer predicate on orders.totalprice and push it down to tablescan
+        String query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice > c.acctbal and c.acctbal > 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey_0", "custkey")),
+                                        Optional.of("(totalprice) > (acctbal)"),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey")))),
+                                        anyTree(
+                                                filter("(acctbal) > (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice >= c.acctbal and c.acctbal > 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey_0", "custkey")),
+                                        Optional.of("(totalprice) >= (acctbal)"),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey")))),
+                                        anyTree(
+                                                filter("(acctbal) > (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice >= c.acctbal and c.acctbal >= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey_0", "custkey")),
+                                        Optional.of("(totalprice) >= (acctbal)"),
+                                        anyTree(
+                                                filter("(totalprice) >= (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey")))),
+                                        anyTree(
+                                                filter("(acctbal) >= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice > c.acctbal and c.acctbal >= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey_0", "custkey")),
+                                        Optional.of("(totalprice) > (acctbal)"),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey")))),
+                                        anyTree(
+                                                filter("(acctbal) >= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))))))));
+
+        //Redo same combination of inequalities with LESS THAN
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice < c.acctbal and c.acctbal < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) < (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice <= c.acctbal and c.acctbal < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) <= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) < (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice <= c.acctbal and c.acctbal <= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) <= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) <= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) <= (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice < c.acctbal and c.acctbal <= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) <= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        // Negative test - non-deterministic predicates are ignored
+        query = "select count(*) from customer c, orders o where o.custkey=c.custkey and o.totalprice < c.acctbal and c.acctbal <= random()";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("((acctbal) <= (random())) AND ((totalprice) < (acctbal))"),
+                                        anyTree(
+                                                tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))),
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey")))))));
+    }
+
+    @Test
+    public void testSimpleInequalityInferencesForOuterJoins()
+    {
+        // Infer predicate on orders.totalprice and push it down to tablescan
+        String query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice > c.acctbal where c.acctbal > 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) > (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) > (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice >= c.acctbal where c.acctbal > 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) >= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) > (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice >= c.acctbal where c.acctbal >= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) >= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) >= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) >= (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice > c.acctbal where c.acctbal >= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) > (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) >= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) > (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        //Redo same combination of inequalities with LESS THAN
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice < c.acctbal where c.acctbal < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) < (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice <= c.acctbal where c.acctbal < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) <= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) < (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice <= c.acctbal where c.acctbal <= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) <= (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) <= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) <= (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice < c.acctbal where c.acctbal <= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        anyTree(
+                                                filter("(acctbal) <= (DOUBLE'1000.0')",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal")))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        // Predicate in ON clause is inferred and pushed to the inner side of the join
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice < c.acctbal and c.acctbal <= 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("((totalprice) < (acctbal)) AND ((acctbal) <= (DOUBLE'1000.0'))"),
+                                        anyTree(
+                                                tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        // Negative tests
+        // Outer join with no WHERE clause - nothing gets inferred
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice < c.acctbal and o.totalprice < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        project(
+                                                tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+
+        query = "select count(*) from customer c left join orders o on o.custkey=c.custkey and o.totalprice < c.acctbal where o.totalprice < 1000";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("(totalprice) < (acctbal)"),
+                                        project(
+                                                tableScan("customer", ImmutableMap.of("custkey", "custkey", "acctbal", "acctbal"))),
+                                        anyTree(
+                                                filter("(totalprice) < (DOUBLE'1000.0')",
+                                                        tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey_0", "custkey"))))))));
+    }
+
+    @Test
+    public void testInequalityInferencesForExpressions()
+    {
+        String query = "select count(*) from orders o, customer c where o.custkey=c.custkey and o.orderkey + o.custkey <= c.nationkey and 100 <= o.orderkey + o.custkey";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("orderkey + custkey <= nationkey"),
+                                        anyTree(
+                                                filter("BIGINT '100' <= orderkey+custkey",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey", "custkey")))),
+                                        anyTree(
+                                                filter("nationkey >= BIGINT '100'",
+                                                        tableScan("customer", ImmutableMap.of("custkey_0", "custkey", "nationkey", "nationkey"))))))));
+
+        query = "select count(*) from orders o left join customer c on o.custkey=c.custkey and o.orderkey + o.custkey <= c.nationkey where 100 <= o.orderkey + o.custkey";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(LEFT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("orderkey + custkey <= nationkey"),
+                                        anyTree(
+                                                filter("BIGINT '100' <= orderkey+custkey",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey", "custkey")))),
+                                        anyTree(
+                                                filter("nationkey >= BIGINT '100'",
+                                                        tableScan("customer", ImmutableMap.of("custkey_0", "custkey", "nationkey", "nationkey"))))))));
+
+        query = "select count(*) from customer c right join orders o on o.custkey=c.custkey and o.orderkey + o.custkey <= c.nationkey where 100 <= o.orderkey + o.custkey";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(RIGHT,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("orderkey + custkey_0 <= nationkey"),
+                                        anyTree(
+                                                filter("nationkey >= BIGINT '100'",
+                                                        tableScan("customer", ImmutableMap.of("custkey", "custkey", "nationkey", "nationkey")))),
+                                        anyTree(
+                                                filter("BIGINT '100' <= orderkey+custkey_0",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey_0", "custkey"))))))));
+
+        // Canonicalize and infer orderkey+custkey <=> custkey+orderkey and therefore infer customer.nationkey >= 100
+        query = "select count(*) from orders o, customer c where o.custkey=c.custkey and o.orderkey + o.custkey <= c.nationkey and 100 <= o.custkey + o.orderkey";
+        assertPlan(query,
+                output(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                        Optional.of("orderkey + custkey <= nationkey"),
+                                        anyTree(
+                                                filter("BIGINT '100' <= custkey + orderkey",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey", "custkey")))),
+                                        anyTree(
+                                                filter("nationkey >= BIGINT'100'",
+                                                        tableScan("customer", ImmutableMap.of("custkey_0", "custkey", "nationkey", "nationkey"))))))));
+
+        // Negative test - do not push down since the inferred predicate on (o.orderkey + c.nationkey) references variables from the outer table
+        query = "select name, address, c.custkey from customer c left join orders o on c.custkey=o.custkey and c.custkey < o.orderkey + c.nationkey where 1000 < c.custkey";
+        assertPlan(query,
+                output(
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                Optional.of("custkey < orderkey + nationkey"),
+                                anyTree(
+                                        filter("custkey > BIGINT'1000'",
+                                                tableScan("customer", ImmutableMap.of("name", "name", "custkey", "custkey", "nationkey", "nationkey", "address", "address")))),
+                                anyTree(
+                                        filter("custkey_0 > BIGINT'1000'",
+                                                tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey_0", "custkey")))))));
+
+        // Infer sq.custkey > 100 in outer query block, push it into inner query block's where and then infer that
+        // 1. customer.custkey > 100
+        // 2. lineitem.partkey > 100 and lineitem.suppkey > 100
+        query = "select o.totalprice, o.comment, sq.name, sq.quantity from orders o left join (select * from customer c left join lineitem l on c.custkey=l.suppkey and c.custkey < l.partkey) sq on o.custkey=sq.custkey and o.orderkey <= sq.custkey where o.orderkey > 100";
+        assertPlan(query,
+                output(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("custkey", "custkey_0")),
+                                Optional.of("orderkey <= custkey_0"),
+                                anyTree(
+                                        filter("orderkey > BIGINT'100'",
+                                                tableScan("orders", ImmutableMap.of("totalprice", "totalprice", "custkey", "custkey", "comment", "comment", "orderkey", "orderkey")))),
+                                anyTree(
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("custkey_0", "suppkey")),
+                                                anyTree(
+                                                        filter("custkey_0 > BIGINT'100'",
+                                                                tableScan("customer", ImmutableMap.of("custkey_0", "custkey", "name", "name")))),
+                                                anyTree(
+                                                        filter("partkey > BIGINT'100' AND suppkey > BIGINT'100' AND suppkey < partkey",
+                                                                tableScan("lineitem", ImmutableMap.of("suppkey", "suppkey", "partkey", "partkey", "quantity", "quantity")))))))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueriesWithInequalityInferenceEnabled.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueriesWithInequalityInferenceEnabled.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.INFER_INEQUALITY_PREDICATES;
+
+public class TestSubqueriesWithInequalityInferenceEnabled
+        extends TestSubqueries
+{
+    private static final Map<String, String> sessionProperties = ImmutableMap.of(INFER_INEQUALITY_PREDICATES, Boolean.toString(true));
+
+    @Override
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions(sessionProperties);
+        tpchAssertions = new TpchQueryAssertions(sessionProperties);
+    }
+}


### PR DESCRIPTION
Presto has a good mechanism for inferring equality predicates through transitive closure from join predicates. These inferred predicates may be pushed down to the table scan leading to improved performance. Among our customers, we have seen a few cases where automatically inferring inequality predicates and pushing them to the table scan would lead to significant improvement. This PR is a first cut at attempting to infer inequality predicates.

Controlled by a feature flag "infer_inequality_predicates"

```
== NO RELEASE NOTE ==
```
