### PR TITLE
Computing wall time for PlanNodeStats from Operator Stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
@@ -40,10 +40,11 @@ public class HashCollisionPlanNodeStats
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            Duration planNodeWallTime,
             Map<String, OperatorInputStats> operatorInputStats,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, planNodeWallTime, operatorInputStats);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -98,6 +99,7 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeRawInputDataSize(),
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
+                merged.getPlanNodeWallTime(),
                 merged.operatorInputStats,
                 operatorHashCollisionsStats);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -44,6 +44,8 @@ public class PlanNodeStats
     private final long planNodeOutputPositions;
     private final DataSize planNodeOutputDataSize;
 
+    private final Duration planNodeWallTime;
+
     protected final Map<String, OperatorInputStats> operatorInputStats;
 
     PlanNodeStats(
@@ -56,6 +58,7 @@ public class PlanNodeStats
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            Duration planNodeWallTime,
             Map<String, OperatorInputStats> operatorInputStats)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -68,6 +71,7 @@ public class PlanNodeStats
         this.planNodeRawInputDataSize = planNodeRawInputDataSize;
         this.planNodeOutputPositions = planNodeOutputPositions;
         this.planNodeOutputDataSize = planNodeOutputDataSize;
+        this.planNodeWallTime = planNodeWallTime;
 
         this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
     }
@@ -93,6 +97,11 @@ public class PlanNodeStats
     public Duration getPlanNodeCpuTime()
     {
         return planNodeCpuTime;
+    }
+
+    public Duration getPlanNodeWallTime()
+    {
+        return planNodeWallTime;
     }
 
     public Set<String> getOperatorTypes()
@@ -170,6 +179,6 @@ public class PlanNodeStats
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeRawInputPositions, planNodeRawInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
-                operatorInputStats);
+                new Duration(Math.max(planNodeWallTime.toMillis(), other.planNodeWallTime.toMillis()), MILLISECONDS), operatorInputStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
@@ -36,10 +36,11 @@ public class WindowPlanNodeStats
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            Duration planNodeWallTime,
             Map<String, OperatorInputStats> operatorInputStats,
             WindowOperatorStats windowOperatorStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, planNodeWallTime, operatorInputStats);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -64,6 +65,7 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeRawInputDataSize(),
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
+                merged.getPlanNodeWallTime(),
                 merged.operatorInputStats,
                 windowOperatorStats);
     }


### PR DESCRIPTION
 Based on [this](https://github.com/prestodb/presto/commit/0f98ae0787c9465ce39503bad7cf4cbe2c15faa7) commit by @arhimondr which added **planNodeCpuMillis** to **PlanNodeStats** from Task or Operator stats. 
Test plan - Did not find a test suite for PlanNodeStats in related previous commits  but integration tested internally. Open to suggestions on testing

== RELEASE NOTES ==

General Changes
* Adding wallTime to PlanNodeStats
