### PR TITLE
[native] Make adding spilits log verbose.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -414,8 +414,8 @@ public class PrestoNativeQueryRunnerUtils
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")
                                 .directory(tempDirectoryPath.toFile())
                                 .redirectErrorStream(true)
-                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".err").toFile()))
+                                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                                .redirectError(ProcessBuilder.Redirect.INHERIT)
                                 .start();
                     }
                     catch (IOException e) {


### PR DESCRIPTION
Native worker log files are flooded by lines like

`Adding X splits to 20230428_175213_06495_q8f8f.1.0.3 for node 0`

This line constitutes almost 85% of overall log line.

```
$ grep -nir "Adding" stderr.20230428_022211_dst.20 | wc -l
312758
$ cat stderr.20230428_022211_dst.20 | wc -l
374969
```
Making this log verbose to control it in production.

```
== NO RELEASE NOTE ==
```
