### PR TITLE
Add new field attemptNumber to TaskId

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -287,7 +287,7 @@ public abstract class AbstractOperatorBenchmark
                 spillSpaceTracker,
                 listJsonCodec(TaskMemoryReservationSummary.class))
                 .addTaskContext(
-                        new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
+                        new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), localQueryRunner.getExecutor()),
                         session,
                         Optional.empty(),
                         false,

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
@@ -93,7 +93,7 @@ public class MemoryLocalQueryRunner
 
         TaskContext taskContext = queryContext
                 .addTaskContext(
-                        new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
+                        new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), localQueryRunner.getExecutor()),
                         localQueryRunner.getDefaultSession(),
                         Optional.empty(),
                         false,

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -90,6 +90,8 @@ public final class SqlStageExecution
             REMOTE_TASK_MISMATCH.toErrorCode(),
             REMOTE_TASK_ERROR.toErrorCode());
 
+    public static final int DEFAULT_TASK_ATTEMPT_NUMBER = 0;
+
     private final Session session;
     private final StageExecutionStateMachine stateMachine;
     private final PlanFragment planFragment;
@@ -450,7 +452,7 @@ public final class SqlStageExecution
             return Optional.empty();
         }
         checkState(!splitsScheduled.get(), "scheduleTask can not be called once splits have been scheduled");
-        return Optional.of(scheduleTask(node, new TaskId(stateMachine.getStageExecutionId(), partition), ImmutableMultimap.of()));
+        return Optional.of(scheduleTask(node, new TaskId(stateMachine.getStageExecutionId(), partition, DEFAULT_TASK_ATTEMPT_NUMBER), ImmutableMultimap.of()));
     }
 
     public synchronized Set<RemoteTask> scheduleSplits(InternalNode node, Multimap<PlanNodeId, Split> splits, Multimap<PlanNodeId, Lifespan> noMoreSplitsNotification)
@@ -471,7 +473,7 @@ public final class SqlStageExecution
         if (tasks == null) {
             // The output buffer depends on the task id starting from 0 and being sequential, since each
             // task is assigned a private buffer based on task id.
-            TaskId taskId = new TaskId(stateMachine.getStageExecutionId(), nextTaskId.getAndIncrement());
+            TaskId taskId = new TaskId(stateMachine.getStageExecutionId(), nextTaskId.getAndIncrement(), DEFAULT_TASK_ATTEMPT_NUMBER);
             task = scheduleTask(node, taskId, splits);
             newTasks.add(task);
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
@@ -33,23 +33,25 @@ public class TaskId
 {
     private final StageExecutionId stageExecutionId;
     private final int id;
+    private final int attemptNumber;
 
     @JsonCreator
     public static TaskId valueOf(String taskId)
     {
-        List<String> parts = parseDottedId(taskId, 4, "taskId");
-        return new TaskId(parts.get(0), parseInt(parts.get(1)), parseInt(parts.get(2)), parseInt(parts.get(3)));
+        List<String> parts = parseDottedId(taskId, 5, "taskId");
+        return new TaskId(parts.get(0), parseInt(parts.get(1)), parseInt(parts.get(2)), parseInt(parts.get(3)), parseInt(parts.get(4)));
     }
 
-    public TaskId(String queryId, int stageId, int stageExecutionId, int id)
+    public TaskId(String queryId, int stageId, int stageExecutionId, int id, int attemptNumber)
     {
-        this(new StageExecutionId(new StageId(new QueryId(queryId), stageId), stageExecutionId), id);
+        this(new StageExecutionId(new StageId(new QueryId(queryId), stageId), stageExecutionId), id, attemptNumber);
     }
 
     @ThriftConstructor
-    public TaskId(StageExecutionId stageExecutionId, int id)
+    public TaskId(StageExecutionId stageExecutionId, int id, int attemptNumber)
     {
         this.stageExecutionId = requireNonNull(stageExecutionId, "stageExecutionId");
+        this.attemptNumber = attemptNumber;
         checkArgument(id >= 0, "id is negative");
         this.id = id;
     }
@@ -66,6 +68,12 @@ public class TaskId
         return id;
     }
 
+    @ThriftField(3)
+    public int getAttemptNumber()
+    {
+        return attemptNumber;
+    }
+
     public QueryId getQueryId()
     {
         return stageExecutionId.getStageId().getQueryId();
@@ -75,7 +83,7 @@ public class TaskId
     @JsonValue
     public String toString()
     {
-        return stageExecutionId + "." + id;
+        return stageExecutionId + "." + id + "." + attemptNumber;
     }
 
     @Override
@@ -88,13 +96,14 @@ public class TaskId
             return false;
         }
         TaskId taskId = (TaskId) o;
-        return id == taskId.id &&
+        return attemptNumber == taskId.attemptNumber &&
+                id == taskId.id &&
                 Objects.equals(stageExecutionId, taskId.stageExecutionId);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(stageExecutionId, id);
+        return Objects.hash(stageExecutionId, id, attemptNumber);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -67,7 +67,7 @@ public final class TestingTaskContext
         return createTaskContext(
                 queryContext,
                 session,
-                new TaskStateMachine(new TaskId("query", 0, 0, 0), executor),
+                new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), executor),
                 Optional.empty());
     }
 
@@ -113,7 +113,7 @@ public final class TestingTaskContext
             this.notificationExecutor = notificationExecutor;
             this.yieldExecutor = yieldExecutor;
             this.session = session;
-            this.taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0), notificationExecutor);
+            this.taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), notificationExecutor);
         }
 
         public Builder setTaskStateMachine(TaskStateMachine taskStateMachine)

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -168,7 +168,7 @@ public class BenchmarkNodeScheduler
                 for (int j = 0; j < MAX_SPLITS_PER_NODE + MAX_PENDING_SPLITS_PER_TASK_PER_NODE; j++) {
                     initialSplits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote(i)));
                 }
-                TaskId taskId = new TaskId("test", 1, 0, i);
+                TaskId taskId = new TaskId("test", 1, 0, i, 0);
                 MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
                 nodeTaskMap.addTask(node, remoteTask);
                 taskMap.put(node, remoteTask);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -784,7 +784,7 @@ public class TestMemoryRevokingScheduler
     {
         QueryContext queryContext = getOrCreateQueryContext(queryId, memoryPool);
 
-        TaskId taskId = new TaskId(queryId.getId(), 0, 0, idGenerator.incrementAndGet());
+        TaskId taskId = new TaskId(queryId.getId(), 0, 0, idGenerator.incrementAndGet(), 0);
         URI location = URI.create("fake://task/" + taskId);
 
         return createSqlTask(

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -301,7 +301,7 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         int task = 0;
         for (InternalNode node : assignments.keySet()) {
-            TaskId taskId = new TaskId("test", 1, 0, task);
+            TaskId taskId = new TaskId("test", 1, 0, task, 0);
             task++;
             MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createTaskStatsTracker(node, taskId));
             remoteTask.startSplits(25);
@@ -802,11 +802,11 @@ public class TestNodeScheduler
 
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         // Max out number of splits on node
-        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        TaskId taskId1 = new TaskId("test", 1, 0, 1, 0);
         RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId1));
         nodeTaskMap.addTask(newNode, remoteTask1);
 
-        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        TaskId taskId2 = new TaskId("test", 1, 0, 2, 0);
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(taskId2, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId2));
         nodeTaskMap.addTask(newNode, remoteTask2);
 
@@ -842,13 +842,13 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         for (InternalNode node : nodeManager.getActiveConnectorNodes(CONNECTOR_ID)) {
             // Max out number of splits on node
-            TaskId taskId = new TaskId("test", 1, 0, 1);
+            TaskId taskId = new TaskId("test", 1, 0, 1, 0);
             RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
             nodeTaskMap.addTask(node, remoteTask);
             tasks.add(remoteTask);
         }
 
-        TaskId taskId = new TaskId("test", 1, 0, 2);
+        TaskId taskId = new TaskId("test", 1, 0, 2, 0);
         RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(taskId, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId));
         // Max out pending splits on new node
         taskMap.put(newNode, newRemoteTask);
@@ -890,7 +890,7 @@ public class TestNodeScheduler
         int counter = 1;
         for (InternalNode node : nodeManager.getActiveConnectorNodes(CONNECTOR_ID)) {
             // Max out number of unacknowledged splits on each task
-            TaskId taskId = new TaskId("test", 1, 0, counter);
+            TaskId taskId = new TaskId("test", 1, 0, counter, 0);
             counter++;
             MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
             nodeTaskMap.addTask(node, remoteTask);
@@ -938,7 +938,7 @@ public class TestNodeScheduler
     {
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
-        TaskId taskId = new TaskId("test", 1, 0, 1);
+        TaskId taskId = new TaskId("test", 1, 0, 1, 0);
         RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(
                 taskId,
                 chosenNode,
@@ -960,7 +960,7 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
 
-        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        TaskId taskId1 = new TaskId("test", 1, 0, 1, 0);
         RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1,
                 chosenNode,
                 ImmutableList.of(
@@ -968,7 +968,7 @@ public class TestNodeScheduler
                         new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
                 nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
 
-        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        TaskId taskId2 = new TaskId("test", 1, 0, 2, 0);
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
                 taskId2,
                 chosenNode,
@@ -1000,7 +1000,7 @@ public class TestNodeScheduler
         InternalNode workerNode = nodeSelector.selectRandomNodes(1).get(0);
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
 
-        TaskId taskId = new TaskId("test", 1, 0, 1);
+        TaskId taskId = new TaskId("test", 1, 0, 1, 0);
         MockRemoteTaskFactory.MockRemoteTask task = remoteTaskFactory.createTableScanTask(taskId, workerNode, ImmutableList.of(), nodeTaskMap.createTaskStatsTracker(workerNode, taskId));
 
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
@@ -1050,7 +1050,7 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
 
-        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        TaskId taskId1 = new TaskId("test", 1, 0, 1, 0);
         List<Split> splits = ImmutableList.of(
                 new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()),
                 new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
@@ -1059,7 +1059,7 @@ public class TestNodeScheduler
                 splits,
                 nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
 
-        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        TaskId taskId2 = new TaskId("test", 1, 0, 2, 0);
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
                 taskId2,
                 chosenNode,
@@ -1090,7 +1090,7 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
 
-        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        TaskId taskId1 = new TaskId("test", 1, 0, 1, 0);
         List<Split> splits = ImmutableList.of(
                 new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()),
                 new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
@@ -1099,7 +1099,7 @@ public class TestNodeScheduler
                 splits,
                 nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
 
-        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        TaskId taskId2 = new TaskId("test", 1, 0, 2, 0);
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
                 taskId2,
                 chosenNode,
@@ -1205,7 +1205,7 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         int task = 0;
         for (InternalNode node : assignments.keySet()) {
-            TaskId taskId = new TaskId("test", 1, 1, task);
+            TaskId taskId = new TaskId("test", 1, 1, task, 0);
             task++;
             MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createTaskStatsTracker(node, taskId));
             remoteTask.startSplits(25);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -186,7 +186,7 @@ public class TestQueryInfo
                 true,
                 Optional.empty(),
                 Optional.of(QueryType.SELECT),
-                Optional.of(ImmutableList.of(new TaskId("0", 1, 1, 1))),
+                Optional.of(ImmutableList.of(new TaskId("0", 1, 1, 1, 0))),
                 Optional.of(ImmutableList.of(new StageId("0", 1))),
                 ImmutableMap.of(),
                 ImmutableSet.of(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -308,7 +308,7 @@ public class TestSqlTask
 
     public SqlTask createInitialTask()
     {
-        TaskId taskId = new TaskId("query", 0, 0, nextTaskId.incrementAndGet());
+        TaskId taskId = new TaskId("query", 0, 0, nextTaskId.incrementAndGet(), 0);
         URI location = URI.create("fake://task/" + taskId);
 
         QueryContext queryContext = new QueryContext(new QueryId("query"),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -124,7 +124,7 @@ public class TestSqlTaskExecution
     private static final ConnectorId CONNECTOR_ID = new ConnectorId("test");
     private static final ConnectorTransactionHandle TRANSACTION_HANDLE = TestingTransactionHandle.create();
     private static final Duration ASSERT_WAIT_TIMEOUT = new Duration(1, HOURS);
-    private static final TaskId TASK_ID = TaskId.valueOf("queryid.0.0.0");
+    private static final TaskId TASK_ID = TaskId.valueOf("queryid.0.0.0.0");
 
     @DataProvider
     public static Object[][] executionStrategies()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -74,7 +74,7 @@ import static org.testng.Assert.assertNull;
 @Test
 public class TestSqlTaskManager
 {
-    private static final TaskId TASK_ID = new TaskId("query", 0, 0, 1);
+    private static final TaskId TASK_ID = new TaskId("query", 0, 0, 1, 0);
     public static final OutputBufferId OUT = new OutputBufferId(0);
 
     private final TaskExecutor taskExecutor;

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
@@ -551,7 +551,7 @@ public class TestSpoolingOutputBuffer
 
     private SpoolingOutputBuffer createSpoolingOutputBuffer()
     {
-        TaskId taskId = new TaskId(queryIdGenerator.createNextQueryId().toString(), 0, 0, 0);
+        TaskId taskId = new TaskId(queryIdGenerator.createNextQueryId().toString(), 0, 0, 0, 0);
         return spoolingOutputBufferFactory.createSpoolingOutputBuffer(
                 taskId,
                 TASK_INSTANCE_ID,

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationController.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationController.java
@@ -182,13 +182,13 @@ class SimulationController
             runningTasks.put(specification, new LeafTask(
                     taskExecutor,
                     specification,
-                    new TaskId(specification.getName(), 0, 0, runningTasks.get(specification).size() + completedTasks.get(specification).size())));
+                    new TaskId(specification.getName(), 0, 0, runningTasks.get(specification).size() + completedTasks.get(specification).size(), 0)));
         }
         else {
             runningTasks.put(specification, new IntermediateTask(
                     taskExecutor,
                     specification,
-                    new TaskId(specification.getName(), 0, 0, runningTasks.get(specification).size() + completedTasks.get(specification).size())));
+                    new TaskId(specification.getName(), 0, 0, runningTasks.get(specification).size() + completedTasks.get(specification).size(), 0)));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
@@ -61,7 +61,7 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskId taskId = new TaskId("test", 0, 0, 0);
+            TaskId taskId = new TaskId("test", 0, 0, 0, 0);
             TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
@@ -155,8 +155,8 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("short_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
-            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("long_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("short_quanta", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("long_quanta", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
 
@@ -189,7 +189,7 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
             globalPhaser.bulkRegister(3);
@@ -230,9 +230,9 @@ public class TestTaskExecutor
         try {
             for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
                 TaskHandle[] taskHandles = {
-                        taskExecutor.addTask(new TaskId("test1", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
-                        taskExecutor.addTask(new TaskId("test2", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
-                        taskExecutor.addTask(new TaskId("test3", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty())
+                        taskExecutor.addTask(new TaskId("test1", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test2", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test3", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty())
                 };
 
                 // move task 0 to next level
@@ -311,7 +311,7 @@ public class TestTaskExecutor
         taskExecutor.start();
 
         try {
-            TaskId taskId = new TaskId("test", 0, 0, 0);
+            TaskId taskId = new TaskId("test", 0, 0, 0, 0);
             TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
@@ -343,8 +343,8 @@ public class TestTaskExecutor
     public void testLevelContributionCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
-        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
 
         for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
             long levelAdvanceTime = SECONDS.toNanos(LEVEL_THRESHOLD_SECONDS[i + 1] - LEVEL_THRESHOLD_SECONDS[i]);
@@ -363,7 +363,7 @@ public class TestTaskExecutor
     public void testUpdateLevelWithCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0, 0), new TaskPriorityTracker(splitQueue), () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
 
         long quantaNanos = MINUTES.toNanos(10);
         handle0.addScheduledNanos(quantaNanos);
@@ -385,7 +385,7 @@ public class TestTaskExecutor
         TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, QUERY_FAIR, splitQueue, ticker);
         taskExecutor.start();
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             // enqueue all batches of splits
             int batchCount = 4;
@@ -426,7 +426,7 @@ public class TestTaskExecutor
         taskExecutor.start();
         try {
             // overwrite the max drivers per task to be 1
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.of(1));
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.of(1));
 
             // enqueue all batches of splits
             int batchCount = 4;
@@ -475,7 +475,7 @@ public class TestTaskExecutor
         taskExecutor.start();
 
         try {
-            TaskId taskId = new TaskId("foo", 0, 0, 0);
+            TaskId taskId = new TaskId("foo", 0, 0, 0, 0);
             TaskHandle taskHandle = taskExecutor.addTask(
                     taskId, () -> 1.0,
                     1,

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -61,7 +61,7 @@ public class TestFixedCountScheduler
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
-                        new TaskId("test", 1, 0, 1),
+                        new TaskId("test", 1, 0, 1, 0),
                         node, ImmutableList.of(),
                         new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(1));
@@ -78,7 +78,7 @@ public class TestFixedCountScheduler
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
-                        new TaskId("test", 1, 0, 1),
+                        new TaskId("test", 1, 0, 1, 0),
                         node, ImmutableList.of(),
                         new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(5));

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -80,8 +80,8 @@ public class TestPartialResultQueryTaskTracker
                 false,
                 false,
                 false);
-        TaskId taskId1 = new TaskId("test1", 1, 0, 1);
-        TaskId taskId2 = new TaskId("test2", 2, 0, 1);
+        TaskId taskId1 = new TaskId("test1", 1, 0, 1, 0);
+        TaskId taskId2 = new TaskId("test2", 2, 0, 1, 0);
         RemoteTask task1 = taskFactory.createTableScanTask(taskId1, node1, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));
         RemoteTask task2 = taskFactory.createTableScanTask(taskId2, node2, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -115,7 +115,7 @@ public class TestMemoryTracking
                 spillSpaceTracker,
                 listJsonCodec(TaskMemoryReservationSummary.class));
         taskContext = queryContext.addTaskContext(
-                new TaskStateMachine(new TaskId("query", 0, 0, 0), notificationExecutor),
+                new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), notificationExecutor),
                 testSessionBuilder().build(),
                 Optional.of(PLAN_FRAGMENT.getRoot()),
                 true,

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -178,7 +178,7 @@ public class TestQueryContext
         MemoryPool reservedPool = new MemoryPool(RESERVED_POOL, new DataSize(10_000, BYTE));
         QueryId queryId = new QueryId("query");
         QueryContext queryContext = createQueryContext(queryId, generalPool);
-        TaskStateMachine taskStateMachine = new TaskStateMachine(TaskId.valueOf("queryid.0.0.0"), TEST_EXECUTOR);
+        TaskStateMachine taskStateMachine = new TaskStateMachine(TaskId.valueOf("queryid.0.0.0.0"), TEST_EXECUTOR);
         TaskContext taskContext = queryContext.addTaskContext(
                 taskStateMachine,
                 TEST_SESSION,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -64,9 +64,9 @@ public class TestExchangeOperator
     private static final List<Type> TYPES = ImmutableList.of(VARCHAR);
     private static final PagesSerdeFactory SERDE_FACTORY = new TestingPagesSerdeFactory();
 
-    private static final String TASK_1_ID = "task1.0.0.0";
-    private static final String TASK_2_ID = "task2.0.0.0";
-    private static final String TASK_3_ID = "task3.0.0.0";
+    private static final String TASK_1_ID = "task1.0.0.0.0";
+    private static final String TASK_2_ID = "task2.0.0.0.0";
+    private static final String TASK_3_ID = "task3.0.0.0.0";
 
     private final LoadingCache<String, TestingTaskBuffer> taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -376,7 +376,7 @@ public class TestHashJoinOperator
     private void innerJoinWithSpill(boolean probeHashEnabled, List<WhenSpill> whenSpill, SingleStreamSpillerFactory buildSpillerFactory, PartitioningSpillerFactory joinSpillerFactory)
             throws Exception
     {
-        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0), executor);
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), executor);
         TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
 
         DriverContext joinDriverContext = taskContext.addPipelineContext(2, true, true, false).addDriverContext();
@@ -495,7 +495,7 @@ public class TestHashJoinOperator
     @Test(timeOut = 60000)
     public void testInnerJoinWithSpillWithEarlyTermination()
     {
-        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0), executor);
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), executor);
         TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
 
         PipelineContext joinPipelineContext = taskContext.addPipelineContext(2, true, true, false);
@@ -677,7 +677,7 @@ public class TestHashJoinOperator
     public void testBuildGracefulSpill()
             throws Exception
     {
-        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0), executor);
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0, 0, 0), executor);
         TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
 
         // build factory

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -62,9 +62,9 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestMergeOperator
 {
-    private static final String TASK_1_ID = "task1.0.0.0";
-    private static final String TASK_2_ID = "task2.0.0.0";
-    private static final String TASK_3_ID = "task3.0.0.0";
+    private static final String TASK_1_ID = "task1.0.0.0.0";
+    private static final String TASK_2_ID = "task2.0.0.0.0";
+    private static final String TASK_3_ID = "task3.0.0.0.0";
 
     private AtomicInteger operatorId = new AtomicInteger();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
@@ -277,7 +277,7 @@ public class TestTableFinishOperator
         return TABLE_COMMIT_CONTEXT_CODEC.toJsonBytes(
                 new TableCommitContext(
                         lifespan,
-                        new TaskId("query", stageId, 0, taskId),
+                        new TaskId("query", stageId, 0, taskId, 0),
                         pageSinkCommitStrategy,
                         lastPage));
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
@@ -264,7 +264,7 @@ public class TestTableWriterOperator
         return wrappedBuffer(TABLE_COMMIT_CONTEXT_CODEC.toJsonBytes(
                 new TableCommitContext(
                         Lifespan.taskWide(),
-                        new TaskId("query", 0, 0, 0),
+                        new TaskId("query", 0, 0, 0, 0),
                         NO_COMMIT,
                         lastPage)));
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -115,18 +115,18 @@ public class TestThriftTaskIntegration
             ThriftTaskClient client = clientFactory.createDriftClient(ThriftTaskClient.class).get();
 
             // get buffer result
-            ListenableFuture<ThriftBufferResult> result = client.getResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 0, 100);
+            ListenableFuture<ThriftBufferResult> result = client.getResults(TaskId.valueOf("queryid.0.0.0.0"), new OutputBufferId(1), 0, 100);
             assertTrue(result.get().isBufferComplete());
             assertTrue(result.get().getSerializedPages().isEmpty());
             assertEquals(result.get().getToken(), 1);
             assertEquals(result.get().getTaskInstanceId(), "test");
 
             // ack buffer result
-            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42).get();    // sync
-            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42);          // fire and forget
+            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0.0"), new OutputBufferId(1), 42).get();    // sync
+            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0.0"), new OutputBufferId(1), 42);          // fire and forget
 
             // abort buffer result
-            client.abortResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1)).get();
+            client.abortResults(TaskId.valueOf("queryid.0.0.0.0"), new OutputBufferId(1)).get();
         }
         catch (Exception e) {
             fail();
@@ -248,7 +248,7 @@ public class TestThriftTaskIntegration
                 @Override
                 public void acknowledgeTaskResults(TaskId taskId, OutputBufferId bufferId, long sequenceId)
                 {
-                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0"));
+                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0.0"));
                     assertEquals(bufferId, new OutputBufferId(1));
                     assertEquals(sequenceId, 42);
                 }
@@ -256,7 +256,7 @@ public class TestThriftTaskIntegration
                 @Override
                 public TaskInfo abortTaskResults(TaskId taskId, OutputBufferId bufferId)
                 {
-                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0"));
+                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0.0"));
                     assertEquals(bufferId, new OutputBufferId(1));
 
                     // null is not going to be consumed

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -258,7 +258,7 @@ public class TestHttpRemoteTask
     {
         return httpRemoteTaskFactory.createRemoteTask(
                 TEST_SESSION,
-                new TaskId("test", 1, 0, 2),
+                new TaskId("test", 1, 0, 2, 0),
                 new InternalNode("node-id", URI.create("http://fake.invalid/"), new NodeVersion("version"), false),
                 createPlanFragment(),
                 ImmutableMultimap.of(),

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -29,12 +29,13 @@ class PrestoTaskTest : public testing::Test {
 };
 
 TEST_F(PrestoTaskTest, basicTaskId) {
-  PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3");
+  PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3.4");
 
   EXPECT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
   EXPECT_EQ(id.stageId(), 1);
   EXPECT_EQ(id.stageExecutionId(), 2);
   EXPECT_EQ(id.id(), 3);
+  EXPECT_EQ(id.attemptNumber(), 4);
 }
 
 TEST_F(PrestoTaskTest, malformedTaskId) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -33,7 +33,11 @@ class PrestoTaskId {
     stageExecutionId_ = parseInt(taskId, start, pos);
 
     start = pos + 1;
-    id_ = parseInt(taskId, start, taskId.length());
+    pos = nextDot(taskId, start);
+    id_ = parseInt(taskId, start, pos);
+
+    start = pos + 1;
+    attemptNumber_ = parseInt(taskId, start, taskId.length());
   }
 
   const std::string& queryId() const {
@@ -50,6 +54,10 @@ class PrestoTaskId {
 
   int32_t id() const {
     return id_;
+  }
+
+  int32_t attemptNumber() const {
+    return attemptNumber_;
   }
 
  private:
@@ -69,5 +77,6 @@ class PrestoTaskId {
   int32_t stageId_;
   int32_t stageExecutionId_;
   int32_t id_;
+  int32_t attemptNumber_;
 };
 } // namespace facebook::presto

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -403,8 +403,7 @@ public class PrestoSparkTaskExecutorFactory
         // We will only cache 1 HT at any time. If the stageId changes, we will drop the old cached HT
         prestoSparkBroadcastTableCacheManager.removeCachedTablesForStagesOtherThan(stageId);
 
-        // TODO: include attemptId in taskId
-        TaskId taskId = new TaskId(new StageExecutionId(stageId, 0), partitionId);
+        TaskId taskId = new TaskId(new StageExecutionId(stageId, 0), partitionId, attemptNumber);
 
         // TODO: Remove this once we can display the plan on Spark UI.
         // Currently, `textPlanFragment` throws an exception if json-based UDFs are used in the query, which can only

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
@@ -87,7 +87,7 @@ public class TestBatchTaskUpdateRequest
                                         new Split(
                                                 new ConnectorId("connector_id"),
                                                 new RemoteTransactionHandle(),
-                                                new RemoteSplit(new Location(stringSerializedReadInfo), TaskId.valueOf("foo.0.0.0"))))),
+                                                new RemoteSplit(new Location(stringSerializedReadInfo), TaskId.valueOf("foo.0.0.0.0"))))),
                         true));
         Session session = TestingSession.testSessionBuilder().build();
         TaskUpdateRequest updateRequest = new TaskUpdateRequest(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -94,6 +94,7 @@ import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEm
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
@@ -128,6 +129,7 @@ public class TestPrestoSparkHttpClient
                 "testid",
                 0,
                 0,
+                0,
                 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
@@ -156,7 +158,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testResultAcknowledge()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString())),
@@ -172,7 +174,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testResultAbort()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString())),
@@ -195,7 +197,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testGetTaskInfo()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString())),
@@ -219,7 +221,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testUpdateTask()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString())),
@@ -254,7 +256,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testGetServerInfo()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         ServerInfo expected = new ServerInfo(UNKNOWN, "test", true, false, Optional.of(Duration.valueOf("2m")));
 
         PrestoSparkHttpServerClient workerClient = new PrestoSparkHttpServerClient(
@@ -275,7 +277,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testGetServerInfoWithRetry()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         ScheduledExecutorService scheduler = newScheduledThreadPool(1);
         ServerInfo expected = new ServerInfo(UNKNOWN, "test", true, false, Optional.of(Duration.valueOf("2m")));
         Duration maxTimeout = new Duration(1, TimeUnit.MINUTES);
@@ -300,7 +302,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testGetServerInfoWithRetryTimeout()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         ScheduledExecutorService scheduler = newScheduledThreadPool(1);
         Duration maxTimeout = new Duration(0, TimeUnit.MILLISECONDS);
         NativeExecutionProcess process = createNativeExecutionProcess(
@@ -318,7 +320,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testResultFetcher()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString())),
@@ -353,8 +355,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testResultFetcherMultipleNonEmptyResults()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
-        URI uri = uriBuilderFrom(BASE_URI).appendPath(TASK_ROOT_PATH).build();
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         int serializedPageSize = (int) new DataSize(1, MEGABYTE).toBytes();
         int numPages = 10;
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
@@ -478,7 +479,7 @@ public class TestPrestoSparkHttpClient
     {
         int numPages = 10;
         int serializedPageSize = (int) new DataSize(32, MEGABYTE).toBytes();
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         BreakingLimitResponseManager breakingLimitResponseManager =
                 new BreakingLimitResponseManager(serializedPageSize, numPages);
@@ -583,7 +584,7 @@ public class TestPrestoSparkHttpClient
         // Expecting recovery from failed requests
         int numTransportErrors = 3;
 
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         TimeoutResponseManager timeoutResponseManager =
                 new TimeoutResponseManager(serializedPageSize, numPages, numTransportErrors);
@@ -626,7 +627,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testResultFetcherTransportErrorFail()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
                 new TestingHttpClient(new TestingResponseManager(taskId.toString(), new TimeoutResponseManager(0, 10, 10))),
@@ -646,7 +647,7 @@ public class TestPrestoSparkHttpClient
     @Test
     public void testInfoFetcher()
     {
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 
         Duration fetchInterval = new Duration(1, TimeUnit.SECONDS);
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
@@ -678,10 +679,10 @@ public class TestPrestoSparkHttpClient
     public void testNativeExecutionTask()
     {
         // We need multi-thread scheduler to increase scheduling concurrency.
-        // Otherwise async execution assumption is not going to hold with a
+        // Otherwise, async execution assumption is not going to hold with a
         // single thread.
         ScheduledExecutorService scheduler = newScheduledThreadPool(4);
-        TaskId taskId = new TaskId("testid", 0, 0, 0);
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         TaskManagerConfig config = new TaskManagerConfig();
         config.setInfoRefreshMaxWait(new Duration(5, TimeUnit.SECONDS));
         config.setInfoUpdateInterval(new Duration(200, TimeUnit.MILLISECONDS));
@@ -778,6 +779,7 @@ public class TestPrestoSparkHttpClient
     private static class TestingHttpClient
             implements com.facebook.airlift.http.client.HttpClient
     {
+        private static final String TASK_ID_REGEX = "\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+.[0-9]+";
         private final ScheduledExecutorService executor;
         private final TestingResponseManager responseManager;
 
@@ -813,7 +815,7 @@ public class TestPrestoSparkHttpClient
                         String path = uri.getPath();
                         if (method.equalsIgnoreCase("GET")) {
                             // GET /v1/task/{taskId}
-                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\z").matcher(path).find()) {
+                            if (Pattern.compile(TASK_ID_REGEX + "\\z").matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createTaskInfoResponse(HttpStatus.OK)));
                                 }
@@ -859,7 +861,7 @@ public class TestPrestoSparkHttpClient
                         }
                         else if (method.equalsIgnoreCase("POST")) {
                             // POST /v1/task/{taskId}/batch
-                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\/batch\\z").matcher(path).find()) {
+                            if (Pattern.compile(format("%s\\/batch\\z", TASK_ID_REGEX)).matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createTaskInfoResponse(HttpStatus.OK)));
                                 }
@@ -871,7 +873,7 @@ public class TestPrestoSparkHttpClient
                         }
                         else if (method.equalsIgnoreCase("DELETE")) {
                             // DELETE /v1/task/{taskId}
-                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\/results\\/[0-9]+\\z").matcher(path).find()) {
+                            if (Pattern.compile(format("%s\\/results\\/[0-9]+\\z", TASK_ID_REGEX)).matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createDummyResultResponse()));
                                 }
@@ -883,7 +885,7 @@ public class TestPrestoSparkHttpClient
                         }
                         else if (method.equalsIgnoreCase("DELETE")) {
                             // DELETE /v1/task/{taskId}/results/{bufferId}
-                            if (Pattern.compile("\\/v1\\/task\\/[a-zA-Z0-9]+.[0-9]+.[0-9]+.[0-9]+\\z").matcher(path).find()) {
+                            if (Pattern.compile(TASK_ID_REGEX + "\\z").matcher(path).find()) {
                                 try {
                                     future.complete(responseHandler.handle(request, responseManager.createDummyResultResponse()));
                                 }
@@ -893,7 +895,10 @@ public class TestPrestoSparkHttpClient
                                 }
                             }
                         }
-                        future.completeExceptionally(new Exception("Unknown path " + path));
+
+                        if (!future.isDone()) {
+                            future.completeExceptionally(new Exception("Unknown path " + path));
+                        }
                     },
                     (long) NO_DURATION.getValue(),
                     NO_DURATION.getUnit());

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
@@ -93,7 +93,7 @@ public class TestPrestoSparkTaskExecution
                 .setSchema(TINY_SCHEMA_NAME)
                 .build();
 
-        taskStateMachine = new TaskStateMachine(new TaskId("test_query_id", 4, 4, 1), taskNotificationExecutor);
+        taskStateMachine = new TaskStateMachine(new TaskId("test_query_id", 4, 4, 1, 0), taskNotificationExecutor);
 
         localExecutionPlan = createTestingPlanner().plan(
                 TestingTaskContext.createTaskContext(taskNotificationExecutor, scheduledExecutor, nativeTestSession),

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestAsyncPageTransportServlet.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestAsyncPageTransportServlet.java
@@ -74,8 +74,8 @@ public class TestAsyncPageTransportServlet
     @Test
     public void testParsing()
     {
-        TestServlet servlet = parse("/v1/task/async/1.2.3.4/results/456/789");
-        assertEquals("1.2.3.4", servlet.taskId.toString());
+        TestServlet servlet = parse("/v1/task/async/0.1.2.3.4/results/456/789");
+        assertEquals("0.1.2.3.4", servlet.taskId.toString());
         assertEquals("456", servlet.bufferId.toString());
         assertEquals(789, servlet.token);
     }
@@ -83,12 +83,12 @@ public class TestAsyncPageTransportServlet
     @Test (expectedExceptions = { IllegalArgumentException.class })
     public void testParseTooFewElements()
     {
-        parse("/v1/task/async/1.2.3.4/results/456");
+        parse("/v1/task/async/SomeQueryId.1.2.3.4/results/456");
     }
 
     @Test (expectedExceptions = { IllegalArgumentException.class })
     public void testParseTooManyElements()
     {
-        parse("/v1/task/async/1.2.3.4/results/456/789/foo");
+        parse("/v1/task/async/SomeQueryId.1.2.3.4/results/456/789/foo");
     }
 }


### PR DESCRIPTION
Add new field `attemptNumber` to `TaskId` class.  

The `TaskId` class needs to be enhanced to capture retry semantics. This is applicable in presto-on-spark (and more-so in presto-on-spark native where the `TaskId` is used to create a remote task on the CPP process. 
Without the additional `attemptNumber` field, 2 attempts of the same task would have identical `TaskId` violating the contract between Presto Java and Presto CPP

For non presto-on-spark use-case (presto classic) this field will be set to `0` by default. 

```
== RELEASE NOTES ==

General Changes
* TaskId will now contain an additional field  `attemptNumber` which is used to capture task retries in presto-on-spark. For presto classic this field will be set to `0` by default. 