### PR TITLE
[native] Remove redundant ProjectNode from leaf node of velox plan

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1169,16 +1169,20 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   const auto type = toLocalExchangeType(node->type);
 
   const auto outputType = toRowType(node->partitioningScheme.outputLayout);
+  const auto names = outputType->names();
 
   // Different source nodes may have different output layouts.
   // Add ProjectNode on top of each source node to re-arrange the output columns
   // to match the output layout of the LocalExchangeNode.
   for (auto i = 0; i < sourceNodes.size(); ++i) {
-    auto names = outputType->names();
     std::vector<core::TypedExprPtr> projections;
     projections.reserve(outputType->size());
 
     auto desiredSourceOutput = toRowType(node->inputs[i]);
+    // If the output layout is identical, do not add ProjectNode.
+    if (outputType->names() == desiredSourceOutput->names()) {
+      continue;
+    }
 
     for (auto j = 0; j < outputType->size(); j++) {
       projections.emplace_back(std::make_shared<core::FieldAccessTypedExpr>(


### PR DESCRIPTION
Test plan -

Query plan difference in tpch q1, ProjectNode is removed from the plan
Fragment 1:
```
<           -- LocalPartition[REPARTITION HASH(0, 1)] -> returnflag:VARCHAR, linestatus:VARCHAR, avg_51:ROW<field0:DOUBLE,field1:BIGINT>, avg_53:ROW<field0:DOUBLE,field1:BIGINT>, avg_52:ROW<field0:DOUBLE,field1:BIGINT>, sum_50:DOUBLE, sum_48:DOUBLE, sum_49:DOUBLE, sum_47:DOUBLE, count_54:BIGINT
<             -- Project[expressions: (returnflag:VARCHAR, "returnflag"), (linestatus:VARCHAR, "linestatus"), (avg_51:ROW<field0:DOUBLE,field1:BIGINT>, "avg_51"), (avg_53:ROW<field0:DOUBLE,field1:BIGINT>, "avg_53"), (avg_52:ROW<field0:DOUBLE,field1:BIGINT>, "avg_52"), (sum_50:DOUBLE, "sum_50"), (sum_48:DOUBLE, "sum_48"), (sum_49:DOUBLE, "sum_49"), (sum_47:DOUBLE, "sum_47"), (count_54:BIGINT, "count_54")] -> returnflag:VARCHAR, linestatus:VARCHAR, avg_51:ROW<field0:DOUBLE,field1:BIGINT>, avg_53:ROW<field0:DOUBLE,field1:BIGINT>, avg_52:ROW<field0:DOUBLE,field1:BIGINT>, sum_50:DOUBLE, sum_48:DOUBLE, sum_49:DOUBLE, sum_47:DOUBLE, count_54:BIGINT
<               -- ShuffleRead[] -> returnflag:VARCHAR, linestatus:VARCHAR, avg_51:ROW<field0:DOUBLE,field1:BIGINT>, avg_53:ROW<field0:DOUBLE,field1:BIGINT>, avg_52:ROW<field0:DOUBLE,field1:BIGINT>, sum_50:DOUBLE, sum_48:DOUBLE, sum_49:DOUBLE, sum_47:DOUBLE, count_54:BIGINT
---
>           -- LocalPartition[REPARTITION HASH(0, 1)] -> returnflag:VARCHAR, linestatus:VARCHAR, sum_48:DOUBLE, avg_51:ROW<field0:DOUBLE,field1:BIGINT>, sum_47:DOUBLE, avg_53:ROW<field0:DOUBLE,field1:BIGINT>, sum_49:DOUBLE, avg_52:ROW<field0:DOUBLE,field1:BIGINT>, sum_50:DOUBLE, count_54:BIGINT
>             -- ShuffleRead[] -> returnflag:VARCHAR, linestatus:VARCHAR, sum_48:DOUBLE, avg_51:ROW<field0:DOUBLE,field1:BIGINT>, sum_47:DOUBLE, avg_53:ROW<field0:DOUBLE,field1:BIGINT>, sum_49:DOUBLE, avg_52:ROW<field0:DOUBLE,field1:BIGINT>, sum_50:DOUBLE, count_54:BIGINT
```

Fragment 0:
```
<       -- Project[expressions: (returnflag:VARCHAR, "returnflag"), (linestatus:VARCHAR, "linestatus"), (sum:DOUBLE, "sum"), (sum_8:DOUBLE, "sum_8"), (sum_9:DOUBLE, "sum_9"), (sum_10:DOUBLE, "sum_10"), (avg:DOUBLE, "avg"), (avg_11:DOUBLE, "avg_11"), (avg_12:DOUBLE, "avg_12"), (count:BIGINT, "count")] -> returnflag:VARCHAR, linestatus:VARCHAR, sum:DOUBLE, sum_8:DOUBLE, sum_9:DOUBLE, sum_10:DOUBLE, avg:DOUBLE, avg_11:DOUBLE, avg_12:DOUBLE, count:BIGINT
<         -- ShuffleRead[] -> returnflag:VARCHAR, linestatus:VARCHAR, sum:DOUBLE, sum_8:DOUBLE, sum_9:DOUBLE, sum_10:DOUBLE, avg:DOUBLE, avg_11:DOUBLE, avg_12:DOUBLE, count:BIGINT
---
>       -- ShuffleRead[] -> returnflag:VARCHAR, linestatus:VARCHAR, sum:DOUBLE, sum_8:DOUBLE, sum_9:DOUBLE, sum_10:DOUBLE, avg:DOUBLE, avg_11:DOUBLE, avg_12:DOUBLE, count:BIGINT
```


```
== NO RELEASE NOTE ==
```
