### PR TITLE
Use avro schema instead of schema stored in hms to avoid the mismatch of columns when reading the data

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
@@ -75,6 +75,7 @@ public enum HiveErrorCode
     HIVE_METASTORE_USER_ERROR(47, USER_ERROR),
     HIVE_RANGER_SERVER_ERROR(48, EXTERNAL),
     HIVE_FUNCTION_INITIALIZATION_ERROR(49, EXTERNAL),
+    HIVE_SERDE_ERROR(50, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -102,7 +102,10 @@ public class BridgingHiveMetastore
     public Optional<Table> getTable(MetastoreContext metastoreContext, HiveTableHandle hiveTableHandle)
     {
         return delegate.getTable(metastoreContext, hiveTableHandle).map(table -> {
-            if (isAvroTableWithSchemaSet(table) || isCsvTable(table)) {
+            if (isAvroTableWithSchemaSet(table)) {
+                return fromMetastoreApiTable(table, delegate.getAvroFields(table.getParameters()), metastoreContext.getColumnConverter());
+            }
+            else if (isCsvTable(table)) {
                 return fromMetastoreApiTable(table, delegate.getFields(metastoreContext, hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName()).get(), metastoreContext.getColumnConverter());
             }
             return fromMetastoreApiTable(table, metastoreContext.getColumnConverter());

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -176,6 +176,11 @@ public interface HiveMetastore
         return Optional.of(table.get().getSd().getCols());
     }
 
+    default List<FieldSchema> getAvroFields(Map<String, String> parameters)
+    {
+        return ImmutableList.of();
+    }
+
     default Optional<PrimaryKeyConstraint<String>> getPrimaryKey(MetastoreContext metastoreContext, String databaseName, String tableName)
     {
         return Optional.empty();


### PR DESCRIPTION
Why is it needed?

Avro table uses its own schema instead of the one stored in HMS. Therefore when a user updates Avro's schema of a table, it causes a mismatch between two schemas, and the table can no longer be accessed by Presto. 

This change allows Presto to use Avro's schema when reading an Avro table just like Hive. 

Test plan

It has been tested in our company's production env with actual cases of the table's schema stored in the HMS that is different from the one stored by Avro on S3.


```
== RELEASE NOTES ==

Hive Changes
* Use Avro schema instead of schema stored in HMS to avoid the mismatch of columns when reading the data
* ...
```
