### PR TITLE
[native] Make presto exchange tests work in http and https mode.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -372,4 +372,9 @@ void PrestoExchangeSource::getMemoryUsage(
   currentBytes = currQueuedMemoryBytes();
   peakBytes = peakQueuedMemoryBytes();
 }
+
+void PrestoExchangeSource::testingClearMemoryUsage() {
+  currQueuedMemoryBytes() = 0;
+  peakQueuedMemoryBytes() = 0;
+}
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -58,6 +58,9 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   /// PrestoExchangeSource.
   static void getMemoryUsage(int64_t& currentBytes, int64_t& peakBytes);
 
+  /// Used by test to clear the node-wise memory usage tracking.
+  static void testingClearMemoryUsage();
+
  private:
   void request() override;
 


### PR DESCRIPTION
Making presto exchange tests work in both http and https mode. Added a memory cleanup function in exchange which is required to run tests multiple times.

```
== NO RELEASE NOTE ==
```
