### PR TITLE
[native] Backout 19605 and 19545 as they cause crashes.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1169,20 +1169,16 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   const auto type = toLocalExchangeType(node->type);
 
   const auto outputType = toRowType(node->partitioningScheme.outputLayout);
-  const auto names = outputType->names();
 
   // Different source nodes may have different output layouts.
   // Add ProjectNode on top of each source node to re-arrange the output columns
   // to match the output layout of the LocalExchangeNode.
   for (auto i = 0; i < sourceNodes.size(); ++i) {
+    auto names = outputType->names();
     std::vector<core::TypedExprPtr> projections;
     projections.reserve(outputType->size());
 
-    auto desiredSourceOutput = toRowType(node->inputs[i]);
-    // If the output layout is identical, do not add ProjectNode.
-    if (outputType->names() == desiredSourceOutput->names()) {
-      continue;
-    }
+    const auto desiredSourceOutput = toRowType(node->inputs[i]);
 
     for (auto j = 0; j < outputType->size(); j++) {
       projections.emplace_back(std::make_shared<core::FieldAccessTypedExpr>(

--- a/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
@@ -112,8 +112,9 @@ TEST_F(TestValues, valuesPlan) {
 
   ASSERT_EQ(values->name(), "Filter");
   ASSERT_EQ(values->sources()[0]->name(), "LocalPartition");
-  ASSERT_EQ(values->sources()[0]->sources()[0]->name(), "Values");
+  ASSERT_EQ(values->sources()[0]->sources()[0]->name(), "Project");
+  ASSERT_EQ(values->sources()[0]->sources()[0]->sources()[0]->name(), "Values");
 
   ASSERT_EQ(values->id(), "4");
-  ASSERT_EQ(values->sources()[0]->sources()[0]->id(), "0");
+  ASSERT_EQ(values->sources()[0]->sources()[0]->sources()[0]->id(), "0");
 }


### PR DESCRIPTION
Test plan - Updated test.

The logic to skip ProjectNode if the desired output names matches
output names may trigger crash for some queries
in LocalPartition -> HashPartitionFunction -> VectorHasher.

If we want to skip redundant projections, we need to have a different change.

```
== NO RELEASE NOTE ==
```
