### PR TITLE
Explain Type Validate should not execute query

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparer.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparer.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.analyzer.utils.StatementUtils;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Execute;
 import com.facebook.presto.sql.tree.Explain;
+import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.collect.ImmutableList;
@@ -44,6 +45,7 @@ import static com.facebook.presto.sql.analyzer.ConstantExpressionVerifier.verify
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PARAMETER_USAGE;
 import static com.facebook.presto.sql.analyzer.utils.AnalyzerUtil.createParsingOptions;
 import static com.facebook.presto.sql.analyzer.utils.ParameterExtractor.getParameterCount;
+import static com.facebook.presto.sql.tree.ExplainType.Type.VALIDATE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -162,6 +164,20 @@ public class BuiltInQueryPreparer
         public boolean isTransactionControlStatement()
         {
             return StatementUtils.isTransactionControlStatement(getStatement());
+        }
+
+        @Override
+        public boolean isExplainTypeValidate()
+        {
+            if (!(statement instanceof Explain)) {
+                return false;
+            }
+
+            return ((Explain) statement).getOptions()
+                    .stream()
+                    .filter(option -> option instanceof ExplainType)
+                    .map(option -> (ExplainType) option)
+                    .anyMatch(explainType -> explainType.getType() == VALIDATE);
         }
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/analyzer/PreparedQuery.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/analyzer/PreparedQuery.java
@@ -54,4 +54,9 @@ public abstract class PreparedQuery
     {
         throw new UnsupportedOperationException("getStatementClass method is not supported!");
     }
+
+    public boolean isExplainTypeValidate()
+    {
+        throw new UnsupportedOperationException("isExplainTypeValidate method is not supported!");
+    }
 }

--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -104,7 +104,7 @@ Validate:
 .. code-block:: none
 
     presto:tiny> EXPLAIN (TYPE VALIDATE) SELECT regionkey, count(*) FROM nation GROUP BY 1;
-     Valid
+     result
     -------
      true
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/AccessControlCheckerExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AccessControlCheckerExecution.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.analyzer.PreparedQuery;
+import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.AnalyzerContext;
+import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.QueryAnalysis;
+import com.facebook.presto.spi.analyzer.QueryAnalyzer;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.SystemSessionProperties.getQueryAnalyzerTimeout;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
+import static com.facebook.presto.util.AnalyzerUtil.getAnalyzerContext;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class AccessControlCheckerExecution
+        implements QueryExecution
+{
+    protected final QueryAnalyzer queryAnalyzer;
+    protected final PreparedQuery preparedQuery;
+    protected final TransactionManager transactionManager;
+    protected final Metadata metadata;
+    protected final AccessControl accessControl;
+    protected final QueryStateMachine stateMachine;
+    protected final ScheduledExecutorService timeoutThreadExecutor;
+
+    private final String slug;
+    private final int retryCount;
+    private final AtomicReference<Optional<ResourceGroupQueryLimits>> resourceGroupQueryLimits = new AtomicReference<>(Optional.empty());
+
+    private final AnalyzerContext analyzerContext;
+
+    public AccessControlCheckerExecution(
+            QueryAnalyzer queryAnalyzer,
+            PreparedQuery preparedQuery,
+            String slug,
+            int retryCount,
+            TransactionManager transactionManager,
+            Metadata metadata,
+            AccessControl accessControl,
+            QueryStateMachine stateMachine,
+            ScheduledExecutorService timeoutThreadExecutor)
+    {
+        this.queryAnalyzer = requireNonNull(queryAnalyzer, "queryAnalyzer is null");
+        this.preparedQuery = requireNonNull(preparedQuery, "preparedQuery is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
+        this.slug = requireNonNull(slug, "slug is null");
+        this.retryCount = retryCount;
+        this.timeoutThreadExecutor = requireNonNull(timeoutThreadExecutor, "timeoutThreadExecutor is null");
+        this.analyzerContext = getAnalyzerContext(queryAnalyzer, metadata.getMetadataResolver(stateMachine.getSession()), new PlanNodeIdAllocator(), new VariableAllocator(), stateMachine.getSession());
+    }
+
+    @Override
+    public String getSlug()
+    {
+        return slug;
+    }
+
+    @Override
+    public int getRetryCount()
+    {
+        return retryCount;
+    }
+
+    @Override
+    public VersionedMemoryPoolId getMemoryPool()
+    {
+        return stateMachine.getMemoryPool();
+    }
+
+    @Override
+    public void setMemoryPool(VersionedMemoryPoolId poolId)
+    {
+        stateMachine.setMemoryPool(poolId);
+    }
+
+    @Override
+    public Session getSession()
+    {
+        return stateMachine.getSession();
+    }
+
+    @Override
+    public DataSize getUserMemoryReservation()
+    {
+        return new DataSize(0, BYTE);
+    }
+
+    @Override
+    public DataSize getTotalMemoryReservation()
+    {
+        return new DataSize(0, BYTE);
+    }
+
+    @Override
+    public DateTime getCreateTime()
+    {
+        return stateMachine.getCreateTime();
+    }
+
+    @Override
+    public Optional<DateTime> getExecutionStartTime()
+    {
+        return stateMachine.getExecutionStartTime();
+    }
+
+    @Override
+    public DateTime getLastHeartbeat()
+    {
+        return stateMachine.getLastHeartbeat();
+    }
+
+    @Override
+    public Optional<DateTime> getEndTime()
+    {
+        return stateMachine.getEndTime();
+    }
+
+    @Override
+    public Duration getTotalCpuTime()
+    {
+        return new Duration(0, NANOSECONDS);
+    }
+
+    @Override
+    public DataSize getRawInputDataSize()
+    {
+        return DataSize.succinctBytes(0);
+    }
+
+    @Override
+    public long getOutputPositions()
+    {
+        return 0;
+    }
+
+    @Override
+    public DataSize getOutputDataSize()
+    {
+        return DataSize.succinctBytes(0);
+    }
+
+    @Override
+    public Optional<ResourceGroupQueryLimits> getResourceGroupQueryLimits()
+    {
+        return resourceGroupQueryLimits.get();
+    }
+
+    @Override
+    public void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits)
+    {
+        if (!this.resourceGroupQueryLimits.compareAndSet(Optional.empty(), Optional.of(requireNonNull(resourceGroupQueryLimits, "resourceGroupQueryLimits is null")))) {
+            throw new IllegalStateException("Cannot set resourceGroupQueryLimits more than once");
+        }
+    }
+
+    @Override
+    public BasicQueryInfo getBasicQueryInfo()
+    {
+        return stateMachine.getFinalQueryInfo()
+                .map(BasicQueryInfo::new)
+                .orElseGet(() -> stateMachine.getBasicQueryInfo(Optional.empty()));
+    }
+
+    @Override
+    public int getRunningTaskCount()
+    {
+        return stateMachine.getCurrentRunningTaskCount();
+    }
+
+    @Override
+    public void start()
+    {
+        try {
+            // transition to running
+            if (!stateMachine.transitionToRunning()) {
+                // query already running or finished
+                return;
+            }
+            ListenableFuture<?> future = executeTask();
+
+            Futures.addCallback(future, new FutureCallback<Object>()
+            {
+                @Override
+                public void onSuccess(@Nullable Object result)
+                {
+                    stateMachine.transitionToFinishing();
+                }
+
+                @Override
+                public void onFailure(Throwable throwable)
+                {
+                    fail(throwable);
+                }
+            }, directExecutor());
+        }
+        catch (Throwable e) {
+            fail(e);
+            throwIfInstanceOf(e, Error.class);
+        }
+    }
+
+    private ListenableFuture<?> executeTask()
+    {
+        stateMachine.beginSemanticAnalyzing();
+
+        QueryAnalysis queryAnalysis;
+        try (TimeoutThread unused = new TimeoutThread(
+                Thread.currentThread(),
+                timeoutThreadExecutor,
+                getQueryAnalyzerTimeout(getSession()))) {
+            queryAnalysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
+        }
+
+        stateMachine.beginColumnAccessPermissionChecking();
+        checkAccessPermissions(queryAnalysis.getAccessControlReferences());
+        stateMachine.endColumnAccessPermissionChecking();
+        return immediateFuture(null);
+    }
+
+    @Override
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+    {
+        // does not have an output
+    }
+
+    @Override
+    public ListenableFuture<QueryState> getStateChange(QueryState currentState)
+    {
+        return stateMachine.getStateChange(currentState);
+    }
+
+    @Override
+    public void addStateChangeListener(StateMachine.StateChangeListener<QueryState> stateChangeListener)
+    {
+        stateMachine.addStateChangeListener(stateChangeListener);
+    }
+
+    @Override
+    public void addFinalQueryInfoListener(StateMachine.StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        stateMachine.addQueryInfoStateChangeListener(stateChangeListener);
+    }
+
+    @Override
+    public void fail(Throwable cause)
+    {
+        stateMachine.transitionToFailed(cause);
+        stateMachine.updateQueryInfo(Optional.empty());
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        return getState().isDone();
+    }
+
+    @Override
+    public void cancelQuery()
+    {
+        stateMachine.transitionToCanceled();
+    }
+
+    @Override
+    public void cancelStage(StageId stageId)
+    {
+        // no-op
+    }
+
+    @Override
+    public void recordHeartbeat()
+    {
+        stateMachine.recordHeartbeat();
+    }
+
+    @Override
+    public void pruneInfo()
+    {
+        // no-op
+    }
+
+    @Override
+    public QueryId getQueryId()
+    {
+        return stateMachine.getQueryId();
+    }
+
+    @Override
+    public QueryInfo getQueryInfo()
+    {
+        return stateMachine.getFinalQueryInfo().orElseGet(() -> stateMachine.updateQueryInfo(Optional.empty()));
+    }
+
+    @Override
+    public Plan getQueryPlan()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public QueryState getState()
+    {
+        return stateMachine.getQueryState();
+    }
+
+    public static class AccessControlCheckerExecutionFactory
+            implements QueryExecution.QueryExecutionFactory<AccessControlCheckerExecution>
+    {
+        private final TransactionManager transactionManager;
+        private final Metadata metadata;
+        private final AccessControl accessControl;
+        private final ScheduledExecutorService timeoutThreadExecutor;
+
+        @Inject
+        public AccessControlCheckerExecutionFactory(
+                TransactionManager transactionManager,
+                MetadataManager metadata,
+                AccessControl accessControl,
+                @ForTimeoutThread ScheduledExecutorService timeoutThreadExecutor)
+        {
+            this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.accessControl = requireNonNull(accessControl, "accessControl is null");
+            this.timeoutThreadExecutor = requireNonNull(timeoutThreadExecutor, "timeoutThreadExecutor is null");
+        }
+
+        @Override
+        public AccessControlCheckerExecution createQueryExecution(
+                AnalyzerProvider analyzerProvider,
+                PreparedQuery preparedQuery,
+                QueryStateMachine stateMachine,
+                String slug,
+                int retryCount,
+                WarningCollector warningCollector,
+                Optional<QueryType> queryType)
+        {
+            return createAccessControlChecker(analyzerProvider.getQueryAnalyzer(), preparedQuery, stateMachine, slug, retryCount);
+        }
+
+        private AccessControlCheckerExecution createAccessControlChecker(
+                QueryAnalyzer queryAnalyzer,
+                PreparedQuery preparedQuery,
+                QueryStateMachine stateMachine,
+                String slug,
+                int retryCount)
+        {
+            return new AccessControlCheckerExecution(queryAnalyzer, preparedQuery, slug, retryCount, transactionManager, metadata, accessControl, stateMachine, timeoutThreadExecutor);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFactoriesManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFactoriesManager.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.common.analyzer.PreparedQuery;
+import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.execution.QueryExecution.QueryExecutionFactory;
+import com.google.inject.Inject;
+
+import static com.facebook.presto.execution.AccessControlCheckerExecution.AccessControlCheckerExecutionFactory;
+import static com.facebook.presto.execution.DDLDefinitionExecution.DDLDefinitionExecutionFactory;
+import static com.facebook.presto.execution.SessionDefinitionExecution.SessionDefinitionExecutionFactory;
+import static com.facebook.presto.execution.SqlQueryExecution.SqlQueryExecutionFactory;
+import static com.google.common.base.Preconditions.checkState;
+
+public class ExecutionFactoriesManager
+{
+    private final SqlQueryExecutionFactory sqlQueryExecutionFactory;
+    private final DDLDefinitionExecutionFactory ddlDefinitionExecutionFactory;
+    private final SessionDefinitionExecutionFactory sessionDefinitionExecutionFactory;
+    private final AccessControlCheckerExecutionFactory accessControlCheckerExecutionFactory;
+
+    @Inject
+    public ExecutionFactoriesManager(
+            SqlQueryExecutionFactory sqlQueryExecutionFactory,
+            DDLDefinitionExecutionFactory ddlDefinitionExecutionFactory,
+            SessionDefinitionExecutionFactory sessionDefinitionExecutionFactory,
+            AccessControlCheckerExecutionFactory accessControlCheckerExecutionFactory)
+    {
+        this.sqlQueryExecutionFactory = sqlQueryExecutionFactory;
+        this.ddlDefinitionExecutionFactory = ddlDefinitionExecutionFactory;
+        this.sessionDefinitionExecutionFactory = sessionDefinitionExecutionFactory;
+        this.accessControlCheckerExecutionFactory = accessControlCheckerExecutionFactory;
+    }
+
+    public QueryExecutionFactory<?> getExecutionFactory(PreparedQuery preparedQuery)
+    {
+        checkState(preparedQuery != null && preparedQuery.getQueryType().isPresent(), "preparedQuery is null or preparedQuery does not have queryType");
+        QueryType queryType = preparedQuery.getQueryType().get();
+
+        if (queryType == QueryType.DATA_DEFINITION) {
+            return ddlDefinitionExecutionFactory;
+        }
+
+        if (queryType == QueryType.CONTROL) {
+            return sessionDefinitionExecutionFactory;
+        }
+
+        if (preparedQuery.isExplainTypeValidate()) {
+            return accessControlCheckerExecutionFactory;
+        }
+
+        return sqlQueryExecutionFactory;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -19,8 +19,10 @@ import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.connector.ConnectorTypeSerdeManager;
@@ -261,6 +263,7 @@ import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NO
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.testing.TreeAssertions.assertFormattedSql;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
@@ -784,16 +787,19 @@ public class LocalQueryRunner
 
     private MaterializedResultWithPlan executeInternal(Session session, @Language("SQL") String sql, WarningCollector warningCollector)
     {
+        if (isExplainTypeValidate(sql, session, warningCollector)) {
+            return executeExplainTypeValidate(sql, session, warningCollector);
+        }
+
         lock.readLock().lock();
         try (Closer closer = Closer.create()) {
             AtomicReference<MaterializedResult.Builder> builder = new AtomicReference<>();
             PageConsumerOutputFactory outputFactory = new PageConsumerOutputFactory(types -> {
-                builder.compareAndSet(null, MaterializedResult.resultBuilder(session, types));
+                builder.compareAndSet(null, resultBuilder(session, types));
                 return builder.get()::page;
             });
 
             Plan plan = createPlan(session, sql, warningCollector);
-
             TaskContext taskContext = TestingTaskContext.builder(notificationExecutor, yieldExecutor, session)
                     .setMaxSpillSize(nodeSpillConfig.getMaxSpillPerNode())
                     .setQueryMaxSpillSize(nodeSpillConfig.getQueryMaxSpillPerNode())
@@ -836,6 +842,45 @@ public class LocalQueryRunner
         finally {
             lock.readLock().unlock();
         }
+    }
+
+    private MaterializedResultWithPlan executeExplainTypeValidate(String sql, Session session, WarningCollector warningCollector)
+    {
+        AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, warningCollector);
+        BuiltInPreparedQuery preparedQuery = new BuiltInQueryPreparer(sqlParser).prepareQuery(analyzerOptions, sql, session.getPreparedStatements(), warningCollector);
+        assertFormattedSql(sqlParser, createParsingOptions(session), preparedQuery.getStatement());
+
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+
+        QueryExplainer queryExplainer = new QueryExplainer(
+                getPlanOptimizers(true),
+                planFragmenter,
+                metadata,
+                accessControl,
+                sqlParser,
+                statsCalculator,
+                costCalculator,
+                dataDefinitionTask,
+                distributedPlanChecker);
+
+        BuiltInQueryAnalyzer queryAnalyzer = new BuiltInQueryAnalyzer(metadata, sqlParser, accessControl, Optional.of(queryExplainer));
+
+        AnalyzerContext analyzerContext = getAnalyzerContext(queryAnalyzer, metadata.getMetadataResolver(session), idAllocator, new VariableAllocator(), session);
+
+        QueryAnalysis queryAnalysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
+        checkAccessPermissions(queryAnalysis.getAccessControlReferences());
+
+        MaterializedResult result = MaterializedResult.resultBuilder(session, BooleanType.BOOLEAN)
+                .row(true)
+                .build();
+        return new MaterializedResultWithPlan(result, null);
+    }
+
+    private boolean isExplainTypeValidate(String sql, Session session, WarningCollector warningCollector)
+    {
+        AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, warningCollector);
+        PreparedQuery preparedQuery = new BuiltInQueryPreparer(sqlParser).prepareQuery(analyzerOptions, sql, session.getPreparedStatements(), warningCollector);
+        return preparedQuery.isExplainTypeValidate();
     }
 
     @Override
@@ -1010,7 +1055,6 @@ public class LocalQueryRunner
     {
         AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, warningCollector);
         BuiltInPreparedQuery preparedQuery = new BuiltInQueryPreparer(sqlParser).prepareQuery(analyzerOptions, sql, session.getPreparedStatements(), warningCollector);
-
         assertFormattedSql(sqlParser, createParsingOptions(session), preparedQuery.getStatement());
 
         return createPlan(session, sql, getPlanOptimizers(forceSingleNode), stage, warningCollector);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkAccessControlChecker.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkAccessControlChecker.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryStateTimer;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
+import com.facebook.presto.spark.execution.PrestoSparkAccessControlCheckerExecution;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
+import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.parser.SqlParser;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkAccessControlChecker
+{
+    private final Metadata metadata;
+    private final SqlParser sqlParser;
+    private final AccessControl accessControl;
+    private final QueryExplainer queryExplainer;
+
+    @Inject
+    public PrestoSparkAccessControlChecker(
+            SqlParser sqlParser,
+            QueryExplainer queryExplainer,
+            Metadata metadata,
+            AccessControl accessControl)
+    {
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
+    public IPrestoSparkQueryExecution createExecution(Session session, BuiltInQueryPreparer.BuiltInPreparedQuery preparedQuery, QueryStateTimer queryStateTimer, WarningCollector warningCollector)
+    {
+        return new PrestoSparkAccessControlCheckerExecution(session, metadata, sqlParser, accessControl, queryExplainer, preparedQuery, queryStateTimer, warningCollector);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -500,6 +500,7 @@ public class PrestoSparkModule
         binder.bind(PrestoSparkExecutionExceptionFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkSettingsRequirements.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkQueryPlanner.class).in(Scopes.SINGLETON);
+        binder.bind(PrestoSparkAccessControlChecker.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkPlanFragmenter.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkRddFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkTaskExecutorFactory.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -162,6 +162,7 @@ public class PrestoSparkQueryExecutionFactory
     private final QuerySessionSupplier sessionSupplier;
     private final BuiltInQueryPreparer queryPreparer;
     private final PrestoSparkQueryPlanner queryPlanner;
+    private final PrestoSparkAccessControlChecker accessControlChecker;
     private final PrestoSparkPlanFragmenter planFragmenter;
     private final PrestoSparkRddFactory rddFactory;
     private final PrestoSparkMetadataStorage metadataStorage;
@@ -200,6 +201,7 @@ public class PrestoSparkQueryExecutionFactory
             QuerySessionSupplier sessionSupplier,
             BuiltInQueryPreparer queryPreparer,
             PrestoSparkQueryPlanner queryPlanner,
+            PrestoSparkAccessControlChecker accessControlChecker,
             PrestoSparkPlanFragmenter planFragmenter,
             PrestoSparkRddFactory rddFactory,
             PrestoSparkMetadataStorage metadataStorage,
@@ -235,6 +237,7 @@ public class PrestoSparkQueryExecutionFactory
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
         this.queryPreparer = requireNonNull(queryPreparer, "queryPreparer is null");
         this.queryPlanner = requireNonNull(queryPlanner, "queryPlanner is null");
+        this.accessControlChecker = requireNonNull(accessControlChecker, "accessControlChecker is null");
         this.planFragmenter = requireNonNull(planFragmenter, "planFragmenter is null");
         this.rddFactory = requireNonNull(rddFactory, "rddFactory is null");
         this.metadataStorage = requireNonNull(metadataStorage, "metadataStorage is null");
@@ -641,6 +644,9 @@ public class PrestoSparkQueryExecutionFactory
                 queryStateTimer.endAnalysis();
                 DDLDefinitionTask<?> task = (DDLDefinitionTask<?>) ddlTasks.get(preparedQuery.getStatement().getClass());
                 return new PrestoSparkDataDefinitionExecution(task, preparedQuery.getStatement(), transactionManager, accessControl, metadata, session, queryStateTimer, warningCollector);
+            }
+            else if (preparedQuery.isExplainTypeValidate()) {
+                return accessControlChecker.createExecution(session, preparedQuery, queryStateTimer, warningCollector);
             }
             else {
                 planAndMore = queryPlanner.createQueryPlan(session, preparedQuery, warningCollector);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAccessControlCheckerExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAccessControlCheckerExecution.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.QueryStateTimer;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.analyzer.Analysis;
+import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
+import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.parser.SqlParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkAccessControlCheckerExecution
+        implements IPrestoSparkQueryExecution
+{
+    private final Session session;
+    private final Metadata metadata;
+    private final SqlParser sqlParser;
+    private final AccessControl accessControl;
+    private final QueryExplainer queryExplainer;
+    private final BuiltInQueryPreparer.BuiltInPreparedQuery preparedQuery;
+    private final QueryStateTimer queryStateTimer;
+    private final WarningCollector warningCollector;
+
+    public PrestoSparkAccessControlCheckerExecution(
+            Session session,
+            Metadata metadata,
+            SqlParser sqlParser,
+            AccessControl accessControl,
+            QueryExplainer queryExplainer,
+            BuiltInQueryPreparer.BuiltInPreparedQuery preparedQuery,
+            QueryStateTimer queryStateTimer,
+            WarningCollector warningCollector)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
+        this.preparedQuery = requireNonNull(preparedQuery, "preparedQuery is null");
+        this.queryStateTimer = requireNonNull(queryStateTimer, "queryStateTimer is null");
+        this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+    }
+
+    @Override
+    public List<List<Object>> execute()
+    {
+        Analyzer analyzer = new Analyzer(
+                session,
+                metadata,
+                sqlParser,
+                accessControl,
+                Optional.of(queryExplainer),
+                preparedQuery.getParameters(),
+                parameterExtractor(preparedQuery.getStatement(), preparedQuery.getParameters()),
+                warningCollector);
+
+        queryStateTimer.beginSemanticAnalyzing();
+        Analysis analysis = analyzer.analyzeSemantic(preparedQuery.getStatement(), false);
+        queryStateTimer.beginColumnAccessPermissionChecking();
+        checkAccessPermissions(analysis.getAccessControlReferences());
+        queryStateTimer.endColumnAccessPermissionChecking();
+
+        List<List<Object>> results = new ArrayList<>();
+        results.add(singletonList(true));
+        return results;
+    }
+
+    public List<? extends Type> getOutputTypes()
+    {
+        return singletonList(BooleanType.BOOLEAN);
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -54,6 +54,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFa
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
 import com.facebook.presto.spark.execution.NativeExecutionModule;
+import com.facebook.presto.spark.execution.PrestoSparkAccessControlCheckerExecution;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.function.FunctionImplementationType;
@@ -531,6 +532,17 @@ public class PrestoSparkQueryRunner
                         OptionalLong.of((Long) getOnlyElement(getOnlyElement(rows).getFields())),
                         ImmutableList.of());
             }
+        }
+        else if (execution instanceof PrestoSparkAccessControlCheckerExecution) {
+            PrestoSparkAccessControlCheckerExecution accessControlCheckerExecution = (PrestoSparkAccessControlCheckerExecution) execution;
+            return new MaterializedResult(
+                    rows,
+                    accessControlCheckerExecution.getOutputTypes(),
+                    ImmutableMap.of(),
+                    ImmutableSet.of(),
+                    Optional.empty(),
+                    OptionalLong.empty(),
+                    ImmutableList.of());
         }
         else {
             return new MaterializedResult(

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -182,6 +182,11 @@ public class TestQueryPlanDeterminism
     }
 
     @Override
+    public void testExplainValidate()
+    {
+    }
+
+    @Override
     protected void assertAccessAllowed(@Language("SQL") String sql, TestingAccessControlManager.TestingPrivilege... deniedPrivileges)
     {
     }


### PR DESCRIPTION
Explain queries (Type Validate) should only do the query analysis along with ACL checks. Current Presto query execution for explain (Type Validate) runs a full query execution on a dummy query. This unnecessary extra computation can be very expensive at tail. In our analysis we have seen this extra computation to be around 5 seconds(P99) on a busy cluster.

In this change we are creating a query execution for access control checks, which gets utilized for explain type validate queries.


```
== RELEASE NOTES ==

General Changes
* Explain (TYPE VALIDATE) returns after the analysis and ACL checks. It no longer executes the dummy query. 
  It now returns the  ``true`` in the output column ``result`` instead of ``valid`` in case of successful execution.  
```
