### PR TITLE
Fix CREATE/DROP TEMPORARY FUNCTION

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/StatementUtils.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/StatementUtils.java
@@ -129,9 +129,9 @@ public final class StatementUtils
         builder.put(DropView.class, QueryType.DATA_DEFINITION);
         builder.put(CreateMaterializedView.class, QueryType.DATA_DEFINITION);
         builder.put(DropMaterializedView.class, QueryType.DATA_DEFINITION);
-        builder.put(CreateFunction.class, QueryType.DATA_DEFINITION);
+        builder.put(CreateFunction.class, QueryType.CONTROL);
         builder.put(AlterFunction.class, QueryType.DATA_DEFINITION);
-        builder.put(DropFunction.class, QueryType.DATA_DEFINITION);
+        builder.put(DropFunction.class, QueryType.CONTROL);
         builder.put(Use.class, QueryType.CONTROL);
         builder.put(SetSession.class, QueryType.CONTROL);
         builder.put(ResetSession.class, QueryType.CONTROL);

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
@@ -13,12 +13,9 @@
  */
 package com.facebook.presto.execution;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analyzer;
@@ -28,8 +25,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.inject.Inject;
@@ -37,11 +32,9 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.metadata.SessionFunctionHandle.SESSION_NAMESPACE;
-import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -50,10 +43,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 public class DropFunctionTask
-        implements DDLDefinitionTask<DropFunction>
+        implements SessionTransactionControlTask<DropFunction>
 {
     private final SqlParser sqlParser;
-    private final Set<SqlFunctionId> removedSessionFunctions = Sets.newConcurrentHashSet();
 
     @Inject
     public DropFunctionTask(SqlParser sqlParser)
@@ -74,15 +66,15 @@ public class DropFunctionTask
     }
 
     @Override
-    public ListenableFuture<?> execute(DropFunction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, WarningCollector warningCollector)
+    public ListenableFuture<?> execute(DropFunction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
-        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, warningCollector);
+        Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, stateMachine.getWarningCollector());
         analyzer.analyze(statement);
         Optional<List<TypeSignature>> parameterTypes = statement.getParameterTypes().map(types -> types.stream().map(TypeSignature::parseTypeSignature).collect(toImmutableList()));
 
         if (statement.isTemporary()) {
-            removeSessionFunction(session,
+            stateMachine.removeSessionFunction(
                     new SqlFunctionId(
                             QualifiedObjectName.valueOf(SESSION_NAMESPACE, statement.getFunctionName().getSuffix()),
                             parameterTypes.orElse(emptyList())),
@@ -96,25 +88,5 @@ public class DropFunctionTask
         }
 
         return immediateFuture(null);
-    }
-
-    private void removeSessionFunction(Session session, SqlFunctionId signature, boolean suppressNotFoundException)
-    {
-        requireNonNull(signature, "signature is null");
-
-        if (!session.getSessionFunctions().containsKey(signature)) {
-            if (!suppressNotFoundException) {
-                throw new PrestoException(NOT_FOUND, format("Session function %s not found", signature.getFunctionName()));
-            }
-        }
-        else {
-            removedSessionFunctions.add(signature);
-        }
-    }
-
-    @VisibleForTesting
-    public Set<SqlFunctionId> getRemovedSessionFunctions()
-    {
-        return removedSessionFunctions;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoDataDefBindingHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoDataDefBindingHelper.java
@@ -121,9 +121,7 @@ public class PrestoDataDefBindingHelper
         dataDefBuilder.put(DropView.class, DropViewTask.class);
         dataDefBuilder.put(CreateMaterializedView.class, CreateMaterializedViewTask.class);
         dataDefBuilder.put(DropMaterializedView.class, DropMaterializedViewTask.class);
-        dataDefBuilder.put(CreateFunction.class, CreateFunctionTask.class);
         dataDefBuilder.put(AlterFunction.class, AlterFunctionTask.class);
-        dataDefBuilder.put(DropFunction.class, DropFunctionTask.class);
         dataDefBuilder.put(Call.class, CallTask.class);
         dataDefBuilder.put(CreateRole.class, CreateRoleTask.class);
         dataDefBuilder.put(DropRole.class, DropRoleTask.class);
@@ -141,6 +139,8 @@ public class PrestoDataDefBindingHelper
         transactionDefBuilder.put(SetRole.class, SetRoleTask.class);
         transactionDefBuilder.put(Prepare.class, PrepareTask.class);
         transactionDefBuilder.put(Deallocate.class, DeallocateTask.class);
+        transactionDefBuilder.put(CreateFunction.class, CreateFunctionTask.class);
+        transactionDefBuilder.put(DropFunction.class, DropFunctionTask.class);
 
         STATEMENT_TASK_TYPES = dataDefBuilder.build();
         TRANSACTION_CONTROL_TYPES = transactionDefBuilder.build();

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoDataDefBindingHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoDataDefBindingHelper.java
@@ -98,7 +98,7 @@ import static com.google.inject.multibindings.MapBinder.newMapBinder;
  */
 public class PrestoDataDefBindingHelper
 {
-    private PrestoDataDefBindingHelper(){}
+    private PrestoDataDefBindingHelper() {}
 
     private static final Map<Class<? extends Statement>, Class<? extends DataDefinitionTask<?>>> STATEMENT_TASK_TYPES;
     private static final Map<Class<? extends Statement>, Class<? extends DataDefinitionTask<?>>> TRANSACTION_CONTROL_TYPES;
@@ -157,10 +157,10 @@ public class PrestoDataDefBindingHelper
 
     public static void bindTransactionControlDefinitionTasks(Binder binder)
     {
-        MapBinder<Class<? extends Statement>, DataDefinitionTask<?>> taskBinder = newMapBinder(binder,
-                new TypeLiteral<Class<? extends Statement>>() {
-                }, new TypeLiteral<DataDefinitionTask<?>>() {
-                });
+        MapBinder<Class<? extends Statement>, DataDefinitionTask<?>> taskBinder = newMapBinder(
+                binder,
+                new TypeLiteral<Class<? extends Statement>>() {},
+                new TypeLiteral<DataDefinitionTask<?>>() {});
 
         TRANSACTION_CONTROL_TYPES.entrySet().stream()
                 .forEach(entry -> taskBinder.addBinding(entry.getKey()).to(entry.getValue()).in(Scopes.SINGLETON));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateFunctionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateFunctionTask.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -54,10 +53,8 @@ public class TestCreateFunctionTask
         CreateFunction statement = (CreateFunction) parser.createStatement(sqlString, ParsingOptions.builder().build());
         TransactionManager transactionManager = createTestTransactionManager();
         QueryStateMachine stateMachine = createQueryStateMachine(sqlString, TEST_SESSION, false, transactionManager, executorService, metadataManager);
-        WarningCollector warningCollector = stateMachine.getWarningCollector();
-        CreateFunctionTask createFunctionTask = new CreateFunctionTask(parser);
-        createFunctionTask.execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), TEST_SESSION, emptyList(), warningCollector);
-        assertEquals(createFunctionTask.getAddedSessionFunctions().size(), 1);
+        new CreateFunctionTask(parser).execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), stateMachine, emptyList());
+        assertEquals(stateMachine.getAddedSessionFunctions().size(), 1);
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Session function .* has already been defined")
@@ -68,9 +65,7 @@ public class TestCreateFunctionTask
         CreateFunction statement = (CreateFunction) parser.createStatement(sqlString, ParsingOptions.builder().build());
         TransactionManager transactionManager = createTestTransactionManager();
         QueryStateMachine stateMachine = createQueryStateMachine(sqlString, TEST_SESSION, false, transactionManager, executorService, metadataManager);
-        WarningCollector warningCollector = stateMachine.getWarningCollector();
-        CreateFunctionTask createFunctionTask = new CreateFunctionTask(parser);
-        createFunctionTask.execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), TEST_SESSION, emptyList(), warningCollector);
-        createFunctionTask.execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), TEST_SESSION, emptyList(), warningCollector);
+        new CreateFunctionTask(parser).execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), stateMachine, emptyList());
+        new CreateFunctionTask(parser).execute(statement, transactionManager, metadataManager, new AllowAllAccessControl(), stateMachine, emptyList());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDropFunctionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDropFunctionTask.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.parser.ParsingOptions;
@@ -86,9 +85,7 @@ public class TestDropFunctionTask
         DropFunction statement = (DropFunction) parser.createStatement(sqlString, ParsingOptions.builder().build());
         TransactionManager tm = createTestTransactionManager();
         QueryStateMachine stateMachine = createQueryStateMachine(sqlString, session, false, tm, executorService, metadataManager);
-        WarningCollector warningCollector = stateMachine.getWarningCollector();
-        DropFunctionTask dropFunctionTask = new DropFunctionTask(parser);
-        dropFunctionTask.execute(statement, tm, metadataManager, new AllowAllAccessControl(), session, emptyList(), warningCollector);
-        return dropFunctionTask.getRemovedSessionFunctions();
+        new DropFunctionTask(parser).execute(statement, tm, metadataManager, new AllowAllAccessControl(), stateMachine, emptyList());
+        return stateMachine.getRemovedSessionFunctions();
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -1303,16 +1303,6 @@ public class TestPrestoSparkQueryRunner
     }
 
     @Test
-    public void testCreateFunction()
-    {
-        assertQuerySucceeds("CREATE FUNCTION unittest.memory.tan (x int) RETURNS double COMMENT 'tangent trigonometric function' LANGUAGE SQL DETERMINISTIC CALLED ON NULL INPUT RETURN sin(x) / cos(x)");
-        MaterializedResult actual = computeActual("select unittest.memory.tan(5)");
-        assertEquals("-3.380515006246586", actual.getOnlyValue().toString());
-        //PoS currently supports one query per session. So temporary function created is not discoverable by another query.
-        assertQuerySucceeds("CREATE TEMPORARY FUNCTION foo() RETURNS int RETURN 1");
-    }
-
-    @Test
     public void testCreateType()
     {
         assertQuerySucceeds("CREATE TYPE unittest.memory.num AS integer");


### PR DESCRIPTION
This feature was broken by https://github.com/prestodb/presto/pull/16699, which no longer added the new temporary functions to the QueryStateMachine.  It has been completely broken since release 0.269.  This commit basically reverts those changes for CREATE/DROP FUNCTION.

Test plan - fixed unit tests and also tested locally with the CLI 
```
presto> CREATE TEMPORARY FUNCTION foo() RETURNS int RETURN 1;
CREATE FUNCTION
presto> SELECT foo();
 _col0 
-------
     1 
(1 row)

presto> CREATE TEMPORARY FUNCTION foo() RETURNS int RETURN 1;
Query 20230418_200502_00002_qud78 failed: Session function presto.session.foo() has already been defined
presto> DROP TEMPORARY FUNCTION foo;
DROP FUNCTION
presto> CREATE TEMPORARY FUNCTION foo() RETURNS int RETURN 1;
CREATE FUNCTION


```

```
== RELEASE NOTES ==

General Changes
* Fix ``CREATE TEMPORARY FUNCTION`` and ``DROP TEMPORARY FUNCTION``, which have not worked since release 0.269.  This also removes ``CREATE FUNCTION`` and ``DROP FUNCTION`` support from Presto-on-Spark
```