### PR TITLE
[native] Increase number of driver threads to x8 concurrency.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -125,7 +125,7 @@ int32_t SystemConfig::numIoThreads() const {
 
 int32_t SystemConfig::numQueryThreads() const {
   auto opt = optionalProperty<int32_t>(std::string(kNumQueryThreads));
-  return opt.value_or(std::thread::hardware_concurrency() * 4);
+  return opt.value_or(std::thread::hardware_concurrency() * 8);
 }
 
 int32_t SystemConfig::numSpillThreads() const {


### PR DESCRIPTION
Test plan - Existing tests.

We see evidence of increased driver executor contention when QPS
increases. To reduce the contention we increase the number of
threads available to see if that will help.

```
== NO RELEASE NOTE ==
```
