### PR TITLE
Fix race condition in close method of DistributedQueryRunner

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -777,7 +777,7 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public final void close()
+    public final synchronized void close()
     {
         cancelAllQueries();
         try {


### PR DESCRIPTION
In internal CI test run where we run tests suite concurrently we saw occasionally exception caused by the race condition from close method of DistributedQueryRunner. This commit makes the close method to be synchronized to fix this issue.

The stack trace of the exception is:
```
java.lang.RuntimeException: java.util.NoSuchElementException
	at com.facebook.airlift.testing.Closeables.closeAllRuntimeException(Closeables.java:81)
	at com.facebook.presto.tests.AbstractTestQueryFramework.close(AbstractTestQueryFramework.java:106)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:65)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:381)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:319)
	at org.testng.internal.invokers.TestMethodWorker.invokeAfterClassMethods(TestMethodWorker.java:220)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:130)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.util.NoSuchElementException
	at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
	at com.google.common.io.Closer.close(Closer.java:212)
	at com.facebook.presto.tests.DistributedQueryRunner.close(DistributedQueryRunner.java:784)
	at com.facebook.airlift.testing.Closeables.closeAllRuntimeException(Closeables.java:76)
	... 14 more
```

```
== NO RELEASE NOTE ==
```
