### PR TITLE
[native] Enable TestPrestoSparkNativeAggregation#testMinMax

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark;
 import com.facebook.presto.nativeworker.AbstractTestNativeAggregations;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.testng.annotations.Ignore;
 
 public class TestPrestoSparkNativeAggregations
         extends AbstractTestNativeAggregations
@@ -40,9 +39,4 @@ public class TestPrestoSparkNativeAggregations
         super.assertQuery(sql);
         PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
     }
-
-    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
-    @Override
-    @Ignore
-    public void testMinMax() {}
 }


### PR DESCRIPTION
The crash of the native process triggered by this test was fixed in https://github.com/facebookincubator/velox/pull/4821

```
== NO RELEASE NOTE ==
```
