### PR TITLE
Support loading json files in a dir to json-function-ns-manager

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionDefinitionProvider.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionDefinitionProvider.java
@@ -15,24 +15,54 @@ package com.facebook.presto.functionNamespace.json;
 
 import com.facebook.airlift.log.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.plugin.base.JsonUtils.parseJson;
+import static java.util.Locale.ENGLISH;
 
 public class JsonFileBasedFunctionDefinitionProvider
         implements FunctionDefinitionProvider
 {
     private static final Logger log = Logger.get(JsonFileBasedFunctionDefinitionProvider.class);
+    private static final int MAX_DIRECTORY_DEPTH = 4;
+    private static final String JSON_FILE_EXTENSION = ".json";
 
     @Override
     public UdfFunctionSignatureMap getUdfDefinition(String filePath)
     {
+        Map<String, List<JsonBasedUdfFunctionMetadata>> udfSignatureMap = new HashMap<>();
+
+        // If any of the files is not a valid source, the function will return null;
         try {
-            return parseJson(Paths.get(filePath), UdfFunctionSignatureMap.class);
+            for (Path path : getFilesInPath(filePath, MAX_DIRECTORY_DEPTH)) {
+                // Note: If a function signature is duplicated, the last definition overrides prior definitions.
+                udfSignatureMap.putAll(parseJson(path, UdfFunctionSignatureMap.class).getUDFSignatureMap());
+            }
+            return new UdfFunctionSignatureMap(udfSignatureMap);
         }
         catch (Exception e) {
             log.info("Failed to load function definition for JsonFileBasedFunctionNamespaceManager " + e.getMessage());
         }
         return null;
+    }
+
+    // Returns the list containing the file if filePath is a single file or all json files inside filePath if it's a dir.
+    // Set maxDepth to 0 for file, 1 for match in a root-level dir, ... & N for match in n-level nested dirs.
+    private List<Path> getFilesInPath(String filePath, int maxDirectoryDepth) throws IOException
+    {
+        try (Stream<Path> stream = Files.find(
+                Paths.get(filePath),
+                maxDirectoryDepth,
+                (p, basicFileAttributes) -> p.getFileName().toString().toLowerCase(ENGLISH).endsWith(JSON_FILE_EXTENSION))) {
+            return stream.collect(Collectors.toList());
+        }
     }
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
@@ -119,7 +119,7 @@ public class JsonFileBasedFunctionNamespaceManager
 
     private void bootstrapNamespaceFromFile()
     {
-        UdfFunctionSignatureMap udfFunctionSignatureMap = functionDefinitionProvider.getUdfDefinition(managerConfig.getFunctionDefinitionFile());
+        UdfFunctionSignatureMap udfFunctionSignatureMap = functionDefinitionProvider.getUdfDefinition(managerConfig.getFunctionDefinitionPath());
         if (udfFunctionSignatureMap == null || udfFunctionSignatureMap.isEmpty()) {
             return;
         }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerConfig.java
@@ -20,19 +20,19 @@ import javax.validation.constraints.NotNull;
 
 public class JsonFileBasedFunctionNamespaceManagerConfig
 {
-    private String functionDefinitionFile = "";
+    private String functionDefinitionPath = "";
 
     @NotNull
-    public String getFunctionDefinitionFile()
+    public String getFunctionDefinitionPath()
     {
-        return functionDefinitionFile;
+        return functionDefinitionPath;
     }
 
     @Config("json-based-function-manager.path-to-function-definition")
-    @ConfigDescription("Path to the Json file which the namespace manager load function data from")
-    public JsonFileBasedFunctionNamespaceManagerConfig setFunctionDefinitionFile(String functionDefinitionFile)
+    @ConfigDescription("Path to a JSON file or directory of JSON files which the namespace manager loads function metadata from")
+    public JsonFileBasedFunctionNamespaceManagerConfig setFunctionDefinitionPath(String functionDefinitionPath)
     {
-        this.functionDefinitionFile = functionDefinitionFile;
+        this.functionDefinitionPath = functionDefinitionPath;
         return this;
     }
 }

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition.json
@@ -1,154 +1,154 @@
 {
-"udfSignatureMap": {
-"add_ARRAY_element_wise":[
-         {
-            "docString":"function to add two string vectors element-wise",
-           "functionKind": "SCALAR",
-            "outputType": "ARRAY<ARRAY<BOOLEAN>>",
-            "paramTypes":[
-                 "ARRAY<ARRAY<BOOLEAN>>",
-                 "ARRAY<ARRAY<BOOLEAN>>"
-            ],
-           "schema":"test_schema",
-           "routineCharacteristics": {
-             "language":"CPP",
-             "determinism":"DETERMINISTIC",
-             "nullCallClause":"CALLED_ON_NULL_INPUT"
-           }
-         },
-         {
-            "docString":"function to add two float vectors element-wise",
-           "functionKind": "SCALAR",
-            "outputType": "ARRAY<ARRAY<BIGINT>>",
-            "paramTypes":[
-                "ARRAY<ARRAY<BIGINT>>",
-                 "ARRAY<ARRAY<BIGINT>>"
-            ],
-           "schema":"test_schema",
-           "routineCharacteristics": {
-             "language":"CPP",
-             "determinism":"DETERMINISTIC",
-             "nullCallClause":"CALLED_ON_NULL_INPUT"
-           }
-         },
-         {
-            "docString":"function to add two int64_t vectors element-wise",
-           "functionKind": "SCALAR",
-            "outputType": "ARRAY<DOUBLE>",
-            "paramTypes":[
-                 "ARRAY<DOUBLE>",
-                 "ARRAY<DOUBLE>"
-            ],
-           "schema":"test_schema",
-           "routineCharacteristics": {
-             "language":"CPP",
-             "determinism":"DETERMINISTIC",
-             "nullCallClause":"CALLED_ON_NULL_INPUT"
-           }
-         }
-      ],
- "ads_product_types_transform":[
-         {
-            "docString":"gff ads product types transform",
-           "functionKind": "SCALAR",
-            "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
-            "paramTypes":[
-                 "ARRAY<map<BIGINT, DOUBLE>>",
-                 "ARRAY<varchar>"
-            ],
-           "schema":"test_schema",
-           "routineCharacteristics": {
-             "language":"CPP",
-             "determinism":"DETERMINISTIC",
-             "nullCallClause":"CALLED_ON_NULL_INPUT"
-           }
-         },
-         {
-            "docString":"gff ads product types transform",
-           "functionKind": "SCALAR",
-            "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
-            "paramTypes":[
-                 "ARRAY<map<BIGINT, DOUBLE>>",
-                 "ARRAY<ARRAY<BOOLEAN>>",
-                 "ARRAY<varchar>"
-            ],
-           "schema":"test_schema",
-           "routineCharacteristics": {
-             "language":"CPP",
-             "determinism":"DETERMINISTIC",
-             "nullCallClause":"CALLED_ON_NULL_INPUT"
-           }
-         }
-      ],
-  "square": [
-    {
-      "docString":"square an integer",
-      "functionKind": "SCALAR",
-      "outputType": "int",
-      "paramTypes":[
-        "int"
-      ],
-      "schema":"test_schema",
-      "routineCharacteristics": {
-        "language":"CPP",
-        "determinism":"DETERMINISTIC",
-        "nullCallClause":"CALLED_ON_NULL_INPUT"
-      }
-    },
-    {
-      "docString":"square a double",
-      "functionKind": "SCALAR",
-      "outputType": "double",
-      "paramTypes":[
-        "double"
-      ],
-      "schema":"test_schema",
-      "routineCharacteristics": {
-        "language":"CPP",
-        "determinism":"DETERMINISTIC",
-        "nullCallClause":"CALLED_ON_NULL_INPUT"
-      }
-    }
-  ],
-  "avg": [
-    {
-      "docString":"Returns mean of integers",
-      "functionKind": "AGGREGATE",
-      "outputType": "int",
-      "paramTypes":[
-        "int"
-      ],
-      "schema":"test_schema",
-      "routineCharacteristics": {
-        "language":"CPP",
-        "determinism":"DETERMINISTIC",
-        "nullCallClause":"CALLED_ON_NULL_INPUT"
+  "udfSignatureMap": {
+    "array_function_1": [
+      {
+        "docString": "combines two string arrays into one",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<ARRAY<BOOLEAN>>",
+        "paramTypes": [
+          "ARRAY<ARRAY<BOOLEAN>>",
+          "ARRAY<ARRAY<BOOLEAN>>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
       },
-      "aggregateMetadata": {
-        "intermediateType": "ROW(bigint, int)",
-        "isOrderSensitive": false
-      }
-    },
-    {
-      "docString":"Returns mean of doubles",
-      "functionKind": "AGGREGATE",
-      "outputType": "double",
-      "paramTypes":[
-        "double"
-      ],
-      "schema":"test_schema",
-      "routineCharacteristics": {
-        "language":"CPP",
-        "determinism":"DETERMINISTIC",
-        "nullCallClause":"CALLED_ON_NULL_INPUT"
+      {
+        "docString": "combines two float arrays into one",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<ARRAY<BIGINT>>",
+        "paramTypes": [
+          "ARRAY<ARRAY<BIGINT>>",
+          "ARRAY<ARRAY<BIGINT>>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
       },
-      "aggregateMetadata": {
-        "intermediateType": "ROW(double, int)",
-        "isOrderSensitive": false
+      {
+        "docString": "combines two double arrays into one",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<DOUBLE>",
+        "paramTypes": [
+          "ARRAY<DOUBLE>",
+          "ARRAY<DOUBLE>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
       }
-    }
-  ]
- }
+    ],
+    "array_function_2": [
+      {
+        "docString": "transforms inputs into the output",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "transforms inputs into the output",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<ARRAY<BOOLEAN>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "square": [
+      {
+        "docString": "square an integer",
+        "functionKind": "SCALAR",
+        "outputType": "int",
+        "paramTypes": [
+          "int"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "square a double",
+        "functionKind": "SCALAR",
+        "outputType": "double",
+        "paramTypes": [
+          "double"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "avg": [
+      {
+        "docString": "Returns mean of integers",
+        "functionKind": "AGGREGATE",
+        "outputType": "int",
+        "paramTypes": [
+          "int"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        },
+        "aggregateMetadata": {
+          "intermediateType": "ROW(bigint, int)",
+          "isOrderSensitive": false
+        }
+      },
+      {
+        "docString": "Returns mean of doubles",
+        "functionKind": "AGGREGATE",
+        "outputType": "double",
+        "paramTypes": [
+          "double"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        },
+        "aggregateMetadata": {
+          "intermediateType": "ROW(double, int)",
+          "isOrderSensitive": false
+        }
+      }
+    ]
+  }
 }
 
 

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/json_udf_function_definition_nested_dir/udf_2.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/json_udf_function_definition_nested_dir/udf_2.json
@@ -1,0 +1,67 @@
+{
+  "udfSignatureMap": {
+    "scalar_function_2": [
+      {
+        "docString": "DUPLICATE IN FILES - transforms inputs into the output ",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "DUPLICATE IN FILES - transforms inputs into the output \"",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<ARRAY<BOOLEAN>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "scalar_function_3": [
+      {
+        "docString": "transforms int input to output",
+        "functionKind": "SCALAR",
+        "outputType": "INT",
+        "paramTypes": [
+          "INT"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "transforms double input to output",
+        "functionKind": "SCALAR",
+        "outputType": "DOUBLE",
+        "paramTypes": [
+          "DOUBLE"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/json_udf_function_definition_nested_dir/udf_empty_map.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/json_udf_function_definition_nested_dir/udf_empty_map.json
@@ -1,0 +1,4 @@
+{
+  "udfSignatureMap": {
+  }
+}

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/not_json.txt
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/not_json.txt
@@ -1,0 +1,2 @@
+This is not a json file.
+It's used to test correctness of `JsonFileBasedFunctionNamespaceManagerModule` loading of json files in a directory.

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/udaf_1.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/udaf_1.json
@@ -1,0 +1,42 @@
+{
+  "udfSignatureMap": {
+    "aggregate_function_1": [
+      {
+        "docString":"a test aggregate function for int input/output",
+        "functionKind": "AGGREGATE",
+        "outputType": "INT",
+        "paramTypes":[
+          "INT"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        },
+        "aggregateMetadata": {
+          "intermediateType": "ROW(BIGINT, INT)",
+          "isOrderSensitive": false
+        }
+      },
+      {
+        "docString":"a test aggregate function for double input/output",
+        "functionKind": "AGGREGATE",
+        "outputType": "DOUBLE",
+        "paramTypes":[
+          "DOUBLE"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        },
+        "aggregateMetadata": {
+          "intermediateType": "ROW(DOUBLE, INT)",
+          "isOrderSensitive": false
+        }
+      }
+    ]
+  }
+}

--- a/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/udf_1.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_function_definition_dir/udf_1.json
@@ -1,0 +1,54 @@
+{
+  "udfSignatureMap": {
+    "scalar_function_1": [
+      {
+        "docString": "combines two double arrays into one",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<DOUBLE>",
+        "paramTypes": [
+          "ARRAY<DOUBLE>",
+          "ARRAY<DOUBLE>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "scalar_function_2": [
+      {
+        "docString": "DUPLICATE IN FILES - transforms inputs into the output ",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "DUPLICATE IN FILES - transforms inputs into the output \"",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY<map<BIGINT, DOUBLE>>",
+        "paramTypes": [
+          "ARRAY<map<BIGINT, DOUBLE>>",
+          "ARRAY<ARRAY<BOOLEAN>>",
+          "ARRAY<varchar>"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Support loading all json files in a dir to json-function-namespace-manager

Before this change, You can only provide a path to a single JSON file to feed into JsonFileBasedFunctionNamespaceManager; this change allows for loading multiple json files in a directory to JsonFileBasedFunctionNamespaceManager. This helps with modularity of function metadata.

Note: Initially I had developed a solution which would enable passing a list of json files (as a string w/ a delimiter); This solution would be more flexible and intentional; however, it would've been difficult to list many files (which can be a typical use case); therefore, I updated the solution to enable loading ALL JSON files from a directory instead of specifying files one by one.

Test plan - Updated the relevant unittest with a test for loading files from a directory

```
== NO RELEASE NOTE ==
```
