### PR TITLE
[native pos] Fix plan conversion for PartitionAndSerialize

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -23,28 +23,19 @@ namespace facebook::presto::operators {
 /// number (INTEGER) and serialized row (VARBINARY).
 class PartitionAndSerializeNode : public velox::core::PlanNode {
  public:
-  static constexpr std::string_view kPartitionColumnNameDefault = "partition";
-  static constexpr std::string_view kDataColumnNameDefault = "data";
-
   PartitionAndSerializeNode(
       const velox::core::PlanNodeId& id,
       std::vector<velox::core::TypedExprPtr> keys,
       uint32_t numPartitions,
-      velox::RowTypePtr outputType,
+      velox::RowTypePtr serializedRowType,
       velox::core::PlanNodePtr source,
       velox::core::PartitionFunctionSpecPtr partitionFunctionFactory)
       : velox::core::PlanNode(id),
         keys_(std::move(keys)),
         numPartitions_(numPartitions),
-        outputType_{std::move(outputType)},
+        serializedRowType_{std::move(serializedRowType)},
         sources_({std::move(source)}),
         partitionFunctionSpec_(std::move(partitionFunctionFactory)) {
-    // Only verify output types are correct. Note column names are not enforced
-    // in the following check.
-    VELOX_USER_CHECK(
-        velox::ROW(
-            {"partition", "data"}, {velox::INTEGER(), velox::VARBINARY()})
-            ->equivalent(*outputType_));
     VELOX_USER_CHECK_NOT_NULL(
         partitionFunctionSpec_, "Partition function factory cannot be null.");
   }
@@ -56,7 +47,10 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
       void* context);
 
   const velox::RowTypePtr& outputType() const override {
-    return outputType_;
+    static const velox::RowTypePtr kRowType{velox::ROW(
+        {"partition", "data"}, {velox::INTEGER(), velox::VARBINARY()})};
+
+    return kRowType;
   }
 
   const std::vector<velox::core::PlanNodePtr>& sources() const override {
@@ -69,6 +63,10 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
 
   uint32_t numPartitions() const {
     return numPartitions_;
+  }
+
+  const velox::RowTypePtr& serializedRowType() const {
+    return serializedRowType_;
   }
 
   const velox::core::PartitionFunctionSpecPtr& partitionFunctionFactory()
@@ -85,7 +83,7 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
 
   const std::vector<velox::core::TypedExprPtr> keys_;
   const uint32_t numPartitions_;
-  const velox::RowTypePtr outputType_;
+  const velox::RowTypePtr serializedRowType_;
   const std::vector<velox::core::PlanNodePtr> sources_;
   const velox::core::PartitionFunctionSpecPtr partitionFunctionSpec_;
 };

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -21,7 +21,9 @@ namespace facebook::presto::operators {
 
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
-addPartitionAndSerializeNode(uint32_t numPartitions);
+addPartitionAndSerializeNode(
+    uint32_t numPartitions,
+    const std::vector<std::string>& serializedColumns = {});
 
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -56,6 +56,12 @@ class PlanNodeSerdeTest : public testing::Test,
     ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
   }
 
+  static std::vector<std::string> reverseColumns(const RowTypePtr& rowType) {
+    auto names = rowType->names();
+    std::reverse(names.begin(), names.end());
+    return names;
+  }
+
   std::vector<RowVectorPtr> data_;
   RowTypePtr type_;
 };
@@ -63,7 +69,8 @@ class PlanNodeSerdeTest : public testing::Test,
 TEST_F(PlanNodeSerdeTest, partitionAndSerializeNode) {
   auto plan = exec::test::PlanBuilder()
                   .values(data_, true)
-                  .addNode(addPartitionAndSerializeNode(4))
+                  .addNode(addPartitionAndSerializeNode(
+                      4, reverseColumns(asRowType(data_[0]->type()))))
                   .localPartition({})
                   .planNode();
   testSerde(plan);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
@@ -33,10 +33,12 @@ public abstract class AbstractTestNativeJoinQueries
     public void testBucketedInnerJoin(Session joinTypeSession)
     {
         assertQuery(joinTypeSession, "SELECT b.name, c.name FROM customer_bucketed b, customer c WHERE b.name=c.name");
-        assertQuery(joinTypeSession, "SELECT b.name FROM customer_bucketed b, customer c " +
+        assertQuery(joinTypeSession, "SELECT b.name, c.custkey FROM customer_bucketed b, customer c " +
                 "WHERE b.name=c.name AND \"$bucket\" = 7");
         assertQuery(joinTypeSession, "SELECT b.* FROM customer_bucketed b, customer c " +
                 "WHERE b.name=c.name AND \"$bucket\" IN (2, 5, 8)");
+        assertQuery(joinTypeSession, "SELECT * FROM customer_bucketed b, customer c " +
+                "WHERE b.name=c.name AND \"$bucket\" = 5");
     }
 
     @Test(dataProvider = "joinTypeProvider")


### PR DESCRIPTION
Extend PartitionAndSerialize plan node to allow specifying the order of columns
for serialization. An earlier solution of adding Project node before
PartitionAndSerialize doesn't work because partition function may reference
original inputs by index.

Depends on #19628

```
== NO RELEASE NOTE ==
```
