### PR TITLE
[native] Do not include row size in UnsafeRow

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -19,7 +19,8 @@
 namespace facebook::presto::operators {
 
 /// Partitions the input row based on partition function and serializes the
-/// entire row.
+/// entire row using UnsafeRow format. The output contains 2 columns: partition
+/// number (INTEGER) and serialized row (VARBINARY).
 class PartitionAndSerializeNode : public velox::core::PlanNode {
  public:
   static constexpr std::string_view kPartitionColumnNameDefault = "partition";


### PR DESCRIPTION
PartitionAndSerialize operator used to include row size in the serialized row: row size | <UnsafeRow>.

This causes row size to be serialized twice as ShuffleWrite::collect was adding row size again.

This change is to not include row size in the serialized row produced by PartitionAndSerialize operator.

```
== NO RELEASE NOTE ==
```
