### PR TITLE
[native] Fix planning of queries with duplicate output columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -181,6 +181,29 @@ public abstract class BasePlanFragmenter
 
         // Only delegate non-coordinatorOnly plan fragment to native engine
         if (isNativeExecutionEnabled(session) && !properties.getPartitioningHandle().isCoordinatorOnly()) {
+            if (root instanceof OutputNode) {
+                // OutputNode is special in that it can have duplicate output variables since it
+                // does not get converted to a PhysicalOperation for execution.
+                // Regular plan nodes, including NativeExecutionNode, must have unique output variables.
+                // Check if OutputNode has duplicate output variables and remove these.
+                // This is safe because OutputNode variables are not used by the workers.
+                OutputNode outputNode = (OutputNode) root;
+                List<VariableReferenceExpression> outputVariables = outputNode.getOutputVariables();
+                List<VariableReferenceExpression> newOutputVariables = new ArrayList<>();
+                List<String> newColumnNames = new ArrayList<>();
+                Set<VariableReferenceExpression> uniqueOutputVariables = new HashSet<>();
+                for (int i = 0; i < outputVariables.size(); ++i) {
+                    VariableReferenceExpression variable = outputVariables.get(i);
+                    if (uniqueOutputVariables.add(variable)) {
+                        newOutputVariables.add(variable);
+                        newColumnNames.add(outputNode.getColumnNames().get(i));
+                    }
+                }
+
+                if (uniqueOutputVariables.size() < outputVariables.size()) {
+                    root = new OutputNode(outputNode.getSourceLocation(), outputNode.getId(), outputNode.getSource(), newColumnNames, newOutputVariables);
+                }
+            }
             root = new NativeExecutionNode(root);
             schedulingOrder = scheduleOrder(root);
         }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -60,7 +60,7 @@ public class TestPrestoSparkNativeExecution
     @Test
     public void testJoins()
     {
-        assertQuery("SELECT count(*) FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.orderkey % 2 = 1");
+        assertQuery("SELECT * FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.orderkey % 2 = 1");
     }
 
     @Test


### PR DESCRIPTION
Fix "Multiple entries with same key: orderkey=9 and orderkey=0" when planning
join query with duplicate output columns:

```
SELECT * FROM orders o, lineitem l WHERE o.orderkey = l.orderkey
```

Fixes #19399

```
== NO RELEASE NOTE ==
```
