### PR TITLE
Improve Verifier matching in EXPLAIN mode

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import static com.facebook.presto.verifier.framework.ExplainMatchResult.MatchType.MATCH;
 import static java.util.Objects.requireNonNull;
 
 public class ExplainMatchResult
@@ -35,7 +36,7 @@ public class ExplainMatchResult
     @Override
     public boolean isMatched()
     {
-        return true;
+        return matchType == MATCH;
     }
 
     @Override

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
@@ -59,7 +59,7 @@ public class TestExplainVerification
         assertTrue(event.isPresent());
 
         // Explain verification do not fail in case of plan changes.
-        assertEvent(event.get(), SUCCEEDED);
+        assertEvent(event.get(), FAILED);
         assertEquals(event.get().getMatchType(), "STRUCTURE_MISMATCH");
         assertEquals(event.get().getControlQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT \"count\"(*)\nFROM\n  structure_mismatch");
         assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT \"count\"(*)\nFROM\n  (structure_mismatch\nCROSS JOIN structure_mismatch)");
@@ -74,7 +74,7 @@ public class TestExplainVerification
         assertTrue(event.isPresent());
 
         // Explain verification do not fail in case of plan changes.
-        assertEvent(event.get(), SUCCEEDED);
+        assertEvent(event.get(), FAILED);
         assertEquals(event.get().getMatchType(), "DETAILS_MISMATCH");
         assertEquals(event.get().getControlQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT 1");
         assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT 2");


### PR DESCRIPTION
  Currently in mode, Verifier checks whether source queries can be
explained instead of whether they produces the same results. Verification is marked as succeeded when both control query and test query can be explained.
  This PR improves it by sorting the details and comparing them line
by line (location information is ignored) and returns matched if and only if there is a exact match.

Test plan - Changed unit tests.

```
== RELEASE NOTES ==

Presto Verifier Changes
* Improve Verifier matching in EXPLAIN mode

```

