### PR TITLE
[native] Fix exchange source unit test.

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -352,7 +352,7 @@ class PrestoExchangeSourceTestSuite : public ::testing::TestWithParam<bool> {
  public:
   void SetUp() override {
     auto& defaultManager = memory::MemoryManager::getInstance();
-    pool_ = memory::addDefaultLeafMemoryPool("PrestoExchangeSourceTest");
+    pool_ = memory::addDefaultLeafMemoryPool();
     memory::MmapAllocator::Options options;
     options.capacity = 1L << 30;
     allocator_ = std::make_unique<memory::MmapAllocator>(options);


### PR DESCRIPTION
Exchange unit tests are parameterized now to test both http and https mode. It's initialization code fails with

```
Reason: (1 vs. 0) Leaf child memory pool PrestoExchangeSourceTest already exists in Memory Pool[__default_root__ AGGREGATE MALLOC no-usage-track thread-safe]<unlimited capacity used 0B available 0B reservation [used 0B, reserved 0B, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0])>
```

Using default memory pool so that we don't create same pool for both runs.

```
== NO RELEASE NOTE ==
```
