### PR TITLE
[ci] Remove do not force execute native test on CI

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -73,8 +73,6 @@ jobs:
           ccache -s
 
       - name: Run unit tests
-        if: always()
-        continue-on-error: true
         run: |
           cd ${GITHUB_WORKSPACE}/presto-native-execution/_build/debug
           ctest -j 1 -VV --output-on-failure --exclude-regex velox.*
@@ -104,8 +102,6 @@ jobs:
           ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm,!presto-test-coverage'
 
       - name: Run e2e tests
-        if: always()
-        continue-on-error: true
         run: |
           rm -rf /tmp/hive_data/tpch/
           ./mvnw test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas


### PR DESCRIPTION
The workaround to force execution of unit test had side effects. The correct solution would be to make the CI signal `test native` as mandatory in Settings > Branches. (https://stackoverflow.com/a/58655352)

CC: @spershin @amitkdutta @mshang816

Test
The following PR (https://github.com/prestodb/presto/pull/19606) has green signal on [test native](https://github.com/prestodb/presto/actions/runs/4935277833/jobs/8821379359?pr=19606) even though it failed. While the current PR will have a [red signal](https://github.com/prestodb/presto/actions/runs/4936249162/jobs/8823555931?pr=19607).

```
== NO RELEASE NOTE ==
```
