### PR TITLE
Extend operator to support memory arbitration integration with disk spilling (#4791)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -288,7 +288,7 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
   lastMemoryReservation = currentBytes;
 
   prestoTaskStats.peakNodeTotalMemoryInBytes =
-      task->queryCtx()->pool()->getMaxBytes();
+      task->queryCtx()->pool()->peakBytes();
 
   prestoTaskStats.rawInputPositions = 0;
   prestoTaskStats.rawInputDataSizeInBytes = 0;


### PR DESCRIPTION
Summary:
Extend Velox operator to support the following memory reclaim related APIs
for the integration of memory arbitration with disk spilling
- canReclaim(): check if an operator is reclaimable or not
- reclaimableBytes(): returns the reclaimable memory bytes
- reclaim(): do memory reclaim
Add implementations for three spillable operators: order by, hash aggregation
and hash build.

Add nonReclaimableSection_ in operator to indicate a reclaimable
operator is currently under non-reclaimable section execution to prevent
it from memory reclamation. This is used when a reclaimable operator is under
memory arbitration

Extend task, driver and spiller to the disk spilling control for memory
reclamation.

X-link: https://github.com/facebookincubator/velox/pull/4791

Reviewed By: oerling

Differential Revision: D45427343

Pulled By: xiaoxmeng

