### PR TITLE
Fix partition table access in Postgres connector

### DIFF
--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -100,7 +100,7 @@ public class PostgreSqlClient
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, escape).orElse(null),
                 escapeNamePattern(tableName, escape).orElse(null),
-                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
+                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE", "PARTITIONED TABLE"});
     }
 
     @Override


### PR DESCRIPTION
Partition table was not accessible from Postgres connector. It is introduced when the Postgresql driver was upgraded to 42.3.3 to address CVE-2022-21724 Vulnerability in #17505 

```
== NO RELEASE NOTE ==
```
