### PR TITLE
[native] Fix "No space left on device" CI error

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -17,7 +17,7 @@ on:
 env:
   MAVEN_OPTS: "-Xmx1024M -XX:+ExitOnOutOfMemoryError"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
-  MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+  MAVEN_FAST_INSTALL: "-B -V -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
   MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
 
 jobs:
@@ -35,36 +35,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
 
-      - name: Get date for ccache
-        id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        shell: bash
+      - name: Get key for ccache
+        id: get-ccache-key
+        run: echo "CCACHE_KEY=$(/bin/date -u "+%Y-%U")" >> "$GITHUB_OUTPUT"
 
       - name: Setup ccache cache
         id: presto_cpp_ccache
         uses: actions/cache@v3
         with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-presto-native-ccache-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-presto-native-ccache-
+          path: ${GITHUB_WORKSPACE}/.ccache
+          key: ${{ runner.os }}-presto-native-ccache-${{ steps.get-ccache-key.outputs.CCACHE_KEY }}
 
       - name: Initiate ccache
         if: steps.presto_cpp_ccache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ~/.ccache
-          export CCACHE_DIR=$(realpath ~/.ccache)
-          ccache -sz -M 5Gi
+          rm -rf ${GITHUB_WORKSPACE}/.ccache
+          mkdir -p ${GITHUB_WORKSPACE}/.ccache
+          export CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache
+          ccache -sz -M 6Gi
 
       - name: Build presto_cpp
         run: |
           source /opt/rh/gcc-toolset-9/enable
-          export CCACHE_DIR=$(realpath ~/.ccache)
+          export CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache
           ccache -s
           cd ${GITHUB_WORKSPACE}/presto-native-execution
           make velox-submodule
@@ -81,27 +75,18 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/presto-native-execution/_build/debug
           # Delete static libraries
-          rm `find ./ -name lib\*.a` 
-
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+          rm `find ./ -name lib\*.a`
 
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm,!presto-test-coverage'
+          # build all dependent components of presto-native-execution
+          ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
 
       - name: Run e2e tests
         run: |
           rm -rf /tmp/hive_data/tpch/
-          ./mvnw test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas
+          
+          for test in $(find ${GITHUB_WORKSPACE}/presto-native-execution/src/test -name 'Test*.java' | grep -o "Test[a-zA-Z]*"); do
+            ./mvnw test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest=${test} -DPRESTO_SERVER=${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server -DDATA_DIR=/tmp/ -Duser.timezone=America/Bahia_Banderas
+          done

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -77,4 +77,9 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testTopN() {}
+
+    // This test is flaky: https://github.com/prestodb/presto/issues/19665
+    @Override
+    @Ignore
+    public void testUnionAll() {}
 }


### PR DESCRIPTION
The problem: test-native jobs usually (or always ?)  runs into disc full problems and the runs get skipped in such cases.

- Fix the out of disc space issue by removing caching for maven. 
- First we build all dependents of presto-native-execution every time which only take around 2+ minutes with "-am" instead of building many component not used. 
- Also remove caching for maven as maven build only takes 2 mins now. This will save us some space to avoid the disc full issue.
- For some reason, tests would fail if they are run together. So as a work-around we run each Test class in separate commands.
- Temporarily disable flaky TestPrestoSparkNativeGeneralQueries.testUnionAll() https://github.com/prestodb/presto/issues/19665

Fixes #19636
