### PR TITLE
[native pos] Fix bucketed with non-bucketed join with a bucket filter

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
@@ -33,6 +33,10 @@ public abstract class AbstractTestNativeJoinQueries
     public void testBucketedInnerJoin(Session joinTypeSession)
     {
         assertQuery(joinTypeSession, "SELECT b.name, c.name FROM customer_bucketed b, customer c WHERE b.name=c.name");
+        assertQuery(joinTypeSession, "SELECT b.name FROM customer_bucketed b, customer c " +
+                "WHERE b.name=c.name AND \"$bucket\" = 7");
+        assertQuery(joinTypeSession, "SELECT b.* FROM customer_bucketed b, customer c " +
+                "WHERE b.name=c.name AND \"$bucket\" IN (2, 5, 8)");
     }
 
     @Test(dataProvider = "joinTypeProvider")


### PR DESCRIPTION
Fix join between bucketed table and non-bucketed table and a filter on
$bucket column.

In this case, some partitions do not have splits for the bucketed table, but we
still need to send no-more-splits message to Velox. Otherwise query Velox task
execution hangs waiting for splits.

Depends on #19627 

```
== NO RELEASE NOTE ==
```
