### PR TITLE
[spark] Enable Presto native integration tests for Spark

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeAggregations;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public class TestPrestoSparkNativeAggregations
+        extends AbstractTestNativeAggregations
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    @Override
+    @Ignore
+    public void testChecksum() {}
+
+    @Override
+    @Ignore
+    public void testMinMax() {}
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeArrayFunctionQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoSparkNativeArrayFunctionQueries
+        extends AbstractTestNativeArrayFunctionQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeBitwiseFunctionQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoSparkNativeBitwiseFunctionQueries
+        extends AbstractTestNativeBitwiseFunctionQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeGeneralQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public class TestPrestoSparkNativeGeneralQueries
+        extends AbstractTestNativeGeneralQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    @Override
+    @Ignore
+    public void testBinaryFunctions() {}
+
+    @Override
+    @Ignore
+    public void testBucketedExecution() {}
+
+    @Override
+    @Ignore
+    public void testCast() {}
+
+    @Override
+    @Ignore
+    public void testCatalogWithCacheEnabled() {}
+
+    @Override
+    @Ignore
+    public void testCreateUnpartitionedTableAsSelect() {}
+
+    @Override
+    @Ignore
+    public void testInformationSchemaTables() {}
+
+    @Override
+    @Ignore
+    public void testOrderBy() {}
+
+    @Override
+    @Ignore
+    public void testShowAndDescribe() {}
+
+    @Override
+    @Ignore
+    public void testSubqueries() {}
+
+    @Override
+    @Ignore
+    public void testTopN() {}
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeJoinQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public class TestPrestoSparkNativeJoinQueries
+        extends AbstractTestNativeJoinQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    @Override
+    @Ignore
+    public void testAntiJoin() {}
+
+    @Override
+    @Ignore
+    public void testBucketedInnerJoin() {}
+
+    @Override
+    @Ignore
+    public void testCrossJoin() {}
+
+    @Override
+    @Ignore
+    public void testInnerJoin() {}
+
+    @Override
+    @Ignore
+    public void testMergeJoin() {}
+
+    @Override
+    @Ignore
+    public void testSemiJoin() {}
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -18,30 +18,6 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
-/**
- * Following JVM argument is needed to run Spark native tests.
- * <p>
- * - PRESTO_SERVER
- * - This tells Spark where to find the Presto native binary to launch the process.
- * Example: -DPRESTO_SERVER=/path/to/native/process/bin
- * <p>
- * - DATA_DIR
- * - Optional path to store TPC-H tables used in the test. If this directory is empty, it will be
- * populated. If tables already exists, they will be reused.
- * <p>
- * Tests can be running in Interactive Debugging Mode that allows for easier debugging
- * experience. Instead of launching its own native process, the test will connect to an existing
- * native process. This gives developers flexibility to connect IDEA and debuggers to the native process.
- * Enable this mode by setting NATIVE_PORT JVM argument.
- * <p>
- * - NATIVE_PORT
- * - This is the port your externally launched native process listens to. It is used to tell Spark where to send
- * requests. This port number has to be the same as to which your externally launched process listens.
- * Example: -DNATIVE_PORT=7777.
- * When NATIVE_PORT is specified, PRESTO_SERVER argument is not requires and is ignored if specified.
- * <p>
- * For test queries requiring shuffle, the disk-based local shuffle will be used.
- */
 public class TestPrestoSparkNativeSimpleQueries
         extends AbstractTestQueryFramework
 {

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeTpchConnectorQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public class TestPrestoSparkNativeTpchConnectorQueries
+        extends AbstractTestNativeTpchConnectorQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    @Override
+    @Ignore
+    public void testMissingTpchConnector() {}
+
+    @Override
+    @Ignore
+    public void testTpchDateFilter() {}
+
+    @Override
+    @Ignore
+    public void testTpchTinyTables() {}
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeTpchQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public class TestPrestoSparkNativeTpchQueries
+        extends AbstractTestNativeTpchQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    @Override
+    @Ignore
+    public void testTpchQ1() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ7() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ8() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ11() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ12() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ14() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ15() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ18() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ20() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ21() {}
+
+    @Override
+    @Ignore
+    public void testTpchQ22() {}
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.nativeworker.AbstractTestNativeWindowQueries;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoSparkNativeWindowQueries
+        extends AbstractTestNativeWindowQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void assertQuery(String sql)
+    {
+        super.assertQuery(sql);
+        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
+    }
+}


### PR DESCRIPTION
* Disables the ones that are not currently supported by Presto-on-Spark
* Reduces log levels during test runs to prevent log spamming

```
== NO RELEASE NOTE ==
```
