### PR TITLE
[native pos] Fix join between bucketed and non-bucketed tables

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spark;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.nativeworker.AbstractTestNativeJoinQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
@@ -52,8 +51,4 @@ public class TestPrestoSparkNativeJoinQueries
     @Override
     @Ignore
     public void testCrossJoin() {}
-
-    @Override
-    @Ignore
-    public void testBucketedInnerJoin(Session joinTypeSession) {}
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -784,6 +784,11 @@ public class PrestoSparkTaskExecutorFactory
         ImmutableSet.Builder<ScheduledSplit> result = ImmutableSet.builder();
         PlanNode root = fragment.getRoot();
         AtomicLong nextSplitId = new AtomicLong();
+        taskSources.stream()
+                .flatMap(source -> source.getSplits().stream())
+                .mapToLong(split -> split.getSequenceId())
+                .max()
+                .ifPresent(id -> nextSplitId.set(id + 1));
         shuffleReadInfos.forEach((planNodeId, info) ->
                 result.add(new ScheduledSplit(nextSplitId.getAndIncrement(), planNodeId, new Split(REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(
                         new Location(format("batch://%s?shuffleInfo=%s", taskId, shuffleInfoTranslator.createSerializedReadInfo(info))),


### PR DESCRIPTION
Similar to PR #19617 we were loosing splits due to duplicate sequence IDs.

```
== NO RELEASE NOTE ==
```
