### PR TITLE
[native] Check if the sparkConxt is already stopped

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -747,7 +747,7 @@ public class PrestoSparkQueryRunner
         public void release(SparkContext sparkContext, boolean forceRelease)
         {
             synchronized (SparkContextHolder.class) {
-                checkState(forceRelease || SparkContextHolder.sparkContext == sparkContext, "unexpected spark context");
+                checkState(forceRelease || sparkContext.isStopped() || SparkContextHolder.sparkContext == sparkContext, "unexpected spark context");
                 referenceCount--;
                 if (referenceCount == 0) {
                     sparkContext.cancelAllJobs();


### PR DESCRIPTION
The sparkContext could be already stopped (due to failures or it's not started at all if there is no test to run), if that's the case, the previous `checkState(SparkContextHolder.sparkContext == sparkContext, "unexpected spark context")` will fail. This PR fixes this issue.

```
== NO RELEASE NOTE ==
```
