### PR TITLE
Convert SqlVarbinary to byte[] in test suite

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -28,6 +28,7 @@ import com.facebook.presto.common.type.SqlTime;
 import com.facebook.presto.common.type.SqlTimeWithTimeZone;
 import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
+import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
@@ -401,6 +402,9 @@ public class MaterializedResult
         }
         else if (prestoValue instanceof ArrayList) {
             convertedValue = newArrayList(((ArrayList) prestoValue).stream().map(x -> convertPrestoValueToTestType(x)).toArray());
+        }
+        else if (prestoValue instanceof SqlVarbinary) {
+            convertedValue = ((SqlVarbinary) prestoValue).getBytes();
         }
         else {
             convertedValue = prestoValue;

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -44,10 +44,6 @@ public class TestPrestoSparkNativeGeneralQueries
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore
-    public void testBinaryFunctions() {}
-
-    @Override
-    @Ignore
     public void testBucketedExecution() {}
 
     @Override


### PR DESCRIPTION
SqlVarbinary needs to be converted to Java's byte[] as test type in order to match the results in test suite.

```
== NO RELEASE NOTE ==
```
