### PR TITLE
[native] Use relative path for json based function registration

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
 import com.google.inject.Module;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.shuffle.ShuffleHandle;
@@ -176,6 +177,7 @@ public class PrestoSparkNativeQueryRunnerUtils
 
     public static void setupJsonFunctionNamespaceManager(QueryRunner queryRunner)
     {
+        String jsonDefinitionPath = Resources.getResource("external_functions.json").getFile();
         queryRunner.installPlugin(new FunctionNamespaceManagerPlugin());
         queryRunner.loadFunctionNamespaceManager(
                 JsonFileBasedFunctionNamespaceManagerFactory.NAME,
@@ -183,7 +185,7 @@ public class PrestoSparkNativeQueryRunnerUtils
                 ImmutableMap.of(
                         "supported-function-languages", "CPP",
                         "function-implementation-type", "CPP",
-                        "json-based-function-manager.path-to-function-definition", "src/test/resources/external_functions.json"));
+                        "json-based-function-manager.path-to-function-definition", jsonDefinitionPath));
     }
 
     public static synchronized Path getBaseDataPath()


### PR DESCRIPTION
Previously the json based function definition file is using static path related to current code repo structure, it'll raise error when we import/reuse the function registration method in other modules (file not found error). This PR changed the file path to a relative path based on current class-loader's resource path.

```
== NO RELEASE NOTE ==
```
