### PR TITLE
[native] Handle Date type in toFilter function

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -638,6 +638,17 @@ std::unique_ptr<common::Filter> toFilter(
       return combineIntegerRanges(bigintFilters, nullAllowed);
     }
 
+    if (type->kind() == TypeKind::DATE) {
+      std::vector<std::unique_ptr<common::BigintRange>> dateFilters;
+      dateFilters.reserve(ranges.size());
+      for (const auto& range : ranges) {
+        dateFilters.emplace_back(
+            dateRangeToFilter(range, nullAllowed, exprConverter, type));
+      }
+      return std::make_unique<common::BigintMultiRange>(
+          std::move(dateFilters), nullAllowed);
+    }
+
     if (type->kind() == TypeKind::VARCHAR) {
       std::vector<std::unique_ptr<common::BytesRange>> bytesFilters;
       bytesFilters.reserve(ranges.size());

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -189,6 +189,26 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testDateFilter()
+    {
+        String tmpTableName = generateRandomTableName();
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", "parquet_pushdown_filter_enabled", "true")
+                .build();
+
+        try {
+            computeExpected(String.format("CREATE TABLE %s (c0 DATE) WITH (format = 'PARQUET')", tmpTableName), ImmutableList.of());
+            computeExpected(String.format("INSERT INTO %s VALUES (DATE '1996-01-02'), (DATE '1996-12-01')", tmpTableName), ImmutableList.of());
+
+            assertQueryResultCount(session, String.format("SELECT * from %s where c0 in (select c0 from %s) ", tmpTableName, tmpTableName), 2);
+        }
+        finally {
+            dropTableIfExists(tmpTableName);
+        }
+    }
+
+    @Test
     public void testOrderBy()
     {
         assertQueryOrdered("SELECT nationkey, regionkey FROM nation ORDER BY nationkey");
@@ -1030,5 +1050,10 @@ public abstract class AbstractTestNativeGeneralQueries
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);
+    }
+
+    private void assertQueryResultCount(Session session, String sql, int expectedResultCount)
+    {
+        assertEquals(getQueryRunner().execute(session, sql).getRowCount(), expectedResultCount);
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -48,6 +48,10 @@ public class TestPrestoSparkNativeGeneralQueries
 
     @Override
     @Ignore
+    public void testDateFilter() {}
+
+    @Override
+    @Ignore
     public void testCreateUnpartitionedTableAsSelect() {}
 
     @Override


### PR DESCRIPTION
This PR fixes TPC-DS Q83 error: 
> VeloxUserError: Filter(MultiRange, deterministic, null not allowed): testInt64() is not supported

In query 83, the date filter is constructed as a generic MultiRange filter instead of BigintMultiRange as dates are converted into `int64_t`. MultiRange filter does not support `testInt64` method and crashes. Instead, we should handle dates the same way we handle integers.

This is complimentary to https://github.com/facebookincubator/velox/pull/4794.

I added a test that verifies this change.

```
== NO RELEASE NOTE ==
```

Fixes https://github.com/prestodb/presto/issues/19522.
