### PR TITLE
[native] Export Ssd cache error counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -244,12 +244,6 @@ void PeriodicTaskManager::addAsyncDataCacheStatsTask() {
         static int64_t memoryNumEvictChecksOld{0};
         static int64_t memoryNumWaitExclusiveOld{0};
         static int64_t memoryNumAllocClocksOld{0};
-        static int64_t ssdReadEntriesOld{0};
-        static int64_t ssdReadBytesOld{0};
-        static int64_t ssdWrittenBytesOld{0};
-        static int64_t ssdWrittenEntriesOld{0};
-        static int64_t ssdCachedBytesOld{0};
-        static int64_t ssdCachedEntriesOld{0};
         REPORT_ADD_STAT_VALUE(
             kCounterMemoryCacheNumHit,
             memoryCacheStats.numHit - memoryNumHitOld);
@@ -268,26 +262,6 @@ void PeriodicTaskManager::addAsyncDataCacheStatsTask() {
         REPORT_ADD_STAT_VALUE(
             kCounterMemoryCacheNumAllocClocks,
             memoryCacheStats.allocClocks - memoryNumAllocClocksOld);
-        if (memoryCacheStats.ssdStats) {
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheReadEntries,
-              memoryCacheStats.ssdStats->entriesRead - ssdReadEntriesOld);
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheReadBytes,
-              memoryCacheStats.ssdStats->bytesRead - ssdReadBytesOld);
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheWrittenEntries,
-              memoryCacheStats.ssdStats->entriesWritten - ssdWrittenEntriesOld);
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheWrittenBytes,
-              memoryCacheStats.ssdStats->bytesWritten - ssdWrittenBytesOld);
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheCachedEntries,
-              memoryCacheStats.ssdStats->entriesCached - ssdCachedEntriesOld);
-          REPORT_ADD_STAT_VALUE(
-              kCounterSsdCacheCachedBytes,
-              memoryCacheStats.ssdStats->bytesCached - ssdCachedBytesOld);
-        }
 
         memoryNumHitOld = memoryCacheStats.numHit;
         memoryNumNewOld = memoryCacheStats.numNew;
@@ -295,14 +269,7 @@ void PeriodicTaskManager::addAsyncDataCacheStatsTask() {
         memoryNumEvictChecksOld = memoryCacheStats.numEvictChecks;
         memoryNumWaitExclusiveOld = memoryCacheStats.numWaitExclusive;
         memoryNumAllocClocksOld = memoryCacheStats.allocClocks;
-        if (memoryCacheStats.ssdStats) {
-          ssdReadEntriesOld = memoryCacheStats.ssdStats->entriesRead;
-          ssdReadBytesOld = memoryCacheStats.ssdStats->bytesRead;
-          ssdWrittenEntriesOld = memoryCacheStats.ssdStats->entriesWritten;
-          ssdWrittenBytesOld = memoryCacheStats.ssdStats->bytesWritten;
-          ssdCachedEntriesOld = memoryCacheStats.ssdStats->entriesCached;
-          ssdCachedBytesOld = memoryCacheStats.ssdStats->bytesCached;
-        }
+
         // All time cumulatives.
         REPORT_ADD_STAT_VALUE(
             kCounterMemoryCacheNumCumulativeHit, memoryCacheStats.numHit);
@@ -338,6 +305,33 @@ void PeriodicTaskManager::addAsyncDataCacheStatsTask() {
           REPORT_ADD_STAT_VALUE(
               kCounterSsdCacheCumulativeCachedBytes,
               memoryCacheStats.ssdStats->bytesCached);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeOpenSsdErrors,
+              memoryCacheStats.ssdStats->openFileErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeOpenCheckpointErrors,
+              memoryCacheStats.ssdStats->openCheckpointErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeOpenLogErrors,
+              memoryCacheStats.ssdStats->openLogErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeDeleteCheckpointErrors,
+              memoryCacheStats.ssdStats->deleteCheckpointErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeGrowFileErrors,
+              memoryCacheStats.ssdStats->growFileErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeWriteSsdErrors,
+              memoryCacheStats.ssdStats->writeSsdErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeWriteCheckpointErrors,
+              memoryCacheStats.ssdStats->writeCheckpointErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeReadSsdErrors,
+              memoryCacheStats.ssdStats->readSsdErrors);
+          REPORT_ADD_STAT_VALUE(
+              kCounterSsdCacheCumulativeReadCheckpointErrors,
+              memoryCacheStats.ssdStats->readCheckpointErrors);
         }
       },
       std::chrono::microseconds{kCachePeriodGlobalCounters},

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -161,27 +161,37 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeReadEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheReadEntries, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeReadBytes, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheReadBytes, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeWrittenEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheWrittenEntries, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeWrittenBytes, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheWrittenBytes, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeCachedEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheCachedEntries, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeCachedBytes, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterSsdCacheCachedBytes, facebook::velox::StatType::AVG);
+      kCounterSsdCacheCumulativeOpenSsdErrors, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeOpenCheckpointErrors,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeOpenLogErrors, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeDeleteCheckpointErrors,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeGrowFileErrors, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeWriteSsdErrors, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeWriteCheckpointErrors,
+      facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeReadSsdErrors, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSsdCacheCumulativeReadCheckpointErrors,
+      facebook::velox::StatType::AVG);
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters
   // have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -224,28 +224,34 @@ constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
     "presto_cpp.memory_cache_num_alloc_clocks"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadEntries{
     "presto_cpp.ssd_cache_cumulative_read_entries"};
-constexpr folly::StringPiece kCounterSsdCacheReadEntries{
-    "presto_cpp.ssd_cache_read_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadBytes{
     "presto_cpp.ssd_cache_cumulative_read_bytes"};
-constexpr folly::StringPiece kCounterSsdCacheReadBytes{
-    "presto_cpp.ssd_cache_read_bytes"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenEntries{
     "presto_cpp.ssd_cache_cumulative_written_entries"};
-constexpr folly::StringPiece kCounterSsdCacheWrittenEntries{
-    "presto_cpp.ssd_cache_written_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenBytes{
     "presto_cpp.ssd_cache_cumulative_written_bytes"};
-constexpr folly::StringPiece kCounterSsdCacheWrittenBytes{
-    "presto_cpp.ssd_cache_written_bytes"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedEntries{
     "presto_cpp.ssd_cache_cumulative_cached_entries"};
-constexpr folly::StringPiece kCounterSsdCacheCachedEntries{
-    "presto_cpp.ssd_cache_cached_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedBytes{
     "presto_cpp.ssd_cache_cumulative_cached_bytes"};
-constexpr folly::StringPiece kCounterSsdCacheCachedBytes{
-    "presto_cpp.ssd_cache_cached_bytes"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeOpenSsdErrors{
+    "presto_cpp.ssd_cache_cumulative_open_ssd_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeOpenCheckpointErrors{
+    "presto_cpp.ssd_cache_cumulative_open_checkpoint_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeOpenLogErrors{
+    "presto_cpp.ssd_cache_cumulative_open_log_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeDeleteCheckpointErrors{
+    "presto_cpp.ssd_cache_cumulative_delete_checkpoint_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeGrowFileErrors{
+    "presto_cpp.ssd_cache_cumulative_grow_file_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeWriteSsdErrors{
+    "presto_cpp.ssd_cache_cumulative_write_ssd_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeWriteCheckpointErrors{
+    "presto_cpp.ssd_cache_cumulative_write_checkpoint_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeReadSsdErrors{
+    "presto_cpp.ssd_cache_cumulative_read_ssd_errors"};
+constexpr folly::StringPiece kCounterSsdCacheCumulativeReadCheckpointErrors{
+    "presto_cpp.ssd_cache_cumulative_read_checkpoint_errors"};
 
 // ================== HiveConnector Counters ==================
 // Format template strings use 'constexpr std::string_view' to be 'fmt::format'


### PR DESCRIPTION
Expose the error counters of Ssd cached tracked in SsdCacheStats.

```
== NO RELEASE NOTE ==
```
