### PR TITLE
Remove the test for sequence function

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -66,8 +66,6 @@ public class TestPrestoSparkNativeExecution
     @Test
     public void testFailures()
     {
-        assertQueryFails("SELECT sequence(1, orderkey) FROM orders",
-                ".*Scalar function name not registered: presto.default.sequence.*");
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
     }
 


### PR DESCRIPTION
Summary:
D44822319
We added support for sequence function so it shouldn't throw "function name not registered" anymore

Differential Revision: D45033949

