### PR TITLE
Fix bug in HBO Canonicalization with TopNRowNumber

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -666,7 +666,7 @@ public class CanonicalPlanGenerator
                 node.getMaxRowCountPerPartition(),
                 node.isPartial(),
                 Optional.empty());
-        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        context.addLimitingNodePlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);
     }
 
@@ -696,7 +696,7 @@ public class CanonicalPlanGenerator
                 distinctVariables,
                 Optional.empty(),
                 0);
-        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        context.addLimitingNodePlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);
     }
 


### PR DESCRIPTION
For nodes which have an implicit limit(Limit, TopN, TopNRowNumber, DistinctLimit), we should use `context.addLimitingNodePlan` instead of `addPlan`. We did it previously for some places, but not all.

This is leading to plan node hashes unable to be assigned correctly, leading to ineffective caching of hashes, which can be problematic when queries have 500+ plan nodes

```
== NO RELEASE NOTE ==
```
