### PR TITLE
[native]Fix duplicate root pool name issue

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -324,8 +324,7 @@ TEST_P(HttpTestSuite, basic) {
 
 TEST_P(HttpTestSuite, httpResponseAllocationFailure) {
   const int64_t memoryCapBytes = 1 << 10;
-  auto rootPool = defaultMemoryManager().addRootPool(
-      "httpResponseAllocationFailure", memoryCapBytes);
+  auto rootPool = defaultMemoryManager().addRootPool("", memoryCapBytes);
   auto leafPool = rootPool->addLeafChild("httpResponseAllocationFailure");
 
   const bool useHttps = GetParam();

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -612,8 +612,7 @@ TEST_P(PrestoExchangeSourceTestSuite, failedProducer) {
 TEST_P(PrestoExchangeSourceTestSuite, exceedingMemoryCapacityForHttpResponse) {
   const int64_t memoryCapBytes = 1 << 10;
   const bool useHttps = GetParam();
-  auto rootPool = defaultMemoryManager().addRootPool(
-      "httpResponseAllocationFailure", memoryCapBytes);
+  auto rootPool = defaultMemoryManager().addRootPool("", memoryCapBytes);
   auto leafPool =
       rootPool->addLeafChild("exceedingMemoryCapacityForHttpResponse");
 
@@ -650,8 +649,7 @@ TEST_P(PrestoExchangeSourceTestSuite, exceedingMemoryCapacityForHttpResponse) {
 
 TEST_P(PrestoExchangeSourceTestSuite, memoryAllocationAndUsageCheck) {
   PrestoExchangeSource::testingClearMemoryUsage();
-  auto rootPool =
-      defaultMemoryManager().addRootPool("memoryAllocationAndUsageCheck");
+  auto rootPool = defaultMemoryManager().addRootPool();
   auto leafPool = rootPool->addLeafChild("memoryAllocationAndUsageCheck");
 
   const bool useHttps = GetParam();


### PR DESCRIPTION
Velox has enforce the duplicate root pool name check that
cause the parameterized test failure.

```
== NO RELEASE NOTE ==
```
