### PR TITLE
[native] Improving SystemConfig.

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -82,10 +82,8 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
         {entry.first, std::make_shared<core::MemConfig>(entry.second)});
   }
 
-  const int64_t maxQueryMemoryPerNode =
-      getMaxMemoryPerNode(kQueryMaxMemoryPerNode, kDefaultMaxMemoryPerNode);
   auto pool = memory::defaultMemoryManager().addRootPool(
-      queryId, maxQueryMemoryPerNode);
+      queryId, SystemConfig::instance()->queryMaxMemoryPerNode());
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       executor().get(),

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -103,10 +103,7 @@ class QueryContextCache {
 
 class QueryContextManager {
  public:
-  QueryContextManager(
-      std::unordered_map<std::string, std::string>& properties,
-      std::unordered_map<std::string, std::string>& nodeProperties)
-      : properties_(properties), nodeProperties_(nodeProperties) {}
+  QueryContextManager() = default;
 
   std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(
       const protocol::TaskId& taskId,
@@ -116,39 +113,13 @@ class QueryContextManager {
           std::unordered_map<std::string, std::string>>&&
           connectorConfigStrings);
 
-  void overrideProperties(
-      const std::string& property,
-      const std::string& value) {
-    properties_[property] = value;
-  }
-
   // Calls the given functor for every present query context.
   void visitAllContexts(std::function<void(
                             const protocol::QueryId&,
                             const velox::core::QueryCtx*)> visitor) const;
 
-  static constexpr const char* kQueryMaxMemoryPerNode =
-      "query.max-memory-per-node";
-  static constexpr int64_t kDefaultMaxMemoryPerNode =
-      std::numeric_limits<int64_t>::max();
-
  private:
-  int64_t getMaxMemoryPerNode(
-      const std::string& property,
-      int64_t defaultMaxMemoryPerNode) {
-    int64_t maxMemoryInBytes = defaultMaxMemoryPerNode;
-    auto it = properties_.find(property);
-    if (it != properties_.end()) {
-      // This can overflow if the properties exceeds 8EB.
-      maxMemoryInBytes =
-          protocol::DataSize(it->second).getValue(protocol::DataUnit::BYTE);
-    }
-    // Return sane value if it is indeed overflow.
-    return (maxMemoryInBytes <= 0) ? defaultMaxMemoryPerNode : maxMemoryInBytes;
-  }
-
   folly::Synchronized<QueryContextCache> queryContextCache_;
-  std::unordered_map<std::string, std::string> properties_;
-  std::unordered_map<std::string, std::string> nodeProperties_;
 };
+
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -30,9 +30,7 @@ struct DriverCountStats {
 
 class TaskManager {
  public:
-  explicit TaskManager(
-      std::unordered_map<std::string, std::string> properties = {},
-      std::unordered_map<std::string, std::string> nodeProperties = {});
+  TaskManager();
 
   void setBaseUri(const std::string& baseUri) {
     baseUri_ = baseUri;
@@ -161,8 +159,6 @@ class TaskManager {
   std::shared_ptr<velox::exec::PartitionedOutputBufferManager> bufferManager_;
   folly::Synchronized<TaskMap> taskMap_;
   QueryContextManager queryContextManager_;
-  int32_t maxDriversPerTask_;
-  int32_t concurrentLifespansPerTask_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -12,8 +12,11 @@
  * limitations under the License.
  */
 
-#include "presto_cpp/main/common/Configs.h"
+#include <re2/re2.h>
+#include <unordered_set>
+
 #include "presto_cpp/main/common/ConfigReader.h"
+#include "presto_cpp/main/common/Configs.h"
 
 #if __has_include("filesystem")
 #include <filesystem>
@@ -25,12 +28,174 @@ namespace fs = std::experimental::filesystem;
 
 namespace facebook::presto {
 
+namespace {
+
+void checkIncomingSystemProperties(
+    const std::unordered_map<std::string, std::string>& values) {
+  static const std::unordered_set<std::string_view> kSupportedSystemProperties{
+      SystemConfig::kMutableConfig,
+      SystemConfig::kPrestoVersion,
+      SystemConfig::kHttpServerHttpPort,
+      SystemConfig::kHttpServerReusePort,
+      SystemConfig::kDiscoveryUri,
+      SystemConfig::kMaxDriversPerTask,
+      SystemConfig::kConcurrentLifespansPerTask,
+      SystemConfig::kHttpExecThreads,
+      SystemConfig::kHttpServerHttpsPort,
+      SystemConfig::kHttpServerHttpsEnabled,
+      SystemConfig::kHttpsSupportedCiphers,
+      SystemConfig::kHttpsCertPath,
+      SystemConfig::kHttpsKeyPath,
+      SystemConfig::kHttpsClientCertAndKeyPath,
+      SystemConfig::kNumIoThreads,
+      SystemConfig::kNumQueryThreads,
+      SystemConfig::kNumSpillThreads,
+      SystemConfig::kSpillerSpillPath,
+      SystemConfig::kShutdownOnsetSec,
+      SystemConfig::kSystemMemoryGb,
+      SystemConfig::kAsyncCacheSsdGb,
+      SystemConfig::kAsyncCacheSsdCheckpointGb,
+      SystemConfig::kAsyncCacheSsdPath,
+      SystemConfig::kAsyncCacheSsdDisableFileCow,
+      SystemConfig::kEnableSerializedPageChecksum,
+      SystemConfig::kUseMmapArena,
+      SystemConfig::kMmapArenaCapacityRatio,
+      SystemConfig::kUseMmapAllocator,
+      SystemConfig::kEnableVeloxTaskLogging,
+      SystemConfig::kEnableVeloxExprSetLogging,
+      SystemConfig::kLocalShuffleMaxPartitionBytes,
+      SystemConfig::kShuffleName,
+      SystemConfig::kHttpEnableAccessLog,
+      SystemConfig::kHttpEnableStatsFilter,
+      SystemConfig::kRegisterTestFunctions,
+      SystemConfig::kHttpMaxAllocateBytes,
+      SystemConfig::kQueryMaxMemoryPerNode,
+      SystemConfig::kEnableMemoryLeakCheck,
+      SystemConfig::kRemoteFunctionServerThriftPort,
+  };
+
+  std::stringstream supported;
+  std::stringstream unsupported;
+  for (const auto& pair : values) {
+    ((kSupportedSystemProperties.count(pair.first) != 0) ? supported
+                                                         : unsupported)
+        << "  " << pair.first << "=" << pair.second << "\n";
+  }
+  auto str = supported.str();
+  if (!str.empty()) {
+    LOG(INFO) << "STARTUP: Supported system properties:\n" << str;
+  }
+  str = unsupported.str();
+  if (!str.empty()) {
+    LOG(WARNING) << "STARTUP: Unsupported system properties:\n" << str;
+  }
+}
+
+void checkIncomingNodeProperties(
+    const std::unordered_map<std::string, std::string>& values) {
+  static const std::unordered_set<std::string_view> kSupportedNodeProperties{
+      NodeConfig::kNodeEnvironment,
+      NodeConfig::kNodeId,
+      NodeConfig::kNodeIp,
+      NodeConfig::kNodeLocation,
+      NodeConfig::kNodeMemoryGb,
+  };
+
+  std::stringstream supported;
+  std::stringstream unsupported;
+  for (const auto& pair : values) {
+    ((kSupportedNodeProperties.count(pair.first) != 0) ? supported
+                                                       : unsupported)
+        << "  " << pair.first << "=" << pair.second << "\n";
+  }
+  auto str = supported.str();
+  if (!str.empty()) {
+    LOG(INFO) << "STARTUP: Supported node properties:\n" << str;
+  }
+  str = unsupported.str();
+  if (!str.empty()) {
+    LOG(WARNING) << "STARTUP: Unsupported node properties:\n" << str;
+  }
+}
+
+enum class CapacityUnit {
+  BYTE,
+  KILOBYTE,
+  MEGABYTE,
+  GIGABYTE,
+  TERABYTE,
+  PETABYTE
+};
+
+double toBytesPerCapacityUnit(CapacityUnit unit) {
+  switch (unit) {
+    case CapacityUnit::BYTE:
+      return 1;
+    case CapacityUnit::KILOBYTE:
+      return exp2(10);
+    case CapacityUnit::MEGABYTE:
+      return exp2(20);
+    case CapacityUnit::GIGABYTE:
+      return exp2(30);
+    case CapacityUnit::TERABYTE:
+      return exp2(40);
+    case CapacityUnit::PETABYTE:
+      return exp2(50);
+    default:
+      VELOX_USER_FAIL("Invalid capacity unit '{}'", (int)unit);
+  }
+}
+
+CapacityUnit valueOfCapacityUnit(const std::string& unitStr) {
+  if (unitStr == "B") {
+    return CapacityUnit::BYTE;
+  }
+  if (unitStr == "kB") {
+    return CapacityUnit::KILOBYTE;
+  }
+  if (unitStr == "MB") {
+    return CapacityUnit::MEGABYTE;
+  }
+  if (unitStr == "GB") {
+    return CapacityUnit::GIGABYTE;
+  }
+  if (unitStr == "TB") {
+    return CapacityUnit::TERABYTE;
+  }
+  if (unitStr == "PB") {
+    return CapacityUnit::PETABYTE;
+  }
+  VELOX_USER_FAIL("Invalid capacity unit '{}'", unitStr);
+}
+
+// Convert capacity string with unit to the capacity number in the specified
+// units
+uint64_t toCapacity(const std::string& from, CapacityUnit to) {
+  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$)");
+  double value;
+  std::string unit;
+  if (!RE2::FullMatch(from, kPattern, &value, &unit)) {
+    VELOX_USER_FAIL("Invalid capacity string '{}'", from);
+  }
+
+  return value *
+      (toBytesPerCapacityUnit(valueOfCapacityUnit(unit)) /
+       toBytesPerCapacityUnit(to));
+}
+
+} // namespace
+
 ConfigBase::ConfigBase()
     : config_(std::make_unique<velox::core::MemConfig>()) {}
 
 void ConfigBase::initialize(const std::string& filePath) {
   // See if we want to create a mutable config.
   auto values = util::readConfig(fs::path(filePath));
+  if (filePath.find("config.properties") != std::string::npos) {
+    checkIncomingSystemProperties(values);
+  } else if (filePath.find("node.properties") != std::string::npos) {
+    checkIncomingNodeProperties(values);
+  }
   bool mutableConfig{false};
   auto it = values.find(std::string(SystemConfig::kMutableConfig));
   if (it != values.end()) {
@@ -79,7 +244,7 @@ int SystemConfig::httpServerHttpsPort() const {
   return requiredProperty<int>(std::string(kHttpServerHttpsPort));
 }
 
-bool SystemConfig::enableHttps() const {
+bool SystemConfig::httpServerHttpsEnabled() const {
   auto opt = optionalProperty<bool>(std::string(kHttpServerHttpsEnabled));
   return opt.value_or(kHttpServerHttpsEnabledDefault);
 }
@@ -237,7 +402,7 @@ bool SystemConfig::enableHttpAccessLog() const {
 }
 
 bool SystemConfig::enableHttpStatsFilter() const {
-  auto opt = optionalProperty<bool>(std::string(kHttpEnableStatFilter));
+  auto opt = optionalProperty<bool>(std::string(kHttpEnableStatsFilter));
   return opt.value_or(kHttpEnableStatsFilterDefault);
 }
 
@@ -249,6 +414,19 @@ bool SystemConfig::registerTestFunctions() const {
 uint64_t SystemConfig::httpMaxAllocateBytes() const {
   auto opt = optionalProperty<uint64_t>(std::string(kHttpMaxAllocateBytes));
   return opt.value_or(kHttpMaxAllocateBytesDefault);
+}
+
+uint64_t SystemConfig::queryMaxMemoryPerNode() const {
+  auto opt = optionalProperty(std::string(kQueryMaxMemoryPerNode));
+  if (opt.hasValue()) {
+    return toCapacity(opt.value(), CapacityUnit::BYTE);
+  }
+  return kQueryMaxMemoryPerNodeDefault;
+}
+
+bool SystemConfig::enableMemoryLeakCheck() const {
+  auto opt = optionalProperty<bool>(std::string(kEnableMemoryLeakCheck));
+  return opt.value_or(kEnableMemoryLeakCheckDefault);
 }
 
 NodeConfig* NodeConfig::instance() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -113,11 +113,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpsKeyPath{"https-key-path"};
   static constexpr std::string_view kHttpsClientCertAndKeyPath{
       "https-client-cert-key-path"};
+
+  /// Number of threads for async io. Disabled if zero.
   static constexpr std::string_view kNumIoThreads{"num-io-threads"};
   static constexpr std::string_view kNumQueryThreads{"num-query-threads"};
   static constexpr std::string_view kNumSpillThreads{"num-spill-threads"};
-  static constexpr std::string_view kSpillerSpillPath =
-      "experimental.spiller-spill-path";
+  static constexpr std::string_view kSpillerSpillPath{
+      "experimental.spiller-spill-path"};
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
   static constexpr std::string_view kSystemMemoryGb{"system-memory-gb"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
@@ -145,7 +147,7 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kShuffleName{"shuffle.name"};
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
-  static constexpr std::string_view kHttpEnableStatFilter{
+  static constexpr std::string_view kHttpEnableStatsFilter{
       "http-server.enable-stats-filter"};
   static constexpr std::string_view kRegisterTestFunctions{
       "register-test-functions"};
@@ -154,6 +156,13 @@ class SystemConfig : public ConfigBase {
   /// the received http response data.
   static constexpr std::string_view kHttpMaxAllocateBytes{
       "http-server.max-response-allocate-bytes"};
+  static constexpr std::string_view kQueryMaxMemoryPerNode{
+      "query.max-memory-per-node"};
+
+  /// This system property is added for not crashing the cluster when memory
+  /// leak is detected. The check should be disabled in production cluster.
+  static constexpr std::string_view kEnableMemoryLeakCheck{
+      "enable-memory-leak-check"};
 
   /// Port used by the remote function thrift server.
   static constexpr std::string_view kRemoteFunctionServerThriftPort{
@@ -189,6 +198,9 @@ class SystemConfig : public ConfigBase {
   static constexpr bool kHttpEnableStatsFilterDefault = false;
   static constexpr bool kRegisterTestFunctionsDefault = false;
   static constexpr uint64_t kHttpMaxAllocateBytesDefault = 64 << 10;
+  /// 1/10 of kSystemMemoryGbDefault.
+  static constexpr uint64_t kQueryMaxMemoryPerNodeDefault = 4UL << 30;
+  static constexpr bool kEnableMemoryLeakCheckDefault = true;
 
   static SystemConfig* instance();
 
@@ -196,7 +208,7 @@ class SystemConfig : public ConfigBase {
 
   bool httpServerReusePort() const;
 
-  bool enableHttps() const;
+  bool httpServerHttpsEnabled() const;
 
   int httpServerHttpsPort() const;
 
@@ -279,6 +291,10 @@ class SystemConfig : public ConfigBase {
   bool registerTestFunctions() const;
 
   uint64_t httpMaxAllocateBytes() const;
+
+  uint64_t queryMaxMemoryPerNode() const;
+
+  bool enableMemoryLeakCheck() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
@@ -38,6 +38,8 @@ class SystemConfigTest : public testing::Test {
     auto sysConfigFile = fileSystem->openFileForWrite(configFilePath);
     sysConfigFile->append(
         fmt::format("{}={}\n", SystemConfig::kPrestoVersion, prestoVersion));
+    sysConfigFile->append(
+        fmt::format("{}=11KB\n", SystemConfig::kQueryMaxMemoryPerNode));
     if (isMutable) {
       sysConfigFile->append(
           fmt::format("{}={}\n", SystemConfig::kMutableConfig, "true"));
@@ -66,6 +68,7 @@ TEST_F(SystemConfigTest, defaultConfig) {
           ->optionalProperty<bool>(std::string{SystemConfig::kMutableConfig})
           .has_value());
   ASSERT_EQ(prestoVersion, systemConfig->prestoVersion());
+  ASSERT_EQ(11 << 10, systemConfig->queryMaxMemoryPerNode());
   ASSERT_THROW(
       systemConfig->setValue(
           std::string(SystemConfig::kPrestoVersion), prestoVersion2),
@@ -88,6 +91,12 @@ TEST_F(SystemConfigTest, mutableConfig) {
           ->setValue(std::string(SystemConfig::kPrestoVersion), prestoVersion2)
           .value());
   ASSERT_EQ(prestoVersion2, systemConfig->prestoVersion());
+  ASSERT_EQ(
+      "11KB",
+      systemConfig
+          ->setValue(std::string(SystemConfig::kQueryMaxMemoryPerNode), "5GB")
+          .value());
+  ASSERT_EQ(5UL << 30, systemConfig->queryMaxMemoryPerNode());
 }
 
 TEST_F(SystemConfigTest, requiredConfigs) {

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -244,8 +244,6 @@ std::shared_ptr<ShuffleReader> LocalPersistentShuffleFactory::createReader(
     const std::string& serializedStr,
     const int32_t partition,
     velox::memory::MemoryPool* pool) {
-  static const uint64_t maxBytesPerPartition =
-      SystemConfig::instance()->localShuffleMaxPartitionBytes();
   const operators::LocalShuffleReadInfo readInfo =
       operators::LocalShuffleReadInfo::deserialize(serializedStr);
   return std::make_shared<operators::LocalPersistentShuffleReader>(


### PR DESCRIPTION
Test plan - Upgraded tests.

- Moved "query.max-memory-per-node" from QueryContextManager to SystemConfig. Removed the awkward handling of it.
- TaskManager and QueryContextManager no longer need system and node properties.
- Added startup logging of the SystemProperties (read from config.properties file). Both supported by Presto Native and not supported.
- Read "task.max-drivers-per-task" and "task.concurrent-lifespans-per-task" from System Config for every Task, rather than cache them in Task Manager. To be able to change them at runtime.
- Added support to read capacity system properties (bytes, kb, gb, etc.).
- Add a system property that allows disabling memory check in Velox.
- Cosmetic changes in SystemConfig.

```
== NO RELEASE NOTE ==
```
