### PR TITLE
Cleanup UnsafeRow related code structure (#4576)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
-#include "velox/row/UnsafeRowDynamicSerializer.h"
+#include "velox/row/UnsafeRowSerializers.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox;


### PR DESCRIPTION
Summary:
Major code structure refactoring and unused code path/tests cleanup. Currently it is often unclear and confusing looking at scattered classes and files. After the change it will be much easier to maintain.

* Migrated UnsafeRow deserialization from UnsafeRowDeserializer to UnsafeRowBatchDeserializer.
* Deprecated and removed UnsafeRowDeserializer.h and its corresponding tests.
* Renamed UnsafeRowBatchDeserializer.h to UnsafeRowDeserializers.h
* Combined UnsafeRowSerializer.h and UnsafeRowDynamicSerializer.h to a single file called UnsafeRowSerializers.h
* Moved UnsafeRow24Deserializer.* to a separate experimental directory for less confusion as it is experimental and not used in the main code path.
* Combined UnsafeRowDeserializerTest.cpp and UnsafeRowSerializerTest.cpp to a single file UnsafeRowSerdeTest.cpp
* Refactored tests accordingly.

X-link: https://github.com/facebookincubator/velox/pull/4576

Reviewed By: amitkdutta

Differential Revision: D44875623

Pulled By: tanjialiang

