### PR TITLE
[Native] Enable Tpch Test for Parquet Format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
 executors:
   build:
     docker:
-      - image : prestocpp/prestocpp-avx-centos:kpai-20221018
+      - image: prestocpp/prestocpp-avx-centos:kpai-20221018
     resource_class: 2xlarge
     environment:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
@@ -31,7 +31,7 @@ executors:
       MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
   check:
     docker:
-      - image : prestocpp/velox-check:mikesh-20210609
+      - image: prestocpp/velox-check:mikesh-20210609
 
 jobs:
   linux-build:
@@ -48,7 +48,7 @@ jobs:
           command: |
             source /opt/rh/gcc-toolset-9/enable
             cd presto-native-execution
-            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DPRESTO_ENABLE_PARQUET=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             ninja -C _build/debug -j 8
       - run:
           name: 'Run Unit Tests'

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -13,14 +13,33 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersHll;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
 import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestNativeAggregations
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createOrders(queryRunner);
+        createOrdersHll(queryRunner);
+        createOrdersEx(queryRunner);
+        createNation(queryRunner);
+        createRegion(queryRunner);
+    }
+
     @Test
     public void testAggregations()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeArrayFunctionQueries.java
@@ -13,12 +13,24 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
 
 public abstract class AbstractTestNativeArrayFunctionQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createOrdersEx(queryRunner);
+    }
+
     @Test
     public void testRepeat()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeBitwiseFunctionQueries.java
@@ -13,12 +13,22 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
 
 public abstract class AbstractTestNativeBitwiseFunctionQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createNation(queryRunner);
+    }
+
     @Test
     public void testBitCount()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -23,12 +24,45 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedLineitemAndOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createEmptyTable;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPart;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPartitionedNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPrestoBenchTables;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createSupplier;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestNativeGeneralQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createCustomer(queryRunner);
+        createOrders(queryRunner);
+        createOrdersEx(queryRunner);
+        createNation(queryRunner);
+        createPartitionedNation(queryRunner);
+        createSupplier(queryRunner);
+        createBucketedCustomer(queryRunner);
+        createPart(queryRunner);
+        createRegion(queryRunner);
+        createEmptyTable(queryRunner);
+        createBucketedLineitemAndOrders(queryRunner);
+
+        createPrestoBenchTables(queryRunner);
+    }
+
     @Test
     public void testCatalogWithCacheEnabled()
     {
@@ -416,7 +450,7 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // numeric limits
         assertQueryFails("SELECT n + m from (values (DECIMAL'99999999999999999999999999999999999999'," +
-                "CAST('1' as DECIMAL(2,0)))) t(n, m)",
+                        "CAST('1' as DECIMAL(2,0)))) t(n, m)",
                 ".*Decimal.*");
         assertQueryFails(
                 "SELECT n + m from (values (CAST('-99999999999999999999999999999999999999' as DECIMAL(38,0))," +
@@ -459,7 +493,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 ") t(n, m)");
         // Divide by zero error.
         assertQueryFails("SELECT n/m from(values (DECIMAL'100', DECIMAL'0.0')) t(n,m)",
-                        ".*Division by zero.*");
+                ".*Division by zero.*");
 
         // Division short decimals.
         assertQuery("SELECT n/m from(values (DECIMAL'100', DECIMAL'299'),(DECIMAL'5.4', DECIMAL'-125')," +
@@ -467,7 +501,7 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // Division overflow.
         assertQueryFails("SELECT n/m from(values (DECIMAL'99999999999999999999999999999999999999', DECIMAL'0.01'))" +
-                        " t(n,m)", ".*Decimal.*");
+                " t(n,m)", ".*Decimal.*");
     }
 
     @Test
@@ -510,6 +544,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "(DECIMAL'3.141592653589793238', NULL), (DECIMAL'-1.54455555555555555551', DECIMAL'-1.54455555555555555555')," +
                 "(NULL, NULL )) t(c0, c1) where c0 <= c1");
     }
+
     @Test
     public void testStringFunctions()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
@@ -14,13 +14,39 @@
 package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedLineitemAndOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPartitionedNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
+
 public abstract class AbstractTestNativeJoinQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createOrders(queryRunner);
+        createBucketedLineitemAndOrders(queryRunner);
+        createOrdersEx(queryRunner);
+        createNation(queryRunner);
+        createPartitionedNation(queryRunner);
+        createRegion(queryRunner);
+        createCustomer(queryRunner);
+        createBucketedCustomer(queryRunner);
+    }
+
     @Test(dataProvider = "joinTypeProvider")
     public void testInnerJoin(Session joinTypeSession)
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchQueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.io.Resources;
 import org.testng.annotations.Ignore;
@@ -20,11 +21,41 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedLineitemAndOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersHll;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPart;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPartSupp;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createSupplier;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class AbstractTestNativeTpchQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createBucketedLineitemAndOrders(queryRunner);
+        createOrders(queryRunner);
+        createOrdersEx(queryRunner);
+        createOrdersHll(queryRunner);
+        createNation(queryRunner);
+        createCustomer(queryRunner);
+        createBucketedCustomer(queryRunner);
+        createPart(queryRunner);
+        createPartSupp(queryRunner);
+        createRegion(queryRunner);
+        createSupplier(queryRunner);
+    }
+
     private static String getTpchQuery(int q)
             throws IOException
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -20,9 +21,18 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+
 public abstract class AbstractTestNativeWindowQueries
         extends AbstractTestQueryFramework
 {
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createOrders(queryRunner);
+    }
+
     private static final List<String> OVER_CLAUSES_WITH_ORDER_BY = Arrays.asList(
             "PARTITION BY orderkey ORDER BY totalprice",
             "PARTITION BY custkey, orderkey ORDER BY totalprice",

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -22,10 +22,11 @@ public class NativeQueryRunnerUtils
 {
     private NativeQueryRunnerUtils() {}
 
-    public static Map<String, String> getNativeWorkerHiveProperties()
+    public static Map<String, String> getNativeWorkerHiveProperties(String storageFormat)
     {
-        return ImmutableMap.of("hive.storage-format", "DWRF",
-                "hive.pushdown-filter-enabled", "true");
+        return ImmutableMap.of("hive.storage-format", storageFormat,
+                "hive.pushdown-filter-enabled", "true",
+                "hive.parquet.pushdown-filter-enabled", "true");
     }
 
     public static Map<String, String> getNativeWorkerSystemProperties()

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
@@ -20,13 +20,15 @@ public class TestPrestoNativeGeneralQueriesThrift
         extends AbstractTestNativeGeneralQueries
 {
     @Override
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
     }
 
     @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
@@ -16,18 +16,18 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
-public class TestPrestoNativeTpchQueriesThrift
+public class TestPrestoNativeTpchQueriesDwrfUsingThrift
         extends AbstractTestNativeTpchQueries
 {
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "DWRF");
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("DWRF");
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
@@ -16,18 +16,18 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
-public class TestPrestoNativeTpchQueriesJSON
+public class TestPrestoNativeTpchQueriesParquetUsingJSON
         extends AbstractTestNativeTpchQueries
 {
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false, "PARQUET");
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -77,6 +77,7 @@ public class PrestoSparkNativeQueryRunnerUtils
     private static final int AVAILABLE_CPU_COUNT = 4;
     private static final String SPARK_SHUFFLE_MANAGER = "spark.shuffle.manager";
     private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
+    private static final String DEFAULT_STORAGE_FORMAT = "DWRF";
     private static Optional<Path> dataDirectory = Optional.empty();
 
     private PrestoSparkNativeQueryRunnerUtils() {}
@@ -135,13 +136,13 @@ public class PrestoSparkNativeQueryRunnerUtils
     {
         ImmutableMap.Builder<String, String> configBuilder = ImmutableMap.builder();
         configBuilder.putAll(getNativeWorkerSystemProperties()).putAll(additionalConfigProperties);
-
+        Optional<Path> dataDir = baseDir.map(path -> Paths.get(path.toString() + '/' + DEFAULT_STORAGE_FORMAT));
         PrestoSparkQueryRunner queryRunner = new PrestoSparkQueryRunner(
                 defaultCatalog,
                 configBuilder.build(),
-                getNativeWorkerHiveProperties(),
+                getNativeWorkerHiveProperties(DEFAULT_STORAGE_FORMAT),
                 additionalSparkProperties,
-                baseDir,
+                dataDir,
                 nativeModules,
                 AVAILABLE_CPU_COUNT);
 
@@ -155,7 +156,7 @@ public class PrestoSparkNativeQueryRunnerUtils
     public static QueryRunner createJavaQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner(Optional.of(getBaseDataPath()), "legacy");
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner(Optional.of(getBaseDataPath()), "legacy", DEFAULT_STORAGE_FORMAT);
     }
 
     public static void assertShuffleMetadata()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -83,7 +83,10 @@ public abstract class AbstractTestQueryFramework
         queryRunner = createQueryRunner();
         expectedQueryRunner = createExpectedQueryRunner();
         sqlParser = new SqlParser();
+        createTables();
     }
+
+    protected void createTables() {}
 
     protected abstract QueryRunner createQueryRunner()
             throws Exception;
@@ -490,11 +493,18 @@ public abstract class AbstractTestQueryFramework
         return queryRunner;
     }
 
+    protected ExpectedQueryRunner getExpectedQueryRunner()
+    {
+        checkState(expectedQueryRunner != null, "expectedQueryRunner not set");
+        return expectedQueryRunner;
+    }
+
     public interface QueryRunnerSupplier
     {
         QueryRunner get()
                 throws Exception;
     }
+
     public interface ExpectedQueryRunnerSupplier
     {
         ExpectedQueryRunner get()


### PR DESCRIPTION
`StorageFormat`  argument is added to specify the hive property "hive.storage-format" when creating Java & Native query Runner. 

Test plan

`TestPrestoNativeTpchQueriesDwrfUsingThrift` & `TestPrestoNativeTpchQueriesParquetUsingJSON` are added to verify TPCH results based on DWRF & Parquet format

```
== NO RELEASE NOTE ==
```
