### PR TITLE
[native] Fix cipher parameter passing in exchange source.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -333,7 +333,7 @@ PrestoExchangeSource::createExchangeSource(
     const auto systemConfig = SystemConfig::instance();
     const auto clientCertAndKeyPath =
         systemConfig->httpsClientCertAndKeyPath().value_or("");
-    const auto ciphers = systemConfig->httpsClientCertAndKeyPath().value_or("");
+    const auto ciphers = systemConfig->httpsSupportedCiphers();
     return std::make_unique<PrestoExchangeSource>(
         folly::Uri(url),
         destination,

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -141,7 +141,7 @@ class SystemConfig : public ConfigBase {
   static constexpr int32_t kHttpExecThreadsDefault = 8;
   static constexpr bool kHttpServerHttpsEnabledDefault = false;
   static constexpr std::string_view kHttpsSupportedCiphersDefault{
-      "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384"};
+      "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384"};
   static constexpr int32_t kNumIoThreadsDefault = 30;
   static constexpr int32_t kShutdownOnsetSecDefault = 10;
   static constexpr int32_t kSystemMemoryGbDefault = 40;
@@ -174,13 +174,12 @@ class SystemConfig : public ConfigBase {
 
   // A list of ciphers (comma separated) that are supported by
   // server and client. Note Java and folly::SSLContext use different names to
-  // refer to the same cipher. (guess for different name, Java specific
-  // authentication, key exchange and cipher together and folly just cipher).
-  // For e.g. TLS_RSA_WITH_AES_256_GCM_SHA384 in Java and AES256-GCM-SHA384 in
-  // folly::SSLContext. The ciphers need to enable worker to worker, worker to
-  // coordinator and coordinator to worker communication. Have at least one
-  // cipher suite that is shared for the above 3, otherwise weird failures will
-  // result.
+  // refer to the same cipher. For e.g. TLS_RSA_WITH_AES_256_GCM_SHA384 in Java
+  // and AES256-GCM-SHA384 in folly::SSLContext. More details can be found here:
+  // https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html. The
+  // ciphers enable worker to worker, worker to coordinator and
+  // coordinator to worker communication. At least one cipher needs to be
+  // shared for the above 3 communication to work.
   std::string httpsSupportedCiphers() const;
 
   // Note: Java packages cert and key in combined JKS file. But CPP requires


### PR DESCRIPTION
While creating exchange source,  we are passing cert key path as cipher parameter. We fixed the issue here, and it was introduced in https://github.com/prestodb/presto/pull/19392. We are working to run PrestoExchange, Announcer and overall e2e tests to run with https mode, which would catch this. Those will take some time due to additional re-factor complexity, by that time this fix will keep the master branch good.

```
== NO RELEASE NOTE ==
```
