### PR TITLE
[native] Fix test data path in Presto-on-Spark native runner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunner.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,6 +33,7 @@ public class PrestoSparkNativeQueryRunner
     private static final int AVAILABLE_CPU_COUNT = 4;
 
     public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner(
+            Optional<Path> baseDir,
             Map<String, String> additionalConfigProperties,
             Map<String, String> additionalSparkProperties,
             ImmutableList<Module> nativeModules)
@@ -47,7 +48,7 @@ public class PrestoSparkNativeQueryRunner
                 configBuilder.build(),
                 getNativeWorkerHiveProperties(),
                 additionalSparkProperties,
-                Optional.ofNullable(dataDirectory).map(Paths::get),
+                baseDir,
                 nativeModules,
                 AVAILABLE_CPU_COUNT);
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -80,7 +80,6 @@ import io.airlift.tpch.TpchTable;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -341,13 +340,13 @@ public class PrestoSparkQueryRunner
         connectorManager.createConnection("tpch", "tpch", ImmutableMap.of());
 
         // Install Hive Plugin
-        File baseDir;
+        Path baseDir;
         if (dataDirectory.isPresent()) {
-            baseDir = dataDirectory.get().resolve("hive_data").toFile();
+            baseDir = dataDirectory.get();
         }
         else {
             try {
-                baseDir = createTempDirectory("PrestoTest").toFile();
+                baseDir = createTempDirectory("PrestoTest");
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -359,7 +358,7 @@ public class PrestoSparkQueryRunner
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
 
-        this.metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+        this.metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.resolve("hive_data").toFile().toURI().toString(), "test");
         if (!metastore.getDatabase(METASTORE_CONTEXT, "hive_test").isPresent()) {
             metastore.createDatabase(METASTORE_CONTEXT, createDatabaseMetastoreObject("hive_test"));
         }


### PR DESCRIPTION
The PR makes sure both actual runner and expected runner share the same test data path when the DATA_DIR arguments is not provided.

```
== NO RELEASE NOTE ==
```
