### PR TITLE
Fix cardinality(map_keys()) and cardinality(map_values())

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -304,7 +304,7 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(new InlineSqlFunctions(metadata, sqlParser).rules())
                                 .addAll(new DesugarLambdaExpression().rules())
-                                .addAll(new SimplifyCardinalityMap().rules())
+                                .addAll(new SimplifyCardinalityMap(metadata.getFunctionAndTypeManager()).rules())
                                 .build()),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCardinalityMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCardinalityMap.java
@@ -13,13 +13,15 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+
 import static com.facebook.presto.sql.planner.iterative.rule.SimplifyCardinalityMapRewriter.rewrite;
 
 public class SimplifyCardinalityMap
         extends RowExpressionRewriteRuleSet
 {
-    public SimplifyCardinalityMap()
+    public SimplifyCardinalityMap(FunctionAndTypeManager functionAndTypeManager)
     {
-        super((expression, context) -> rewrite(expression));
+        super((expression, context) -> rewrite(expression, functionAndTypeManager, context.getSession()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCardinalityMapRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCardinalityMapRewriter.java
@@ -13,15 +13,26 @@
  */
 
 package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Transforms:
@@ -41,14 +52,23 @@ public class SimplifyCardinalityMapRewriter
 
     private SimplifyCardinalityMapRewriter() {}
 
-    public static RowExpression rewrite(RowExpression expression)
+    public static RowExpression rewrite(RowExpression expression, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
-        return RowExpressionTreeRewriter.rewriteWith(new Visitor(), expression);
+        return RowExpressionTreeRewriter.rewriteWith(new Visitor(functionAndTypeManager, session), expression);
     }
 
     private static class Visitor
             extends RowExpressionRewriter<Void>
     {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final Session session;
+
+        public Visitor(FunctionAndTypeManager functionAndTypeManager, Session session)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.session = requireNonNull(session, "session is null");
+        }
+
         @Override
         public RowExpression rewriteCall(CallExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
         {
@@ -76,10 +96,21 @@ public class SimplifyCardinalityMapRewriter
         private RowExpression newFunctionIfRewritten(CallExpression node, List<RowExpression> rewrittenArguments)
         {
             if (!node.getArguments().equals(rewrittenArguments)) {
+                List<Type> types = rewrittenArguments.stream()
+                        .map(RowExpression::getType)
+                        .collect(toImmutableList());
+                // rewrite the FunctionHandle, as the input types may have changed
+                // e.g. from ArrayCardinalityFunction for cardinality(map_keys(x)) to
+                // MapCardinalityFunction for cardinality(x)
+                FunctionHandle rewrittenFunctionHandle = functionAndTypeManager.resolveFunction(
+                        Optional.of(session.getSessionFunctions()),
+                        session.getTransactionId(),
+                        QualifiedObjectName.valueOf(node.getFunctionHandle().getName()),
+                        fromTypes(types));
                 return new CallExpression(
                         node.getSourceLocation(),
                         node.getDisplayName(),
-                        node.getFunctionHandle(),
+                        rewrittenFunctionHandle,
                         node.getType(),
                         rewrittenArguments);
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import static com.facebook.presto.common.type.StandardTypes.INTEGER;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.spi.function.FunctionImplementationType.THRIFT;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
@@ -199,7 +200,7 @@ public class TestInlineSqlFunctions
     private void assertNotInlined(String expression, Map<String, String> sessionValues, String variable, Type type)
     {
         RowExpression inputExpression = new TestingRowExpressionTranslator(tester.getMetadata()).translate(expression, ImmutableMap.of(variable, type));
-        RuleAssert ruleAssert = tester.assertThat(new SimplifyCardinalityMap().projectRowExpressionRewriteRule());
+        RuleAssert ruleAssert = tester.assertThat(new SimplifyCardinalityMap(createTestFunctionAndTypeManager()).projectRowExpressionRewriteRule());
         sessionValues.forEach((k, v) -> ruleAssert.setSystemProperty(k, v));
         ruleAssert
                 .on(p -> p.project(assignment(p.variable("var"), inputExpression), p.values(p.variable(variable, type))))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyCardinalityMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyCardinalityMap.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.sql.planner.PlannerUtils.createMapType;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
@@ -79,7 +80,7 @@ public class TestSimplifyCardinalityMap
     private void assertRewriteDoesNotFire(String expression)
     {
         RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(expression, ImmutableMap.of());
-        tester().assertThat(new SimplifyCardinalityMap().projectRowExpressionRewriteRule())
+        tester().assertThat(new SimplifyCardinalityMap(createTestFunctionAndTypeManager()).projectRowExpressionRewriteRule())
                 .on(p -> p.project(assignment(p.variable("x"), inputExpression), p.values()))
                 .doesNotFire();
     }
@@ -91,7 +92,7 @@ public class TestSimplifyCardinalityMap
         Map<String, Type> types = ImmutableMap.of("m", mapType, "m_1", mapType, "m_2", mapType);
         RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(inputExpressionStr, types);
 
-        tester().assertThat(new SimplifyCardinalityMap().projectRowExpressionRewriteRule())
+        tester().assertThat(new SimplifyCardinalityMap(createTestFunctionAndTypeManager()).projectRowExpressionRewriteRule())
                 .on(p -> p.project(assignment(p.variable("x"), inputExpression), p.values(p.variable("m", mapType), p.variable("m_1", mapType), p.variable("m_2", mapType))))
                 .matches(project(ImmutableMap.of("x", expression(expectedExpressionStr)), values("m", "m_1", "m_2")));
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -838,6 +838,12 @@ public abstract class AbstractTestQueries
         // Make sure that even if the map constructor throws with the NULL key the block builders are left in a consistent state
         // and the TRY() call eventually succeeds and return NULL values.
         assertQuery("SELECT JSON_FORMAT(CAST(TRY(MAP(ARRAY[NULL], ARRAY[x])) AS JSON)) FROM (VALUES 1, 2) t(x)", "SELECT * FROM (VALUES NULL, NULL)");
+
+        assertQuery("SELECT cardinality(m) FROM (SELECT map_agg(orderkey, orderkey) m FROM orders)", "SELECT count(orderkey) FROM orders");
+        assertQuery("SELECT cardinality(map_keys(m)) FROM (SELECT map_agg(orderkey, orderkey) m FROM orders)", "SELECT count(orderkey) FROM orders");
+        assertQuery("SELECT cardinality(map_values(m)) FROM (SELECT map_agg(orderkey, orderkey) m FROM orders)", "SELECT count(orderkey) FROM orders");
+        assertQuery("SELECT cardinality(map_keys(m)) + cardinality(map_values(m)) FROM (SELECT map_agg(orderkey, orderkey) m FROM orders)", "SELECT count(orderkey) * 2 FROM orders");
+        assertQuery("SELECT cardinality(map(array[cardinality(map_values(m))], array[cardinality(map_values(m))])) FROM (SELECT map_agg(orderkey, orderkey) m FROM orders)", "SELECT 1");
     }
 
     @Test


### PR DESCRIPTION
Fix wrong results for cardinality(map_keys(x)) and cardinality(map_values(x)). This was caused by not rewriting the function handle from the ArrayCardinalityFunction functionHandle to the MapCardinalityFunction functionHandle in SimplifyCardinalityMap when we rewrite cardinality(map_keys(x)) to cardinality(x). The bug was introduced by 4c7f007f244dee9fdb8607c4d4dcba4c881bab83

Test plan - new unit test

```
== RELEASE NOTES ==

General Changes
* Fix a bug where ``cardinality(map_keys(x))`` and ``cardinality(map_values(x))`` would return wrong results

```
