### PR TITLE
[native] Use UnsafeRowFast in PartitionAndSerialize

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -15,8 +15,14 @@ add_library(
   presto_operators PartitionAndSerialize.cpp ShuffleRead.cpp ShuffleWrite.cpp
                    UnsafeRowExchangeSource.cpp LocalPersistentShuffle.cpp)
 
-target_link_libraries(presto_operators presto_common velox_core velox_exec
-                      velox_presto_serializer velox_vector)
+target_link_libraries(
+  presto_operators
+  presto_common
+  velox_core
+  velox_exec
+  velox_presto_serializer
+  velox_vector
+  velox_row_fast)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)


### PR DESCRIPTION
UnsafeRowFast is much faster than UnsafeRowSerializer.

See https://github.com/facebookincubator/velox/pull/4850

```
== NO RELEASE NOTE ==
```
