### PR TITLE
[native]Get max http response allocation bytes from config when send …

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -27,7 +27,9 @@ class HttpResponse {
  public:
   HttpResponse(
       std::unique_ptr<proxygen::HTTPMessage> headers,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      uint64_t minResponseAllocBytes,
+      uint64_t maxResponseAllocBytes);
 
   ~HttpResponse();
 
@@ -125,6 +127,7 @@ class HttpClient {
   const folly::SocketAddress address_;
   const folly::HHWheelTimer::UniquePtr timer_;
   const std::function<void(int)> reportOnBodyStatsFunc_;
+  const uint64_t maxResponseAllocBytes_;
 
   std::unique_ptr<proxygen::SessionPool> sessionPool_;
 };


### PR DESCRIPTION
It is safer to get max response allocation size from system config when
send request instead of on body call. There are some race condition such
as ungraceful server shutdown, that can lead to crash when async http
on body call tries to access system config.

```
== NO RELEASE NOTE ==
```
