### PR TITLE
Add BLACKHOLE aggregate function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -38,6 +38,10 @@ General Aggregate Functions
 
     Returns the average interval length of all input values.
 
+.. function:: blackhole(x) -> varbinary
+
+    Consumes given values with minimal resource usage and always returns the ``OK`` value.
+
 .. function:: bool_and(boolean) -> boolean
 
     Returns ``TRUE`` if every input value is ``TRUE``, otherwise ``FALSE``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -314,6 +314,7 @@ import static com.facebook.presto.operator.aggregation.AlternativeArbitraryAggre
 import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregationFunction.ALTERNATIVE_MAX;
 import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.BlackholeAggregation.BLACKHOLE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.DecimalAverageAggregation.DECIMAL_AVERAGE_AGGREGATION;
@@ -865,6 +866,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(DECIMAL_DISTINCT_FROM_OPERATOR)
                 .function(new Histogram(featuresConfig.getHistogramGroupImplementation()))
                 .function(CHECKSUM_AGGREGATION)
+                .function(BLACKHOLE_AGGREGATION)
                 .function(IDENTITY_CAST)
                 .function(ARBITRARY_AGGREGATION)
                 .functions(GREATEST, LEAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BlackholeAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BlackholeAggregation.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.function.Signature.comparableTypeParameter;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+
+/**
+ * Aggregating function that does nothing on the input data and always returns
+ * the "OK" varchar value.
+ *
+ * It works similar to the CHECKSUM function, but it does not compute the hash to
+ * minimize resource usage. It can be used when you need to scan all data in a table.
+ */
+public class BlackholeAggregation
+        extends SqlAggregationFunction
+{
+    public static final BlackholeAggregation BLACKHOLE_AGGREGATION = new BlackholeAggregation();
+    private static final String NAME = "blackhole";
+    private static final Slice OUTPUT = utf8Slice("OK");
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(BlackholeAggregation.class, "output", NullableLongState.class, BlockBuilder.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(BlackholeAggregation.class, "input", Type.class, NullableLongState.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(BlackholeAggregation.class, "combine", NullableLongState.class, NullableLongState.class);
+
+    public BlackholeAggregation()
+    {
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.VARBINARY),
+                ImmutableList.of(parseTypeSignature("T")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Consumes given values as a blackhole.";
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type valueType = boundVariables.getTypeVariable("T");
+        return generateAggregation(valueType);
+    }
+
+    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(BlackholeAggregation.class.getClassLoader());
+
+        List<Type> inputTypes = ImmutableList.of(type);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(type),
+                INPUT_FUNCTION.bindTo(type),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        NullableLongState.class,
+                        StateCompiler.generateStateSerializer(NullableLongState.class, classLoader),
+                        StateCompiler.generateStateFactory(NullableLongState.class, classLoader))),
+                VARBINARY);
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(BIGINT), VARBINARY,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type type)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type), new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(Type type, NullableLongState state, Block block, int position)
+    {
+        // do nothing
+    }
+
+    public static void combine(NullableLongState state, NullableLongState otherState)
+    {
+        // do nothing
+    }
+
+    public static void output(NullableLongState state, BlockBuilder out)
+    {
+        VARBINARY.writeSlice(out, OUTPUT);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBlackholeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBlackholeAggregation.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createShortDecimalsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+
+public class TestBlackholeAggregation
+{
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+    private static final SqlVarbinary EXPECTED_OUTPUT = new SqlVarbinary("OK".getBytes(UTF_8));
+
+    @Test
+    public void testEmpty()
+    {
+        JavaAggregationFunctionImplementation booleanAgg = getAggregation(BOOLEAN);
+        assertAggregation(booleanAgg, EXPECTED_OUTPUT, createBooleansBlock());
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        JavaAggregationFunctionImplementation booleanAgg = getAggregation(BOOLEAN);
+        Block block = createBooleansBlock(null, null, true, false, false);
+        assertAggregation(booleanAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testLong()
+    {
+        JavaAggregationFunctionImplementation longAgg = getAggregation(BIGINT);
+        Block block = createLongsBlock(null, 1L, 2L, 100L, null, Long.MAX_VALUE, Long.MIN_VALUE);
+        assertAggregation(longAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testDouble()
+    {
+        JavaAggregationFunctionImplementation doubleAgg = getAggregation(DOUBLE);
+        Block block = createDoublesBlock(null, 2.0, null, 3.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN);
+        assertAggregation(doubleAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testString()
+    {
+        JavaAggregationFunctionImplementation stringAgg = getAggregation(VARCHAR);
+        Block block = createStringsBlock("a", "a", null, "b", "c");
+        assertAggregation(stringAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testShortDecimal()
+    {
+        JavaAggregationFunctionImplementation decimalAgg = getAggregation(createDecimalType(10, 2));
+        Block block = createShortDecimalsBlock("11.11", "22.22", null, "33.33", "44.44");
+        assertAggregation(decimalAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testLongDecimal()
+    {
+        JavaAggregationFunctionImplementation decimalAgg = getAggregation(createDecimalType(19, 2));
+        Block block = createLongDecimalsBlock("11.11", "22.22", null, "33.33", "44.44");
+        assertAggregation(decimalAgg, EXPECTED_OUTPUT, block);
+    }
+
+    @Test
+    public void testArray()
+    {
+        ArrayType arrayType = new ArrayType(BIGINT);
+        JavaAggregationFunctionImplementation stringAgg = getAggregation(arrayType);
+        Block block = createArrayBigintBlock(asList(null, asList(1L, 2L), asList(3L, 4L), asList(5L, 6L)));
+        assertAggregation(stringAgg, EXPECTED_OUTPUT, block);
+    }
+
+    private JavaAggregationFunctionImplementation getAggregation(Type argument)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(FUNCTION_AND_TYPE_MANAGER.lookupFunction("blackhole", fromTypes(argument)));
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -260,6 +260,22 @@ public abstract class AbstractTestNativeAggregations
         assertQuerySucceeds("SELECT orderkey, arbitrary(tax_as_real) FROM lineitem GROUP BY 1");
     }
 
+    @Test
+    public void testBlackhole()
+    {
+        assertQuery("SELECT blackhole(v) FROM (VALUES 1.0, 3.0, 5.0, NULL ) as t (v)");
+        assertQuery("SELECT blackhole(orderkey) FROM lineitem WHERE orderkey < 2");
+        assertQuery("SELECT blackhole(orderkey) FROM lineitem WHERE orderkey  = -1");
+        assertQuery("SELECT blackhole(orderkey) FROM lineitem");
+        assertQuery("SELECT blackhole(extendedprice) FROM lineitem where orderkey < 20");
+        assertQuery("SELECT blackhole(shipdate) FROM lineitem");
+        assertQuery("SELECT blackhole(comment) FROM lineitem");
+        assertQuery("SELECT blackhole(quantities) FROM orders_ex");
+        assertQuery("SELECT blackhole(quantity_by_linenumber) FROM orders_ex");
+        assertQuery("SELECT shipmode, blackhole(extendedprice) FROM lineitem GROUP BY shipmode");
+        assertQuery("SELECT blackhole(from_unixtime(orderkey, '+01:00')) FROM lineitem WHERE orderkey < 20");
+    }
+
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);


### PR DESCRIPTION
Add a new aggregate UDF called `blackhole` which used to fake-consume data with minimal resource usage.

It is similar to the JMH blackhole function, or the `checksum` function, but it does not 
calculate the value hash to minimize resource usage, instead it always returns the `OK` 
value.

This function can be used to scan tables, for example to measure scan performance or to
leverage Presto to validate that data files are not corrupted.

Test plan:
- add new unit tests
- updated SQL unit tests for aggregate functions

```
== RELEASE NOTES ==

General Changes
* Add a new func:`blackhole` aggregate function. 
```