### PR TITLE
[native] Refactor local and remote function registration

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -332,17 +332,8 @@ void PrestoServer::run() {
         server->runOperation(message, downstream);
       });
 
-  static const std::string kPrestoDefaultPrefix{"presto.default."};
-  velox::functions::prestosql::registerAllScalarFunctions(kPrestoDefaultPrefix);
-  velox::aggregate::prestosql::registerAllAggregateFunctions(
-      kPrestoDefaultPrefix);
-  velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
-  if (SystemConfig::instance()->registerTestFunctions()) {
-    velox::functions::prestosql::registerComparisonFunctions(
-        "json.test_schema.");
-    velox::aggregate::prestosql::registerAllAggregateFunctions(
-        "json.test_schema.");
-  }
+  registerFunctions();
+  registerRemoteFunctions();
   registerVectorSerdes();
   registerPrestoPlanNodeSerDe();
 
@@ -658,6 +649,22 @@ void PrestoServer::registerCustomOperators() {
   facebook::velox::exec::Operator::registerOperator(
       std::make_unique<operators::ShuffleReadTranslator>());
 }
+
+void PrestoServer::registerFunctions() {
+  static const std::string kPrestoDefaultPrefix{"presto.default."};
+  velox::functions::prestosql::registerAllScalarFunctions(kPrestoDefaultPrefix);
+  velox::aggregate::prestosql::registerAllAggregateFunctions(
+      kPrestoDefaultPrefix);
+  velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
+  if (SystemConfig::instance()->registerTestFunctions()) {
+    velox::functions::prestosql::registerComparisonFunctions(
+        "json.test_schema.");
+    velox::aggregate::prestosql::registerAllAggregateFunctions(
+        "json.test_schema.");
+  }
+}
+
+void PrestoServer::registerRemoteFunctions() {}
 
 void PrestoServer::registerVectorSerdes() {
   if (!velox::isRegisteredVectorSerde()) {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -101,6 +101,10 @@ class PrestoServer {
 
   virtual void registerCustomOperators();
 
+  virtual void registerFunctions();
+
+  virtual void registerRemoteFunctions();
+
   virtual void registerVectorSerdes();
 
   virtual void registerFileSystems();

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -82,6 +82,8 @@ class PartitionAndSerializeOperator : public Operator {
   }
 
  private:
+  using TRowSize = uint32_t;
+
   void computePartitions(FlatVector<int32_t>& partitionsVector) {
     auto numInput = input_->size();
     partitions_.resize(numInput);
@@ -142,8 +144,6 @@ class PartitionAndSerializeOperator : public Operator {
       offset += size;
     }
   }
-
-  using TRowSize = uint32_t;
 
   const uint32_t numPartitions_;
   std::unique_ptr<core::PartitionFunction> partitionFunction_;


### PR DESCRIPTION
Summary:
Small refactor to allow specializations of PrestoServer to register
their own local and remote functions. These function will be
overridden in Presto-on-Spark.

Differential Revision: D45546530

```
== NO RELEASE NOTE ==
```

