### PR TITLE
[native] Simplify zoombie task logging.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -482,20 +482,6 @@ struct ZombieTaskCounts {
   }
 
   void logZombieTaskStatus(const std::string& hangingClassName) {
-    auto length = 0;
-    for (auto& id : taskIds) {
-      length += id.length() + 2; // for comma and space
-    }
-    std::string taskIdsStr;
-    taskIdsStr.reserve(length);
-    for (auto i = 0; i < taskIds.size(); i++) {
-      if (i == taskIds.size() - 1) {
-        taskIdsStr.append(taskIds[i]);
-      } else {
-        taskIdsStr.append(taskIds[i]).append(", ");
-      }
-    }
-
     LOG(ERROR) << "There are " << numTotal << " zombie " << hangingClassName
                << " that satisfy cleanup conditions but could not be "
                   "cleaned up, because the "
@@ -504,7 +490,8 @@ struct ZombieTaskCounts {
                << numRunning << "] FINISHED[" << numFinished << "] CANCELED["
                << numCanceled << "] ABORTED[" << numAborted << "] FAILED["
                << numFailed << "]  Sample task IDs (shows only "
-               << numSampleTaskId << " IDs): {" << taskIdsStr << "}";
+               << numSampleTaskId << " IDs): {" << folly::join(',', taskIds)
+               << "}";
   }
 };
 


### PR DESCRIPTION
Zoombie task logging iterates over all task ids and concatenate them to one string. Using folly::join to simplify it.


```
== NO RELEASE NOTE ==
```
