### PR TITLE
Add ability to run AQE with optimizations end to end

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveHistoryBasedStatsTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveHistoryBasedStatsTracking.java
@@ -25,7 +25,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tests.statistics.InMemoryHistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.testing.InMemoryHistoryBasedPlanStatisticsProvider;
 import com.google.common.collect.ImmutableList;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
@@ -113,7 +113,7 @@ public class HistoricalPlanStatisticsUtil
         return Optional.empty();
     }
 
-    private static boolean similarStats(double stats1, double stats2, double threshold)
+    public static boolean similarStats(double stats1, double stats2, double threshold)
     {
         if (isNaN(stats1) && isNaN(stats2)) {
             return true;

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
@@ -106,6 +106,18 @@ public class HistoryBasedPlanStatisticsCalculator
         return planCanonicalInfoProvider;
     }
 
+    @VisibleForTesting
+    public StatsCalculator getDelegate()
+    {
+        return delegate;
+    }
+
+    @VisibleForTesting
+    public Supplier<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProvider()
+    {
+        return historyBasedPlanStatisticsProvider;
+    }
+
     private Map<PlanCanonicalizationStrategy, PlanNodeWithHash> getPlanNodeHashes(PlanNode plan, Session session)
     {
         if (!useHistoryBasedPlanStatisticsEnabled(session) || !plan.getStatsEquivalentPlanNode().isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -52,7 +52,7 @@ public class StatsCalculatorModule
         return historyBasedPlanStatisticsManager.getHistoryBasedPlanStatisticsCalculator(delegate);
     }
 
-    private static ComposableStatsCalculator createComposableStatsCalculator(
+    public static ComposableStatsCalculator createComposableStatsCalculator(
             Metadata metadata,
             ScalarStatsCalculator scalarStatsCalculator,
             StatsNormalizer normalizer,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -94,7 +94,7 @@ public class DetermineJoinDistributionType
         PlanNodeStatsEstimate buildSideStatsEstimate = context.getStatsProvider().getStats(buildSide);
         double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide);
         return buildSideSizeInBytes <= joinMaxBroadcastTableSize.toBytes()
-            || (isSizeBasedJoinDistributionTypeEnabled(context.getSession())
+                || (isSizeBasedJoinDistributionTypeEnabled(context.getSession())
                 && getSourceTablesSizeInBytes(buildSide, context) <= joinMaxBroadcastTableSize.toBytes());
     }
 
@@ -214,38 +214,38 @@ public class DetermineJoinDistributionType
     public static double getFirstKnownOutputSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider)
     {
         return Stream.of(node)
-            .flatMap(planNode -> {
-                if (planNode instanceof GroupReference) {
-                    return lookup.resolveGroup(node);
-                }
-                return Stream.of(planNode);
-            })
-            .mapToDouble(resolvedNode -> {
-                double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(resolvedNode);
-                if (!isNaN(outputSizeInBytes)) {
-                    return outputSizeInBytes;
-                }
+                .flatMap(planNode -> {
+                    if (planNode instanceof GroupReference) {
+                        return lookup.resolveGroup(node);
+                    }
+                    return Stream.of(planNode);
+                })
+                .mapToDouble(resolvedNode -> {
+                    double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(resolvedNode);
+                    if (!isNaN(outputSizeInBytes)) {
+                        return outputSizeInBytes;
+                    }
 
-                if (EXPANDING_NODE_CLASSES.stream().anyMatch(clazz -> clazz.isInstance(resolvedNode))) {
-                    return NaN;
-                }
-
-                List<PlanNode> sourceNodes = resolvedNode.getSources();
-                if (sourceNodes.isEmpty()) {
-                    return NaN;
-                }
-
-                double sourcesOutputSizeInBytes = 0;
-                for (PlanNode sourceNode : sourceNodes) {
-                    double firstKnownOutputSizeInBytes = getFirstKnownOutputSizeInBytes(sourceNode, lookup, statsProvider);
-                    if (isNaN(firstKnownOutputSizeInBytes)) {
+                    if (EXPANDING_NODE_CLASSES.stream().anyMatch(clazz -> clazz.isInstance(resolvedNode))) {
                         return NaN;
                     }
-                    sourcesOutputSizeInBytes += firstKnownOutputSizeInBytes;
-                }
-                return sourcesOutputSizeInBytes;
-            })
-            .sum();
+
+                    List<PlanNode> sourceNodes = resolvedNode.getSources();
+                    if (sourceNodes.isEmpty()) {
+                        return NaN;
+                    }
+
+                    double sourcesOutputSizeInBytes = 0;
+                    for (PlanNode sourceNode : sourceNodes) {
+                        double firstKnownOutputSizeInBytes = getFirstKnownOutputSizeInBytes(sourceNode, lookup, statsProvider);
+                        if (isNaN(firstKnownOutputSizeInBytes)) {
+                            return NaN;
+                        }
+                        sourcesOutputSizeInBytes += firstKnownOutputSizeInBytes;
+                    }
+                    return sourcesOutputSizeInBytes;
+                })
+                .sum();
     }
 
     private void addJoinsWithDifferentDistributions(JoinNode joinNode, List<PlanNodeWithCost> possibleJoinNodes, Context context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -189,7 +190,7 @@ public class DetermineJoinDistributionType
         }
 
         List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
-                .whereIsInstanceOfAny(ImmutableList.of(TableScanNode.class, ValuesNode.class))
+                .whereIsInstanceOfAny(ImmutableList.of(TableScanNode.class, ValuesNode.class, RemoteSourceNode.class))
                 .findAll();
 
         return sourceNodes.stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/JoinSwappingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/JoinSwappingUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties;
+import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
+import static com.facebook.presto.SystemSessionProperties.isJoinSpillingEnabled;
+import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.defaultParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.exactlyPartitionedOn;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.fixedParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.singleStream;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.gatheringExchange;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.systemPartitionedExchange;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class JoinSwappingUtils
+{
+    public static Optional<JoinNode> createRuntimeSwappedJoinNode(
+            JoinNode joinNode,
+            Metadata metadata,
+            SqlParser parser,
+            Lookup lookup,
+            Session session,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        JoinNode swapped = joinNode.flipChildren();
+
+        PlanNode newLeft = swapped.getLeft();
+        Optional<VariableReferenceExpression> leftHashVariable = swapped.getLeftHashVariable();
+        // Remove unnecessary LocalExchange in the current probe side. If the immediate left child (new probe side) of the join node
+        // is a localExchange, there are two cases: an Exchange introduced by the current probe side (previous build side); or it is a UnionNode.
+        // If the exchangeNode has more than 1 sources, it corresponds to the second case, otherwise it corresponds to the first case and could be safe to remove
+        PlanNode resolvedSwappedLeft = lookup.resolve(newLeft);
+        if (resolvedSwappedLeft instanceof ExchangeNode && resolvedSwappedLeft.getSources().size() == 1) {
+            // Ensure the new probe after skipping the local exchange will satisfy the required probe side property
+            if (checkProbeSidePropertySatisfied(resolvedSwappedLeft.getSources().get(0), metadata, parser, lookup, session, variableAllocator)) {
+                newLeft = resolvedSwappedLeft.getSources().get(0);
+                // The HashGenerationOptimizer will generate hashVariables and append to the output layout of the nodes following the same order. Therefore,
+                // we use the index of the old hashVariable in the ExchangeNode output layout to retrieve the hashVariable from the new left node, and feed
+                // it as the leftHashVariable of the swapped join node.
+                if (swapped.getLeftHashVariable().isPresent()) {
+                    int hashVariableIndex = resolvedSwappedLeft.getOutputVariables().indexOf(swapped.getLeftHashVariable().get());
+                    leftHashVariable = Optional.of(resolvedSwappedLeft.getSources().get(0).getOutputVariables().get(hashVariableIndex));
+                    // When join output layout contains new left side's hashVariable (e.g., a nested join in a single stage, the inner join's output layout possibly
+                    // carry the join hashVariable from its new probe), after removing the local exchange at the new probe, the output variables of the join node will
+                    // also change, which has to be broadcast upwards (rewriting plan nodes) until the point where this hashVariable is no longer the output.
+                    // This is against typical iterativeOptimizer behavior and given this case is rare, just abort the swapping for this scenario.
+                    if (swapped.getOutputVariables().contains(swapped.getLeftHashVariable().get())) {
+                        return Optional.empty();
+                    }
+                }
+            }
+        }
+
+        // Add additional localExchange if the new build side does not satisfy the partitioning conditions.
+        List<VariableReferenceExpression> buildJoinVariables = swapped.getCriteria().stream()
+                .map(JoinNode.EquiJoinClause::getRight)
+                .collect(toImmutableList());
+        PlanNode newRight = swapped.getRight();
+        if (!checkBuildSidePropertySatisfied(swapped.getRight(), buildJoinVariables, metadata, parser, lookup, session, variableAllocator)) {
+            if (getTaskConcurrency(session) > 1) {
+                newRight = systemPartitionedExchange(
+                        idAllocator.getNextId(),
+                        LOCAL,
+                        swapped.getRight(),
+                        buildJoinVariables,
+                        swapped.getRightHashVariable());
+            }
+            else {
+                newRight = gatheringExchange(idAllocator.getNextId(), LOCAL, swapped.getRight());
+            }
+        }
+
+        JoinNode newJoinNode = new JoinNode(
+                swapped.getSourceLocation(),
+                swapped.getId(),
+                swapped.getType(),
+                newLeft,
+                newRight,
+                swapped.getCriteria(),
+                swapped.getOutputVariables(),
+                swapped.getFilter(),
+                leftHashVariable,
+                swapped.getRightHashVariable(),
+                swapped.getDistributionType(),
+                swapped.getDynamicFilters());
+
+        return Optional.of(newJoinNode);
+    }
+
+    // Check if the new probe side after removing unnecessary local exchange is valid.
+    public static boolean checkProbeSidePropertySatisfied(PlanNode node, Metadata metadata, SqlParser parser, Lookup lookup, Session session, VariableAllocator variableAllocator)
+    {
+        StreamPreferredProperties requiredProbeProperty;
+        if (isSpillEnabled(session) && isJoinSpillingEnabled(session)) {
+            requiredProbeProperty = fixedParallelism();
+        }
+        else {
+            requiredProbeProperty = defaultParallelism(session);
+        }
+        StreamPropertyDerivations.StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, lookup, session, variableAllocator);
+        return requiredProbeProperty.isSatisfiedBy(nodeProperty);
+    }
+
+    // Check if the property of a planNode satisfies the requirements for directly feeding as the build side of a JoinNode.
+    private static boolean checkBuildSidePropertySatisfied(
+            PlanNode node,
+            List<VariableReferenceExpression> partitioningColumns,
+            Metadata metadata,
+            SqlParser parser,
+            Lookup lookup,
+            Session session,
+            VariableAllocator variableAllocator)
+    {
+        StreamPreferredProperties requiredBuildProperty;
+        if (getTaskConcurrency(session) > 1) {
+            requiredBuildProperty = exactlyPartitionedOn(partitioningColumns);
+        }
+        else {
+            requiredBuildProperty = singleStream();
+        }
+        StreamPropertyDerivations.StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, lookup, session, variableAllocator);
+        return requiredBuildProperty.isSatisfiedBy(nodeProperty);
+    }
+
+    private static StreamPropertyDerivations.StreamProperties derivePropertiesRecursively(
+            PlanNode node,
+            Metadata metadata,
+            SqlParser parser,
+            Lookup lookup,
+            Session session,
+            VariableAllocator variableAllocator)
+    {
+        PlanNode actual = lookup.resolve(node);
+        List<StreamPropertyDerivations.StreamProperties> inputProperties = actual.getSources().stream()
+                .map(source -> derivePropertiesRecursively(source, metadata, parser, lookup, session, variableAllocator))
+                .collect(toImmutableList());
+        return StreamPropertyDerivations.deriveProperties(actual, inputProperties, metadata, session, TypeProvider.viewOf(variableAllocator.getVariables()), parser);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
@@ -19,38 +19,21 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
-import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Rule;
-import com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties;
-import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 
-import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
-import static com.facebook.presto.SystemSessionProperties.isJoinSpillingEnabled;
-import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
+import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.createRuntimeSwappedJoinNode;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
-import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.defaultParallelism;
-import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.exactlyPartitionedOn;
-import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.fixedParallelism;
-import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.singleStream;
-import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
-import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
-import static com.facebook.presto.sql.planner.plan.ExchangeNode.gatheringExchange;
-import static com.facebook.presto.sql.planner.plan.ExchangeNode.systemPartitionedExchange;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -116,112 +99,18 @@ public class RuntimeReorderJoinSides
         if (!isSwappedJoinValid(joinNode)) {
             return Result.empty();
         }
-        JoinNode swapped = joinNode.flipChildren();
 
-        PlanNode newLeft = swapped.getLeft();
-        Optional<VariableReferenceExpression> leftHashVariable = swapped.getLeftHashVariable();
-        // Remove unnecessary LocalExchange in the current probe side. If the immediate left child (new probe side) of the join node
-        // is a localExchange, there are two cases: an Exchange introduced by the current probe side (previous build side); or it is a UnionNode.
-        // If the exchangeNode has more than 1 sources, it corresponds to the second case, otherwise it corresponds to the first case and could be safe to remove
-        PlanNode resolvedSwappedLeft = context.getLookup().resolve(newLeft);
-        if (resolvedSwappedLeft instanceof ExchangeNode && resolvedSwappedLeft.getSources().size() == 1) {
-            // Ensure the new probe after skipping the local exchange will satisfy the required probe side property
-            if (checkProbeSidePropertySatisfied(resolvedSwappedLeft.getSources().get(0), context)) {
-                newLeft = resolvedSwappedLeft.getSources().get(0);
-                // The HashGenerationOptimizer will generate hashVariables and append to the output layout of the nodes following the same order. Therefore,
-                // we use the index of the old hashVariable in the ExchangeNode output layout to retrieve the hashVariable from the new left node, and feed
-                // it as the leftHashVariable of the swapped join node.
-                if (swapped.getLeftHashVariable().isPresent()) {
-                    int hashVariableIndex = resolvedSwappedLeft.getOutputVariables().indexOf(swapped.getLeftHashVariable().get());
-                    leftHashVariable = Optional.of(resolvedSwappedLeft.getSources().get(0).getOutputVariables().get(hashVariableIndex));
-                    // When join output layout contains new left side's hashVariable (e.g., a nested join in a single stage, the inner join's output layout possibly
-                    // carry the join hashVariable from its new probe), after removing the local exchange at the new probe, the output variables of the join node will
-                    // also change, which has to be broadcast upwards (rewriting plan nodes) until the point where this hashVariable is no longer the output.
-                    // This is against typical iterativeOptimizer behavior and given this case is rare, just abort the swapping for this scenario.
-                    if (swapped.getOutputVariables().contains(swapped.getLeftHashVariable().get())) {
-                        return Result.empty();
-                    }
-                }
-            }
+        Optional<JoinNode> rewrittenNode = createRuntimeSwappedJoinNode(joinNode, metadata, parser, context.getLookup(), context.getSession(), context.getVariableAllocator(), context.getIdAllocator());
+        if (rewrittenNode.isPresent()) {
+            log.debug(format("Probe size: %.2f is smaller than Build size: %.2f => invoke runtime join swapping on JoinNode ID: %s.", leftOutputSizeInBytes, rightOutputSizeInBytes, joinNode.getId()));
+            return Result.ofPlanNode(rewrittenNode.get());
         }
-
-        // Add additional localExchange if the new build side does not satisfy the partitioning conditions.
-        List<VariableReferenceExpression> buildJoinVariables = swapped.getCriteria().stream()
-                .map(JoinNode.EquiJoinClause::getRight)
-                .collect(toImmutableList());
-        PlanNode newRight = swapped.getRight();
-        if (!checkBuildSidePropertySatisfied(swapped.getRight(), buildJoinVariables, context)) {
-            if (getTaskConcurrency(context.getSession()) > 1) {
-                newRight = systemPartitionedExchange(
-                        context.getIdAllocator().getNextId(),
-                        LOCAL,
-                        swapped.getRight(),
-                        buildJoinVariables,
-                        swapped.getRightHashVariable());
-            }
-            else {
-                newRight = gatheringExchange(context.getIdAllocator().getNextId(), LOCAL, swapped.getRight());
-            }
-        }
-
-        JoinNode newJoinNode = new JoinNode(
-                swapped.getSourceLocation(),
-                swapped.getId(),
-                swapped.getType(),
-                newLeft,
-                newRight,
-                swapped.getCriteria(),
-                swapped.getOutputVariables(),
-                swapped.getFilter(),
-                leftHashVariable,
-                swapped.getRightHashVariable(),
-                swapped.getDistributionType(),
-                swapped.getDynamicFilters());
-
-        log.debug(format("Probe size: %.2f is smaller than Build size: %.2f => invoke runtime join swapping on JoinNode ID: %s.", leftOutputSizeInBytes, rightOutputSizeInBytes, newJoinNode.getId()));
-        return Result.ofPlanNode(newJoinNode);
+        return Result.empty();
     }
 
     private boolean isSwappedJoinValid(JoinNode join)
     {
         return !(join.getDistributionType().get() == REPLICATED && join.getType() == LEFT) &&
                 !(join.getDistributionType().get() == PARTITIONED && join.getCriteria().isEmpty() && join.getType() == RIGHT);
-    }
-
-    // Check if the new probe side after removing unnecessary local exchange is valid.
-    private boolean checkProbeSidePropertySatisfied(PlanNode node, Context context)
-    {
-        StreamPreferredProperties requiredProbeProperty;
-        if (isSpillEnabled(context.getSession()) && isJoinSpillingEnabled(context.getSession())) {
-            requiredProbeProperty = fixedParallelism();
-        }
-        else {
-            requiredProbeProperty = defaultParallelism(context.getSession());
-        }
-        StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, context);
-        return requiredProbeProperty.isSatisfiedBy(nodeProperty);
-    }
-
-    // Check if the property of a planNode satisfies the requirements for directly feeding as the build side of a JoinNode.
-    private boolean checkBuildSidePropertySatisfied(PlanNode node, List<VariableReferenceExpression> partitioningColumns, Context context)
-    {
-        StreamPreferredProperties requiredBuildProperty;
-        if (getTaskConcurrency(context.getSession()) > 1) {
-            requiredBuildProperty = exactlyPartitionedOn(partitioningColumns);
-        }
-        else {
-            requiredBuildProperty = singleStream();
-        }
-        StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, context);
-        return requiredBuildProperty.isSatisfiedBy(nodeProperty);
-    }
-
-    private StreamProperties derivePropertiesRecursively(PlanNode node, Metadata metadata, SqlParser parser, Context context)
-    {
-        PlanNode actual = context.getLookup().resolve(node);
-        List<StreamProperties> inputProperties = actual.getSources().stream()
-                .map(source -> derivePropertiesRecursively(source, metadata, parser, context))
-                .collect(toImmutableList());
-        return StreamPropertyDerivations.deriveProperties(actual, inputProperties, metadata, context.getSession(), TypeProvider.viewOf(context.getVariableAllocator().getVariables()), parser);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -56,6 +56,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.MergeJoinNode;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
@@ -786,6 +787,24 @@ public class PropertyDerivations
             properties.local(LocalProperties.translate(constantAppendedLocalProperties, column -> Optional.ofNullable(assignments.get(column))));
 
             return properties.build();
+        }
+
+        @Override
+        public ActualProperties visitRemoteSource(RemoteSourceNode node, List<ActualProperties> inputProperties)
+        {
+            if (node.getOrderingScheme().isPresent()) {
+                return ActualProperties.builder()
+                        .global(singleStreamPartition())
+                        .unordered(false)
+                        .build();
+            }
+            if (node.isEnsureSourceOrdering()) {
+                return ActualProperties.builder()
+                        .global(singleStreamPartition())
+                        .build();
+            }
+
+            return ActualProperties.builder().build();
         }
 
         private Global deriveGlobalProperties(TableLayout layout, Map<ColumnHandle, VariableReferenceExpression> assignments, Map<ColumnHandle, ConstantExpression> constants)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -47,6 +47,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.MergeJoinNode;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
@@ -616,6 +617,19 @@ public final class StreamPropertyDerivations
         public StreamProperties visitSample(SampleNode node, List<StreamProperties> inputProperties)
         {
             return Iterables.getOnlyElement(inputProperties);
+        }
+
+        @Override
+        public StreamProperties visitRemoteSource(RemoteSourceNode node, List<StreamProperties> inputProperties)
+        {
+            if (node.getOrderingScheme().isPresent()) {
+                return StreamProperties.ordered();
+            }
+            if (node.isEnsureSourceOrdering()) {
+                return StreamProperties.singleStream();
+            }
+
+            return StreamProperties.fixedStreams();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/InMemoryHistoryBasedPlanStatisticsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/InMemoryHistoryBasedPlanStatisticsProvider.java
@@ -11,7 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.tests.statistics;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
 
 import com.facebook.presto.spi.plan.PlanNodeWithHash;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -429,6 +429,7 @@ public class LocalQueryRunner
         this.scalarStatsCalculator = new ScalarStatsCalculator(metadata);
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, new SessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig());
+        historyBasedPlanStatisticsManager.addHistoryBasedPlanStatisticsProviderFactory(new InMemoryHistoryBasedPlanStatisticsProvider());
         this.fragmentStatsProvider = new FragmentStatsProvider();
         this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.function.Function;
 
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 
 public class StatsCalculatorTester
         implements AutoCloseable
@@ -49,14 +50,14 @@ public class StatsCalculatorTester
         return metadata;
     }
 
-    public FragmentStatsProvider getFragmentStatsProvider()
+    public StatsCalculatorTester(LocalQueryRunner queryRunner)
     {
-        return queryRunner.getFragmentStatsProvider();
+        this(queryRunner, queryRunner.getStatsCalculator());
     }
 
-    private StatsCalculatorTester(LocalQueryRunner queryRunner)
+    public StatsCalculatorTester(LocalQueryRunner queryRunner, StatsCalculator statsCalculator)
     {
-        this.statsCalculator = queryRunner.getStatsCalculator();
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.session = queryRunner.getDefaultSession();
         this.metadata = queryRunner.getMetadata();
         this.queryRunner = queryRunner;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -54,7 +54,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
-import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.getFirstKnownOutputSizeInBytes;
+import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.getFirstKnownOutputSizeInBytes;
 import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.getSourceTablesSizeInBytes;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -326,6 +326,18 @@ public class PlanBuilder
         return new RemoteSourceNode(Optional.empty(), idAllocator.getNextId(), sourceFragmentIds, ImmutableList.of(), false, Optional.empty(), REPARTITION);
     }
 
+    public RemoteSourceNode remoteSource(List<PlanFragmentId> sourceFragmentIds, PlanNode statsEquivalentPlanNode)
+    {
+        return new RemoteSourceNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                Optional.of(statsEquivalentPlanNode),
+                sourceFragmentIds, ImmutableList.of(),
+                false,
+                Optional.empty(),
+                REPARTITION);
+    }
+
     public CallExpression binaryOperation(OperatorType operatorType, RowExpression left, RowExpression right)
     {
         FunctionHandle functionHandle = new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver()).arithmeticFunction(operatorType, left.getType(), right.getType());

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -38,7 +38,6 @@ import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
-import com.facebook.presto.cost.StatsCalculatorModule;
 import com.facebook.presto.cost.TaskCountEstimator;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
 import com.facebook.presto.event.QueryMonitor;
@@ -122,6 +121,7 @@ import com.facebook.presto.spark.node.PrestoSparkTaskManager;
 import com.facebook.presto.spark.planner.PrestoSparkPlanFragmenter;
 import com.facebook.presto.spark.planner.PrestoSparkQueryPlanner;
 import com.facebook.presto.spark.planner.PrestoSparkRddFactory;
+import com.facebook.presto.spark.planner.PrestoSparkStatsCalculatorModule;
 import com.facebook.presto.spark.planner.optimizers.AdaptivePlanOptimizers;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorTypeSerde;
@@ -426,7 +426,7 @@ public class PrestoSparkModule
         jsonBinder(binder).addKeyDeserializerBinding(VariableReferenceExpression.class).to(VariableReferenceExpressionDeserializer.class);
 
         // statistics calculator / cost calculator
-        binder.install(new StatsCalculatorModule());
+        binder.install(new PrestoSparkStatsCalculatorModule());
         binder.bind(CostCalculator.class).to(CostCalculatorUsingExchanges.class).in(Scopes.SINGLETON);
         binder.bind(CostCalculator.class).annotatedWith(CostCalculator.EstimatedExchanges.class).to(CostCalculatorWithEstimatedExchanges.class).in(Scopes.SINGLETON);
         binder.bind(CostComparator.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -96,10 +96,8 @@ public class PrestoSparkQueryPlanner
         this.planCanonicalInfoProvider = requireNonNull(historyBasedPlanStatisticsManager, "historyBasedPlanStatisticsManager is null").getPlanCanonicalInfoProvider();
     }
 
-    public PlanAndMore createQueryPlan(Session session, BuiltInPreparedQuery preparedQuery, WarningCollector warningCollector)
+    public PlanAndMore createQueryPlan(Session session, BuiltInPreparedQuery preparedQuery, WarningCollector warningCollector, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
     {
-        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-
         Analyzer analyzer = new Analyzer(
                 session,
                 metadata,
@@ -112,12 +110,11 @@ public class PrestoSparkQueryPlanner
 
         Analysis analysis = analyzer.analyze(preparedQuery.getStatement());
 
-        final VariableAllocator planVariableAllocator = new VariableAllocator();
         LogicalPlanner logicalPlanner = new LogicalPlanner(
                 session,
                 idAllocator,
                 metadata,
-                planVariableAllocator,
+                variableAllocator,
                 sqlParser);
 
         PlanNode planNode = session.getRuntimeStats().profileNanos(
@@ -130,7 +127,7 @@ public class PrestoSparkQueryPlanner
                 optimizers.getPlanningTimeOptimizers(),
                 planChecker,
                 sqlParser,
-                planVariableAllocator,
+                variableAllocator,
                 idAllocator,
                 warningCollector,
                 statsCalculator,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spark.planner.optimizers;
 
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.OptimizerStatsRecorder;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
@@ -44,11 +46,13 @@ public class AdaptivePlanOptimizers
     @Inject
     public AdaptivePlanOptimizers(
             MBeanExporter exporter,
+            Metadata metadata,
+            SqlParser sqlParser,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator)
     {
         this.exporter = exporter;
-        this.adaptiveOptimizers = ImmutableList.of(new IterativeOptimizer(ruleStats, statsCalculator, costCalculator, ImmutableSet.of(new PickJoinSides())));
+        this.adaptiveOptimizers = ImmutableList.of(new IterativeOptimizer(ruleStats, statsCalculator, costCalculator, ImmutableSet.of(new PickJoinSides(metadata, sqlParser))));
     }
 
     @PostConstruct

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
@@ -41,8 +41,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.isSizeBasedJoinDistributionTypeEnabled;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.isAdaptiveJoinSideSwitchingEnabled;
-import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isBelowBroadcastLimit;
-import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isSmallerThanThreshold;
+import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.isBelowBroadcastLimit;
+import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.isSmallerThanThreshold;
 import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.createRuntimeSwappedJoinNode;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkHistoryBasedTracking.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkHistoryBasedTracking.java
@@ -23,7 +23,7 @@ import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.facebook.presto.tests.statistics.InMemoryHistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.testing.InMemoryHistoryBasedPlanStatisticsProvider;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveJoinQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/adaptive/execution/TestPrestoSparkAdaptiveJoinQueries.java
@@ -15,8 +15,16 @@ package com.facebook.presto.spark.adaptive.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.spark.TestPrestoSparkJoinQueries;
+import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+import static com.facebook.presto.SystemSessionProperties.USE_HISTORY_BASED_PLAN_STATISTICS;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 
 public class TestPrestoSparkAdaptiveJoinQueries
         extends TestPrestoSparkJoinQueries
@@ -26,6 +34,34 @@ public class TestPrestoSparkAdaptiveJoinQueries
     {
         return Session.builder(super.getSession())
                 .setSystemProperty(SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED, "true")
+                .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "true")
                 .build();
+    }
+
+    @Test
+    public void testQuerySucceedsWithAQE()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, PARTITIONED.name())
+                .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "false")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "10MB")
+                .build();
+
+        assertQuery(session, "SELECT orderkey FROM nation n JOIN orders o ON n.nationkey = o.orderkey");
+    }
+
+    @Test
+    public void testQueryFailsWithoutAQE()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED, "false")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, PARTITIONED.name())
+                .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "false")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "1MB")
+                .build();
+
+        assertQueryFails(session, "SELECT orderkey FROM nation n JOIN orders o ON n.nationkey = o.orderkey", ".*Query exceeded per-node total memory limit of 1MB.*");
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
@@ -35,9 +35,11 @@ import com.facebook.presto.spark.PrestoSparkSessionProperties;
 import com.facebook.presto.spark.PrestoSparkSessionPropertyManagerProvider;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.TestingMetadata;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -367,7 +369,7 @@ public class TestPickJoinSides
     {
         int aSize = 100;
         int bSize = 10_000;
-        tester.assertThat(new PickJoinSides())
+        tester.assertThat(new PickJoinSides(tester.getMetadata(), tester.getSqlParser()))
                 .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "false")
                 .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
                         .setTotalSize(aSize)
@@ -458,7 +460,7 @@ public class TestPickJoinSides
 
     private RuleAssert assertPickJoinSides()
     {
-        return tester.assertThat(new PickJoinSides())
+        return tester.assertThat(new PickJoinSides(tester.getMetadata(), tester.getSqlParser()))
                 .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "100MB")
                 .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "true");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
@@ -44,4 +44,10 @@ public class RuntimeSourceInfo
     {
         return true;
     }
+
+    @Override
+    public boolean estimateSizeUsingVariables()
+    {
+        return false;
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -40,7 +40,7 @@ import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tests.statistics.InMemoryHistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.testing.InMemoryHistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
Test plan - added unit tests.  TODO: do a verifier run

This PR adds the missing features to complete the work to incorporate the PickJoinSides optimization into AQE
1. Adds a new stats calculator for Presto on Spark that chooses runtime stats over historical stats if they are different
2. Support size-based joins for remote source nodes in PickJoinSides
3. Fix PickJoinSides to correctly set local exchanges
4. Add a re-optimization step into the PrestoSparkAdaptiveExecutor

```
== RELEASE NOTES ==

General Changes
* TODO: release note about pick join sides optimizer

```

