### PR TITLE
[native] Allow ShuffleRead/Write to report runtime statistics

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -84,13 +84,15 @@ class LocalPersistentShuffleWriter : public ShuffleWriter {
 
   void noMoreData(bool success) override;
 
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    // Fake counter for testing only.
+    return {{"local.write", 2345}};
+  }
+
  private:
   // Finds and creates the next file for writing the next block of the
   // given 'partition'.
   std::unique_ptr<velox::WriteFile> getNextOutputFile(int32_t partition);
-
-  // Returns the number of stored files for a given partition.
-  int getWritePartitionFilesCount(int32_t partition) const;
 
   // Writes the in-progress block to the given partition.
   void storePartitionBlock(int32_t partition);
@@ -131,6 +133,11 @@ class LocalPersistentShuffleReader : public ShuffleReader {
   bool hasNext() override;
 
   velox::BufferPtr next(bool success) override;
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    // Fake counter for testing only.
+    return {{"local.read", 123}};
+  }
 
  private:
   // Returns all created shuffle files for 'partition_'.

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -28,6 +28,9 @@ class ShuffleWriter {
   /// Tell the shuffle system the writer is done.
   /// @param success set to false to indicate aborted client.
   virtual void noMoreData(bool success) = 0;
+
+  /// Runtime statistics.
+  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
 };
 
 class ShuffleReader {
@@ -40,6 +43,9 @@ class ShuffleReader {
   /// Read the next block of data.
   /// @param success set to false to indicate aborted client.
   virtual velox::BufferPtr next(bool success) = 0;
+
+  /// Runtime statistics.
+  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
 };
 
 class ShuffleInterfaceFactory {

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -63,6 +63,13 @@ class ShuffleWriteOperator : public Operator {
   void noMoreInput() override {
     Operator::noMoreInput();
     shuffle_->noMoreData(true);
+
+    {
+      auto lockedStats = stats_.wlock();
+      for (const auto& [name, value] : shuffle_->stats()) {
+        lockedStats->runtimeStats[name] = RuntimeMetric(value);
+      }
+    }
   }
 
   RowVectorPtr getOutput() override {

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -51,6 +51,10 @@ void UnsafeRowExchangeSource::request() {
   }
 }
 
+folly::F14FastMap<std::string, int64_t> UnsafeRowExchangeSource::stats() const {
+  return shuffle_->stats();
+}
+
 namespace {
 std::optional<std::string> getSerializedShuffleInfo(folly::Uri& uri) {
   for (auto& pair : uri.getQueryParams()) {

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.h
@@ -38,9 +38,7 @@ class UnsafeRowExchangeSource : public velox::exec::ExchangeSource {
 
   void close() override {}
 
-  folly::F14FastMap<std::string, int64_t> stats() const override {
-    return {{"unsafeRowExchangeSource.numBatches", numBatches_}};
-  }
+  folly::F14FastMap<std::string, int64_t> stats() const override;
 
   /// url needs to follow below format:
   /// batch://<taskid>?shuffleInfo=<serialized-shuffle-info>


### PR DESCRIPTION
Extend ShuffleRead and ShuffleWrite APIs to allow for reporting of runtime statistics as named 64-bit counters. These appear as runtime stats of the ShuffleWrite and Exchange operators after being aggregated using sum, min and max.

Depends on https://github.com/facebookincubator/velox/pull/4685

```
== NO RELEASE NOTE ==
```
