### PR TITLE
[native] Fix testMissingTpchConnector for Spark native

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spark;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.nativeworker.AbstractTestNativeTpchConnectorQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
@@ -41,11 +42,18 @@ public class TestPrestoSparkNativeTpchConnectorQueries
         PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
     }
 
-    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
-    @Ignore
-    public void testMissingTpchConnector() {}
+    public void testMissingTpchConnector()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+        // No tpch connector exists in the native worker.
+        assertQueryFails(session, "SELECT * FROM nation", ".*Connector with ID 'tpch' not registered.*");
+    }
 
+    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore
     public void testTpchDateFilter() {}


### PR DESCRIPTION
Since Spark Native exception propagation does not go through coordinator code path. We expect different exception message from this test case.

```
== NO RELEASE NOTE ==
```
