### PR TITLE
Increase timeout for TestQueryPlanDeterminism.testLargeQuery

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -213,6 +213,14 @@ public class TestQueryPlanDeterminism
         return super.computeExpected(sql, resultTypes);
     }
 
+    // Give more time for large queries in plan determinsm check.
+    @Override
+    @Test(timeOut = 100_000)
+    public void testLargeQuery()
+    {
+        super.testLargeQuery();
+    }
+
     @Test
     public void testTpchQ9deterministic()
     {


### PR DESCRIPTION
This test is in AbstractTestQueries. I initially put the timeout for this test to 5x of local runtime, which holds true for most implementations of AbstractTestQueries.

But TestQueryPlanDeterminism seems to take extra overhead for large plans, and takes 20s locally. Putting it to 100s in this one.
```
== NO RELEASE NOTE ==
```
