### PR TITLE
[native] Separate io pools size configs

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -564,10 +564,11 @@ std::vector<std::string> PrestoServer::registerConnectors(
     const fs::path& configDirectoryPath) {
   static const std::string kPropertiesExtension = ".properties";
 
-  auto numIoThreads = SystemConfig::instance()->numIoThreads();
-  if (numIoThreads) {
+  const auto numConnectorIoThreads =
+      SystemConfig::instance()->numConnectorIoThreads();
+  if (numConnectorIoThreads) {
     connectorIoExecutor_ =
-        std::make_unique<folly::IOThreadPoolExecutor>(numIoThreads);
+        std::make_unique<folly::IOThreadPoolExecutor>(numConnectorIoThreads);
   }
   std::vector<std::string> catalogNames;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -48,6 +48,7 @@ void checkIncomingSystemProperties(
       SystemConfig::kHttpsKeyPath,
       SystemConfig::kHttpsClientCertAndKeyPath,
       SystemConfig::kNumIoThreads,
+      SystemConfig::kNumConnectorIoThreads,
       SystemConfig::kNumQueryThreads,
       SystemConfig::kNumSpillThreads,
       SystemConfig::kSpillerSpillPath,
@@ -307,6 +308,11 @@ int32_t SystemConfig::httpExecThreads() const {
 int32_t SystemConfig::numIoThreads() const {
   auto opt = optionalProperty<int32_t>(std::string(kNumIoThreads));
   return opt.value_or(kNumIoThreadsDefault);
+}
+
+int32_t SystemConfig::numConnectorIoThreads() const {
+  auto opt = optionalProperty<int32_t>(std::string(kNumConnectorIoThreads));
+  return opt.value_or(kNumConnectorIoThreadsDefault);
 }
 
 int32_t SystemConfig::numQueryThreads() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -116,6 +116,8 @@ class SystemConfig : public ConfigBase {
 
   /// Number of threads for async io. Disabled if zero.
   static constexpr std::string_view kNumIoThreads{"num-io-threads"};
+  static constexpr std::string_view kNumConnectorIoThreads{
+      "num-connector-io-threads"};
   static constexpr std::string_view kNumQueryThreads{"num-query-threads"};
   static constexpr std::string_view kNumSpillThreads{"num-spill-threads"};
   static constexpr std::string_view kSpillerSpillPath{
@@ -179,6 +181,7 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpsSupportedCiphersDefault{
       "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384"};
   static constexpr int32_t kNumIoThreadsDefault = 30;
+  static constexpr int32_t kNumConnectorIoThreadsDefault = 30;
   static constexpr int32_t kShutdownOnsetSecDefault = 10;
   static constexpr int32_t kSystemMemoryGbDefault = 40;
   static constexpr int32_t kMmapArenaCapacityRatioDefault = 10;
@@ -247,8 +250,11 @@ class SystemConfig : public ConfigBase {
 
   int32_t httpExecThreads() const;
 
-  // Process-wide number of query execution threads
+  /// Size of global IO executor.
   int32_t numIoThreads() const;
+
+  /// Size of IO executor for connectors to do preload/prefetch
+  int32_t numConnectorIoThreads() const;
 
   int32_t numQueryThreads() const;
 


### PR DESCRIPTION
Global IO pool and connector IO pool sizes are currently controlled by a single property. We should separate them to separate properties.
```
== NO RELEASE NOTE ==
```
