### PR TITLE
Better exception handling in HttpNativeExecutionTaskInfoFetcher

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -18,8 +18,11 @@ import com.facebook.presto.connector.system.GlobalSystemConnector;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import io.airlift.units.Duration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.SystemSessionProperties.getExchangeMaterializationStrategy;
 import static com.facebook.presto.SystemSessionProperties.getPartitioningProviderCatalog;
@@ -39,6 +42,7 @@ public class PrestoSparkSettingsRequirements
     public static final String SPARK_TASK_CPUS_PROPERTY = "spark.task.cpus";
     public static final String SPARK_EXECUTOR_CORES_PROPERTY = "spark.executor.cores";
     public static final String SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS_CONFIG = "spark.dynamicAllocation.maxExecutors";
+    public static final Duration MAX_TASK_ERROR_DURATION = new Duration(1, TimeUnit.MINUTES);
 
     public void verify(SparkContext sparkContext, Session session)
     {
@@ -98,5 +102,6 @@ public class PrestoSparkSettingsRequirements
     {
         config.setExchangeMaterializationStrategy(NONE);
         config.setPartitioningProviderCatalog(GlobalSystemConnector.NAME);
+        config.setRemoteTaskMaxErrorDuration(MAX_TASK_ERROR_DURATION);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -171,6 +171,11 @@ public class NativeExecutionProcess
         }
     }
 
+    public boolean isAlive()
+    {
+        return process.isAlive();
+    }
+
     public int getPort()
     {
         return port;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/operator/NativeExecutionOperator.java
@@ -190,9 +190,13 @@ public class NativeExecutionOperator
 
             return null;
         }
-        catch (InterruptedException e) {
+        catch (InterruptedException | RuntimeException e) {
+            String error = e.getMessage();
+            if (!process.isAlive()) {
+                error = String.format("Native process has crashed. %s", e.getMessage());
+            }
             log.error(e);
-            throw new RuntimeException(e);
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, error, e);
         }
     }
 


### PR DESCRIPTION
HttpNativeExecutionTaskInfoFetcher swallows any taskInfo fetcher
exception and just logs to stdout. In this commit, we introduced the
backoff error tracker (same as the one in the Presto's taskInfo fetcher)
which will retry with backoff and throw the exception to the caller if
the retry still fail after certain duration.

This makes sure if the native process crashed or lost response, the task
on java side is able to be aware of the failure and fail the task eventually.

We also added the native process live check once the TaskInfo fetcher failed
and updated the exception message if the failure is due to native process crash.

```
== NO RELEASE NOTE ==
```
