### PR TITLE
Upgrade Alluxio to 2.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.8.1</dep.alluxio.version>
+        <dep.alluxio.version>2.9.3</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.pinot.version>0.11.0</dep.pinot.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -19,6 +19,8 @@ import alluxio.client.quota.CacheScope;
 import com.facebook.presto.hive.HiveFileContext;
 import com.google.common.collect.ImmutableMap;
 
+import static com.facebook.presto.common.RuntimeUnit.BYTE;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static java.util.Objects.requireNonNull;
 
@@ -49,9 +51,18 @@ public class PrestoCacheContext
     }
 
     @Override
-    public void incrementCounter(String name, long value)
+    public void incrementCounter(String name, StatsUnit unit, long value)
     {
-        hiveFileContext.incrementCounter(name, NONE, value);
+        switch (unit) {
+            case BYTE:
+                hiveFileContext.incrementCounter(name, BYTE, value);
+                break;
+            case NANO:
+                hiveFileContext.incrementCounter(name, NANO, value);
+                break;
+            default:
+                hiveFileContext.incrementCounter(name, NONE, value);
+        }
     }
 
     public HiveFileContext getHiveFileContext()


### PR DESCRIPTION
Alluxio 2.9.3 supports more under storage for local cache
This will fix https://github.com/prestodb/presto/issues/19026


```
== RELEASE NOTES ==

Hive Changes
* Replace the version of Alluxio from 2.8.1 to 2.9.3
```
