### PR TITLE
[native] Refactor PeriodicTaskManager and expose additional periodic task API

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -45,120 +45,148 @@ static constexpr size_t kCachePeriodGlobalCounters{60'000'000}; // 60 seconds.
 static constexpr size_t kOsPeriodGlobalCounters{2'000'000}; // 2 seconds
 
 PeriodicTaskManager::PeriodicTaskManager(
-    folly::CPUThreadPoolExecutor* driverCPUExecutor,
-    folly::IOThreadPoolExecutor* httpExecutor,
-    TaskManager* taskManager,
-    std::vector<std::shared_ptr<velox::connector::Connector>> connectors)
+    folly::CPUThreadPoolExecutor* const driverCPUExecutor,
+    folly::IOThreadPoolExecutor* const httpExecutor,
+    TaskManager* const taskManager,
+    const velox::memory::MemoryAllocator* const memoryAllocator,
+    const velox::cache::AsyncDataCache* const asyncDataCache,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<velox::connector::Connector>>& connectors)
     : driverCPUExecutor_(driverCPUExecutor),
       httpExecutor_(httpExecutor),
       taskManager_(taskManager),
-      memoryManager_(velox::memory::MemoryManager::getInstance()),
+      memoryAllocator_(memoryAllocator),
+      asyncDataCache_(asyncDataCache),
       connectors_(connectors) {}
 
 void PeriodicTaskManager::start() {
-  // Add new functions here.
-
   // If executors are null, don't bother starting this task.
   if (driverCPUExecutor_ or httpExecutor_) {
-    scheduler_.addFunction(
-        [driverCPUExecutor = driverCPUExecutor_,
-         httpExecutor = httpExecutor_]() {
-          if (driverCPUExecutor) {
-            // Report the current queue size of the thread pool.
-            REPORT_ADD_STAT_VALUE(
-                kCounterDriverCPUExecutorQueueSize,
-                driverCPUExecutor->getTaskQueueSize());
-
-            // Report the latency between scheduling the task and its execution.
-            folly::stop_watch<std::chrono::milliseconds> timer;
-            driverCPUExecutor->add([timer = timer]() {
-              REPORT_ADD_STAT_VALUE(
-                  kCounterDriverCPUExecutorLatencyMs, timer.elapsed().count());
-            });
-          }
-
-          if (httpExecutor) {
-            // Report the latency between scheduling the task and its execution.
-            folly::stop_watch<std::chrono::milliseconds> timer;
-            httpExecutor->add([timer = timer]() {
-              REPORT_ADD_STAT_VALUE(
-                  kCounterHTTPExecutorLatencyMs, timer.elapsed().count());
-            });
-          }
-        },
-        std::chrono::microseconds{kTaskPeriodGlobalCounters},
-        "executor_counters");
+    addExecutorStatsTask();
   }
-
   if (taskManager_) {
-    scheduler_.addFunction(
-        [taskManager = taskManager_]() {
-          // Report the number of tasks and drivers in the system.
-          size_t numTasks{0};
-          auto taskNumbers = taskManager->getTaskNumbers(numTasks);
-          REPORT_ADD_STAT_VALUE(kCounterNumTasks, taskManager->getNumTasks());
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumTasksRunning,
-              taskNumbers[velox::exec::TaskState::kRunning]);
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumTasksFinished,
-              taskNumbers[velox::exec::TaskState::kFinished]);
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumTasksCancelled,
-              taskNumbers[velox::exec::TaskState::kCanceled]);
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumTasksAborted,
-              taskNumbers[velox::exec::TaskState::kAborted]);
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumTasksFailed,
-              taskNumbers[velox::exec::TaskState::kFailed]);
-          auto driverCountStats = taskManager->getDriverCountStats();
-
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumRunningDrivers, driverCountStats.numRunningDrivers);
-          REPORT_ADD_STAT_VALUE(
-              kCounterNumBlockedDrivers, driverCountStats.numBlockedDrivers);
-
-          REPORT_ADD_STAT_VALUE(
-              kCounterTotalPartitionedOutputBuffer,
-              velox::exec::PartitionedOutputBufferManager::getInstance()
-                  .lock()
-                  ->numBuffers());
-        },
-        std::chrono::microseconds{kTaskPeriodGlobalCounters},
-        "task_counters");
-
-    scheduler_.addFunction(
-        [taskManager = taskManager_]() {
-          // Report the number of tasks and drivers in the system.
-          taskManager->cleanOldTasks();
-        },
-        std::chrono::microseconds{kTaskPeriodCleanOldTasks},
-        "clean_old_tasks");
+    addTaskStatsTask();
+    addTaskCleanupTask();
   }
+  if (memoryAllocator_) {
+    addMemoryAllocatorStatsTask();
+  }
+  addPrestoExchangeSourceMemoryStatsTask();
+  if (asyncDataCache_) {
+    addAsyncDataCacheStatsTask();
+  }
+  addConnectorStatsTask();
+  addOperatingSystemStatsTask();
 
-  if (auto* allocator = velox::memory::MemoryAllocator::getInstance()) {
-    scheduler_.addFunction(
-        [allocator]() {
+  // This should be the last call in this method.
+  scheduler_.start();
+}
+
+void PeriodicTaskManager::stop() {
+  scheduler_.cancelAllFunctionsAndWait();
+  scheduler_.shutdown();
+}
+
+void PeriodicTaskManager::addExecutorStatsTask() {
+  scheduler_.addFunction(
+      [driverCPUExecutor = driverCPUExecutor_, httpExecutor = httpExecutor_]() {
+        if (driverCPUExecutor) {
+          // Report the current queue size of the thread pool.
           REPORT_ADD_STAT_VALUE(
-              kCounterMappedMemoryBytes, (allocator->numMapped() * 4096l));
-          REPORT_ADD_STAT_VALUE(
-              kCounterAllocatedMemoryBytes,
-              (allocator->numAllocated() * 4096l));
-          // TODO(jtan6): Remove condition after T150019700 is done
-          if (auto* mmapAllocator =
-                  dynamic_cast<velox::memory::MmapAllocator*>(allocator)) {
+              kCounterDriverCPUExecutorQueueSize,
+              driverCPUExecutor->getTaskQueueSize());
+
+          // Report the latency between scheduling the task and its execution.
+          folly::stop_watch<std::chrono::milliseconds> timer;
+          driverCPUExecutor->add([timer = timer]() {
             REPORT_ADD_STAT_VALUE(
-                kCounterMappedMemoryRawAllocBytesSmall,
-                (mmapAllocator->numMallocBytes()))
-          }
-          // TODO(xiaoxmeng): add memory allocation size stats.
-        },
-        std::chrono::microseconds{kMemoryPeriodGlobalCounters},
-        "mmap_memory_counters");
-  }
+                kCounterDriverCPUExecutorLatencyMs, timer.elapsed().count());
+          });
+        }
 
-  // Presto exchange source memory usage update.
+        if (httpExecutor) {
+          // Report the latency between scheduling the task and its execution.
+          folly::stop_watch<std::chrono::milliseconds> timer;
+          httpExecutor->add([timer = timer]() {
+            REPORT_ADD_STAT_VALUE(
+                kCounterHTTPExecutorLatencyMs, timer.elapsed().count());
+          });
+        }
+      },
+      std::chrono::microseconds{kTaskPeriodGlobalCounters},
+      "executor_counters");
+}
+
+void PeriodicTaskManager::addTaskStatsTask() {
+  scheduler_.addFunction(
+      [taskManager = taskManager_]() {
+        // Report the number of tasks and drivers in the system.
+        size_t numTasks{0};
+        auto taskNumbers = taskManager->getTaskNumbers(numTasks);
+        REPORT_ADD_STAT_VALUE(kCounterNumTasks, taskManager->getNumTasks());
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumTasksRunning,
+            taskNumbers[velox::exec::TaskState::kRunning]);
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumTasksFinished,
+            taskNumbers[velox::exec::TaskState::kFinished]);
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumTasksCancelled,
+            taskNumbers[velox::exec::TaskState::kCanceled]);
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumTasksAborted,
+            taskNumbers[velox::exec::TaskState::kAborted]);
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumTasksFailed,
+            taskNumbers[velox::exec::TaskState::kFailed]);
+
+        auto driverCountStats = taskManager->getDriverCountStats();
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumRunningDrivers, driverCountStats.numRunningDrivers);
+        REPORT_ADD_STAT_VALUE(
+            kCounterNumBlockedDrivers, driverCountStats.numBlockedDrivers);
+        REPORT_ADD_STAT_VALUE(
+            kCounterTotalPartitionedOutputBuffer,
+            velox::exec::PartitionedOutputBufferManager::getInstance()
+                .lock()
+                ->numBuffers());
+      },
+      std::chrono::microseconds{kTaskPeriodGlobalCounters},
+      "task_counters");
+}
+
+void PeriodicTaskManager::addTaskCleanupTask() {
+  scheduler_.addFunction(
+      [taskManager = taskManager_]() {
+        // Report the number of tasks and drivers in the system.
+        taskManager->cleanOldTasks();
+      },
+      std::chrono::microseconds{kTaskPeriodCleanOldTasks},
+      "clean_old_tasks");
+}
+
+void PeriodicTaskManager::addMemoryAllocatorStatsTask() {
+  scheduler_.addFunction(
+      [allocator = memoryAllocator_]() {
+        REPORT_ADD_STAT_VALUE(
+            kCounterMappedMemoryBytes, (allocator->numMapped() * 4096l));
+        REPORT_ADD_STAT_VALUE(
+            kCounterAllocatedMemoryBytes, (allocator->numAllocated() * 4096l));
+        // TODO(jtan6): Remove condition after T150019700 is done
+        if (auto* mmapAllocator =
+                dynamic_cast<const velox::memory::MmapAllocator*>(allocator)) {
+          REPORT_ADD_STAT_VALUE(
+              kCounterMappedMemoryRawAllocBytesSmall,
+              (mmapAllocator->numMallocBytes()))
+        }
+        // TODO(xiaoxmeng): add memory allocation size stats.
+      },
+      std::chrono::microseconds{kMemoryPeriodGlobalCounters},
+      "mmap_memory_counters");
+}
+
+void PeriodicTaskManager::addPrestoExchangeSourceMemoryStatsTask() {
   scheduler_.addFunction(
       []() {
         int64_t currQueuedMemoryBytes{0};
@@ -172,157 +200,157 @@ void PeriodicTaskManager::start() {
       },
       std::chrono::microseconds{kExchangeSourcePeriodGlobalCounters},
       "exchange_source_counters");
+}
 
-  if (auto* asyncDataCache = dynamic_cast<velox::cache::AsyncDataCache*>(
-          velox::memory::MemoryAllocator::getInstance())) {
-    scheduler_.addFunction(
-        [asyncDataCache]() {
-          const auto memoryCacheStats = asyncDataCache->refreshStats();
+void PeriodicTaskManager::addAsyncDataCacheStatsTask() {
+  scheduler_.addFunction(
+      [asyncDataCache = asyncDataCache_]() {
+        const auto memoryCacheStats = asyncDataCache->refreshStats();
 
-          // Snapshots.
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumEntries, memoryCacheStats.numEntries);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumEmptyEntries,
-              memoryCacheStats.numEmptyEntries);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumSharedEntries, memoryCacheStats.numShared);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumExclusiveEntries,
-              memoryCacheStats.numExclusive);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumPrefetchedEntries,
-              memoryCacheStats.numPrefetch);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheTotalTinyBytes, memoryCacheStats.tinySize);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheTotalLargeBytes, memoryCacheStats.largeSize);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheTotalTinyPaddingBytes,
-              memoryCacheStats.tinyPadding);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheTotalLargePaddingBytes,
-              memoryCacheStats.largePadding);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheTotalPrefetchBytes,
-              memoryCacheStats.prefetchBytes);
-          REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheSumEvictScore, memoryCacheStats.sumEvictScore);
+        // Snapshots.
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumEntries, memoryCacheStats.numEntries);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumEmptyEntries,
+            memoryCacheStats.numEmptyEntries);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumSharedEntries, memoryCacheStats.numShared);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumExclusiveEntries,
+            memoryCacheStats.numExclusive);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumPrefetchedEntries,
+            memoryCacheStats.numPrefetch);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheTotalTinyBytes, memoryCacheStats.tinySize);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheTotalLargeBytes, memoryCacheStats.largeSize);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheTotalTinyPaddingBytes,
+            memoryCacheStats.tinyPadding);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheTotalLargePaddingBytes,
+            memoryCacheStats.largePadding);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheTotalPrefetchBytes,
+            memoryCacheStats.prefetchBytes);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheSumEvictScore, memoryCacheStats.sumEvictScore);
 
-          // Interval cumulatives.
-          static int64_t memoryNumHitOld{0};
-          static int64_t memoryNumNewOld{0};
-          static int64_t memoryNumEvictOld{0};
-          static int64_t memoryNumEvictChecksOld{0};
-          static int64_t memoryNumWaitExclusiveOld{0};
-          static int64_t memoryNumAllocClocksOld{0};
-          static int64_t ssdReadEntriesOld{0};
-          static int64_t ssdReadBytesOld{0};
-          static int64_t ssdWrittenBytesOld{0};
-          static int64_t ssdWrittenEntriesOld{0};
-          static int64_t ssdCachedBytesOld{0};
-          static int64_t ssdCachedEntriesOld{0};
+        // Interval cumulatives.
+        static int64_t memoryNumHitOld{0};
+        static int64_t memoryNumNewOld{0};
+        static int64_t memoryNumEvictOld{0};
+        static int64_t memoryNumEvictChecksOld{0};
+        static int64_t memoryNumWaitExclusiveOld{0};
+        static int64_t memoryNumAllocClocksOld{0};
+        static int64_t ssdReadEntriesOld{0};
+        static int64_t ssdReadBytesOld{0};
+        static int64_t ssdWrittenBytesOld{0};
+        static int64_t ssdWrittenEntriesOld{0};
+        static int64_t ssdCachedBytesOld{0};
+        static int64_t ssdCachedEntriesOld{0};
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumHit,
+            memoryCacheStats.numHit - memoryNumHitOld);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumNew,
+            memoryCacheStats.numNew - memoryNumNewOld);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumEvict,
+            memoryCacheStats.numEvict - memoryNumEvictOld);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumEvictChecks,
+            memoryCacheStats.numEvictChecks - memoryNumEvictChecksOld);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumWaitExclusive,
+            memoryCacheStats.numWaitExclusive - memoryNumWaitExclusiveOld);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumAllocClocks,
+            memoryCacheStats.allocClocks - memoryNumAllocClocksOld);
+        if (memoryCacheStats.ssdStats) {
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumHit,
-              memoryCacheStats.numHit - memoryNumHitOld);
+              kCounterSsdCacheReadEntries,
+              memoryCacheStats.ssdStats->entriesRead - ssdReadEntriesOld);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumNew,
-              memoryCacheStats.numNew - memoryNumNewOld);
+              kCounterSsdCacheReadBytes,
+              memoryCacheStats.ssdStats->bytesRead - ssdReadBytesOld);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumEvict,
-              memoryCacheStats.numEvict - memoryNumEvictOld);
+              kCounterSsdCacheWrittenEntries,
+              memoryCacheStats.ssdStats->entriesWritten - ssdWrittenEntriesOld);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumEvictChecks,
-              memoryCacheStats.numEvictChecks - memoryNumEvictChecksOld);
+              kCounterSsdCacheWrittenBytes,
+              memoryCacheStats.ssdStats->bytesWritten - ssdWrittenBytesOld);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumWaitExclusive,
-              memoryCacheStats.numWaitExclusive - memoryNumWaitExclusiveOld);
+              kCounterSsdCacheCachedEntries,
+              memoryCacheStats.ssdStats->entriesCached - ssdCachedEntriesOld);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumAllocClocks,
-              memoryCacheStats.allocClocks - memoryNumAllocClocksOld);
-          if (memoryCacheStats.ssdStats) {
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheReadEntries,
-                memoryCacheStats.ssdStats->entriesRead - ssdReadEntriesOld);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheReadBytes,
-                memoryCacheStats.ssdStats->bytesRead - ssdReadBytesOld);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheWrittenEntries,
-                memoryCacheStats.ssdStats->entriesWritten -
-                    ssdWrittenEntriesOld);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheWrittenBytes,
-                memoryCacheStats.ssdStats->bytesWritten - ssdWrittenBytesOld);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCachedEntries,
-                memoryCacheStats.ssdStats->entriesCached - ssdCachedEntriesOld);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCachedBytes,
-                memoryCacheStats.ssdStats->bytesCached - ssdCachedBytesOld);
-          }
+              kCounterSsdCacheCachedBytes,
+              memoryCacheStats.ssdStats->bytesCached - ssdCachedBytesOld);
+        }
 
-          memoryNumHitOld = memoryCacheStats.numHit;
-          memoryNumNewOld = memoryCacheStats.numNew;
-          memoryNumEvictOld = memoryCacheStats.numEvict;
-          memoryNumEvictChecksOld = memoryCacheStats.numEvictChecks;
-          memoryNumWaitExclusiveOld = memoryCacheStats.numWaitExclusive;
-          memoryNumAllocClocksOld = memoryCacheStats.allocClocks;
-          if (memoryCacheStats.ssdStats) {
-            ssdReadEntriesOld = memoryCacheStats.ssdStats->entriesRead;
-            ssdReadBytesOld = memoryCacheStats.ssdStats->bytesRead;
-            ssdWrittenEntriesOld = memoryCacheStats.ssdStats->entriesWritten;
-            ssdWrittenBytesOld = memoryCacheStats.ssdStats->bytesWritten;
-            ssdCachedEntriesOld = memoryCacheStats.ssdStats->entriesCached;
-            ssdCachedBytesOld = memoryCacheStats.ssdStats->bytesCached;
-          }
-          // All time cumulatives.
+        memoryNumHitOld = memoryCacheStats.numHit;
+        memoryNumNewOld = memoryCacheStats.numNew;
+        memoryNumEvictOld = memoryCacheStats.numEvict;
+        memoryNumEvictChecksOld = memoryCacheStats.numEvictChecks;
+        memoryNumWaitExclusiveOld = memoryCacheStats.numWaitExclusive;
+        memoryNumAllocClocksOld = memoryCacheStats.allocClocks;
+        if (memoryCacheStats.ssdStats) {
+          ssdReadEntriesOld = memoryCacheStats.ssdStats->entriesRead;
+          ssdReadBytesOld = memoryCacheStats.ssdStats->bytesRead;
+          ssdWrittenEntriesOld = memoryCacheStats.ssdStats->entriesWritten;
+          ssdWrittenBytesOld = memoryCacheStats.ssdStats->bytesWritten;
+          ssdCachedEntriesOld = memoryCacheStats.ssdStats->entriesCached;
+          ssdCachedBytesOld = memoryCacheStats.ssdStats->bytesCached;
+        }
+        // All time cumulatives.
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeHit, memoryCacheStats.numHit);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeNew, memoryCacheStats.numNew);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeEvict, memoryCacheStats.numEvict);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeEvictChecks,
+            memoryCacheStats.numEvictChecks);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeWaitExclusive,
+            memoryCacheStats.numWaitExclusive);
+        REPORT_ADD_STAT_VALUE(
+            kCounterMemoryCacheNumCumulativeAllocClocks,
+            memoryCacheStats.allocClocks);
+        if (memoryCacheStats.ssdStats) {
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeHit, memoryCacheStats.numHit);
+              kCounterSsdCacheCumulativeReadEntries,
+              memoryCacheStats.ssdStats->entriesRead)
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeNew, memoryCacheStats.numNew);
+              kCounterSsdCacheCumulativeReadBytes,
+              memoryCacheStats.ssdStats->bytesRead);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeEvict, memoryCacheStats.numEvict);
+              kCounterSsdCacheCumulativeWrittenEntries,
+              memoryCacheStats.ssdStats->entriesWritten);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeEvictChecks,
-              memoryCacheStats.numEvictChecks);
+              kCounterSsdCacheCumulativeWrittenBytes,
+              memoryCacheStats.ssdStats->bytesWritten);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeWaitExclusive,
-              memoryCacheStats.numWaitExclusive);
+              kCounterSsdCacheCumulativeCachedEntries,
+              memoryCacheStats.ssdStats->entriesCached);
           REPORT_ADD_STAT_VALUE(
-              kCounterMemoryCacheNumCumulativeAllocClocks,
-              memoryCacheStats.allocClocks);
-          if (memoryCacheStats.ssdStats) {
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeReadEntries,
-                memoryCacheStats.ssdStats->entriesRead)
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeReadBytes,
-                memoryCacheStats.ssdStats->bytesRead);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeWrittenEntries,
-                memoryCacheStats.ssdStats->entriesWritten);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeWrittenBytes,
-                memoryCacheStats.ssdStats->bytesWritten);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeCachedEntries,
-                memoryCacheStats.ssdStats->entriesCached);
-            REPORT_ADD_STAT_VALUE(
-                kCounterSsdCacheCumulativeCachedBytes,
-                memoryCacheStats.ssdStats->bytesCached);
-          }
-        },
-        std::chrono::microseconds{kCachePeriodGlobalCounters},
-        "cache_counters");
-  }
+              kCounterSsdCacheCumulativeCachedBytes,
+              memoryCacheStats.ssdStats->bytesCached);
+        }
+      },
+      std::chrono::microseconds{kCachePeriodGlobalCounters},
+      "cache_counters");
+}
 
-  for (auto connector : connectors_) {
+void PeriodicTaskManager::addConnectorStatsTask() {
+  for (auto itr : connectors_) {
     static std::unordered_map<std::string, int64_t> oldValues;
     // Export HiveConnector stats
     if (auto hiveConnector =
             std::dynamic_pointer_cast<velox::connector::hive::HiveConnector>(
-                connector)) {
+                itr.second)) {
       auto connectorId = hiveConnector->connectorId();
       const auto kNumElementsMetricName = fmt::format(
           kCounterHiveFileHandleCacheNumElementsFormat, connectorId);
@@ -394,7 +422,9 @@ void PeriodicTaskManager::start() {
           fmt::format("{}.hive_connector_counters", connectorId));
     }
   }
+}
 
+void PeriodicTaskManager::addOperatingSystemStatsTask() {
   scheduler_.addFunction(
       []() {
         struct rusage usage;
@@ -416,14 +446,5 @@ void PeriodicTaskManager::start() {
       },
       std::chrono::microseconds{kOsPeriodGlobalCounters},
       "os_counters");
-
-  // This should be the last call in this method.
-  scheduler_.start();
 }
-
-void PeriodicTaskManager::stop() {
-  scheduler_.cancelAllFunctionsAndWait();
-  scheduler_.shutdown();
-}
-
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -25,44 +25,70 @@ namespace facebook::velox::connector {
 class Connector;
 }
 
+namespace facebook::velox::cache {
+class AsyncDataCache;
+}
+
 namespace facebook::presto {
 
 class TaskManager;
 
-// Manages a set of periodic tasks via folly::FunctionScheduler.
-// This is a place to add a new task or add more functionality to an existing
-// one.
+/// Manages a set of periodic tasks via folly::FunctionScheduler.
+/// This is a place to add a new task or add more functionality to an existing
+/// one.
 class PeriodicTaskManager {
  public:
   explicit PeriodicTaskManager(
-      folly::CPUThreadPoolExecutor* driverCPUExecutor,
-      folly::IOThreadPoolExecutor* httpExecutor,
-      TaskManager* taskManager,
-      std::vector<std::shared_ptr<velox::connector::Connector>> connectors);
+      folly::CPUThreadPoolExecutor* const driverCPUExecutor,
+      folly::IOThreadPoolExecutor* const httpExecutor,
+      TaskManager* const taskManager,
+      const velox::memory::MemoryAllocator* const memoryAllocator,
+      const velox::cache::AsyncDataCache* const asyncDataCache,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<velox::connector::Connector>>& connectors);
+
   ~PeriodicTaskManager() {
     stop();
   }
 
-  // All the tasks will start here.
+  /// Invoked to start all registered, and fundamental periodic tasks running at
+  /// the background.
+  ///
+  /// NOTE: start() shall be called after everything in PrestoServer is
+  /// initialized because PeriodicTaskManager replies on proper initializations
+  /// of various entities in the system to work as expected.
   void start();
 
-  // Add a task to run periodically.
+  /// Add a task to run periodically.
   template <typename TFunc>
   void addTask(TFunc&& func, size_t periodMicros, const std::string& taskName) {
     scheduler_.addFunction(
         func, std::chrono::microseconds{periodMicros}, taskName);
   }
 
-  // Stops all periodic tasks. Returns only when everything is stopped.
+  /// Stops all periodic tasks. Returns only when everything is stopped.
   void stop();
 
  private:
+  void addExecutorStatsTask();
+  void addTaskStatsTask();
+  void addTaskCleanupTask();
+  void addMemoryAllocatorStatsTask();
+  void addPrestoExchangeSourceMemoryStatsTask();
+  void addAsyncDataCacheStatsTask();
+  void addConnectorStatsTask();
+  void addOperatingSystemStatsTask();
+
   folly::FunctionScheduler scheduler_;
-  folly::CPUThreadPoolExecutor* driverCPUExecutor_;
-  folly::IOThreadPoolExecutor* httpExecutor_;
-  TaskManager* taskManager_;
-  velox::memory::MemoryManager& memoryManager_;
-  std::vector<std::shared_ptr<velox::connector::Connector>> connectors_;
+  folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
+  folly::IOThreadPoolExecutor* const httpExecutor_;
+  TaskManager* const taskManager_;
+  const velox::memory::MemoryAllocator* const memoryAllocator_;
+  const velox::cache::AsyncDataCache* const asyncDataCache_;
+  const std::unordered_map<
+      std::string,
+      std::shared_ptr<velox::connector::Connector>>& connectors_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -60,6 +60,7 @@ struct ServerOperation;
 class SignalHandler;
 class TaskManager;
 class TaskResource;
+class PeriodicTaskManager;
 
 class PrestoServer {
  public:
@@ -80,6 +81,10 @@ class PrestoServer {
   }
 
  protected:
+  /// Hook for derived PrestoServer implementations to add additional periodic
+  /// tasks.
+  virtual void addAdditionalPeriodicTasks();
+
   virtual std::function<folly::SocketAddress()> discoveryAddressLookup();
 
   virtual std::shared_ptr<velox::exec::TaskListener> getTaskListener();
@@ -149,6 +154,7 @@ class PrestoServer {
   std::atomic<NodeState> nodeState_{NodeState::ACTIVE};
   std::atomic_bool shuttingDown_{false};
   std::chrono::steady_clock::time_point start_;
+  std::unique_ptr<PeriodicTaskManager> periodicTaskManager_;
 
   // We update these members asynchronously and return in http requests w/o
   // delay.


### PR DESCRIPTION
* Breaks down PeriodicTaskManager::start() to be smaller methods for better readability.
* Added addAdditionalPeriodicTasks() API exposure to external extenders of PrestoServer for additional task scheduling.
* Advanced Velox version
```
== NO RELEASE NOTE ==
```
