### PR TITLE
[native] Set string buffer size in PartitionAndSerialize operator

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -118,9 +118,12 @@ class PartitionAndSerializeOperator : public Operator {
 
     // Allocate memory.
     auto buffer = dataVector.getBufferWithSpace(totalSize);
+    // getBufferWithSpace() may return a buffer that already has content, so we
+    // only use the space after that.
+    auto rawBuffer = buffer->asMutable<char>() + buffer->size();
+    buffer->setSize(buffer->size() + totalSize);
 
     // Serialize rows.
-    auto rawBuffer = buffer->asMutable<char>();
     size_t offset = 0;
     for (auto i = 0; i < numInput; ++i) {
       dataVector.setNoCopy(


### PR DESCRIPTION
PartitionAndSerialize didn't set the size for the string buffers and produced invalid string vectors. This bug is similar to the one fixed in https://github.com/facebookincubator/velox/pull/3265. This bug may exist in TableScan as well: https://github.com/facebookincubator/velox/issues/4608

There is no convenient way to add a test for this fix. We should add a method to Velox to check integrity of the vector and use it in TaskCursor to ensure all vectors produced by query plans used in tests are valid.

```
== NO RELEASE NOTE ==
```
