### PR TITLE
[native] Temporarily remove sequence function test

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeExecution.java
@@ -66,8 +66,6 @@ public class TestPrestoSparkNativeExecution
     @Test
     public void testFailures()
     {
-        assertQueryFails("SELECT sequence(1, orderkey) FROM orders",
-                ".*Scalar function name not registered: presto.default.sequence.*");
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
     }
 


### PR DESCRIPTION
We're going to add support for sequence function in velox, so it shouldn't throw "function name not registered" anymore

```
== NO RELEASE NOTE ==
```
