### PR TITLE
[native] Add support for mutable System Config

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   PeriodicTaskManager.cpp
   PrestoExchangeSource.cpp
   PrestoServer.cpp
+  PrestoServerOperations.cpp
   PrestoTask.cpp
   QueryContextManager.cpp
   ServerOperation.cpp

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -43,7 +43,6 @@ class HttpServer;
 }
 
 namespace proxygen {
-class HTTPMessage;
 class ResponseHandler;
 } // namespace proxygen
 
@@ -56,7 +55,6 @@ namespace facebook::presto {
 // Three states our server can be in.
 enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };
 
-struct ServerOperation;
 class SignalHandler;
 class TaskManager;
 class TaskResource;
@@ -125,15 +123,6 @@ class PrestoServer {
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
   void populateMemAndCPUInfo();
-
-  /// Invoked to run operation on this server per http request.
-  void runOperation(
-      proxygen::HTTPMessage* message,
-      proxygen::ResponseHandler* downstream);
-
-  std::string connectorOperation(
-      const ServerOperation& op,
-      proxygen::HTTPMessage* message);
 
   const std::string configDirectoryPath_;
 

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/PrestoServerOperations.h"
+#include <velox/common/base/Exceptions.h>
+#include <velox/common/base/VeloxException.h>
+#include "presto_cpp/main/ServerOperation.h"
+#include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/http/HttpServer.h"
+#include "velox/connectors/hive/HiveConnector.h"
+
+namespace facebook::presto {
+
+namespace {
+
+std::string unsupportedAction(const ServerOperation& op) {
+  VELOX_USER_FAIL(
+      "Target '{}' does not support action '{}'",
+      ServerOperation::targetString(op.target),
+      ServerOperation::actionString(op.action));
+}
+
+std::string clearConnectorCache(proxygen::HTTPMessage* message) {
+  const auto name = message->getQueryParam("name");
+  const auto id = message->getQueryParam("id");
+  if (name == "hive") {
+    // ======== HiveConnector Operations ========
+    auto hiveConnector =
+        std::dynamic_pointer_cast<velox::connector::hive::HiveConnector>(
+            velox::connector::getConnector(id));
+    VELOX_USER_CHECK_NOT_NULL(
+        hiveConnector,
+        "No '{}' connector found for connector id '{}'",
+        name,
+        id);
+    return hiveConnector->clearFileHandleCache().toString();
+  }
+  VELOX_USER_FAIL("connector '{}' operation is not supported", name);
+}
+
+std::string getConnectorCacheStats(proxygen::HTTPMessage* message) {
+  const auto name = message->getQueryParam("name");
+  const auto id = message->getQueryParam("id");
+  if (name == "hive") {
+    // ======== HiveConnector Operations ========
+    auto hiveConnector =
+        std::dynamic_pointer_cast<velox::connector::hive::HiveConnector>(
+            velox::connector::getConnector(id));
+    VELOX_USER_CHECK_NOT_NULL(
+        hiveConnector,
+        "No '{}' connector found for connector id '{}'",
+        name,
+        id);
+    return hiveConnector->fileHandleCacheStats().toString();
+  }
+  VELOX_USER_FAIL("connector '{}' operation is not supported", name);
+}
+
+} // namespace
+
+void PrestoServerOperations::runOperation(
+    proxygen::HTTPMessage* message,
+    proxygen::ResponseHandler* downstream) {
+  try {
+    const ServerOperation op = buildServerOpFromHttpMsgPath(message->getPath());
+    switch (op.target) {
+      case ServerOperation::Target::kConnector:
+        http::sendOkResponse(downstream, connectorOperation(op, message));
+        break;
+      case ServerOperation::Target::kSystemConfig:
+        http::sendOkResponse(downstream, systemConfigOperation(op, message));
+        break;
+    }
+  } catch (const velox::VeloxUserError& ex) {
+    http::sendErrorResponse(downstream, ex.what());
+  } catch (const velox::VeloxException& ex) {
+    http::sendErrorResponse(downstream, ex.what());
+  }
+}
+
+std::string PrestoServerOperations::connectorOperation(
+    const ServerOperation& op,
+    proxygen::HTTPMessage* message) {
+  switch (op.action) {
+    case ServerOperation::Action::kClearCache:
+      return clearConnectorCache(message);
+    case ServerOperation::Action::kGetCacheStats:
+      return getConnectorCacheStats(message);
+    default:
+      break;
+  }
+  return unsupportedAction(op);
+}
+
+std::string PrestoServerOperations::systemConfigOperation(
+    const ServerOperation& op,
+    proxygen::HTTPMessage* message) {
+  switch (op.action) {
+    case ServerOperation::Action::kSetProperty: {
+      const auto name = message->getQueryParam("name");
+      const auto value = message->getQueryParam("value");
+      VELOX_USER_CHECK(
+          !name.empty() && !value.empty(),
+          "Missing 'name' or 'value' parameter for '{}.{}' operation",
+          ServerOperation::targetString(op.target),
+          ServerOperation::actionString(op.action));
+      return fmt::format(
+          "Have set system property value '{}' to '{}'. Old value was '{}'.\n",
+          name,
+          value,
+          SystemConfig::instance()->setValue(name, value).value_or(""));
+    }
+    case ServerOperation::Action::kGetProperty: {
+      const auto name = message->getQueryParam("name");
+      VELOX_USER_CHECK(
+          !name.empty(),
+          "Missing 'name' parameter for '{}.{}' operation",
+          ServerOperation::targetString(op.target),
+          ServerOperation::actionString(op.action));
+      return fmt::format(
+          "{}\n",
+          SystemConfig::instance()->optionalProperty(name).value_or(""));
+    }
+    default:
+      break;
+  }
+  return unsupportedAction(op);
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace proxygen {
+class HTTPMessage;
+class ResponseHandler;
+} // namespace proxygen
+
+namespace facebook::presto {
+
+struct ServerOperation;
+
+/// Static class implements Presto Server Operations.
+class PrestoServerOperations {
+ public:
+  static void runOperation(
+      proxygen::HTTPMessage* message,
+      proxygen::ResponseHandler* downstream);
+
+  static std::string connectorOperation(
+      const ServerOperation& op,
+      proxygen::HTTPMessage* message);
+
+  static std::string systemConfigOperation(
+      const ServerOperation& op,
+      proxygen::HTTPMessage* message);
+};
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -13,7 +13,7 @@
  */
 #pragma once
 
-#include <proxygen/lib/http/HTTPMessage.h>
+#include <folly/container/F14Map.h>
 #include <string>
 
 namespace facebook::presto {
@@ -23,15 +23,16 @@ struct ServerOperation {
   /// The target this operation is operating upon
   enum class Target {
     kConnector,
+    kSystemConfig,
   };
 
   /// The action this operation is trying to take
-  enum class Action { kClearCache, kGetCacheStats };
+  enum class Action { kClearCache, kGetCacheStats, kSetProperty, kGetProperty };
 
-  static const std::unordered_map<std::string, Target> kTargetLookup;
-  static const std::unordered_map<Target, std::string> kReverseTargetLookup;
-  static const std::unordered_map<std::string, Action> kActionLookup;
-  static const std::unordered_map<Action, std::string> kReverseActionLookup;
+  static const folly::F14FastMap<std::string, Target> kTargetLookup;
+  static const folly::F14FastMap<Target, std::string> kReverseTargetLookup;
+  static const folly::F14FastMap<std::string, Action> kActionLookup;
+  static const folly::F14FastMap<Action, std::string> kReverseActionLookup;
 
   static Target targetFromString(const std::string& str);
   static std::string targetString(Target target);
@@ -43,7 +44,6 @@ struct ServerOperation {
 };
 
 /// Builds a server operation from an HTTP request. Throws upon build failure.
-ServerOperation buildServerOpFromHttpRequest(
-    const proxygen::HTTPMessage* httpMsg);
+ServerOperation buildServerOpFromHttpMsgPath(const std::string& httpMsgPath);
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -27,6 +27,13 @@ class ConfigBase {
   /// @param filePath Path to configuration file.
   void initialize(const std::string& filePath);
 
+  /// Adds or replaces value at the given key. Can be used by debugging or
+  /// testing code.
+  /// Returns previous value if there was any.
+  folly::Optional<std::string> setValue(
+      const std::string& propertyName,
+      const std::string& value);
+
   template <typename T>
   T requiredProperty(const std::string& propertyName) const {
     auto propertyValue = config_->get<T>(propertyName);
@@ -58,8 +65,9 @@ class ConfigBase {
     return config_->get(propertyName);
   }
 
-  const std::unordered_map<std::string, std::string>& values() const {
-    return config_->values();
+  /// Returns copy of the config values map.
+  std::unordered_map<std::string, std::string> values() const {
+    return config_->valuesCopy();
   }
 
  protected:
@@ -72,13 +80,14 @@ class ConfigBase {
 /// Provides access to system properties defined in config.properties file.
 class SystemConfig : public ConfigBase {
  public:
+  static constexpr std::string_view kMutableConfig{"mutable-config"};
   static constexpr std::string_view kPrestoVersion{"presto.version"};
   static constexpr std::string_view kHttpServerHttpPort{
       "http-server.http.port"};
-  // This option allows a port closed in TIME_WAIT state to be reused
-  // immediately upon worker startup. This property is mainly used by batch
-  // processing. For interactive query, the worker uses a dynamic port upon
-  // startup.
+  /// This option allows a port closed in TIME_WAIT state to be reused
+  /// immediately upon worker startup. This property is mainly used by batch
+  /// processing. For interactive query, the worker uses a dynamic port upon
+  /// startup.
   static constexpr std::string_view kHttpServerReusePort{
       "http-server.reuse-port"};
   static constexpr std::string_view kDiscoveryUri{"discovery.uri"};
@@ -136,9 +145,10 @@ class SystemConfig : public ConfigBase {
   /// the received http response data.
   static constexpr std::string_view kHttpMaxAllocateBytes{
       "http-server.max-response-allocate-bytes"};
-  // Most server nodes today (May 2022) have at least 16 cores.
-  // Setting the default maximum drivers per task to this value will
-  // provide a better off-shelf experience.
+
+  /// Most server nodes today (May 2022) have at least 16 cores.
+  /// Setting the default maximum drivers per task to this value will
+  /// provide a better off-shelf experience.
   static constexpr int32_t kMaxDriversPerTaskDefault = 16;
   static constexpr bool kHttpServerReusePortDefault = false;
   static constexpr int32_t kConcurrentLifespansPerTaskDefault = 1;

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(presto_common_test CommonTest.cpp)
+add_executable(presto_common_test CommonTest.cpp SystemConfigTest.cpp)
 
 add_test(presto_common_test presto_common_test)
 
@@ -18,6 +18,7 @@ target_link_libraries(
   presto_common
   presto_exception
   velox_exception
+  velox_file
   ${RE2}
   gtest
   gtest_main)

--- a/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "presto_cpp/main/common/Configs.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+
+namespace facebook::presto::test {
+
+using namespace velox;
+
+class SystemConfigTest : public testing::Test {
+ protected:
+  void setUpConfigFile(bool isMutable) {
+    velox::filesystems::registerLocalFileSystem();
+
+    char path[] = "/tmp/velox_system_config_test_XXXXXX";
+    const char* tempDirectoryPath = mkdtemp(path);
+    if (tempDirectoryPath == nullptr) {
+      throw std::logic_error("Cannot open temp directory");
+    }
+    configFilePath = tempDirectoryPath;
+    configFilePath += "/config.properties";
+
+    auto fileSystem = filesystems::getFileSystem(configFilePath, nullptr);
+    auto sysConfigFile = fileSystem->openFileForWrite(configFilePath);
+    sysConfigFile->append(
+        fmt::format("{}={}\n", SystemConfig::kPrestoVersion, prestoVersion));
+    if (isMutable) {
+      sysConfigFile->append(
+          fmt::format("{}={}\n", SystemConfig::kMutableConfig, "true"));
+    }
+    sysConfigFile->close();
+  }
+
+  std::string configFilePath;
+  const std::string prestoVersion{"SystemConfigTest1"};
+  const std::string prestoVersion2{"SystemConfigTest2"};
+};
+
+TEST_F(SystemConfigTest, defaultConfig) {
+  setUpConfigFile(false);
+  auto systemConfig = SystemConfig::instance();
+  systemConfig->initialize(configFilePath);
+
+  ASSERT_FALSE(
+      systemConfig
+          ->optionalProperty<bool>(std::string{SystemConfig::kMutableConfig})
+          .has_value());
+  ASSERT_EQ(prestoVersion, systemConfig->prestoVersion());
+  ASSERT_THROW(
+      systemConfig->setValue(
+          std::string(SystemConfig::kPrestoVersion), prestoVersion2),
+      VeloxException);
+}
+
+TEST_F(SystemConfigTest, mutableConfig) {
+  setUpConfigFile(true);
+  auto systemConfig = SystemConfig::instance();
+  systemConfig->initialize(configFilePath);
+
+  ASSERT_TRUE(
+      systemConfig
+          ->optionalProperty<bool>(std::string{SystemConfig::kMutableConfig})
+          .value());
+  ASSERT_EQ(prestoVersion, systemConfig->prestoVersion());
+  ASSERT_EQ(
+      prestoVersion,
+      systemConfig
+          ->setValue(std::string(SystemConfig::kPrestoVersion), prestoVersion2)
+          .value());
+  ASSERT_EQ(prestoVersion2, systemConfig->prestoVersion());
+}
+
+} // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -21,7 +21,6 @@ class ServerOperationTest : public testing::Test {};
 
 TEST_F(ServerOperationTest, targetActionLookup) {
   {
-    auto size = ServerOperation::kTargetLookup.size();
     // Targets lookup verification
     EXPECT_EQ(
         ServerOperation::kTargetLookup.size(),
@@ -87,6 +86,25 @@ TEST_F(ServerOperationTest, stringEnumConversion) {
   }
   EXPECT_THROW(
       ServerOperation::actionFromString("UNKNOWN_ACTION"),
+      velox::VeloxUserError);
+}
+
+TEST_F(ServerOperationTest, buildServerOp) {
+  ServerOperation op;
+  op = buildServerOpFromHttpMsgPath("/v1/operation/connector/clearCache");
+  EXPECT_EQ(ServerOperation::Target::kConnector, op.target);
+  EXPECT_EQ(ServerOperation::Action::kClearCache, op.action);
+
+  op = buildServerOpFromHttpMsgPath("/v1/operation/connector/getCacheStats");
+  EXPECT_EQ(ServerOperation::Target::kConnector, op.target);
+  EXPECT_EQ(ServerOperation::Action::kGetCacheStats, op.action);
+
+  op = buildServerOpFromHttpMsgPath("/v1/operation/systemConfig/setProperty");
+  EXPECT_EQ(ServerOperation::Target::kConnector, op.target);
+  EXPECT_EQ(ServerOperation::Action::kSetProperty, op.action);
+
+  EXPECT_THROW(
+      op = buildServerOpFromHttpMsgPath("/v1/operation/whatzit/setProperty"),
       velox::VeloxUserError);
 }
 


### PR DESCRIPTION
Adding support to Native Worker to have mutable System Config.
It is activated by having "mutable-config=true" in config.properties file.
Examples of use:
```
curl "127.0.0.1:7777/v1/operation/systemConfig/setProperty?name=shutdown-onset-sec&value=2"
curl "myhost:7777/v1/operation/systemConfig/setProperty?name=shutdown-onset-sec&value=2"
curl "127.0.0.1:7777/v1/operation/systemConfig/getProperty?name=shutdown-onset-sec"
curl "myhost:7777/v1/operation/systemConfig/getProperty?name=shutdown-onset-sec"
```
Test plan - new tests.

```
== NO RELEASE NOTE ==
```
