### PR TITLE
[native] Allow native log redirection to be configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -272,6 +272,8 @@ public final class SystemSessionProperties
     public static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
 
+    public static final String INHERIT_NATIVE_EXECUTION_LOG = "inherit_native_execution_log";
+
     private final List<PropertyMetadata<?>> sessionProperties;
 
     public SystemSessionProperties()
@@ -1446,6 +1448,11 @@ public final class SystemSessionProperties
                         true,
                         false),
                 booleanProperty(
+                        INHERIT_NATIVE_EXECUTION_LOG,
+                        "Redirect native execution process logs to the same stderr and stdout as the running Spark Java process",
+                        featuresConfig.isInheritNativeExecutionLog(),
+                        false),
+                booleanProperty(
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,
                         "(Deprecated) Randomize null join key for outer join",
                         false,
@@ -2476,6 +2483,11 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionProcessReuseEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_PROCESS_REUSE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isInheritNativeExecutionLog(Session session)
+    {
+        return session.getSystemProperty(INHERIT_NATIVE_EXECUTION_LOG, Boolean.class);
     }
 
     public static RandomizeOuterJoinNullKeyStrategy getRandomizeOuterJoinNullKeyStrategy(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -239,6 +239,7 @@ public class FeaturesConfig
     private boolean pushRemoteExchangeThroughGroupId;
     private boolean isOptimizeMultipleApproxPercentileOnSameFieldEnabled = true;
     private boolean nativeExecutionEnabled;
+    private boolean inheritNativeExecutionLog = true;
     private String nativeExecutionExecutablePath = "./presto_server";
     private String nativeExecutionProgramArguments = "";
     private boolean nativeExecutionProcessReuseEnabled = true;
@@ -2270,6 +2271,19 @@ public class FeaturesConfig
     public boolean isNativeExecutionEnabled()
     {
         return this.nativeExecutionEnabled;
+    }
+
+    @Config("inherit-native-execution-log")
+    @ConfigDescription("Redirect native execution process logs to the same stderr and stdout as the running Spark Java process")
+    public FeaturesConfig setInheritNativeExecutionLog(boolean inheritNatiaveExecutionLog)
+    {
+        this.inheritNativeExecutionLog = inheritNatiaveExecutionLog;
+        return this;
+    }
+
+    public boolean isInheritNativeExecutionLog()
+    {
+        return this.inheritNativeExecutionLog;
     }
 
     @Config("native-execution-executable-path")

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -62,6 +62,7 @@ public class PrestoSparkNativeQueryRunnerUtils
                 .put("native-execution-enabled", "true")
                 .put("spark.initial-partition-count", "1")
                 .put("register-test-functions", "true")
+                .put("inherit-native-execution-log", "false")
                 .put("spark.partition-count-auto-tune-enabled", "false");
 
         if (System.getProperty("NATIVE_PORT") == null) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -123,8 +123,10 @@ public class NativeExecutionProcess
         }
 
         ProcessBuilder processBuilder = new ProcessBuilder(getLaunchCommand());
-        processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        if (SystemSessionProperties.isInheritNativeExecutionLog(session)) {
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        }
         try {
             process = processBuilder.start();
         }


### PR DESCRIPTION
Native process logs are spamming the logging. We need to be able to disable native logs inherit redirection. This PR allows disabling the redirection by a boolean system property "inherit-native-execution-log"

```
== NO RELEASE NOTE ==
```
