### PR TITLE
Filter Hudi partitions from metastore based on constraint predicate

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -101,6 +101,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -606,6 +607,17 @@ public final class HiveUtil
     public static NullableValue parsePartitionValue(HivePartitionKey key, Type type, DateTimeZone timeZone)
     {
         return parsePartitionValue(key.getName(), key.getValue().orElse(HIVE_DEFAULT_DYNAMIC_PARTITION), type, timeZone);
+    }
+
+    public static NullableValue parsePartitionValue(String partitionName, String value, Type type, ZoneId hiveStorageTimeZoneId)
+    {
+        requireNonNull(hiveStorageTimeZoneId, "hiveStorageTimeZoneId is null");
+        return parsePartitionValue(partitionName, value, type, getDateTimeZone(hiveStorageTimeZoneId));
+    }
+
+    private static DateTimeZone getDateTimeZone(ZoneId hiveStorageTimeZoneId)
+    {
+        return DateTimeZone.forID(hiveStorageTimeZoneId.getId());
     }
 
     public static NullableValue parsePartitionValue(String partitionName, String value, Type type, DateTimeZone timeZone)

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -170,6 +170,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-metastore</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -106,7 +106,7 @@ public class HudiSplitManager
 
         // Retrieve and prune partitions
         HoodieTimer timer = new HoodieTimer().startTimer();
-        List<String> partitions = hudiPartitionManager.getEffectivePartitions(session, metastore, table.getSchemaName(), table.getTableName(), layout.getTupleDomain());
+        List<String> partitions = hudiPartitionManager.getEffectivePartitions(session, metastore, table.getSchemaTableName(), layout.getTupleDomain());
         log.debug("Took %d ms to get %d partitions", timer.endTimer(), partitions.size());
         if (partitions.isEmpty()) {
             return new FixedSplitSource(ImmutableList.of());

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiIntegration.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiIntegration.java
@@ -15,10 +15,13 @@
 package com.facebook.presto.hudi;
 
 import com.facebook.presto.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static com.facebook.presto.hudi.HudiQueryRunner.createHudiQueryRunner;
+import static java.lang.String.format;
 
 public class TestHudiIntegration
         extends com.facebook.presto.hive.hudi.TestHudiIntegration
@@ -28,5 +31,15 @@ public class TestHudiIntegration
             throws Exception
     {
         return createHudiQueryRunner(Optional.empty());
+    }
+
+    @Test
+    public void testQueryWithPartitionFilter()
+    {
+        @Language("SQL") String sqlTemplate = "SELECT symbol, ts, dt FROM %s WHERE symbol = 'GOOG' AND dt > '2018-08-30'";
+        @Language("SQL") String sqlResult = "SELECT * FROM VALUES " +
+                "('GOOG', '2018-08-31 09:59:00', '2018-08-31')," +
+                "('GOOG', '2018-08-31 10:59:00', '2018-08-31')";
+        assertQuery(format(sqlTemplate, "stock_ticks_cow"), sqlResult);
     }
 }

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiPartitionManager.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestHudiPartitionManager.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi;
+
+import com.facebook.presto.cache.CacheConfig;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.hive.HiveBucketProperty;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.OrcFileWriterConfig;
+import com.facebook.presto.hive.ParquetFileWriterConfig;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.PrestoTableType;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
+import static com.facebook.presto.hive.HiveColumnHandle.MAX_PARTITION_KEY_COLUMN_INDEX;
+import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+public class TestHudiPartitionManager
+{
+    private static final String SCHEMA_NAME = "schema";
+    private static final String TABLE_NAME = "table";
+    private static final String USER_NAME = "user";
+    private static final String LOCATION = "somewhere/over/the/rainbow";
+    private static final Column PARTITION_COLUMN = new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty());
+    private static final Column BUCKET_COLUMN = new Column("c1", HIVE_INT, Optional.empty(), Optional.empty());
+    private static final Table TABLE = new Table(
+            SCHEMA_NAME,
+            TABLE_NAME,
+            USER_NAME,
+            PrestoTableType.MANAGED_TABLE,
+            new Storage(fromHiveStorageFormat(PARQUET),
+                    LOCATION,
+                    Optional.of(new HiveBucketProperty(
+                            ImmutableList.of(BUCKET_COLUMN.getName()),
+                            100,
+                            ImmutableList.of(),
+                            HIVE_COMPATIBLE,
+                            Optional.empty())),
+                    false,
+                    ImmutableMap.of(),
+                    ImmutableMap.of()),
+            ImmutableList.of(BUCKET_COLUMN),
+            ImmutableList.of(PARTITION_COLUMN),
+            ImmutableMap.of(),
+            Optional.empty(),
+            Optional.empty());
+
+    private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");
+    private final HudiPartitionManager hudiPartitionManager = new HudiPartitionManager(new TestingTypeManager());
+    private final TestingExtendedHiveMetastore metastore = new TestingExtendedHiveMetastore(TABLE, PARTITIONS);
+
+    @Test
+    public void testParseValuesAndFilterPartition()
+    {
+        ConnectorSession session = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig().setMaxBucketsForGroupedExecution(100),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig(),
+                        new CacheConfig()).getSessionProperties());
+        TupleDomain<ColumnHandle> constraintSummary = TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        new HudiColumnHandle(
+                                MAX_PARTITION_KEY_COLUMN_INDEX,
+                                PARTITION_COLUMN.getName(),
+                                PARTITION_COLUMN.getType(),
+                                Optional.empty(),
+                                HudiColumnHandle.ColumnType.PARTITION_KEY),
+                        Domain.singleValue(VARCHAR, utf8Slice("2019-07-23"))));
+        List<String> actualPartitions = hudiPartitionManager.getEffectivePartitions(
+                session,
+                metastore,
+                new SchemaTableName(SCHEMA_NAME, TABLE_NAME),
+                constraintSummary);
+        assertEquals(actualPartitions, ImmutableList.of("ds=2019-07-23"));
+    }
+}

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingExtendedHiveMetastore.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingExtendedHiveMetastore.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.UnimplementedHiveMetastore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingExtendedHiveMetastore
+        extends UnimplementedHiveMetastore
+{
+    private final Table table;
+    private final List<String> partitions;
+
+    public TestingExtendedHiveMetastore(Table table, List<String> partitions)
+    {
+        this.table = requireNonNull(table, "table is null");
+        this.partitions = requireNonNull(partitions, "partitions is null");
+    }
+
+    @Override
+    public Optional<Table> getTable(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        return Optional.of(table);
+    }
+
+    @Override
+    public List<String> getPartitionNamesByFilter(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        return partitions;
+    }
+}

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingTypeManager.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingTypeManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hudi;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestingTypeManager
+        implements TypeManager
+{
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        for (Type type : getTypes()) {
+            if (signature.getBase().equals(type.getTypeSignature().getBase())) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
+    public boolean canCoerce(Type actualType, Type expectedType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private List<Type> getTypes()
+    {
+        return ImmutableList.of(BOOLEAN, INTEGER, BIGINT, DOUBLE, VARCHAR, VARBINARY, TIMESTAMP, DATE, HYPER_LOG_LOG);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/hudi/issues/8485

Test plan - (Please fill in how you tested your changes)

- Added a unit test.
- Tested a query with `>=` partition predicate and compared plans (check number of rows in `Fragment 2` in the below plans).

Query: `select count(1) from inventory where inv_date_sk>=2451676;`

Before this fix:
```
 Fragment 1 [SINGLE]
     CPU: 103.25ms, Scheduled: 194.86ms, Input: 261 rows (2.29kB); per task: avg.: 261.00 std.dev.: 0.00, Output: 1 row (9B)
     Output layout: [count]
     Output partitioning: SINGLE []
     Stage Execution Strategy: UNGROUPED_EXECUTION
     - Aggregate(FINAL) => [count:bigint]
             CPU: 9.00ms (0.46%), Scheduled: 11.00ms (0.03%), Output: 1 row (9B)
             Input avg.: 261.00 rows, Input std.dev.: 0.00%
             count := "presto.default.count"((count_4)) (1:24)
         - LocalExchange[SINGLE] () => [count_4:bigint]
                 CPU: 17.00ms (0.86%), Scheduled: 19.00ms (0.05%), Output: 261 rows (2.29kB)
                 Input avg.: 16.31 rows, Input std.dev.: 245.74%
             - RemoteSource[2] => [count_4:bigint]
                     CPU: 18.00ms (0.91%), Scheduled: 60.00ms (0.15%), Output: 261 rows (2.29kB)
                     Input avg.: 16.31 rows, Input std.dev.: 245.74%

 Fragment 2 [SOURCE]
     CPU: 1.96s, Scheduled: 31.81s, Input: 11745000 rows (4.08MB); per task: avg.: 11745000.00 std.dev.: 0.00, Output: 261 rows (2.29kB)
     Output layout: [count_4]
     Output partitioning: SINGLE []
     Stage Execution Strategy: UNGROUPED_EXECUTION
     - Aggregate(PARTIAL) => [count_4:bigint]
             CPU: 197.00ms (9.99%), Scheduled: 220.00ms (0.55%), Output: 261 rows (2.29kB)
             Input avg.: 23793.10 rows, Input std.dev.: 94.41%
             count_4 := "presto.default.count"(*) (1:24)
         - ScanFilterProject[table = TableHandle {connectorId='hudi', connectorHandle='default.inventory', layout='Optional[default.inventory]'}, grouped = false, filterPredicate = (inv_date_sk) >= (INTEGER'2451676'), projectLocality = LOCAL] => []
                 CPU: 1.73s (87.77%), Scheduled: 39.99s (99.23%), Output: 6210000 rows (0B)
                 Input avg.: 45000.00 rows, Input std.dev.: 0.00%
                 inv_date_sk := -13:inv_date_sk:int:PARTITION_KEY (1:38)
                 Input: 11745000 rows (4.08MB), Filtered: 47.13%
```
After the fix:
```
 Fragment 1 [SINGLE]
     CPU: 70.04ms, Scheduled: 914.23ms, Input: 138 rows (1.21kB); per task: avg.: 138.00 std.dev.: 0.00, Output: 1 row (9B)
     Output layout: [count]
     Output partitioning: SINGLE []
     Stage Execution Strategy: UNGROUPED_EXECUTION
     - Aggregate(FINAL) => [count:bigint]
             CPU: 7.00ms (0.26%), Scheduled: 104.00ms (0.42%), Output: 1 row (9B)
             Input avg.: 138.00 rows, Input std.dev.: 0.00%
             count := "presto.default.count"((count_4)) (1:24)
         - LocalExchange[SINGLE] () => [count_4:bigint]
                 CPU: 12.00ms (0.45%), Scheduled: 58.00ms (0.23%), Output: 138 rows (1.21kB)
                 Input avg.: 8.63 rows, Input std.dev.: 174.29%
             - RemoteSource[2] => [count_4:bigint]
                     CPU: 15.00ms (0.56%), Scheduled: 196.00ms (0.78%), Output: 138 rows (1.21kB)
                     Input avg.: 8.63 rows, Input std.dev.: 174.29%

 Fragment 2 [SOURCE]
     CPU: 2.68s, Scheduled: 21.44s, Input: 6210000 rows (2.16MB); per task: avg.: 6210000.00 std.dev.: 0.00, Output: 138 rows (1.21kB)
     Output layout: [count_4]
     Output partitioning: SINGLE []
     Stage Execution Strategy: UNGROUPED_EXECUTION
     - Aggregate(PARTIAL) => [count_4:bigint]
             CPU: 197.00ms (9.99%), Scheduled: 220.00ms (0.55%), Output: 261 rows (2.29kB)
             Input avg.: 23793.10 rows, Input std.dev.: 94.41%
             count_4 := "presto.default.count"(*) (1:24)
         - TableScan[TableHandle {connectorId='hudi', connectorHandle='default.inventory', layout='Optional[default.inventory]'}, layout='Optional[default.inventory{domains={inv_date_sk=[ [["2451676", <max>)] ]}}]
                 CPU: 1.32s (49.44%), Scheduled: 21.21s (84.75%), Output: 6210000 rows (0B)
                 Input avg.: 45000.00 rows, Input std.dev.: 0.00%
                 LAYOUT: default.inventory{domains={inv_date_sk=[ [["2451676", <max>)] ]}}
                 inv_date_sk:int:-13:PARTITION_KEY:: [["2451676", "2452635"]]
                 Input: 6210000 rows (2.16MB), Filtered: 0.00%
```
== RELEASE NOTES ==

```
== NO RELEASE NOTE ==
```
