### PR TITLE
Optimize joins with or condition

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -263,6 +263,7 @@ public final class SystemSessionProperties
     public static final String MERGE_DUPLICATE_AGGREGATIONS = "merge_duplicate_aggregations";
     public static final String MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER = "merge_aggregations_with_and_without_filter";
     public static final String SIMPLIFY_PLAN_WITH_EMPTY_INPUT = "simplify_plan_with_empty_input";
+    public static final String PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN = "push_down_filter_expression_evaluation_through_cross_join";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1522,6 +1523,11 @@ public final class SystemSessionProperties
                         SIMPLIFY_PLAN_WITH_EMPTY_INPUT,
                         "Simplify the query plan with empty input",
                         featuresConfig.isSimplifyPlanWithEmptyInput(),
+                        false),
+                booleanProperty(
+                        PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN,
+                        "Push down expression evaluation in filter through cross join",
+                        featuresConfig.isPushDownFilterExpressionEvaluationThroughCrossJoin(),
                         false));
     }
 
@@ -2552,5 +2558,10 @@ public final class SystemSessionProperties
     public static boolean isSimplifyPlanWithEmptyInputEnabled(Session session)
     {
         return session.getSystemProperty(SIMPLIFY_PLAN_WITH_EMPTY_INPUT, Boolean.class) || session.getSystemProperty(OPTIMIZE_JOINS_WITH_EMPTY_SOURCES, Boolean.class);
+    }
+
+    public static boolean isPushdownFilterExpressionEvaluationThroughCrossJoin(Session session)
+    {
+        return session.getSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -255,6 +255,7 @@ public class FeaturesConfig
     private boolean mergeDuplicateAggregationsEnabled = true;
     private boolean mergeAggregationsWithAndWithoutFilter;
     private boolean simplifyPlanWithEmptyInput = true;
+    private boolean pushDownFilterExpressionEvaluationThroughCrossJoin = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2480,6 +2481,19 @@ public class FeaturesConfig
     public FeaturesConfig setSimplifyPlanWithEmptyInput(boolean simplifyPlanWithEmptyInput)
     {
         this.simplifyPlanWithEmptyInput = simplifyPlanWithEmptyInput;
+        return this;
+    }
+
+    public boolean isPushDownFilterExpressionEvaluationThroughCrossJoin()
+    {
+        return this.pushDownFilterExpressionEvaluationThroughCrossJoin;
+    }
+
+    @Config("optimizer.push-down-filter-expression-evaluation-through-cross-join")
+    @ConfigDescription("Push down expression evaluation in filter through cross join")
+    public FeaturesConfig setPushDownFilterExpressionEvaluationThroughCrossJoin(boolean pushDownFilterExpressionEvaluationThroughCrossJoin)
+    {
+        this.pushDownFilterExpressionEvaluationThroughCrossJoin = pushDownFilterExpressionEvaluationThroughCrossJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -255,7 +255,8 @@ public class FeaturesConfig
     private boolean mergeDuplicateAggregationsEnabled = true;
     private boolean mergeAggregationsWithAndWithoutFilter;
     private boolean simplifyPlanWithEmptyInput = true;
-    private boolean pushDownFilterExpressionEvaluationThroughCrossJoin = true;
+    private PushDownFilterThroughCrossJoinStrategy pushDownFilterExpressionEvaluationThroughCrossJoin = PushDownFilterThroughCrossJoinStrategy.REWRITTEN_TO_INNER_JOIN;
+    private boolean rewriteCrossJoinWithOrFilterToInnerJoin = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -344,6 +345,13 @@ public class FeaturesConfig
     {
         DISABLED,
         KEY_FROM_OUTER_JOIN, // Enabled only when join keys are from output of outer joins
+        ALWAYS
+    }
+
+    public enum PushDownFilterThroughCrossJoinStrategy
+    {
+        DISABLED,
+        REWRITTEN_TO_INNER_JOIN, // Enabled only when the change can enable rewriting cross join to inner join
         ALWAYS
     }
 
@@ -2484,16 +2492,29 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isPushDownFilterExpressionEvaluationThroughCrossJoin()
+    public PushDownFilterThroughCrossJoinStrategy getPushDownFilterExpressionEvaluationThroughCrossJoin()
     {
         return this.pushDownFilterExpressionEvaluationThroughCrossJoin;
     }
 
     @Config("optimizer.push-down-filter-expression-evaluation-through-cross-join")
     @ConfigDescription("Push down expression evaluation in filter through cross join")
-    public FeaturesConfig setPushDownFilterExpressionEvaluationThroughCrossJoin(boolean pushDownFilterExpressionEvaluationThroughCrossJoin)
+    public FeaturesConfig setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy strategy)
     {
-        this.pushDownFilterExpressionEvaluationThroughCrossJoin = pushDownFilterExpressionEvaluationThroughCrossJoin;
+        this.pushDownFilterExpressionEvaluationThroughCrossJoin = strategy;
+        return this;
+    }
+
+    public boolean isRewriteCrossJoinWithOrFilterToInnerJoin()
+    {
+        return this.rewriteCrossJoinWithOrFilterToInnerJoin;
+    }
+
+    @Config("optimizer.rewrite-cross-join-with-or-filter-to-inner-join")
+    @ConfigDescription("Enable optimization to rewrite cross join with or filter to inner join")
+    public FeaturesConfig setRewriteCrossJoinWithOrFilterToInnerJoin(boolean rewriteCrossJoinWithOrFilterToInnerJoin)
+    {
+        this.rewriteCrossJoinWithOrFilterToInnerJoin = rewriteCrossJoinWithOrFilterToInnerJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.planner.iterative.properties.LogicalPropertiesPro
 import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregations;
 import com.facebook.presto.sql.planner.iterative.rule.CombineApproxPercentileFunctions;
 import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
+import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithOrFilterToInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarLambdaExpression;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
@@ -442,7 +443,9 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new PushDownFilterExpressionEvaluationThroughCrossJoin(metadata.getFunctionAndTypeManager()))),
+                        ImmutableSet.of(
+                                new PushDownFilterExpressionEvaluationThroughCrossJoin(metadata.getFunctionAndTypeManager()),
+                                new CrossJoinWithOrFilterToInnerJoin(metadata.getFunctionAndTypeManager()))),
                 new KeyBasedSampler(metadata, sqlParser),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -73,6 +73,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PullConstantsAboveGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushDownDereferences;
+import com.facebook.presto.sql.planner.iterative.rule.PushDownFilterExpressionEvaluationThroughCrossJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughOffset;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughOuterJoin;
@@ -437,6 +438,11 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RewriteAggregationIfToFilter(metadata.getFunctionAndTypeManager()))),
                 predicatePushDown,
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new PushDownFilterExpressionEvaluationThroughCrossJoin(metadata.getFunctionAndTypeManager()))),
                 new KeyBasedSampler(metadata, sqlParser),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.CastType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlannerUtils;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteCrossJoinOrToInnerJoinEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractDisjuncts;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.not;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Inner join with "or" inside join clause will be run as cross join with filter, which can degrade performance, especially when selectivity of join is low.
+ * When the join condition has pattern of l_key1=r_key1 or l_key1=r_key2, we can rewrite it to a inner join. For example:
+ * <pre>
+ * - Filter l_key1=r_key1 or l_key1=r_key2
+ *      - Cross join
+ *          - scan l
+ *          - scan r
+ * </pre>
+ * into:
+ * <pre>
+ *     - Project
+ *          - Filter
+ *              CASE field WHEN 1 l_key1 = r_key1 WHEN 2 NOT(coalesce(l_key1 = r_key1, false)) and l_key2 = r_key2 else NULL END
+ *              - Inner Join
+ *                  l_key = r_key and l_field = r_field
+ *                  - Project
+ *                      key1 := key1
+ *                      key2 := key2
+ *                      field := field
+ *                      key := case field when 1 then key1 when 2 then key2 else null end
+ *                      - Unnest
+ *                          field <- unnest arr
+ *                          - Project
+ *                              key1 := key1
+ *                              key2 := key2
+ *                              arr := array[1, 2]
+ *                              _ scan l
+ *                                  key1, key2
+ *                   - Project
+ *                      key1 := key1
+ *                      key2 := key2
+ *                      field := field
+ *                      key := case field when 1 then key1 when 2 then key2 else null end
+ *                      - Unnest
+ *                          field <- unnest arr
+ *                          - Project
+ *                              key1 := key1
+ *                              key2 := key2
+ *                              arr := array[1, 2]
+ *                              _ scan r
+ *                                  key1, key2
+ * </pre>
+ */
+public class CrossJoinWithOrFilterToInnerJoin
+        implements Rule<FilterNode>
+{
+    private static final List<Type> SUPPORTED_JOIN_KEY_TYPE = ImmutableList.of(BIGINT, INTEGER, VARCHAR, DATE);
+    private static final Capture<JoinNode> CHILD = newCapture();
+
+    private static final Pattern<FilterNode> PATTERN = filter()
+            .with(source().matching(join().matching(x -> x.getType().equals(JoinNode.Type.INNER) && x.getCriteria().isEmpty()).capturedAs(CHILD)));
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public CrossJoinWithOrFilterToInnerJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    // Valid only if it's an equal expression, and one argument from left of join and the other argument from right of join.
+    private static boolean isValidExpression(RowExpression rowExpression, List<VariableReferenceExpression> leftInput, List<VariableReferenceExpression> rightInput)
+    {
+        if (!(rowExpression instanceof CallExpression) || !((CallExpression) rowExpression).getDisplayName().equals("EQUAL")) {
+            return false;
+        }
+        CallExpression callExpression = (CallExpression) rowExpression;
+        RowExpression argument0 = callExpression.getArguments().get(0);
+        RowExpression argument1 = callExpression.getArguments().get(1);
+        return SUPPORTED_JOIN_KEY_TYPE.containsAll(ImmutableList.of(argument0.getType(), argument1.getType()))
+                && ((leftInput.contains(argument0) && rightInput.contains(argument1)) || (leftInput.contains(argument1) && rightInput.contains(argument0)));
+    }
+
+    public static RowExpression getCandidateOrExpression(RowExpression filterPredicate, List<VariableReferenceExpression> leftInput, List<VariableReferenceExpression> rightInput)
+    {
+        List<RowExpression> andConjuncts = extractConjuncts(filterPredicate);
+        for (RowExpression conjunct : andConjuncts) {
+            List<RowExpression> equalExpressionList = extractDisjuncts(conjunct);
+            if (!equalExpressionList.isEmpty() && equalExpressionList.stream().allMatch(x -> isValidExpression(x, leftInput, rightInput))) {
+                return conjunct;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRewriteCrossJoinOrToInnerJoinEnabled(session);
+    }
+
+    private RewrittenJoinInput rewriteJoinInput(List<VariableReferenceExpression> variablesInOrCondition, PlanNode joinInput, Type finalJoinKeyType, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        Map<VariableReferenceExpression, VariableReferenceExpression> castVariableMap = new HashMap<>();
+        Map<VariableReferenceExpression, RowExpression> castExpressionMap = new HashMap<>();
+        if (!variablesInOrCondition.stream().allMatch(x -> x.getType().equals(finalJoinKeyType))) {
+            // cast all to varchar type
+            for (int i = 0; i < variablesInOrCondition.size(); ++i) {
+                CallExpression castExpression = call("CAST", functionAndTypeManager.lookupCast(CastType.CAST, variablesInOrCondition.get(i).getType(), VARCHAR), VARCHAR, variablesInOrCondition.get(i));
+                VariableReferenceExpression castVariable = variableAllocator.newVariable(castExpression);
+                castVariableMap.put(variablesInOrCondition.get(i), castVariable);
+                castExpressionMap.put(castVariable, castExpression);
+            }
+        }
+
+        ImmutableList.Builder<RowExpression> constantsArgument = ImmutableList.builder();
+        for (int i = 0; i < variablesInOrCondition.size(); ++i) {
+            constantsArgument.add(constant((long) i + 1, INTEGER));
+        }
+        CallExpression arrayConstruct = call(functionAndTypeManager, "array_constructor", new ArrayType(INTEGER), constantsArgument.build());
+
+        VariableReferenceExpression arrayVariable = variableAllocator.newVariable(arrayConstruct);
+        ImmutableMap.Builder<VariableReferenceExpression, RowExpression> projectAssignment = ImmutableMap.builder();
+        PlanNode project = PlannerUtils.addProjections(joinInput, idAllocator, projectAssignment.put(arrayVariable, arrayConstruct).putAll(castExpressionMap).build());
+
+        VariableReferenceExpression unnestVariable = variableAllocator.newVariable("field", INTEGER);
+        UnnestNode unnest = new UnnestNode(joinInput.getSourceLocation(),
+                idAllocator.getNextId(),
+                project,
+                project.getOutputVariables().stream().filter(x -> !x.equals(arrayVariable)).collect(toImmutableList()),
+                ImmutableMap.of(arrayVariable, ImmutableList.of(unnestVariable)),
+                Optional.empty());
+
+        ImmutableList.Builder<RowExpression> whenExpression = ImmutableList.builder();
+        whenExpression.add(unnestVariable);
+        for (int i = 0; i < variablesInOrCondition.size(); ++i) {
+            whenExpression.add(new SpecialFormExpression(WHEN, finalJoinKeyType, constant((long) i + 1, INTEGER), castVariableMap.isEmpty() ? variablesInOrCondition.get(i) : castVariableMap.get(variablesInOrCondition.get(i))));
+        }
+        whenExpression.add(constantNull(finalJoinKeyType));
+        SpecialFormExpression joinKeyExpression = new SpecialFormExpression(SWITCH, finalJoinKeyType, whenExpression.build());
+        VariableReferenceExpression newJoinVariable = variableAllocator.newVariable(joinKeyExpression);
+        PlanNode rewrittenInput = PlannerUtils.addProjections(unnest, idAllocator, variableAllocator, ImmutableList.of(joinKeyExpression), ImmutableList.of(newJoinVariable));
+        return new RewrittenJoinInput(rewrittenInput, unnestVariable, newJoinVariable);
+    }
+
+    private VariableReferenceExpression getVariableInEqualComparison(RowExpression rowExpression, List<VariableReferenceExpression> candidate)
+    {
+        checkArgument(rowExpression instanceof CallExpression && ((CallExpression) rowExpression).getDisplayName().equals("EQUAL"));
+        CallExpression callExpression = (CallExpression) rowExpression;
+        RowExpression argument0 = callExpression.getArguments().get(0);
+        RowExpression argument1 = callExpression.getArguments().get(1);
+        if (candidate.contains(argument0)) {
+            return (VariableReferenceExpression) argument0;
+        }
+        else if (candidate.contains(argument1)) {
+            return (VariableReferenceExpression) argument1;
+        }
+        checkState(false, "argument does not exist in candidate list");
+        return null;
+    }
+
+    @Override
+    public Result apply(FilterNode filterNode, Captures captures, Context context)
+    {
+        JoinNode joinNode = captures.get(CHILD);
+        if (!(joinNode.getType().equals(JoinNode.Type.INNER) && joinNode.getCriteria().isEmpty())) {
+            return Result.empty();
+        }
+        RowExpression candidateOrExpressions = getCandidateOrExpression(filterNode.getPredicate(), joinNode.getLeft().getOutputVariables(), joinNode.getRight().getOutputVariables());
+        if (candidateOrExpressions == null) {
+            return Result.empty();
+        }
+        List<RowExpression> andConjuncts = extractConjuncts(filterNode.getPredicate());
+        List<RowExpression> leftAndConjuncts = andConjuncts.stream().filter(x -> !x.equals(candidateOrExpressions)).collect(toImmutableList());
+        List<RowExpression> equalExpressionList = extractDisjuncts(candidateOrExpressions);
+        List<VariableReferenceExpression> variablesUsedInOrComparisionFromLeft = equalExpressionList.stream().map(x -> getVariableInEqualComparison(x, joinNode.getLeft().getOutputVariables())).collect(toImmutableList());
+        List<VariableReferenceExpression> variablesUsedInOrComparisionFromRight = equalExpressionList.stream().map(x -> getVariableInEqualComparison(x, joinNode.getRight().getOutputVariables())).collect(toImmutableList());
+
+        if (variablesUsedInOrComparisionFromLeft.isEmpty() || variablesUsedInOrComparisionFromRight.isEmpty()) {
+            return Result.empty();
+        }
+        // Apply optimization only when the variables in or condition is of type int/bigint/varchar/date types.
+        if (variablesUsedInOrComparisionFromLeft.stream().anyMatch(x -> !SUPPORTED_JOIN_KEY_TYPE.contains(x.getType()))
+                || variablesUsedInOrComparisionFromRight.stream().anyMatch(x -> !SUPPORTED_JOIN_KEY_TYPE.contains(x.getType()))) {
+            return Result.empty();
+        }
+
+        // Check if all candidate variables are of the same type
+        Type joinKeyType = VARCHAR;
+        List<Type> leftOrPredicateTypes = variablesUsedInOrComparisionFromLeft.stream().map(x -> x.getType()).distinct().collect(toImmutableList());
+        List<Type> rightOrPredicateTypes = variablesUsedInOrComparisionFromRight.stream().map(x -> x.getType()).distinct().collect(toImmutableList());
+        if (leftOrPredicateTypes.size() == 1 && rightOrPredicateTypes.size() == 1 && leftOrPredicateTypes.get(0).equals(rightOrPredicateTypes.get(0))) {
+            joinKeyType = leftOrPredicateTypes.get(0);
+        }
+
+        RewrittenJoinInput leftJoinInput = rewriteJoinInput(variablesUsedInOrComparisionFromLeft, joinNode.getLeft(), joinKeyType, context.getVariableAllocator(), context.getIdAllocator());
+        RewrittenJoinInput rightJoinInput = rewriteJoinInput(variablesUsedInOrComparisionFromRight, joinNode.getRight(), joinKeyType, context.getVariableAllocator(), context.getIdAllocator());
+
+        ImmutableList.Builder<VariableReferenceExpression> joinOutput = ImmutableList.builder();
+        joinOutput.addAll(joinNode.getOutputVariables()).add(leftJoinInput.getJoinKey()).add(leftJoinInput.getUnnestIndex());
+        JoinNode newJoinNode = new JoinNode(joinNode.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                joinNode.getType(),
+                leftJoinInput.getNode(),
+                rightJoinInput.getNode(),
+                ImmutableList.of(new JoinNode.EquiJoinClause(leftJoinInput.getJoinKey(), rightJoinInput.getJoinKey()),
+                        new JoinNode.EquiJoinClause(leftJoinInput.getUnnestIndex(), rightJoinInput.getUnnestIndex())),
+                joinOutput.build(),
+                joinNode.getFilter(),
+                Optional.empty(),
+                Optional.empty(),
+                joinNode.getDistributionType(),
+                joinNode.getDynamicFilters());
+
+        // Deduplicate the rows which matched multiple times
+        ImmutableList.Builder<RowExpression> whenExpression = ImmutableList.builder();
+        whenExpression.add(leftJoinInput.getUnnestIndex());
+        for (int i = 0; i < equalExpressionList.size(); ++i) {
+            ImmutableList.Builder<RowExpression> matchCondition = ImmutableList.builder();
+            for (int j = 0; j < i; ++j) {
+                matchCondition.add(not(functionAndTypeManager, coalesceNullToFalse(equalExpressionList.get(j))));
+            }
+            matchCondition.add(equalExpressionList.get(i));
+            whenExpression.add(new SpecialFormExpression(WHEN, BOOLEAN, constant((long) i + 1, INTEGER), and(matchCondition.build())));
+        }
+        whenExpression.add(constantNull(BOOLEAN));
+        SpecialFormExpression dedupFilter = new SpecialFormExpression(SWITCH, BOOLEAN, whenExpression.build());
+        FilterNode newFilterNode = new FilterNode(joinNode.getSourceLocation(), context.getIdAllocator().getNextId(), newJoinNode, dedupFilter);
+        if (!leftAndConjuncts.isEmpty()) {
+            newFilterNode = new FilterNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), newFilterNode, and(leftAndConjuncts));
+        }
+        // So that the output of new node is exactly the same
+        Assignments.Builder identity = Assignments.builder();
+        identity.putAll(filterNode.getOutputVariables().stream().collect(toImmutableMap(x -> x, x -> x)));
+        ProjectNode projectUnusedOutput = new ProjectNode(context.getIdAllocator().getNextId(), newFilterNode, identity.build());
+        return Result.ofPlanNode(projectUnusedOutput);
+    }
+
+    private SpecialFormExpression coalesceNullToFalse(RowExpression rowExpression)
+    {
+        return new SpecialFormExpression(rowExpression.getSourceLocation(), COALESCE, BOOLEAN, rowExpression, constant(false, BOOLEAN));
+    }
+
+    private static class RewrittenJoinInput
+    {
+        private final PlanNode node;
+        private final VariableReferenceExpression unnestIndex;
+        private final VariableReferenceExpression joinKey;
+
+        public RewrittenJoinInput(PlanNode node, VariableReferenceExpression unnestIndex, VariableReferenceExpression joinKey)
+        {
+            this.node = node;
+            this.unnestIndex = unnestIndex;
+            this.joinKey = joinKey;
+        }
+
+        public PlanNode getNode()
+        {
+            return node;
+        }
+
+        public VariableReferenceExpression getJoinKey()
+        {
+            return joinKey;
+        }
+
+        public VariableReferenceExpression getUnnestIndex()
+        {
+            return unnestIndex;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushDownFilterExpressionEvaluationThroughCrossJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushDownFilterExpressionEvaluationThroughCrossJoin.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlannerUtils;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractDisjuncts;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.rewriteExpressionWithCSE;
+import static com.facebook.presto.sql.planner.VariablesExtractor.extractAll;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Stream.concat;
+
+/**
+ * Output of cross join is larger than input, push down expression evaluation can save calculation cost.
+ * <pre>
+ *     - Filter l_key1 = cardinality(r_key1)
+ *          - Cross Join
+ *              - scan l
+ *              - scan r
+ * </pre>
+ * to
+ * <pre>
+ *     - Filter l_key1 = card
+ *          - Cross Join
+ *              - scan l
+ *              - project
+ *                  card := cardinality(r_key1)
+ *                  - scan r
+ * </pre>
+ */
+public class PushDownFilterExpressionEvaluationThroughCrossJoin
+        implements Rule<FilterNode>
+{
+    private static final Capture<JoinNode> CHILD = newCapture();
+
+    private static final Pattern<FilterNode> PATTERN = filter()
+            .with(source().matching(join().matching(x -> x.getCriteria().isEmpty() && x.getType().equals(JoinNode.Type.INNER)).capturedAs(CHILD)));
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public PushDownFilterExpressionEvaluationThroughCrossJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return true;
+    }
+
+    @Override
+    public Result apply(FilterNode filterNode, Captures captures, Context context)
+    {
+        JoinNode joinNode = captures.get(CHILD);
+        List<Set<RowExpression>> rowExpressionToProject = getRowExpressions(filterNode.getPredicate(), joinNode.getLeft().getOutputVariables(), joinNode.getRight().getOutputVariables());
+        if (rowExpressionToProject.stream().allMatch(x -> x.isEmpty())) {
+            return Result.empty();
+        }
+        Map<RowExpression, VariableReferenceExpression> rewrittenExpressionMap = concat(rowExpressionToProject.get(0).stream(), rowExpressionToProject.get(1).stream())
+                .collect(toImmutableMap(identity(), x -> context.getVariableAllocator().newVariable(x)));
+        RowExpression rewrittenFilter = rewriteExpressionWithCSE(filterNode.getPredicate(), rewrittenExpressionMap);
+
+        Map<VariableReferenceExpression, RowExpression> leftAssignment = rowExpressionToProject.get(0).stream().collect(toImmutableMap(x -> rewrittenExpressionMap.get(x), identity()));
+        Map<VariableReferenceExpression, RowExpression> rightAssignment = rowExpressionToProject.get(1).stream().collect(toImmutableMap(x -> rewrittenExpressionMap.get(x), identity()));
+
+        PlanNode leftInput = joinNode.getLeft();
+        if (!leftAssignment.isEmpty()) {
+            leftInput = PlannerUtils.addProjections(joinNode.getLeft(), context.getIdAllocator(), leftAssignment);
+        }
+        PlanNode rightInput = joinNode.getRight();
+        if (!rightAssignment.isEmpty()) {
+            rightInput = PlannerUtils.addProjections(joinNode.getRight(), context.getIdAllocator(), rightAssignment);
+        }
+
+        Assignments.Builder identity = Assignments.builder();
+        identity.putAll(filterNode.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
+        return Result.ofPlanNode(
+                new ProjectNode(
+                        context.getIdAllocator().getNextId(),
+                        new FilterNode(
+                                filterNode.getSourceLocation(),
+                                context.getIdAllocator().getNextId(),
+                                new JoinNode(
+                                        joinNode.getSourceLocation(),
+                                        context.getIdAllocator().getNextId(),
+                                        joinNode.getType(),
+                                        leftInput,
+                                        rightInput,
+                                        joinNode.getCriteria(),
+                                        ImmutableList.<VariableReferenceExpression>builder()
+                                                .addAll(leftInput.getOutputVariables())
+                                                .addAll(rightInput.getOutputVariables())
+                                                .build(),
+                                        joinNode.getFilter(),
+                                        joinNode.getLeftHashVariable(),
+                                        joinNode.getRightHashVariable(),
+                                        joinNode.getDistributionType(),
+                                        joinNode.getDynamicFilters()),
+                                rewrittenFilter),
+                        identity.build()));
+    }
+
+    // TODO: this function only works for filter in form of and(or(exp1 = exp2, exp3 = exp4), or(exp5 = exp6, exp7=exp8)) etc. make it generic to work for all RowExpressions
+    private List<Set<RowExpression>> getRowExpressions(RowExpression filterPredicate, List<VariableReferenceExpression> left, List<VariableReferenceExpression> right)
+    {
+        Set<RowExpression> leftRowExpression = new HashSet<>();
+        Set<RowExpression> rightRowExpression = new HashSet<>();
+        RowExpressionDeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
+        for (RowExpression conjunct : extractConjuncts(filterPredicate)) {
+            for (RowExpression disjunct : extractDisjuncts(conjunct)) {
+                if (disjunct instanceof CallExpression && ((CallExpression) disjunct).getDisplayName().equals("EQUAL")) {
+                    CallExpression callExpression = (CallExpression) disjunct;
+                    RowExpression argument0 = callExpression.getArguments().get(0);
+                    RowExpression argument1 = callExpression.getArguments().get(1);
+
+                    List<VariableReferenceExpression> variablesInArgument0 = extractAll(argument0);
+                    if (!variablesInArgument0.isEmpty() && determinismEvaluator.isDeterministic(argument0) && !(argument0 instanceof VariableReferenceExpression)) {
+                        if (left.containsAll(variablesInArgument0)) {
+                            leftRowExpression.add(argument0);
+                        }
+                        else if (right.containsAll(variablesInArgument0)) {
+                            rightRowExpression.add(argument0);
+                        }
+                    }
+
+                    List<VariableReferenceExpression> variablesInArgument1 = extractAll(argument1);
+                    if (!variablesInArgument1.isEmpty() && determinismEvaluator.isDeterministic(argument1) && !(argument1 instanceof VariableReferenceExpression)) {
+                        if (left.containsAll(variablesInArgument1)) {
+                            leftRowExpression.add(argument1);
+                        }
+                        else if (right.containsAll(variablesInArgument1)) {
+                            rightRowExpression.add(argument1);
+                        }
+                    }
+                }
+            }
+        }
+        return ImmutableList.of(leftRowExpression, rightRowExpression);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
@@ -95,6 +95,11 @@ public final class Expressions
         return COMPARISON_FUNCTIONS.contains(callExpression.getFunctionHandle().getName());
     }
 
+    public static CallExpression not(FunctionAndTypeManager functionAndTypeManager, RowExpression rowExpression)
+    {
+        return call(functionAndTypeManager, "not", BOOLEAN, rowExpression);
+    }
+
     public static CallExpression call(String displayName, FunctionHandle functionHandle, Type returnType, RowExpression... arguments)
     {
         return call(displayName, functionHandle, returnType, asList(arguments));

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.PushDownFilterThroughCrossJoinStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
 import com.google.common.collect.ImmutableMap;
@@ -226,7 +227,8 @@ public class TestFeaturesConfig
                 .setMergeDuplicateAggregationsEnabled(true)
                 .setMergeAggregationsWithAndWithoutFilter(false)
                 .setSimplifyPlanWithEmptyInput(true)
-                .setPushDownFilterExpressionEvaluationThroughCrossJoin(true));
+                .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.REWRITTEN_TO_INNER_JOIN)
+                .setRewriteCrossJoinWithOrFilterToInnerJoin(true));
     }
 
     @Test
@@ -402,7 +404,8 @@ public class TestFeaturesConfig
                 .put("optimizer.merge-duplicate-aggregations", "false")
                 .put("optimizer.merge-aggregations-with-and-without-filter", "true")
                 .put("optimizer.simplify-plan-with-empty-input", "false")
-                .put("optimizer.push-down-filter-expression-evaluation-through-cross-join", "false")
+                .put("optimizer.push-down-filter-expression-evaluation-through-cross-join", "DISABLED")
+                .put("optimizer.rewrite-cross-join-with-or-filter-to-inner-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -576,7 +579,8 @@ public class TestFeaturesConfig
                 .setMergeDuplicateAggregationsEnabled(false)
                 .setMergeAggregationsWithAndWithoutFilter(true)
                 .setSimplifyPlanWithEmptyInput(false)
-                .setPushDownFilterExpressionEvaluationThroughCrossJoin(false);
+                .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.DISABLED)
+                .setRewriteCrossJoinWithOrFilterToInnerJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -225,7 +225,8 @@ public class TestFeaturesConfig
                 .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(true)
                 .setMergeDuplicateAggregationsEnabled(true)
                 .setMergeAggregationsWithAndWithoutFilter(false)
-                .setSimplifyPlanWithEmptyInput(true));
+                .setSimplifyPlanWithEmptyInput(true)
+                .setPushDownFilterExpressionEvaluationThroughCrossJoin(true));
     }
 
     @Test
@@ -401,6 +402,7 @@ public class TestFeaturesConfig
                 .put("optimizer.merge-duplicate-aggregations", "false")
                 .put("optimizer.merge-aggregations-with-and-without-filter", "true")
                 .put("optimizer.simplify-plan-with-empty-input", "false")
+                .put("optimizer.push-down-filter-expression-evaluation-through-cross-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -573,7 +575,8 @@ public class TestFeaturesConfig
                 .setUseDefaultsForCorrelatedAggregationPushdownThroughOuterJoins(false)
                 .setMergeDuplicateAggregationsEnabled(false)
                 .setMergeAggregationsWithAndWithoutFilter(true)
-                .setSimplifyPlanWithEmptyInput(false);
+                .setSimplifyPlanWithEmptyInput(false)
+                .setPushDownFilterExpressionEvaluationThroughCrossJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -463,6 +463,11 @@ public final class PlanMatchPattern
         return node(UnnestNode.class, source);
     }
 
+    public static PlanMatchPattern unnest(Map<String, List<String>> unnestVariables, PlanMatchPattern source)
+    {
+        return node(UnnestNode.class, source).with(new UnnestMatcher(unnestVariables));
+    }
+
     public static PlanMatchPattern exchange(PlanMatchPattern... sources)
     {
         return node(ExchangeNode.class, sources);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -178,9 +178,6 @@ final class RowExpressionVerifier
             }
             return getValueFromLiteral(literal).equals(String.valueOf(LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual)));
         }
-        if (actual instanceof VariableReferenceExpression && expected.getExpression() instanceof SymbolReference && expected.getType().equals(actual.getType().toString())) {
-            return visitSymbolReference((SymbolReference) expected.getExpression(), actual);
-        }
         if (!(actual instanceof CallExpression) || !functionResolution.isCastFunction(((CallExpression) actual).getFunctionHandle())) {
             return false;
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/UnnestMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/UnnestMatcher.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class UnnestMatcher
+        implements Matcher
+{
+    private final Map<String, List<String>> unnestMap;
+
+    public UnnestMatcher(Map<String, List<String>> unnestMap)
+    {
+        this.unnestMap = ImmutableMap.copyOf(unnestMap);
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof UnnestNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        UnnestNode unnestNode = (UnnestNode) node;
+        if (unnestMap.size() != unnestNode.getUnnestVariables().size()) {
+            return MatchResult.NO_MATCH;
+        }
+
+        if (!AggregationMatcher.matches(unnestMap.keySet(), unnestNode.getUnnestVariables().keySet(), symbolAliases)) {
+            return MatchResult.NO_MATCH;
+        }
+
+        List<String> expectedUnnestVariables = unnestMap.values().stream().flatMap(Collection::stream).collect(toImmutableList());
+        List<VariableReferenceExpression> actualUnnestVariables = unnestNode.getUnnestVariables().values().stream().flatMap(Collection::stream).collect(toImmutableList());
+        if (expectedUnnestVariables.size() != actualUnnestVariables.size()) {
+            return MatchResult.NO_MATCH;
+        }
+
+        SymbolAliases.Builder builder = SymbolAliases.builder();
+        for (int i = 0; i < expectedUnnestVariables.size(); ++i) {
+            builder.put(expectedUnnestVariables.get(i), createSymbolReference(actualUnnestVariables.get(i)));
+        }
+        return MatchResult.match(builder.build());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCrossJoinWithOrFilterToInnerJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCrossJoinWithOrFilterToInnerJoin.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unnest;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestCrossJoinWithOrFilterToInnerJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testTriggerForBigInt()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 = right_k2"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "case left_idx when 1 then left_k1 = right_k1 when 2 then not(coalesce(left_k1 = right_k1, false)) and left_k2 = right_k2 else null end",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(equiJoinClause("expr", "expr_2"), equiJoinClause("left_idx", "right_idx")),
+                                                project(
+                                                        ImmutableMap.of("expr", expression("case left_idx when 1 then left_k1 when 2 then left_k2 else null end")),
+                                                        unnest(
+                                                                ImmutableMap.of("left_array", ImmutableList.of("left_idx")),
+                                                                project(
+                                                                        ImmutableMap.of("left_array", expression("array[1, 2]")),
+                                                                        values("left_k1", "left_k2")))),
+                                                project(
+                                                        ImmutableMap.of("expr_2", expression("case right_idx when 1 then right_k1 when 2 then right_k2 else null end")),
+                                                        unnest(
+                                                                ImmutableMap.of("right_array", ImmutableList.of("right_idx")),
+                                                                project(
+                                                                        ImmutableMap.of("right_array", expression("array[1, 2]")),
+                                                                        values("right_k1", "right_k2"))))))));
+    }
+
+    @Test
+    public void testMultipleOrConditions()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("left_k3", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    p.variable("right_k3", BIGINT);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 = right_k2 or left_k3 = right_k3"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2"), p.variable("left_k3")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"), p.variable("right_k3"))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "case left_idx when 1 then left_k1 = right_k1 when 2 then not(coalesce(left_k1 = right_k1, false)) and left_k2 = right_k2 " +
+                                                "when 3 then not(coalesce(left_k1 = right_k1, false)) and not(coalesce(left_k2 = right_k2, false)) and left_k3 = right_k3 else null end",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(equiJoinClause("expr", "expr_2"), equiJoinClause("left_idx", "right_idx")),
+                                                project(
+                                                        ImmutableMap.of("expr", expression("case left_idx when 1 then left_k1 when 2 then left_k2 when 3 then left_k3 else null end")),
+                                                        unnest(
+                                                                ImmutableMap.of("left_array", ImmutableList.of("left_idx")),
+                                                                project(
+                                                                        ImmutableMap.of("left_array", expression("array[1, 2, 3]")),
+                                                                        values("left_k1", "left_k2", "left_k3")))),
+                                                project(
+                                                        ImmutableMap.of("expr_2", expression("case right_idx when 1 then right_k1 when 2 then right_k2 when 3 then right_k3 else null end")),
+                                                        unnest(
+                                                                ImmutableMap.of("right_array", ImmutableList.of("right_idx")),
+                                                                project(
+                                                                        ImmutableMap.of("right_array", expression("array[1, 2, 3]")),
+                                                                        values("right_k1", "right_k2", "right_k3"))))))));
+    }
+
+    @Test
+    public void testNotTriggerForDouble()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", DOUBLE);
+                    p.variable("left_k2", DOUBLE);
+                    p.variable("right_k1", DOUBLE);
+                    p.variable("right_k2", DOUBLE);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 = right_k2"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", DOUBLE), p.variable("left_k2", DOUBLE)),
+                                    p.values(p.variable("right_k1", DOUBLE), p.variable("right_k2", DOUBLE))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerForCastToDouble()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", VARCHAR);
+                    p.variable("left_k2", VARCHAR);
+                    p.variable("right_k1", VARCHAR);
+                    p.variable("right_k2", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or CAST(left_k2 AS DOUBLE) = CAST(right_k2 AS DOUBLE)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", VARCHAR), p.variable("left_k2", VARCHAR)),
+                                    p.values(p.variable("right_k1", VARCHAR), p.variable("right_k2", VARCHAR))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testOrWithCast()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 = CAST(right_k2 AS BIGINT)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2", VARCHAR))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testOrWithCastBothRules()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 = CAST(right_k2 AS BIGINT)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2", VARCHAR))));
+                })
+                .matches(
+                        project(
+                                project(
+                                        filter(
+                                                "case left_idx when 1 then left_k1 = right_k1 when 2 then not(coalesce(left_k1 = right_k1, false)) and left_k2 = cast_0 else null end",
+                                                join(
+                                                        JoinNode.Type.INNER,
+                                                        ImmutableList.of(equiJoinClause("expr", "expr_2"), equiJoinClause("left_idx", "right_idx")),
+                                                        project(
+                                                                ImmutableMap.of("expr", expression("case left_idx when 1 then left_k1 when 2 then left_k2 else null end")),
+                                                                unnest(
+                                                                        ImmutableMap.of("left_array", ImmutableList.of("left_idx")),
+                                                                        project(
+                                                                                ImmutableMap.of("left_array", expression("array[1, 2]")),
+                                                                                values("left_k1", "left_k2")))),
+                                                        project(
+                                                                ImmutableMap.of("expr_2", expression("case right_idx when 1 then right_k1 when 2 then cast_0 else null end")),
+                                                                unnest(
+                                                                        ImmutableMap.of("right_array", ImmutableList.of("right_idx")),
+                                                                        project(
+                                                                                ImmutableMap.of("right_array", expression("array[1, 2]")),
+                                                                                project(
+                                                                                        ImmutableMap.of("cast_0", expression("CAST(right_k2 AS bigint)")),
+                                                                                        values("right_k1", "right_k2"))))))))));
+    }
+
+    @Test
+    public void testConditionWithAnd()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("(left_k1 = right_k1 or left_k2 = right_k2) and left_k1+right_k2 > 10"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "left_k1+right_k2 > 10",
+                                        filter(
+                                                "case left_idx when 1 then left_k1 = right_k1 when 2 then not(coalesce(left_k1 = right_k1, false)) and left_k2 = right_k2 else null end",
+                                                join(
+                                                        JoinNode.Type.INNER,
+                                                        ImmutableList.of(equiJoinClause("expr", "expr_2"), equiJoinClause("left_idx", "right_idx")),
+                                                        project(
+                                                                ImmutableMap.of("expr", expression("case left_idx when 1 then left_k1 when 2 then left_k2 else null end")),
+                                                                unnest(
+                                                                        ImmutableMap.of("left_array", ImmutableList.of("left_idx")),
+                                                                        project(
+                                                                                ImmutableMap.of("left_array", expression("array[1, 2]")),
+                                                                                values("left_k1", "left_k2")))),
+                                                        project(
+                                                                ImmutableMap.of("expr_2", expression("case right_idx when 1 then right_k1 when 2 then right_k2 else null end")),
+                                                                unnest(
+                                                                        ImmutableMap.of("right_array", ImmutableList.of("right_idx")),
+                                                                        project(
+                                                                                ImmutableMap.of("right_array", expression("array[1, 2]")),
+                                                                                values("right_k1", "right_k2")))))))));
+    }
+
+    @Test
+    public void testNonMatchingCondition()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("(left_k1 = right_k1 or left_k2 = right_k2) or left_k1+right_k2 > 10"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNonMatchingCondition2()
+    {
+        tester().assertThat(new CrossJoinWithOrFilterToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or left_k2 > right_k2"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testTriggerWithAddition()
+    {
+        tester().assertThat(new PushDownFilterExpressionEvaluationThroughCrossJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("left_k1+left_k2 = right_k1+right_k2"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "add_1 = add_0",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(),
+                                                project(
+                                                        ImmutableMap.of("add_1", expression("left_k1+left_k2")),
+                                                        values("left_k1", "left_k2")),
+                                                project(
+                                                        ImmutableMap.of("add_0", expression("right_k1+right_k2")),
+                                                        values("right_k1", "right_k2"))))));
+    }
+
+    @Test
+    public void testTriggerWithArrayCardinality()
+    {
+        tester().assertThat(new PushDownFilterExpressionEvaluationThroughCrossJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("right_k1", new ArrayType(BIGINT));
+                    return p.filter(
+                            p.rowExpression("left_k1 = cardinality(right_k1)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1")),
+                                    p.values(p.variable("right_k1", new ArrayType(BIGINT)))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "left_k1 = card",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(),
+                                                values("left_k1"),
+                                                project(
+                                                        ImmutableMap.of("card", expression("cardinality(right_k1)")),
+                                                        values("right_k1"))))));
+    }
+
+    @Test
+    public void testCast()
+    {
+        tester().assertThat(new PushDownFilterExpressionEvaluationThroughCrossJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", VARCHAR);
+                    p.variable("left_k2", VARCHAR);
+                    p.variable("right_k1", VARCHAR);
+                    p.variable("right_k2", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or CAST(left_k2 AS DOUBLE) = CAST(right_k2 AS DOUBLE)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", VARCHAR), p.variable("left_k2", VARCHAR)),
+                                    p.values(p.variable("right_k1", VARCHAR), p.variable("right_k2", VARCHAR))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "left_k1 = right_k1 OR cast_1 = cast_0",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(),
+                                                project(
+                                                        ImmutableMap.of("cast_1", expression("CAST(left_k2 AS double)")),
+                                                        values("left_k1", "left_k2")),
+                                                project(
+                                                        ImmutableMap.of("cast_0", expression("CAST(right_k2 AS double)")),
+                                                        values("right_k1", "right_k2"))))));
+    }
+
+    @Test
+    public void testCoalesce()
+    {
+        tester().assertThat(new PushDownFilterExpressionEvaluationThroughCrossJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", VARCHAR);
+                    p.variable("right_k3", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("left_k1 = right_k1 or CAST(left_k1 AS VARCHAR) = COALESCE(right_k2, right_k3)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2", VARCHAR), p.variable("right_k3", VARCHAR))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "left_k1 = right_k1 OR cast_1 = expr",
+                                        join(
+                                                JoinNode.Type.INNER,
+                                                ImmutableList.of(),
+                                                project(
+                                                        ImmutableMap.of("cast_1", expression("CAST(left_k1 AS varchar)")),
+                                                        values("left_k1")),
+                                                project(
+                                                        ImmutableMap.of("expr", expression("COALESCE(right_k2, right_k3)")),
+                                                        values("right_k1", "right_k2", "right_k3"))))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
@@ -100,7 +100,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                     p.variable("right_k1", VARCHAR);
                     p.variable("right_k2", VARCHAR);
                     return p.filter(
-                            p.rowExpression("left_k1 = right_k1 or CAST(left_k2 AS DOUBLE) = CAST(right_k2 AS DOUBLE)"),
+                            p.rowExpression("left_k1 = right_k1 or CAST(left_k2 AS BIGINT) = CAST(right_k2 AS BIGINT)"),
                             p.join(JoinNode.Type.INNER,
                                     p.values(p.variable("left_k1", VARCHAR), p.variable("left_k2", VARCHAR)),
                                     p.values(p.variable("right_k1", VARCHAR), p.variable("right_k2", VARCHAR))));
@@ -113,10 +113,10 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                                 JoinNode.Type.INNER,
                                                 ImmutableList.of(),
                                                 project(
-                                                        ImmutableMap.of("cast_1", expression("CAST(left_k2 AS double)")),
+                                                        ImmutableMap.of("cast_1", expression("CAST(left_k2 AS bigint)")),
                                                         values("left_k1", "left_k2")),
                                                 project(
-                                                        ImmutableMap.of("cast_0", expression("CAST(right_k2 AS double)")),
+                                                        ImmutableMap.of("cast_0", expression("CAST(right_k2 AS bigint)")),
                                                         values("right_k1", "right_k2"))))));
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_T
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.SIMPLIFY_PLAN_WITH_EMPTY_INPUT;
 import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -6584,7 +6585,7 @@ public abstract class AbstractTestQueries
     public void testPushFilterExpressionDownCrossJoin()
     {
         Session enableOptimization = Session.builder(getSession())
-                .setSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, "true")
+                .setSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, "ALWAYS")
                 .build();
         String sql = "with t1 as (select * from (values (1, 2), (null, 2), (1, null), (null, null)) t(k1, k2)), t2 as (select * from (values (1, 2), (null, 1), (null, 2), (null, null)) t(k1, k2)) " +
                 "select * from t1 join t2 on t1.k1=t2.k1 or coalesce(t1.k2, 1)= coalesce(t2.k2, 2)";
@@ -6595,5 +6596,38 @@ public abstract class AbstractTestQueries
 
         sql = "select o.orderkey, l.partkey, l.suppkey from lineitem l join orders o on (l.orderkey = o.orderkey or (l.partkey + l.suppkey) = o.orderkey) and l.quantity*totalprice > 1000 where l.quantity < 5 and o.totalprice < 2000";
         assertQuery(enableOptimization, sql);
+    }
+
+    @Test
+    public void testInnerJoinWithOrCondition()
+    {
+        Session enableOptimization = Session.builder(getSession())
+                .setSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, "disabled")
+                .setSystemProperty(REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN, "true")
+                .build();
+        String sql = "with t1 as (select * from (values (1, 2), (null, 2), (1, null), (null, null)) t(k1, k2)), t2 as (select * from (values (1, 2), (null, 1), (null, 2), (null, null)) t(k1, k2)) " +
+                "select * from t1 join t2 on t1.k1=t2.k1 or t1.k2=t2.k2";
+        assertQuery(enableOptimization, sql);
+
+        sql = "select o.orderkey, l.partkey from lineitem l join orders o on l.orderkey = o.orderkey or l.partkey = o.orderkey where l.quantity < 5 and o.totalprice < 2000";
+        assertQuery(enableOptimization, sql);
+
+        sql = "select o.orderkey, l.partkey from lineitem l join orders o on (l.orderkey = o.orderkey or l.partkey = o.orderkey) and l.quantity*totalprice > 1000 where l.quantity < 5 and o.totalprice < 2000";
+        assertQuery(enableOptimization, sql);
+
+        Session enablePushFilterOptimization = Session.builder(getSession())
+                .setSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, "REWRITTEN_TO_INNER_JOIN")
+                .setSystemProperty(REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN, "true")
+                .build();
+
+        sql = "with t1 as (select * from (values (1, 2), (null, 2), (1, null), (null, null)) t(k1, k2)), t2 as (select * from (values (1, 2), (null, 1), (null, 2), (null, null)) t(k1, k2)) " +
+                "select * from t1 join t2 on t1.k1=t2.k1 or coalesce(t1.k2, 1)= coalesce(t2.k2, 2)";
+        assertQuery(enablePushFilterOptimization, sql);
+
+        sql = "select o.orderkey, l.partkey, l.suppkey from lineitem l join orders o on l.orderkey = o.orderkey or (l.partkey + l.suppkey) = o.orderkey where l.quantity < 5 and o.totalprice < 2000";
+        assertQuery(enablePushFilterOptimization, sql);
+
+        sql = "select o.orderkey, l.partkey, l.suppkey from lineitem l join orders o on (l.orderkey = o.orderkey or (l.partkey + l.suppkey) = o.orderkey) and l.quantity*totalprice > 1000 where l.quantity < 5 and o.totalprice < 2000";
+        assertQuery(enablePushFilterOptimization, sql);
     }
 }


### PR DESCRIPTION
This PR includes two changes, 
* add a rule to push down filter expressions through cross join
This rule tries to push the filter expression evaluation down the cross join, for example:
cross join -> filter(cardinality(l_arr) > 2) to  project(card := cardinality(l_arr)) -> cross join -> filter(card > 2).
This rule can save calculation cost as cross join has more output than input.

* add a rule to convert cross join with filter to inner join (relied on the above rule to convert callexpression in equal comparison to variable references)
For queries with pattern left join right with l_key1=r_key1 or l_key2=r_key2, it will generate plan which has a cross join, followed by a filter. In this optimization, it will rewrite the query to:
`left/right -> unnest(array[0, 1]) -> project(key = case idx when 0 then l/r_key1, when 1 then l/r_key2) -> join(l_key = r_key) -> filter(filter duplicate)`
When l_key1, l_key2, r_key1, r_key2 are not of the same type, we will cast them to VARCHAR and the newly created join key l_key/r_key will be VARCHAR type.
This optimization only works if the join key to be compared is of type bigint, int, date and varchar.


### Test plan - (Please fill in how you tested your changes)
Add unit tests, and also verifier test([run1](https://www.internalfb.com/intern/presto/verifier/results/?test_id=111295&build=&user=&limit=400&error_regex=&suite=) [run2](https://www.internalfb.com/intern/presto/verifier/results/?test_id=111296&build=&user=&limit=300&error_regex=&suite=))

```
== RELEASE NOTES ==

General Changes
* Add an optimization to convert applicable cross join with an or filter to inner join. It's controlled by session property `rewrite_cross_join_or_to_inner_join`
* Add an optimization to push down filter expression evaluation through cross join. It's controlled by session property `push_down_filter_expression_evaluation_through_cross_join`
```
