### PR TITLE
[native] Fix access of MemoryPool crash in HttpClient

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -23,6 +23,7 @@
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/StatsReporter.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Operator.h"
 
 using namespace facebook::velox;
@@ -106,9 +107,11 @@ void PrestoExchangeSource::doRequest() {
       .method(proxygen::HTTPMethod::GET)
       .url(path)
       .header(protocol::PRESTO_MAX_SIZE_HTTP_HEADER, "32MB")
-      .send(httpClient_.get(), pool_)
+      .send(httpClient_.get(), pool_.get())
       .via(driverCPUExecutor())
       .thenValue([path, self](std::unique_ptr<http::HttpResponse> response) {
+        velox::common::testutil::TestValue::adjust(
+            "facebook::presto::PrestoExchangeSource::doRequest", self.get());
         auto* headers = response->headers();
         if (headers->getStatusCode() != http::kHttpOk &&
             headers->getStatusCode() != http::kHttpNoContent) {
@@ -133,6 +136,13 @@ void PrestoExchangeSource::doRequest() {
 
 void PrestoExchangeSource::processDataResponse(
     std::unique_ptr<http::HttpResponse> response) {
+  if (closed_.load()) {
+    // If PrestoExchangeSource is already closed, just free all buffers
+    // allocated without doing any processing. This can happen when a super slow
+    // response comes back after its owning 'Task' gets destroyed.
+    response->freeBuffers();
+    return;
+  }
   auto* headers = response->headers();
   VELOX_CHECK(
       !headers->getIsChunked(),
@@ -262,7 +272,7 @@ void PrestoExchangeSource::acknowledgeResults(int64_t ackSequence) {
   http::RequestBuilder()
       .method(proxygen::HTTPMethod::GET)
       .url(ackPath)
-      .send(httpClient_.get(), pool_)
+      .send(httpClient_.get(), pool_.get())
       .via(driverCPUExecutor())
       .thenValue([self](std::unique_ptr<http::HttpResponse> response) {
         VLOG(1) << "Ack " << response->headers()->getStatusCode();
@@ -281,7 +291,7 @@ void PrestoExchangeSource::abortResults() {
   http::RequestBuilder()
       .method(proxygen::HTTPMethod::DELETE)
       .url(basePath_)
-      .send(httpClient_.get(), pool_)
+      .send(httpClient_.get(), pool_.get())
       .via(driverCPUExecutor())
       .thenValue([queue, self](std::unique_ptr<http::HttpResponse> response) {
         auto statusCode = response->headers()->getStatusCode();

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -104,6 +104,15 @@ void HttpResponse::append(std::unique_ptr<folly::IOBuf>&& iobuf) {
   bodyChain_.back()->trimEnd(roundedSize - dataLength);
 }
 
+void HttpResponse::freeBuffers() {
+  for (auto& iobuf : bodyChain_) {
+    if (iobuf != nullptr) {
+      pool_->free(iobuf->writableData(), iobuf->capacity());
+    }
+  }
+  bodyChain_.clear();
+}
+
 FOLLY_ALWAYS_INLINE size_t
 HttpResponse::nextAllocationSize(uint64_t dataLength) const {
   const size_t minAllocSize = velox::bits::nextPowerOfTwo(

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -70,6 +70,8 @@ class HttpResponse {
     return std::move(bodyChain_);
   }
 
+  void freeBuffers();
+
   std::string dumpBodyChain() const;
 
  private:
@@ -78,15 +80,6 @@ class HttpResponse {
     VELOX_CHECK(!hasError())
     error_ = exception.what();
     freeBuffers();
-  }
-
-  void freeBuffers() {
-    for (auto& iobuf : bodyChain_) {
-      if (iobuf != nullptr) {
-        pool_->free(iobuf->writableData(), iobuf->capacity());
-      }
-    }
-    bodyChain_.clear();
   }
 
   // Returns the next buffer allocation size given the new request 'dataLength'.

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -41,7 +41,7 @@ void UnsafeRowExchangeSource::request() {
       // 'ioBuf' attached to SerializedPage on destruction.
       queue_->enqueueLocked(
           std::make_unique<velox::exec::SerializedPage>(
-              std::move(ioBuf), pool_, [buffer](auto&) {}),
+              std::move(ioBuf), pool_.get(), [buffer](auto&) {}),
           promises);
     }
   }

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -24,10 +24,12 @@
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/testutil/TestValue.h"
 
 using namespace facebook::presto;
 using namespace facebook::velox;
 using namespace facebook::velox::memory;
+using namespace facebook::velox::common::testutil;
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
@@ -79,7 +81,7 @@ class Producer {
             auto [promise, future] = folly::makePromiseContract<bool>();
 
             std::move(future)
-                .via(folly::EventBaseManager().getEventBase())
+                .via(folly::EventBaseManager::get()->getEventBase())
                 .thenValue([this, downstream, taskId, sequence](
                                bool /*value*/) {
                   auto [data, noMoreData] = getData(sequence);
@@ -188,6 +190,10 @@ class Producer {
     }
 
     std::move(future).get(std::chrono::microseconds(120'000));
+  }
+
+  folly::Promise<bool>& promise() {
+    return promise_;
   }
 
  private:
@@ -303,10 +309,12 @@ class PrestoExchangeSourceTest : public testing::Test {
     options.capacity = 1L << 30;
     allocator_ = std::make_unique<memory::MmapAllocator>(options);
     memory::MemoryAllocator::setDefaultInstance(allocator_.get());
+    TestValue::enable();
   }
 
   void TearDown() override {
     memory::MemoryAllocator::setDefaultInstance(nullptr);
+    TestValue::disable();
   }
 
   void requestNextPage(
@@ -430,6 +438,61 @@ TEST_F(PrestoExchangeSourceTest, slowProducer) {
   producer->waitForDeleteResults();
   serverWrapper.stop();
   EXPECT_EQ(pool_->getCurrentBytes(), 0);
+}
+
+TEST_F(PrestoExchangeSourceTest, slowProducerAndEarlyTerminatingConsumer) {
+  std::atomic<bool> codePointHit{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::presto::PrestoExchangeSource::doRequest",
+      std::function<void(const PrestoExchangeSource*)>(
+          ([&](const auto* prestoExchangeSource) {
+            codePointHit = true;
+          })));
+  auto producer = std::make_unique<Producer>();
+
+  auto producerServer = std::make_unique<http::HttpServer>(
+      std::make_unique<http::HttpConfig>(folly::SocketAddress("127.0.0.1", 0)));
+  producer->registerEndpoints(producerServer.get());
+
+  test::HttpServerWrapper serverWrapper(std::move(producerServer));
+  auto producerAddress = serverWrapper.start().get();
+
+  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  queue->addSourceLocked();
+  queue->noMoreSources();
+  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
+      makeProducerUri(producerAddress), 3, queue, pool_.get());
+
+  requestNextPage(queue, exchangeSource);
+
+  // Simulation of an early destruction of 'Task' will release following
+  // resources, including pool_
+  exchangeSource->close();
+  queue->close();
+  exchangeSource.reset();
+  queue.reset();
+  pool_.reset();
+
+  // We want to wait a bit on the promise state to be valid. That way we are
+  // sure getResults() on the server side (producer) goes into empty data
+  // condition because we did not enqueue any data in producer yet. This allows
+  // us to have full control to simulate a super late response return by
+  // enqueuing a result afterwards.
+  while (!producer->promise().valid()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  // We shall not crash here when response comes back super late.
+  producer->enqueue("I'm a super slow response");
+
+  // We need to wait a bit for response handling mechanism to happen in the
+  // background. There is no way to know where we are for response handling as
+  // all resources have been cleaned up, so explicitly waiting is the only way
+  // to allow the execution of background processing. We expect the test to not
+  // crash.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_TRUE(codePointHit);
+  serverWrapper.stop();
 }
 
 TEST_F(PrestoExchangeSourceTest, failedProducer) {


### PR DESCRIPTION
The following event sequence can lead to a crash:
1. An HTTP request was sent out from PrestoExchangeSource of a task.
2. The task got cancelled or aborted due to any reasons. And in turn cleaned up.
3. Response of that HTTP request in 1 returned and uses the original task's ExchangeClient's MemoryPool to do work.
4. Crash happened because the MemoryPool was already cleaned up.

The solution is to change raw pointer in ExchangeSource to shared_ptr such that they have a shared ownership and will always be a valid pointer.

```
== NO RELEASE NOTE ==
```
