### PR TITLE
[native][wip] Fix AccessLogFilter test CMake.

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -9,11 +9,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(presto_http HttpClient.cpp HttpServer.cpp
-                        filters/AccessLogFilter.cpp filters/StatsFilter.cpp)
+add_library(presto_http HttpClient.cpp HttpServer.cpp)
+
+add_subdirectory(filters)
 
 target_link_libraries(
   presto_http
+  http_filters
   presto_common
   velox_memory
   velox_exception

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(access_log_test AccessLogFilterTest.cpp)
 
 add_test(access_log_test access_log_test)
 
-target_link_libraries(access_log_test presto_http gtest gtest_main)
+target_link_libraries(access_log_test presto_http gtest gtest_main ${PROXYGEN_LIBRARIES})


### PR DESCRIPTION
AccessLogFilter test is not running in CI, because the test is not added in CMake properly. While fixing that, found Mocks.h is not added in proxygen CMAKE

https://github.com/facebook/proxygen/blob/main/proxygen/httpserver/CMakeLists.txt#L194

CC: @vermapratyush 

```
== NO RELEASE NOTE ==
```
