### PR TITLE
Disabling flaky test to unblock others

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -201,7 +201,7 @@ public class TestDistributedClusterStatsResource
         return client.execute(request, createJsonResponseHandler(jsonCodec(ClusterStatsResource.ClusterStats.class)));
     }
 
-    @Test(timeOut = 120_000)
+    @Test(timeOut = 120_000, enabled = false)
     public void testClusterStatsLocalInfoReturn()
             throws Exception
     {


### PR DESCRIPTION
Disabling TestDistributedClusterStatsResource#testClusterStatsLocalInfoReturn

Issue: https://github.com/prestodb/presto/issues/19610

Test plan - unit test

```
== NO RELEASE NOTE ==
```
