### PR TITLE
[native] Fix INTERVAL DAY TO SECOND type conversion in Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/TypeSignatureTypeConverter.cpp
+++ b/presto-native-execution/presto_cpp/main/types/TypeSignatureTypeConverter.cpp
@@ -142,6 +142,10 @@ TypePtr typeFromString(const std::string& typeName) {
     return TIMESTAMP_WITH_TIME_ZONE();
   }
 
+  if (upper == INTERVAL_DAY_TIME()->toString()) {
+    return INTERVAL_DAY_TIME();
+  }
+
   if (upper == HYPERLOGLOG()->toString()) {
     return HYPERLOGLOG();
   }


### PR DESCRIPTION
This PR fixes conversion from "INTERVAL DAY TO SECOND" Java type to Velox's INTERVAL_DAY_TIME.

Before the PR, a query that contains a filter on INTERVAL_DAY_TIME would fail with an error like this:
```sql
select * from table where date1 > date2 + INTERVAL '5' DAY
```

```
...
Caused by: VeloxUserError:  Failed to parse type [interval day to second]: Reason: Specified element is not found: 
INTERVAL DAY TO SECOND
```

The code was missing conversion for INTERVAL_DAY_TIME.

```
== NO RELEASE NOTE ==
```
