### PR TITLE
Enable by default adding worker hostname to the ORC/DWRF file metadata

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -55,7 +55,7 @@ public class OrcFileWriterConfig
     private boolean isStringDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionarySortingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
     private boolean isFlatMapWriterEnabled = DEFAULT_FLAT_MAP_WRITER_ENABLED;
-    private boolean addHostnameToFileMetadataEnabled;
+    private boolean addHostnameToFileMetadataEnabled = true;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -65,7 +65,7 @@ public class TestOrcFileWriterConfig
                 .setStringDictionaryEncodingEnabled(true)
                 .setStringDictionarySortingEnabled(true)
                 .setFlatMapWriterEnabled(false)
-                .setAddHostnameToFileMetadataEnabled(false));
+                .setAddHostnameToFileMetadataEnabled(true));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.string-dictionary-encoding-enabled", "false")
                 .put("hive.orc.writer.string-dictionary-sorting-enabled", "false")
                 .put("hive.orc.writer.flat-map-writer-enabled", "true")
-                .put("hive.orc.writer.add-hostname-to-file-metadata-enabled", "true")
+                .put("hive.orc.writer.add-hostname-to-file-metadata-enabled", "false")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -108,7 +108,7 @@ public class TestOrcFileWriterConfig
                 .setStringDictionaryEncodingEnabled(false)
                 .setStringDictionarySortingEnabled(false)
                 .setFlatMapWriterEnabled(true)
-                .setAddHostnameToFileMetadataEnabled(true);
+                .setAddHostnameToFileMetadataEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Make ORC/DWRF file writer add the hostname to the file metadata by default. 

This is needed to easily identify hosts with bad hardware writing corrupted files.

Test plan:
- unit test
- already tested and enabled in Sapphire
- previously was tested with the Verifier

```
== NO RELEASE NOTE ==
```
