### PR TITLE
[native] Make http filters library instead of directly including files.

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -9,11 +9,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(presto_http HttpClient.cpp HttpServer.cpp
-                        filters/AccessLogFilter.cpp filters/StatsFilter.cpp)
+add_library(presto_http HttpClient.cpp HttpServer.cpp)
+
+add_subdirectory(filters)
 
 target_link_libraries(
   presto_http
+  http_filters
   presto_common
   velox_memory
   velox_exception

--- a/presto-native-execution/presto_cpp/main/http/filters/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/filters/CMakeLists.txt
@@ -9,8 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(access_log_test AccessLogFilterTest.cpp)
 
-add_test(access_log_test access_log_test)
+add_library(http_filters AccessLogFilter.cpp StatsFilter.cpp)
 
-target_link_libraries(access_log_test presto_http gtest gtest_main)
+target_link_libraries(http_filters presto_common ${PROXYGEN_LIBRARIES})


### PR DESCRIPTION
Filters are directly added as files in `presto_http` library. We should make a library of filters and include that.

```
== NO RELEASE NOTE ==
```
