### PR TITLE
Fix bug in RowExpression translation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
@@ -54,7 +54,7 @@ public class TranslateExpressionsUtil
     public static RowExpression toRowExpression(Expression expression, Metadata metadata, Session session, SqlParser sqlParser, VariableAllocator variableAllocator, Analysis analysis, SqlToRowExpressionTranslator.Context context)
     {
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType()).build();
-        Map<NodeRef<Expression>, Type> types = analyzeExpression(session,
+        analyzeExpression(session,
                 metadata,
                 new DenyAllAccessControl(),
                 sqlParser,
@@ -68,7 +68,7 @@ public class TranslateExpressionsUtil
                 expression,
                 metadata,
                 session,
-                types,
+                analysis.getTypes(), // We need to pass all types when translating subqueries. TODO(pranjalssh): Add a proper test for complex queries which need this
                 context);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -94,7 +94,6 @@ import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -273,7 +272,7 @@ public final class SqlToRowExpressionTranslator
                 SqlFunctionProperties sqlFunctionProperties,
                 Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions)
         {
-            this.types = ImmutableMap.copyOf(requireNonNull(types, "types is null"));
+            this.types = requireNonNull(types, "types is null");
             this.layout = layout;
             this.functionAndTypeResolver = functionAndTypeResolver;
             this.user = user;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3667,7 +3667,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testCorrelatedScalarSubqueries()
     {
-        assertQuery("SELECT (SELECT n.nationkey) FROM nation n");
+        assertQuery("SELECT (SELECT n.nationkey + n.NATIONKEY) FROM nation n");
         assertQuery("SELECT (SELECT 2 * n.nationkey) FROM nation n");
         assertQuery("SELECT nationkey FROM nation n WHERE 2 = (SELECT 2 * n.nationkey)");
         assertQuery("SELECT nationkey FROM nation n ORDER BY (SELECT 2 * n.nationkey)");


### PR DESCRIPTION
This does 2 fixes to RowExpression translation logic.

1) Use analysis.getTypes() instead of using return value from analyzeExpressions(). For some complex subquery cases, this is needed. Its safer to do that since it contains types of all expression objects. I tested this locally on queries from verifier - but wasn't able to write a test case for this.

2) Handle duplicate keys in ImmutableMap in SubqueryPlanner. Added test

```
== NO RELEASE NOTE ==
```
