### PR TITLE
[Presto-on-Spark] Add new SparkProcessType LOCAL_EXECUTOR

### DIFF
--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SparkProcessType.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SparkProcessType.java
@@ -17,4 +17,5 @@ public enum SparkProcessType
 {
     DRIVER,
     EXECUTOR,
+    LOCAL_EXECUTOR,
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -238,6 +238,7 @@ public class PrestoSparkRunner
         private final Map<String, String> sessionPropertyConfigurationProperties;
         private final Map<String, Map<String, String>> functionNamespaceProperties;
         private final Map<String, Map<String, String>> tempStorageProperties;
+        private final boolean isLocal;
 
         public DistributionBasedPrestoSparkTaskExecutorFactoryProvider(PrestoSparkDistribution distribution)
         {
@@ -252,6 +253,7 @@ public class PrestoSparkRunner
             this.sessionPropertyConfigurationProperties = distribution.getSessionPropertyConfigurationProperties().orElse(null);
             this.functionNamespaceProperties = distribution.getFunctionNamespaceProperties().orElse(null);
             this.tempStorageProperties = distribution.getTempStorageProperties().orElse(null);
+            this.isLocal = distribution.getSparkContext().isLocal();
         }
 
         @Override
@@ -278,7 +280,7 @@ public class PrestoSparkRunner
             synchronized (DistributionBasedPrestoSparkTaskExecutorFactoryProvider.class) {
                 if (service == null) {
                     service = createService(
-                            SparkProcessType.EXECUTOR,
+                            isLocal ? SparkProcessType.LOCAL_EXECUTOR : SparkProcessType.EXECUTOR,
                             packageSupplier,
                             configProperties,
                             catalogProperties,


### PR DESCRIPTION
Currently, Presto-on-Spark has only 2 types of process DRIVER
and EXECUTOR. To support running presto-on-spark queries
in spark's  "local" mode, some of the downstream logic need to
distinguish between a local executor and a remote executor.
This PR adds a new SparkProcessType - LOCAL_EXECUTOR to enable
these scenarios

Example of how this would be used: https://github.com/facebookexternal/presto-facebook/pull/2309
```
== NO RELEASE NOTE ==
```
