### PR TITLE
[native] Add basic http stats filter.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -29,6 +29,7 @@
 #include "presto_cpp/main/connectors/hive/storage_adapters/FileSystems.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/http/filters/AccessLogFilter.h"
+#include "presto_cpp/main/http/filters/StatsFilter.h"
 #include "presto_cpp/main/operators/LocalPersistentShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleInterface.h"
@@ -533,7 +534,7 @@ PrestoServer::getHttpServerFilters() {
 
 std::unique_ptr<proxygen::RequestHandlerFactory>
 PrestoServer::getHttpStatsFilter() {
-  return nullptr;
+  return std::make_unique<http::filters::StatsFilterFactory>();
 }
 
 std::vector<std::string> PrestoServer::registerConnectors(

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(presto_http HttpClient.cpp HttpServer.cpp
-                        filters/AccessLogFilter.cpp)
+                        filters/AccessLogFilter.cpp filters/StatsFilter.cpp)
 
 target_link_libraries(
   presto_http

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -48,8 +48,6 @@ class AbstractRequestHandler : public proxygen::RequestHandler {
  public:
   void onRequest(
       std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override {
-    REPORT_ADD_STAT_VALUE(kCounterNumHTTPRequest, 1);
-    startTime_ = std::chrono::steady_clock::now();
     headers_ = std::move(headers);
     body_.clear();
   }
@@ -61,21 +59,14 @@ class AbstractRequestHandler : public proxygen::RequestHandler {
   void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override {}
 
   void requestComplete() noexcept override {
-    REPORT_ADD_STAT_VALUE(
-        kCounterHTTPRequestLatencyMs,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - startTime_)
-            .count());
     delete this;
   }
 
   void onError(proxygen::ProxygenError err) noexcept override {
-    REPORT_ADD_STAT_VALUE(kCounterNumHTTPRequestError, 1);
     delete this;
   }
 
  protected:
-  std::chrono::steady_clock::time_point startTime_;
   std::unique_ptr<proxygen::HTTPMessage> headers_;
   std::vector<std::unique_ptr<folly::IOBuf>> body_;
 };

--- a/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/AccessLogFilter.cpp
@@ -13,11 +13,6 @@
  */
 
 #include <fmt/format.h>
-#include <glog/logging.h>
-#include <proxygen/httpserver/Filters.h>
-#include <proxygen/httpserver/RequestHandlerFactory.h>
-#include <string>
-
 #include "presto_cpp/main/http/filters/AccessLogFilter.h"
 
 namespace facebook::presto::http::filters {

--- a/presto-native-execution/presto_cpp/main/http/filters/StatsFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/StatsFilter.cpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/http/filters/StatsFilter.h"
+#include "presto_cpp/main/common/Counters.h"
+#include "velox/common/base/StatsReporter.h"
+
+namespace facebook::presto::http::filters {
+
+StatsFilter::StatsFilter(proxygen::RequestHandler* upstream)
+    : Filter(upstream) {}
+
+void StatsFilter::onRequest(
+    std::unique_ptr<proxygen::HTTPMessage> msg) noexcept {
+  startTime_ = std::chrono::steady_clock::now();
+  REPORT_ADD_STAT_VALUE(kCounterNumHTTPRequest, 1);
+  Filter::onRequest(std::move(msg));
+}
+
+void StatsFilter::requestComplete() noexcept {
+  REPORT_ADD_STAT_VALUE(
+      kCounterHTTPRequestLatencyMs,
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - startTime_)
+          .count());
+  delete this;
+}
+
+void StatsFilter::onError(proxygen::ProxygenError err) noexcept {
+  REPORT_ADD_STAT_VALUE(kCounterNumHTTPRequestError, 1);
+  delete this;
+}
+
+} // namespace facebook::presto::http::filters


### PR DESCRIPTION
This PR adds a basic http stats filter. The counters are request count, request latency and error count. These counters were already exported from http server. Here we refactored them into a filter. Inside Meta, these are already exported via internal stat filter implementation, hence having them inside http server was reported these twice in the very hot path which is inefficient. Also removed unused includes `AccessLogFilter`.
 
```
== NO RELEASE NOTE ==
```
