### PR TITLE
[native] Fix MoveEvaluationOrder linter error

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2336,8 +2336,9 @@ core::PlanNodePtr addProjectIfNeeded(
     projections.push_back(std::make_shared<core::FieldAccessTypedExpr>(
         outputType->childAt(i), outputType->nameOf(i)));
   }
+  const auto planNodeId = planNode->id();
   return std::make_shared<core::ProjectNode>(
-      fmt::format("{}.project", planNode->id()),
+      fmt::format("{}.project", planNodeId),
       outputNames,
       projections,
       std::move(planNode));


### PR DESCRIPTION
Linter error suggests potential variable access after move
Variable planNode is accessed, and is moved-from in an unspecified order

```
== NO RELEASE NOTE ==
```
