### PR TITLE
Extend Presto-on-Spark runner to support pluggable native modules

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -24,6 +24,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
@@ -17,7 +17,9 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.nativeworker.AbstractNativeRunner;
 import com.facebook.presto.spi.security.PrincipalType;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Module;
 
 import java.nio.file.Paths;
 import java.util.Map;
@@ -30,7 +32,10 @@ public class PrestoSparkNativeQueryRunner
 {
     private static final int AVAILABLE_CPU_COUNT = 4;
 
-    public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner(Map<String, String> additionalConfigProperties, Map<String, String> additionalSparkProperties)
+    public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner(
+            Map<String, String> additionalConfigProperties,
+            Map<String, String> additionalSparkProperties,
+            ImmutableList<Module> nativeModules)
     {
         String dataDirectory = System.getProperty("DATA_DIR");
 
@@ -43,6 +48,7 @@ public class PrestoSparkNativeQueryRunner
                 getNativeWorkerHiveProperties(),
                 additionalSparkProperties,
                 Optional.ofNullable(dataDirectory).map(Paths::get),
+                nativeModules,
                 AVAILABLE_CPU_COUNT);
 
         ExtendedHiveMetastore metastore = queryRunner.getMetastore();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -54,7 +54,6 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFa
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
 import com.facebook.presto.spark.execution.NativeExecutionModule;
-import com.facebook.presto.spark.execution.TestNativeExecutionModule;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.function.FunctionImplementationType;
@@ -221,7 +220,8 @@ public class PrestoSparkQueryRunner
 
     public static PrestoSparkQueryRunner createHivePrestoSparkQueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> additionalConfigProperties, Map<String, String> hiveProperties, Optional<Path> dataDirectory)
     {
-        PrestoSparkQueryRunner queryRunner = new PrestoSparkQueryRunner("hive", additionalConfigProperties, hiveProperties, ImmutableMap.of(), dataDirectory, DEFAULT_AVAILABLE_CPU_COUNT);
+        PrestoSparkQueryRunner queryRunner = new PrestoSparkQueryRunner(
+                "hive", additionalConfigProperties, hiveProperties, ImmutableMap.of(), dataDirectory, ImmutableList.of(new NativeExecutionModule()), DEFAULT_AVAILABLE_CPU_COUNT);
         ExtendedHiveMetastore metastore = queryRunner.getMetastore();
         if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {
             metastore.createDatabase(METASTORE_CONTEXT, createDatabaseMetastoreObject("tpch"));
@@ -272,11 +272,17 @@ public class PrestoSparkQueryRunner
 
     public PrestoSparkQueryRunner(String defaultCatalog, Map<String, String> additionalConfigProperties, Map<String, String> hiveProperties, Optional<Path> dataDirectory)
     {
-        this(defaultCatalog, additionalConfigProperties, hiveProperties, ImmutableMap.of(), dataDirectory, DEFAULT_AVAILABLE_CPU_COUNT);
+        this(defaultCatalog, additionalConfigProperties, hiveProperties, ImmutableMap.of(), dataDirectory, ImmutableList.of(new NativeExecutionModule()), DEFAULT_AVAILABLE_CPU_COUNT);
     }
 
     public PrestoSparkQueryRunner(
-            String defaultCatalog, Map<String, String> additionalConfigProperties, Map<String, String> hiveProperties, Map<String, String> additionalSparkProperties, Optional<Path> dataDirectory, int availableCpuCount)
+            String defaultCatalog,
+            Map<String, String> additionalConfigProperties,
+            Map<String, String> hiveProperties,
+            Map<String, String> additionalSparkProperties,
+            Optional<Path> dataDirectory,
+            ImmutableList<Module> additionalModules,
+            int availableCpuCount)
     {
         setupLogging();
 
@@ -288,14 +294,10 @@ public class PrestoSparkQueryRunner
         configProperties.put("task.concurrency", Integer.toString(DEFAULT_TASK_CONCURRENCY));
         configProperties.putAll(additionalConfigProperties);
 
-        ImmutableList.Builder<Module> additionalModules = ImmutableList.builder();
-        additionalModules.add(new PrestoSparkLocalMetadataStorageModule());
-        if (System.getProperty("NATIVE_PORT") != null) {
-            additionalModules.add(new TestNativeExecutionModule());
-        }
-        else {
-            additionalModules.add(new NativeExecutionModule());
-        }
+        ImmutableList.Builder<Module> moduleBuilder = ImmutableList.builder();
+        moduleBuilder.add(new PrestoSparkLocalMetadataStorageModule());
+        moduleBuilder.addAll(additionalModules);
+
         PrestoSparkInjectorFactory injectorFactory = new PrestoSparkInjectorFactory(
                 DRIVER,
                 configProperties.build(),
@@ -306,7 +308,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 new SqlParserOptions(),
-                additionalModules.build(),
+                moduleBuilder.build(),
                 true);
 
         Injector injector = injectorFactory.create();
@@ -410,6 +412,7 @@ public class PrestoSparkQueryRunner
         logging.setLevel("org.apache.parquet.hadoop", WARN);
         logging.setLevel("parquet.hadoop", WARN);
     }
+
     @Override
     public int getNodeCount()
     {


### PR DESCRIPTION
In different test environment (e.g OSS vs facebook internal), it requires different native execution modules to run the native execution queries, this PR make the native modules pluggable for different test scenarios.

```
== NO RELEASE NOTE ==
```
