### PR TITLE
Fix access of MemoryPool crash in HttpClient (#4706)

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -104,6 +104,15 @@ void HttpResponse::append(std::unique_ptr<folly::IOBuf>&& iobuf) {
   bodyChain_.back()->trimEnd(roundedSize - dataLength);
 }
 
+void HttpResponse::freeBuffers() {
+  for (auto& iobuf : bodyChain_) {
+    if (iobuf != nullptr) {
+      pool_->free(iobuf->writableData(), iobuf->capacity());
+    }
+  }
+  bodyChain_.clear();
+}
+
 FOLLY_ALWAYS_INLINE size_t
 HttpResponse::nextAllocationSize(uint64_t dataLength) const {
   const size_t minAllocSize = velox::bits::nextPowerOfTwo(

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -70,6 +70,8 @@ class HttpResponse {
     return std::move(bodyChain_);
   }
 
+  void freeBuffers();
+
   std::string dumpBodyChain() const;
 
  private:
@@ -78,15 +80,6 @@ class HttpResponse {
     VELOX_CHECK(!hasError())
     error_ = exception.what();
     freeBuffers();
-  }
-
-  void freeBuffers() {
-    for (auto& iobuf : bodyChain_) {
-      if (iobuf != nullptr) {
-        pool_->free(iobuf->writableData(), iobuf->capacity());
-      }
-    }
-    bodyChain_.clear();
   }
 
   // Returns the next buffer allocation size given the new request 'dataLength'.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/4706

The following event sequence can lead to a crash:
1. An HTTP request was sent out from PrestoExchangeSource of a task.
2. The task got cancelled or aborted due to any reasons. And in turn cleaned up.
3. Response of that HTTP request in 1 returned and uses the original task's ExchangeClient's MemoryPool to do work.
4. Crash happened because the MemoryPool was already cleaned up.

The solution is to change raw pointer in ExchangeSource to shared_ptr such that they have a shared ownership and will always be a valid pointer.

```
== NO RELEASE NOTE ==
```

Pull Request resolved: https://github.com/prestodb/presto/pull/19433

Reviewed By: xiaoxmeng, amitkdutta, spershin

Differential Revision: D45203187

Pulled By: tanjialiang

