### PR TITLE
Convert INTERVAL_DAY_TIME to logical type (#4406)

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -117,9 +117,6 @@ velox::variant VeloxExprConverter::getConstantValue(
           0);
     case TypeKind::DATE:
       return valueVector->as<velox::SimpleVector<velox::Date>>()->valueAt(0);
-    case TypeKind::INTERVAL_DAY_TIME:
-      return valueVector->as<velox::SimpleVector<velox::IntervalDayTime>>()
-          ->valueAt(0);
     case TypeKind::BOOLEAN:
       return valueVector->as<velox::SimpleVector<bool>>()->valueAt(0);
     case TypeKind::DOUBLE:

--- a/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
@@ -116,7 +116,6 @@ velox::VectorPtr readScalarBlock(
     case velox::TypeKind::REAL:
     case velox::TypeKind::VARCHAR:
     case velox::TypeKind::DATE:
-    case velox::TypeKind::INTERVAL_DAY_TIME:
     case velox::TypeKind::SHORT_DECIMAL:
       return std::make_shared<velox::FlatVector<U>>(
           pool,


### PR DESCRIPTION
Summary:
Removed TypeKind::INTERVAL_DAY_TIME enum value and replaced it with a
logical type IntervalDayTimeType based on BigintType and therefore backed
by physical TypeKind::BIGINT type.

Data of interval type is stored in memory using 64-bit integers, e.g.
FlatVector<int64_t>. The individual value is the number of milliseconds in the
interval. A variant holding interval value stores a single 64-bit integer.

Removed IntervalDayTime value type and replaced it with a special type that is
used only to allow for proper signature generation for simple functions.

```
template <typename T>
struct DateMinusIntervalDayTime {
  VELOX_DEFINE_FUNCTION_TYPES(T);

  FOLLY_ALWAYS_INLINE void call(
      Date& result,
      const arg_type<Date>& date,
      const arg_type<IntervalDayTime>& interval) {
    ...
  }
};

registerFunction<DateMinusIntervalDayTime, Date, Date, IntervalDayTime>(
    {prefix + "minus"});
```

See #4069

X-link: https://github.com/facebookincubator/velox/pull/4406

Reviewed By: pedroerp

Differential Revision: D44370558

Pulled By: mbasmanova

