### PR TITLE
[native] Fix PartitionedOutput to PartitionAndSerialize node translation

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -44,10 +44,6 @@ public class TestPrestoSparkNativeTpchQueries
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore
-    public void testTpchQ1() {}
-
-    @Override
-    @Ignore
     public void testTpchQ7() {}
 
     @Override


### PR DESCRIPTION
PartitionedOutput plan node may change the order of input columns. In these cases, when translating PartitionedOutput to PartitionAndSerialize we need to add a ProjectNode that will reorder the columns.


```
== NO RELEASE NOTE ==
```
