### PR TITLE
[native] Implement Decimal Types as Logical Types (#4434)

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -47,6 +47,8 @@ option(PRESTO_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(PRESTO_ENABLE_TESTING "Enable tests" ON)
 
 # Set all Velox options below
+add_compile_definitions(FOLLY_HAVE_INT128_T=1)
+
 if(PRESTO_ENABLE_S3)
   set(VELOX_ENABLE_S3
       ON

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -104,6 +104,9 @@ velox::variant VeloxExprConverter::getConstantValue(
   }
 
   switch (typeKind) {
+    case TypeKind::HUGEINT:
+      return valueVector->as<velox::SimpleVector<velox::int128_t>>()->valueAt(
+          0);
     case TypeKind::BIGINT:
       return valueVector->as<velox::SimpleVector<int64_t>>()->valueAt(0);
     case TypeKind::INTEGER:
@@ -392,14 +395,6 @@ std::shared_ptr<const ConstantTypedExpr> VeloxExprConverter::toVeloxExpr(
       return std::make_shared<ConstantTypedExpr>(
           std::make_shared<velox::ConstantVector<velox::ComplexType>>(
               pool_, 1, 0, valueVector));
-    }
-    case TypeKind::SHORT_DECIMAL:
-    case TypeKind::LONG_DECIMAL: {
-      auto valueVector =
-          protocol::readBlock(type, pexpr->valueBlock.data, pool_);
-      return std::make_shared<ConstantTypedExpr>(
-          velox::BaseVector::wrapInConstant(
-              1 /*length*/, 0 /*index*/, valueVector));
     }
     default: {
       const auto value = getConstantValue(type, pexpr->valueBlock);

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/Base64Test.cpp
@@ -90,71 +90,62 @@ TEST_F(Base64Test, simpleLongDecimal) {
   // Unscaled value = 0
   const std::string data0 =
       "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
-  auto vector0 = readBlock(LONG_DECIMAL(24, 2), data0, pool_.get());
+  auto vector0 = readBlock(DECIMAL(24, 2), data0, pool_.get());
 
-  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector0->typeKind());
+  ASSERT_EQ(TypeKind::HUGEINT, vector0->typeKind());
   ASSERT_EQ(1, vector0->size());
   ASSERT_FALSE(vector0->isNullAt(0));
 
-  auto decimalVector0 =
-      vector0->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
-  ASSERT_EQ(UnscaledLongDecimal(0), decimalVector0->valueAt(0));
+  auto decimalVector0 = vector0->as<FlatVector<int128_t>>();
+  ASSERT_EQ(0, decimalVector0->valueAt(0));
 
   // Unscaled value = 100
   const std::string data1 =
       "DAAAAElOVDEyOF9BUlJBWQEAAAAAZAAAAAAAAAAAAAAAAAAAAA==";
-  auto vector1 = readBlock(LONG_DECIMAL(24, 2), data1, pool_.get());
+  auto vector1 = readBlock(DECIMAL(24, 2), data1, pool_.get());
 
-  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector1->typeKind());
+  ASSERT_EQ(TypeKind::HUGEINT, vector1->typeKind());
   ASSERT_EQ(1, vector1->size());
   ASSERT_FALSE(vector1->isNullAt(0));
 
-  auto decimalVector1 =
-      vector1->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
-  ASSERT_EQ(UnscaledLongDecimal(100), decimalVector1->valueAt(0));
+  auto decimalVector1 = vector1->as<FlatVector<int128_t>>();
+  ASSERT_EQ(100, decimalVector1->valueAt(0));
 
   // Unscaled value = -100
   const std::string data2 =
       "DAAAAElOVDEyOF9BUlJBWQEAAAAAZAAAAAAAAAAAAAAAAAAAgA==";
-  auto vector2 = readBlock(LONG_DECIMAL(24, 2), data2, pool_.get());
+  auto vector2 = readBlock(DECIMAL(24, 2), data2, pool_.get());
 
-  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector2->typeKind());
+  ASSERT_EQ(TypeKind::HUGEINT, vector2->typeKind());
   ASSERT_EQ(1, vector2->size());
   ASSERT_FALSE(vector2->isNullAt(0));
 
-  auto decimalVector2 =
-      vector2->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
-  ASSERT_EQ(UnscaledLongDecimal(-100), decimalVector2->valueAt(0));
+  auto decimalVector2 = vector2->as<FlatVector<int128_t>>();
+  ASSERT_EQ(-100, decimalVector2->valueAt(0));
 
   // Unscaled value = 10^20
   const std::string data3 =
       "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAQYy1ex2sFAAAAAAAAAA==";
-  auto vector3 = readBlock(LONG_DECIMAL(24, 2), data3, pool_.get());
+  auto vector3 = readBlock(DECIMAL(24, 2), data3, pool_.get());
 
-  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector3->typeKind());
+  ASSERT_EQ(TypeKind::HUGEINT, vector3->typeKind());
   ASSERT_EQ(1, vector3->size());
   ASSERT_FALSE(vector3->isNullAt(0));
 
-  auto decimalVector3 =
-      vector3->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
-  ASSERT_EQ(
-      UnscaledLongDecimal(DecimalUtil::kPowersOfTen[20]),
-      decimalVector3->valueAt(0));
+  auto decimalVector3 = vector3->as<FlatVector<int128_t>>();
+  ASSERT_EQ(DecimalUtil::kPowersOfTen[20], decimalVector3->valueAt(0));
 
   // Unscaled value = -10^20
   const std::string data4 =
       "DAAAAElOVDEyOF9BUlJBWQEAAAAAAAAQYy1ex2sFAAAAAAAAgA==";
-  auto vector4 = readBlock(LONG_DECIMAL(24, 2), data4, pool_.get());
+  auto vector4 = readBlock(DECIMAL(24, 2), data4, pool_.get());
 
-  ASSERT_EQ(TypeKind::LONG_DECIMAL, vector4->typeKind());
+  ASSERT_EQ(TypeKind::HUGEINT, vector4->typeKind());
   ASSERT_EQ(1, vector4->size());
   ASSERT_FALSE(vector4->isNullAt(0));
 
-  auto decimalVector4 =
-      vector4->as<FlatVector<facebook::velox::UnscaledLongDecimal>>();
-  ASSERT_EQ(
-      UnscaledLongDecimal(-DecimalUtil::kPowersOfTen[20]),
-      decimalVector4->valueAt(0));
+  auto decimalVector4 = vector4->as<FlatVector<int128_t>>();
+  ASSERT_EQ(-DecimalUtil::kPowersOfTen[20], decimalVector4->valueAt(0));
 }
 
 TEST_F(Base64Test, singleString) {


### PR DESCRIPTION
Summary:
The scope of this PR is to address a couple of correlated enhancements for Decimal Types listed below
1) Introduced `TypeKind::HUGEINT` (`HugeintType`) with `int128_t` as its CPP type.
 The support is limited to the needs of the LongDecimalType.
2) Removed the `TypeKind::SHORT_DECIMAL`, `TypeKind::LONG_DECIMAL` enum values and
replaced them with a Velox type ShortDecimalType based on BigintType and LongDecimalType
based on HugeintType. This change replaces Decimal CPP types `UnscaledShortDecimal` with `int64_t`,
`UnscaledLongDecimal` with `int128_t`.
3) Removed `SHORT_DECIMAL`, `LONG_DECIMAL` APIs and replaced them with `DECIMAL`.

The above changes mean data of decimal types are stored in memory using 64-bit/128-bit integers.
 e.g: `FlatVector<int64_t>`, `FlatVector<int128_t>`. The individual value is an unscaled decimal value.
A variant similarly holds an unscaled value using 64-bit/128-bit integers.
The Decimal Type must be present to interpret the decimal semantics.

Earlier, the decimal limit check was enabled in UnscaledXXXDecimal only in debug mode.
That won't catch overflows in production (release build). The new approach would be to explicitly call `DecimalUtil::valueInRange(int128_t)`where ever a decimal value is computed.
See usage in SumAggregate.h, DecimalArithmetic.cpp.
This is what the Presto Java implementation does as well.

Vector functions must use `DECIMAL` in the signature.

Simple functions require a unique type for ShortDecimal and LongDecimal to bind the appropriate
implementation. Therefore, simple functions are not supported for Decimal Types.

See https://github.com/facebookincubator/velox/discussions/4069

X-link: https://github.com/facebookincubator/velox/pull/4434

Differential Revision: D45443908

Pulled By: Yuhta

