### PR TITLE
[Native] Fix CI failure

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -779,6 +779,10 @@ void setCellFromVariant(
     columnVector->setNull(row, true);
     return;
   }
+  if (columnVector->typeKind() == TypeKind::HUGEINT) {
+    setCellFromVariantByKind<TypeKind::HUGEINT>(columnVector, row, value);
+    return;
+  }
   VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
       setCellFromVariantByKind,
       columnVector->typeKind(),

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -417,11 +417,11 @@ public abstract class AbstractTestNativeGeneralQueries
         // numeric limits
         assertQueryFails("SELECT n + m from (values (DECIMAL'99999999999999999999999999999999999999'," +
                 "CAST('1' as DECIMAL(2,0)))) t(n, m)",
-                ".*Decimal overflow.*");
+                ".*Decimal.*");
         assertQueryFails(
                 "SELECT n + m from (values (CAST('-99999999999999999999999999999999999999' as DECIMAL(38,0))," +
                         "CAST('-1' as DECIMAL(15,0)))) t(n,m)",
-                ".*Decimal overflow.*");
+                ".*Decimal.*");
 
         // Subtraction of long decimals.
         assertQuery(
@@ -440,7 +440,7 @@ public abstract class AbstractTestNativeGeneralQueries
         // Subtraction Overflow
         assertQueryFails(
                 "SELECT n - m from (values (DECIMAL'-99999999999999999999999999999999999999', decimal'1')) " +
-                        "t(n,m)", ".*Decimal overflow.*");
+                        "t(n,m)", ".*Decimal.*");
         // Multiplication.
         assertQuery("SELECT n * m from (values (DECIMAL'99999999999999999999', DECIMAL'-0.000003')," +
                 "(DECIMAL'-0.00000000000000001', DECIMAL'10000000000'),(DECIMAL'-12345678902345.124', DECIMAL'-0.275')," +
@@ -449,7 +449,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "(DECIMAL '-3.4', DECIMAL '-625'), (DECIMAL '-0.0004', DECIMAL '-0.0123')) t(n,m)");
         // Multiplication overflow.
         assertQueryFails("SELECT n*m from (values (DECIMAL'14621507953634074601941877663083790335', DECIMAL'10')) " +
-                "t(n,m)", ".*Decimal overflow.*");
+                "t(n,m)", ".*Decimal.*");
         // Division long decimals.
         assertQuery("SELECT n/m from(values " +
                 "(CAST('10000000000000000.00' as decimal(19, 2)), DECIMAL'30000000000000.00')," +
@@ -467,7 +467,7 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // Division overflow.
         assertQueryFails("SELECT n/m from(values (DECIMAL'99999999999999999999999999999999999999', DECIMAL'0.01'))" +
-                        " t(n,m)", ".*Decimal overflow.*");
+                        " t(n,m)", ".*Decimal.*");
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesJSON.java
@@ -20,25 +20,14 @@ public class TestPrestoNativeGeneralQueriesJSON
         extends AbstractTestNativeGeneralQueries
 {
     @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
+    protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
     }
 
     @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner()
-            throws Exception
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    public void testDecimalArithmetic() {}
-
-    @Override
-    public void testDecimalLiterals() {}
-
-    @Override
-    public void testDecimalLogicalFunctions() {}
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
@@ -20,25 +20,14 @@ public class TestPrestoNativeGeneralQueriesThrift
         extends AbstractTestNativeGeneralQueries
 {
     @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
+    protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
     }
 
     @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner()
-            throws Exception
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    public void testDecimalArithmetic() {}
-
-    @Override
-    public void testDecimalLiterals() {}
-
-    @Override
-    public void testDecimalLogicalFunctions() {}
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -77,13 +77,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testTopN() {}
-
-    @Override
-    public void testDecimalArithmetic() {}
-
-    @Override
-    public void testDecimalLiterals() {}
-
-    @Override
-    public void testDecimalLogicalFunctions() {}
 }


### PR DESCRIPTION
Recent Decimal Type refactoring missed handling TypeKind::HUGEINT
in setCellFromVariantByKind. This is now handled.
The Decimal overflow message also changed in this refactor.
Few Decimal overflow tests in AbstractTestNativeGeneralQueries.java
have been fixed to handle the new message.

Reverts "[native] Disable tests from GeneralQueries test suite"

```
== NO RELEASE NOTE ==
```
