### PR TITLE
[native] Remove obsolete cache enabling logic

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -114,11 +114,6 @@ class PrestoServer {
   void initializeVeloxMemory();
 
  protected:
-  virtual std::shared_ptr<velox::connector::Connector> connectorWithCache(
-      const std::string& connectorName,
-      const std::string& connectorId,
-      std::shared_ptr<const velox::Config> properties);
-
   void reportMemoryInfo(proxygen::ResponseHandler* downstream);
 
   void reportServerInfo(proxygen::ResponseHandler* downstream);
@@ -166,9 +161,6 @@ class PrestoServer {
   std::string nodeId_;
   std::string address_;
   std::string nodeLocation_;
-
-  /// Total capacity of all caches in the connectors
-  size_t cacheRamCapacityGb_{0};
 };
 
 } // namespace facebook::presto


### PR DESCRIPTION
Presto native's cache system is different from Presto Java's. Here are a couple of refactorings regarding the current caching properties.
1. Presto native's in-memory caching is always enabled, and cannot be configured as it is deeply built-in with the system. So we remove the cache.enabled property requirement from catalog properties.
2. Presto native's SSD caching can be configured to be on/off. But we use our own property name, so we are not using cache.max-cache-size anymore, hence removing it.
3. Always enable pre-fetching.

```
== NO RELEASE NOTE ==
```
