### PR TITLE
Fix bug in expression ordering

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -243,6 +243,8 @@ public class ExpressionEquivalence
         }
     }
 
+    // When constant expressions using complex types are present, this comparator will treat them as equal
+    // and produce inconsistent orderings.
     private static class RowExpressionComparator
             implements Comparator<RowExpression>
     {
@@ -304,9 +306,9 @@ public class ExpressionEquivalence
                     return ((Slice) leftValue).compareTo((Slice) rightValue);
                 }
 
-                // value is some random type (say regex), so we just randomly choose a greater value
+                // value is some random type (say regex), so we treat them as equal.
                 // todo: support all known type
-                return -1;
+                return 0;
             }
 
             if (left instanceof InputReferenceExpression) {


### PR DESCRIPTION
Fix this crash:
```
Comparison method violates its general contract!
	at java.base/java.util.TimSort.mergeHi(TimSort.java:903)
	at java.base/java.util.TimSort.mergeAt(TimSort.java:520)
	at java.base/java.util.TimSort.mergeCollapse(TimSort.java:448)
	at java.base/java.util.TimSort.sort(TimSort.java:245)
	at java.base/java.util.Arrays.sort(Arrays.java:1441)
	at com.google.common.collect.Ordering.sortedCopy(Ordering.java:852)
	at com.facebook.presto.sql.planner.optimizations.ExpressionEquivalence$CanonicalizationVisitor.visitSpecialForm(ExpressionEquivalence.java:237)
	at com.facebook.presto.sql.planner.optimizations.ExpressionEquivalence$CanonicalizationVisitor.visitSpecialForm(ExpressionEquivalence.java:125)
	at com.facebook.presto.spi.relation.SpecialFormExpression.accept(SpecialFormExpression.java:127)
```

In comparator, we should return 0(not -1) when we don't know about ordering of 2 items. If we return invalid values(which violate transitivity properties of comparison), java sort may crash. Fixed in code where it was doing that. 


I found a query failing on nightly verifier due to this. Surprisingly, it wasn't triggered before(or on release 281 where we already use RowExpression throughout optimizer). So we hopefully don't need a hotfix?

Adding a test for this case will be crazy... I just tested locally for offending query

```
== NO RELEASE NOTE ==
```
