### PR TITLE
Fix reading HUDI MOR Bootstrap tables in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static com.facebook.presto.hive.HiveUtil.isHudiRealtimeSplit;
 import static java.util.Objects.requireNonNull;
 
 public class GenericHiveRecordCursorProvider
@@ -62,7 +61,7 @@ public class GenericHiveRecordCursorProvider
         // make sure the FileSystem is created with the proper Configuration object
         Path path = new Path(fileSplit.getPath());
         try {
-            if (!fileSplit.getCustomSplitInfo().isEmpty() && isHudiRealtimeSplit(fileSplit.getCustomSplitInfo())) {
+            if (!fileSplit.getCustomSplitInfo().isEmpty()) {
                 if (configuration instanceof HiveCachingHdfsConfiguration.CachingJobConf) {
                     configuration = ((HiveCachingHdfsConfiguration.CachingJobConf) configuration).getConfig();
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
-import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -254,7 +253,7 @@ public final class HiveUtil
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, getInputFormatName(schema), true);
         JobConf jobConf = toJobConf(configuration);
         FileSplit fileSplit = new FileSplit(path, start, length, (String[]) null);
-        if (!customSplitInfo.isEmpty() && isHudiRealtimeSplit(customSplitInfo)) {
+        if (!customSplitInfo.isEmpty()) {
             fileSplit = recreateSplitWithCustomInfo(fileSplit, customSplitInfo);
 
             // Add additional column information for record reader
@@ -308,12 +307,6 @@ public final class HiveUtil
                     firstNonNull(e.getMessage(), e.getClass().getName())),
                     e);
         }
-    }
-
-    public static boolean isHudiRealtimeSplit(Map<String, String> customSplitInfo)
-    {
-        String customSplitClass = customSplitInfo.get(CUSTOM_FILE_SPLIT_CLASS_KEY);
-        return HoodieRealtimeFileSplit.class.getName().equals(customSplitClass);
     }
 
     public static void setReadColumns(Configuration configuration, List<Integer> readHiveColumnIndexes)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeBootstrapBaseFileSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeBootstrapBaseFileSplitConverter.java
@@ -36,12 +36,12 @@ import static java.util.Objects.requireNonNull;
 public class HudiRealtimeBootstrapBaseFileSplitConverter
         implements CustomSplitConverter
 {
-    private static final String DELTA_FILE_PATHS_KEY = "delta_file_paths";
-    private static final String BASE_PATH_KEY = "base_path";
-    private static final String MAX_COMMIT_TIME_KEY = "max_commit_time";
-    private static final String BOOTSTRAP_FILE_SPLIT_PATH = "bootstrap_split_path";
-    private static final String BOOTSTRAP_FILE_SPLIT_START = "bootstrap_split_start";
-    private static final String BOOTSTRAP_FILE_SPLIT_LEN = "bootstrap_split_len";
+    public static final String DELTA_FILE_PATHS_KEY = "delta_file_paths";
+    public static final String BASE_PATH_KEY = "base_path";
+    public static final String MAX_COMMIT_TIME_KEY = "max_commit_time";
+    public static final String BOOTSTRAP_FILE_SPLIT_PATH = "bootstrap_split_path";
+    public static final String BOOTSTRAP_FILE_SPLIT_START = "bootstrap_split_start";
+    public static final String BOOTSTRAP_FILE_SPLIT_LEN = "bootstrap_split_len";
 
     @Override
     public Optional<Map<String, String>> extractCustomSplitInfo(FileSplit split)


### PR DESCRIPTION
1. Removed  `isHudiRealtimeSplit(customSplitInfo)` condition in HiveUtil.java to support additional custom Hudi splits- BootstrapBaseFileSplit and RealtimeBootstrapBaseFileSplit. In general, any custom split if present should go through this conversion irrespective.
2. A new copy of JobConf is created in the case of BootstrapBaseFileSplit https://github.com/apache/hudi/blob/master/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java#L132, so we need to pass the actual config for copying to work correctly. More info #18911 .

```
== NO RELEASE NOTE ==
```
