### PR TITLE
[native] Remove singleton dependency from http server.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -256,7 +256,9 @@ void PrestoServer::run() {
     announcer->start();
   }
 
-  auto httpConfig = std::make_unique<http::HttpConfig>(httpSocketAddress);
+  const bool reusePort = SystemConfig::instance()->httpServerReusePort();
+  auto httpConfig =
+      std::make_unique<http::HttpConfig>(httpSocketAddress, reusePort);
 
   std::unique_ptr<http::HttpsConfig> httpsConfig;
   if (httpsPort.has_value()) {
@@ -264,7 +266,7 @@ void PrestoServer::run() {
     httpsSocketAddress.setFromLocalPort(httpsPort.value());
 
     httpsConfig = std::make_unique<http::HttpsConfig>(
-        httpsSocketAddress, certPath, keyPath, ciphers);
+        httpsSocketAddress, certPath, keyPath, ciphers, reusePort);
   }
 
   httpServer_ = std::make_unique<http::HttpServer>(

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -19,9 +19,7 @@
 #include <re2/re2.h>
 #include <wangle/ssl/SSLContextConfig.h>
 #include "presto_cpp/external/json/json.hpp"
-#include "presto_cpp/main/common/Counters.h"
 #include "presto_cpp/main/http/HttpConstants.h"
-#include "velox/common/base/StatsReporter.h"
 
 namespace facebook::presto::http {
 
@@ -223,12 +221,13 @@ class DispatchingRequestHandlerFactory
 
 class HttpConfig {
  public:
-  HttpConfig(const folly::SocketAddress& address);
+  HttpConfig(const folly::SocketAddress& address, bool reusePort = false);
 
   proxygen::HTTPServer::IPConfig ipConfig() const;
 
  private:
   const folly::SocketAddress address_;
+  const bool reusePort_{false};
 };
 
 class HttpsConfig {
@@ -237,7 +236,8 @@ class HttpsConfig {
       const folly::SocketAddress& address,
       const std::string& certPath,
       const std::string& keyPath,
-      const std::string& supportedCiphers);
+      const std::string& supportedCiphers,
+      bool reusePort = false);
 
   proxygen::HTTPServer::IPConfig ipConfig() const;
 
@@ -246,6 +246,7 @@ class HttpsConfig {
   const std::string certPath_;
   const std::string keyPath_;
   std::string supportedCiphers_;
+  const bool reusePort_;
 };
 
 class HttpServer {

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -20,6 +20,7 @@
 #include <velox/common/memory/Memory.h>
 #include "presto_cpp/main/http/HttpClient.h"
 #include "presto_cpp/main/http/HttpServer.h"
+#include "velox/common/base/StatsReporter.h"
 
 namespace fs = boost::filesystem;
 

--- a/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/StatsReporter.h"
 
 namespace facebook::presto::test {
 


### PR DESCRIPTION
Http server does not need to depend on singleton Systemconfig. Here we remove the dependency and pass port reuse field in protocol config constructor.
 
```
== NO RELEASE NOTE ==
```
