### PR TITLE
Buffer compilation issue

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
@@ -58,6 +58,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.units.Duration;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -420,7 +421,7 @@ public class NativeCassandraSession
 
         ImmutableList.Builder<CassandraPartition> partitions = ImmutableList.builder();
         for (Row row : rows) {
-            buffer.clear();
+            ((Buffer) buffer).clear();
             map.clear();
             stringBuilder.setLength(0);
             for (int i = 0; i < partitionKeyColumns.size(); i++) {
@@ -445,7 +446,7 @@ public class NativeCassandraSession
                 stringBuilder.append(" = ");
                 stringBuilder.append(CassandraType.getColumnValueForCql(row, i, columnHandle.getCassandraType()));
             }
-            buffer.flip();
+            ((Buffer) buffer).flip();
             byte[] key = new byte[buffer.limit()];
             buffer.get(key);
             TupleDomain<ColumnHandle> tupleDomain = TupleDomain.fromFixedValues(map);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import org.roaringbitmap.RoaringBitmap;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -223,7 +224,7 @@ public class HiveManifestUtils
         // Serialize the compressed data into ByteBuffer
         ByteBuffer byteBuffer = ByteBuffer.allocate(roaringBitmap.serializedSizeInBytes());
         roaringBitmap.serialize(byteBuffer);
-        byteBuffer.flip();
+        ((Buffer) byteBuffer).flip();
 
         return new String(byteBuffer.array(), ISO_8859_1);
     }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -323,7 +324,7 @@ public class RawRowEncoder
         checkArgument(currentColumnIndex == columnHandles.size(), format("Missing %d columns", columnHandles.size() - currentColumnIndex + 1));
 
         resetColumnIndex(); // reset currentColumnIndex to prepare for next row
-        buffer.clear(); // set buffer position back to 0 to prepare for next row, this method does not affect the backing byte array
+        ((Buffer) buffer).clear(); // set buffer position back to 0 to prepare for next row, this method does not affect the backing byte array
         return buffer.array();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
@@ -21,6 +21,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
@@ -58,7 +59,7 @@ final class AesSpillCipher
         ByteBuffer output = ByteBuffer.allocate(cipher.getOutputSize(encryptedData.remaining()));
         try {
             cipher.doFinal(encryptedData, output);
-            output.flip();
+            ((Buffer) output).flip();
             return output;
         }
         catch (GeneralSecurityException e) {
@@ -82,7 +83,7 @@ final class AesSpillCipher
                 .put(iv);
         try {
             cipher.doFinal(data, output);
-            output.flip();
+            ((Buffer) output).flip();
             return output;
         }
         catch (GeneralSecurityException e) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TestingEncryptionLibrary.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TestingEncryptionLibrary.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Base64;
@@ -63,7 +64,7 @@ public class TestingEncryptionLibrary
         ByteBuffer output = ByteBuffer.allocate(keyMetadata.length + encoded.remaining());
         output.put(keyMetadata);
         output.put(encoded);
-        output.flip();
+        ((Buffer) output).flip();
         byte[] encrypted = new byte[output.remaining()];
         output.get(encrypted);
         return encrypted;
@@ -79,7 +80,7 @@ public class TestingEncryptionLibrary
 
         ByteBuffer encoded = ByteBuffer.allocate(inputBuffer.remaining());
         encoded.put(inputBuffer);
-        encoded.flip();
+        ((Buffer) encoded).flip();
         ByteBuffer decodedByteBuffer = DECODER.decode(encoded);
         byte[] decoded = new byte[decodedByteBuffer.remaining()];
         decodedByteBuffer.get(decoded);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zlib/DeflateCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zlib/DeflateCompressor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.zlib;
 
 import io.airlift.compress.Compressor;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.OptionalInt;
 import java.util.zip.Deflater;
@@ -77,6 +78,6 @@ public class DeflateCompressor
         int outputOffset = output.arrayOffset() + output.position();
 
         int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-        output.position(output.position() + written);
+        ((Buffer) output).position(output.position() + written);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zlib/InflateDecompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zlib/InflateDecompressor.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.zlib;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -56,6 +57,6 @@ public class InflateDecompressor
         int outputOffset = output.arrayOffset() + output.position();
 
         int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-        output.position(output.position() + written);
+        ((Buffer) output).position(output.position() + written);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.zstd;
 import com.github.luben.zstd.Zstd;
 import io.airlift.compress.Compressor;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.OptionalInt;
 
@@ -61,6 +62,6 @@ public class ZstdJniCompressor
         int outputOffset = output.arrayOffset() + output.position();
 
         int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-        output.position(output.position() + written);
+        ((Buffer) output).position(output.position() + written);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniDecompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniDecompressor.java
@@ -17,6 +17,7 @@ import com.github.luben.zstd.Zstd;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static java.lang.StrictMath.toIntExact;
@@ -47,6 +48,6 @@ public class ZstdJniDecompressor
         int outputOffset = output.arrayOffset() + output.position();
 
         int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-        output.position(output.position() + written);
+        ((Buffer) output).position(output.position() + written);
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -48,6 +48,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static com.facebook.presto.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
@@ -315,7 +316,7 @@ public class Decoders
 
         final int bufferSize = readIntLittleEndian(bufferInputStream);
         FlatDefinitionLevelDecoder definitionLevelDecoder = new FlatDefinitionLevelDecoder(valueCount, bufferInputStream.sliceStream(bufferSize));
-        buffer.position(buffer.position() + bufferSize + 4);
+        ((Buffer) buffer).position(buffer.position() + bufferSize + 4);
         return definitionLevelDecoder;
     }
 
@@ -332,7 +333,7 @@ public class Decoders
 
         final int bufferSize = readIntLittleEndian(bufferInputStream);
         RepetitionLevelDecoder repetitionLevelDecoder = new RepetitionLevelDecoder(valueCount, bitWidth, bufferInputStream.sliceStream(bufferSize));
-        buffer.position(buffer.position() + bufferSize + 4);
+        ((Buffer) buffer).position(buffer.position() + bufferSize + 4);
         return repetitionLevelDecoder;
     }
 
@@ -349,7 +350,7 @@ public class Decoders
 
         final int bufferSize = readIntLittleEndian(bufferInputStream);
         DefinitionLevelDecoder definitionLevelDecoder = new DefinitionLevelDecoder(valueCount, bitWidth, bufferInputStream.sliceStream(bufferSize));
-        buffer.position(buffer.position() + bufferSize + 4);
+        ((Buffer) buffer).position(buffer.position() + bufferSize + 4);
         return definitionLevelDecoder;
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/BooleanRLEValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/BooleanRLEValuesDecoder.java
@@ -19,6 +19,7 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -156,7 +157,7 @@ public class BooleanRLEValuesDecoder
                     int fullBytes = remainingPackedBlock / 8;
 
                     if (fullBytes > 0) {
-                        inputBuffer.position(inputBuffer.position() + fullBytes);
+                        ((Buffer) inputBuffer).position(inputBuffer.position() + fullBytes);
                     }
 
                     remainingPackedBlock = remainingPackedBlock % 8;

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -243,7 +244,7 @@ public class PinotSegmentPageSource
         }
         finally {
             if (byteBuffer != null) {
-                byteBuffer.clear();
+                ((Buffer) byteBuffer).clear();
             }
         }
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
@@ -23,6 +23,7 @@ import scala.Tuple2;
 
 import javax.annotation.Nullable;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -347,8 +348,8 @@ public class PrestoSparkRowBatch
             int nextRow = currentRow + 1;
             int nextRowOffset = nextRow < rowCount ? rowOffsets[nextRow] : totalSizeInBytes;
             int rowSize = nextRowOffset - currentRowOffset;
-            rowData.limit(currentRowOffset + rowSize);
-            rowData.position(currentRowOffset);
+            ((Buffer) rowData).limit(currentRowOffset + rowSize);
+            ((Buffer) rowData).position(currentRowOffset);
 
             short rowsCount = rowData.getShort(currentRowOffset);
             row.setPositionCount(rowsCount);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShufflePageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShufflePageInput.java
@@ -31,6 +31,7 @@ import scala.collection.Iterator;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -91,7 +92,7 @@ public class PrestoSparkShufflePageInput
                         short entryRowCount = getShortLittleEndian(buffer);
                         rowCount += entryRowCount;
                         currentIteratorProcessedRows += entryRowCount;
-                        buffer.position(buffer.position() + 2);
+                        ((Buffer) buffer).position(buffer.position() + 2);
                         output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
                     }
                     else if (row.getArray() != null) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -62,7 +63,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class PrestoSparkUtils
 {
     private static final int COMPRESSION_LEVEL = 3; // default level
-    private PrestoSparkUtils() {}
+
+    private PrestoSparkUtils()
+    {
+    }
 
     public static PrestoSparkSerializedPage toPrestoSparkSerializedPage(SerializedPage serializedPage)
     {
@@ -173,7 +177,7 @@ public class PrestoSparkUtils
                 int outputOffset = output.arrayOffset() + output.position();
 
                 int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-                output.position(output.position() + written);
+                ((Buffer) output).position(output.position() + written);
             }
         };
     }
@@ -204,7 +208,7 @@ public class PrestoSparkUtils
                 int outputOffset = output.arrayOffset() + output.position();
 
                 int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
-                output.position(output.position() + written);
+                ((Buffer) output).position(output.position() + written);
             }
         };
     }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 
@@ -239,8 +240,8 @@ public class PrestoSparkShuffleSerializer
                         throw new UncheckedIOException(e);
                     }
 
-                    buffer.position(0);
-                    buffer.limit(length);
+                    ((Buffer) buffer).position(0);
+                    ((Buffer) buffer).limit(length);
                     row.setBuffer(buffer);
                     return tuple;
                 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
@@ -23,6 +23,7 @@ import io.airlift.slice.Slices;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
@@ -98,7 +99,7 @@ public class PagesSerde
             ByteBuffer decompressionBuffer = ByteBuffer.allocate(uncompressedSize);
 
             decompressor.get().decompress(slice.toByteBuffer(), decompressionBuffer);
-            decompressionBuffer.flip();
+            ((Buffer) decompressionBuffer).flip();
             checkState(decompressionBuffer.remaining() == uncompressedSize, "page size changed after decompression into decompressionBuffer");
 
             slice = Slices.wrappedBuffer(decompressionBuffer);


### PR DESCRIPTION
JVM 17 has defined two position methods.
ByteBuffer BtyeBuffer.position(int) Available in JVM17
Buffer  Buffer.position(int) Available in JVM8.

When compiled with JVM17, the code links against JVM17
implementations with a target compatibility of JVM8.
When run on JVM8, they fail with NoSuchMethodError.

This change downcasts the caller, to link with JVM8 methods.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
