### PR TITLE
Fixing flaky test by increasing timeout

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -488,11 +488,11 @@ public class TestResourceManagerClusterStateProvider
         assertEquals(provider.getAdjustedQueueSize(), expectedAdjustedQueueSize);
     }
 
-    @Test(timeOut = 15_000)
+    @Test(timeOut = 20_000)
     public void testWorkerMemoryInfo()
             throws Exception
     {
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(new InMemoryNodeManager(), new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("4s"), Duration.valueOf("0s"), Duration.valueOf("4s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(new InMemoryNodeManager(), new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), Duration.valueOf("4s"), true, newSingleThreadScheduledExecutor());
 
         assertWorkerMemoryInfo(provider, 0);
 
@@ -502,8 +502,9 @@ public class TestResourceManagerClusterStateProvider
         provider.registerNodeHeartbeat(createNodeStatus("nodeId2", GENERAL_POOL, createMemoryPoolInfo(200, 20, 10)));
         assertWorkerMemoryInfo(provider, 2);
 
-        // Expire nodes
-        Thread.sleep(SECONDS.toMillis(5));
+        // Node expiration timeout was set as 4 seconds
+        // Waiting for the expiration to cross the threshold + adding buffer to avoid flakiness
+        Thread.sleep(SECONDS.toMillis(10));
 
         assertWorkerMemoryInfo(provider, 0);
     }


### PR DESCRIPTION
Test relies on sleep timeout to expire nodes but the timeout was set as 4 second and sleep is 5 second. Increasing sleep from 5 to 10 seconds and timeout from 4 to 5 second. This gives enough time for the node status to expire and not have flaky behavior.

Test plan - unit test (ran ~20 times consecutively locally to make sure it's not flaky)

Issue https://github.com/prestodb/presto/issues/19632
```
== NO RELEASE NOTE ==
```
