### PR TITLE
[native] Align serialized row sizes at 16 bytes in PartitionAndSerialize

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -20,7 +20,8 @@ namespace facebook::presto::operators {
 
 /// Partitions the input row based on partition function and serializes the
 /// entire row using UnsafeRow format. The output contains 2 columns: partition
-/// number (INTEGER) and serialized row (VARBINARY).
+/// number (INTEGER) and serialized row (VARBINARY). Each row is padded with
+/// zeros to align at 16 bytes.
 class PartitionAndSerializeNode : public velox::core::PlanNode {
  public:
   static constexpr std::string_view kPartitionColumnNameDefault = "partition";

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -398,6 +398,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     rows.reserve(serializedData->size());
     for (auto i = 0; i < serializedData->size(); ++i) {
       auto serializedRow = serializedData->valueAt(i);
+      EXPECT_EQ(serializedRow.size() % 16, 0);
       rows.push_back(
           std::string_view(serializedRow.data(), serializedRow.size()));
     }


### PR DESCRIPTION
Shuffle service uses folly::crc32 to compute checksum of shuffle data. folly::crc32 is optimized to use SIMD if row starts and sizes are aligned at 16 bytes. Make sure PartitionAndSerialize produces rows aligned this way.

```
== NO RELEASE NOTE ==
```
