### PR TITLE
Fix error log message

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -302,7 +302,7 @@ public final class InternalResourceGroupManager<C>
             }
         }
         catch (Throwable t) {
-            log.error(t, "Error while executing refreshAndStartQueries");
+            log.error(t, "Error while executing refreshResourceGroupRuntimeInfo");
         }
     }
 


### PR DESCRIPTION
The PR fixes minor mistake in the error log message.

Method `refreshResourceGroupRuntimeInfo()` does not call `refreshAndStartQueries()` method, so the current message is confusing.

```
== NO RELEASE NOTE ==
```
