### PR TITLE
Add an array udf array_cum_sum

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -40,6 +40,13 @@ Array Functions
     Returns the average of all non-null elements of the ``array``. If there is no non-null elements, returns
     ``null``.
 
+.. function:: array_cum_sum(array(T)) -> array(T)
+
+    Returns the array whose elements are the cumulative sum of the input array, i.e. result[i] = input[1]+input[2]+...+input[i].
+    If there there is null elements in the array, the cumulative sum at and after the element is null. ::
+
+        SELECT array_cum_sum(ARRAY [1, 2, null, 3]) -- array[1, 3, null, null]
+
 .. function:: array_distinct(x) -> array
 
     Remove duplicate values from the array ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -96,6 +96,7 @@ import com.facebook.presto.operator.scalar.ArrayAnyMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
 import com.facebook.presto.operator.scalar.ArrayCombinationsFunction;
 import com.facebook.presto.operator.scalar.ArrayContains;
+import com.facebook.presto.operator.scalar.ArrayCumSum;
 import com.facebook.presto.operator.scalar.ArrayDistinctFromOperator;
 import com.facebook.presto.operator.scalar.ArrayDistinctFunction;
 import com.facebook.presto.operator.scalar.ArrayElementAtFunction;
@@ -682,6 +683,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(ClassificationPrecisionAggregation.class)
                 .aggregates(ClassificationRecallAggregation.class)
                 .aggregates(ClassificationThresholdsAggregation.class)
+                .scalar(ArrayCumSum.class)
                 .scalar(RepeatFunction.class)
                 .scalars(SequenceFunction.class)
                 .scalars(SessionFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayCumSum.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayCumSum.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OperatorDependency;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
+
+@Description("Get the cumulative sum array for the input array")
+@ScalarFunction(value = "array_cum_sum", deterministic = true)
+public final class ArrayCumSum
+{
+    private ArrayCumSum() {}
+
+    @TypeParameter("T")
+    @SqlType("array(T)")
+    public static Block sum(
+            @OperatorDependency(operator = ADD, argumentTypes = {"T", "T"}) MethodHandle addFunction,
+            @TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
+        if (positionCount == 0) {
+            return resultBuilder.build();
+        }
+
+        if (arrayBlock.isNull(0)) {
+            return RunLengthEncodedBlock.create(elementType, null, positionCount);
+        }
+
+        elementType.appendTo(arrayBlock, 0, resultBuilder);
+        if (arrayBlock.mayHaveNull()) {
+            int pos = 1;
+            for (; pos < positionCount; ++pos) {
+                if (arrayBlock.isNull(pos)) {
+                    break;
+                }
+                writeSum(elementType, resultBuilder, addFunction, pos, arrayBlock);
+            }
+            for (; pos < positionCount; ++pos) {
+                resultBuilder.appendNull();
+            }
+        }
+        else {
+            for (int pos = 1; pos < positionCount; ++pos) {
+                writeSum(elementType, resultBuilder, addFunction, pos, arrayBlock);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    private static void writeSum(Type elementType, BlockBuilder resultBuilder, MethodHandle addFunction, int pos, Block arrayBlock)
+    {
+        try {
+            writeNativeValue(elementType, resultBuilder, addFunction.invoke(readNativeValue(elementType, resultBuilder, pos - 1), readNativeValue(elementType, arrayBlock, pos)));
+        }
+        catch (Throwable throwable) {
+            throw internalError(throwable);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -111,6 +111,16 @@ public abstract class AbstractTestFunctions
         functionAssertions.assertFunction(format("\"%s\"(%s)", operator.getFunctionName().getObjectName(), value), expectedType, expected);
     }
 
+    protected void assertFunctionDoubleArrayWithError(String projection, Type expectedType, List<Double> expected, double delta)
+    {
+        functionAssertions.assertFunctionDoubleArrayWithError(projection, expectedType, expected, delta);
+    }
+
+    protected void assertFunctionFloatArrayWithError(String projection, Type expectedType, List<Float> expected, float delta)
+    {
+        functionAssertions.assertFunctionFloatArrayWithError(projection, expectedType, expected, delta);
+    }
+
     protected void assertDecimalFunction(String statement, SqlDecimal expectedResult)
     {
         assertFunction(

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -265,6 +265,28 @@ public final class FunctionAssertions
         assertEquals(actual.doubleValue(), expected, delta);
     }
 
+    public void assertFunctionDoubleArrayWithError(String projection, Type expectedType, List<Double> expected, double delta)
+    {
+        Object actual = selectSingleValue(projection, expectedType, compiler);
+        assertTrue(actual instanceof ArrayList);
+        ArrayList<Object> arrayList = (ArrayList) actual;
+        assertTrue(arrayList.size() == expected.size());
+        for (int i = 0; i < arrayList.size(); ++i) {
+            assertEquals((double) arrayList.get(i), expected.get(i), delta);
+        }
+    }
+
+    public void assertFunctionFloatArrayWithError(String projection, Type expectedType, List<Float> expected, float delta)
+    {
+        Object actual = selectSingleValue(projection, expectedType, compiler);
+        assertTrue(actual instanceof ArrayList);
+        ArrayList<Object> arrayList = (ArrayList) actual;
+        assertTrue(arrayList.size() == expected.size());
+        for (int i = 0; i < arrayList.size(); ++i) {
+            assertEquals((float) arrayList.get(i), expected.get(i), delta);
+        }
+    }
+
     public void assertFunctionString(String projection, Type expectedType, String expected)
     {
         Object actual = selectSingleValue(projection, expectedType, compiler);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCumulativeSumFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCumulativeSumFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.SqlDecimal;
+import com.facebook.presto.metadata.OperatorNotFoundException;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+
+public class TestArrayCumulativeSumFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testIntArray()
+    {
+        assertFunction("array_cum_sum(ARRAY [cast(5 as INTEGER), 6, 0])", new ArrayType(INTEGER), ImmutableList.of(5, 11, 11));
+        assertFunction("array_cum_sum(ARRAY [cast(5 as INTEGER), 6, null, null, 2, 1])", new ArrayType(INTEGER), Arrays.asList(5, 11, null, null, null, null));
+        assertFunction("array_cum_sum(ARRAY [cast(null as INTEGER), 6, 2, 3, 2, 1])", new ArrayType(INTEGER), Arrays.asList(null, null, null, null, null, null));
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(integer)))", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(NULL AS array(integer)))", new ArrayType(INTEGER), null);
+        assertFunctionThrowsIncorrectly("array_cum_sum(ARRAY [cast(2147483647 as integer), 2147483647, 2147483647])", PrestoException.class, "integer addition overflow:.*");
+    }
+
+    @Test
+    public void testBigIntArray()
+    {
+        assertFunction("array_cum_sum(ARRAY [cast(5 as bigint), 6, 0])", new ArrayType(BIGINT), ImmutableList.of(5L, 11L, 11L));
+        assertFunction("array_cum_sum(ARRAY [cast(5 as bigint), 6, null, null, 2, 1])", new ArrayType(BIGINT), Arrays.asList(5L, 11L, null, null, null, null));
+        assertFunction("array_cum_sum(ARRAY [cast(null as bigint), 6, 2, 3, 2, 1])", new ArrayType(BIGINT), Arrays.asList(null, null, null, null, null, null));
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(bigint)))", new ArrayType(BIGINT), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(NULL AS array(bigint)))", new ArrayType(BIGINT), null);
+        assertFunction("array_cum_sum(ARRAY [cast(2147483647 as bigint), 2147483647, 2147483647])", new ArrayType(BIGINT), ImmutableList.of(2147483647L, 4294967294L, 6442450941L));
+    }
+
+    @Test
+    public void testRealArray()
+    {
+        assertFunctionFloatArrayWithError("array_cum_sum(ARRAY [cast(5.1 as real), 6.1, 0.5])", new ArrayType(REAL), ImmutableList.of(5.1f, 11.2f, 11.7f), 1e-5f);
+        assertFunction("array_cum_sum(ARRAY [cast(5.1 as real), 6, null, null, 2, 1.2])", new ArrayType(REAL), Arrays.asList(5.1f, 11.1f, null, null, null, null));
+        assertFunction("array_cum_sum(ARRAY [cast(null as real), 6.2, 2, 3, 2, 1])", new ArrayType(REAL), Arrays.asList(null, null, null, null, null, null));
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(real)))", new ArrayType(REAL), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(NULL AS array(real)))", new ArrayType(REAL), null);
+    }
+
+    @Test
+    public void testDoubleArray()
+    {
+        assertFunctionDoubleArrayWithError("array_cum_sum(ARRAY [cast(5.1 as double), 6.1, 0.5])", new ArrayType(DOUBLE), ImmutableList.of(5.1, 11.2, 11.7), 1e-5);
+        assertFunction("array_cum_sum(ARRAY [cast(5.1 as double), 6, null, null, 2, 1.2])", new ArrayType(DOUBLE), Arrays.asList(5.1, 11.1, null, null, null, null));
+        assertFunction("array_cum_sum(ARRAY [cast(null as double), 6.2, 2, 3, 2, 1])", new ArrayType(DOUBLE), Arrays.asList(null, null, null, null, null, null));
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(double)))", new ArrayType(DOUBLE), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(NULL AS array(double)))", new ArrayType(DOUBLE), null);
+    }
+
+    @Test
+    public void testVarcharArray()
+    {
+        assertFunctionThrowsIncorrectly("array_cum_sum(ARRAY [cast(5.1 as varchar), '6.1', '0.5'])", OperatorNotFoundException.class, ".*cannot be applied to.*");
+        assertFunctionThrowsIncorrectly("array_cum_sum(ARRAY [cast(null as varchar), '6.1', '0.5'])", OperatorNotFoundException.class, ".*cannot be applied to.*");
+    }
+
+    @Test
+    public void testDecimalArray()
+    {
+        assertFunction("array_cum_sum(cast(ARRAY[5.1, 6.1, 0.5] as array(decimal(2, 1))))", new ArrayType(createDecimalType(2, 1)),
+                ImmutableList.of(SqlDecimal.of(51, 2, 1), SqlDecimal.of(112, 2, 1), SqlDecimal.of(117, 2, 1)));
+        assertFunction("array_cum_sum(cast(ARRAY[5.1, 6, null, null, 2, 1.2] as array(decimal(2, 1))))", new ArrayType(createDecimalType(2, 1)),
+                Arrays.asList(SqlDecimal.of(51, 2, 1), SqlDecimal.of(111, 2, 1), null, null, null, null));
+        assertFunction("array_cum_sum(cast(ARRAY[null, 6, 2, 3, 2, 1.2] as array(decimal(2, 1))))", new ArrayType(createDecimalType(2, 1)), Arrays.asList(null, null, null, null, null, null));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -6629,5 +6630,110 @@ public abstract class AbstractTestQueries
 
         sql = "select o.orderkey, l.partkey, l.suppkey from lineitem l join orders o on (l.orderkey = o.orderkey or (l.partkey + l.suppkey) = o.orderkey) and l.quantity*totalprice > 1000 where l.quantity < 5 and o.totalprice < 2000";
         assertQuery(enablePushFilterOptimization, sql);
+    }
+
+    @Test
+    public void testArrayCumSum()
+    {
+        // int
+        String sql = "select array_cum_sum(k) from (values (array[cast(5 as INTEGER), 6, 0]), (ARRAY[]), (CAST(NULL AS array(integer)))) t(k)";
+        assertQuery(sql, "values array[cast(5 as integer), cast(11 as integer), cast(11 as integer)], array[], null");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(5 as INTEGER), 6, 0]), (ARRAY[]), (CAST(NULL AS array(integer))), (ARRAY [cast(2147483647 as INTEGER), 2147483647, 2147483647])) t(k)";
+        assertQueryFails(sql, "integer addition overflow:.*");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(5 as INTEGER), 6, null, 2, 3])) t(k)";
+        assertQuery(sql, "values array[cast(5 as integer), cast(11 as integer), cast(null as integer), cast(null as integer), cast(null as integer)]");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(null as INTEGER), 6, null, 2, 3])) t(k)";
+        assertQuery(sql, "values array[cast(null as integer), cast(null as integer), cast(null as integer), cast(null as integer), cast(null as integer)]");
+
+        // bigint
+        sql = "select array_cum_sum(k) from (values (array[cast(5 as bigint), 6, 0]), (ARRAY[]), (CAST(NULL AS array(bigint))), (ARRAY [cast(2147483647 as bigint), 2147483647, 2147483647])) t(k)";
+        assertQuery(sql, "values array[cast(5 as bigint), cast(11 as bigint), cast(11 as bigint)], array[], null, array[cast(2147483647 as bigint), cast(4294967294 as bigint), cast(6442450941 as bigint)]");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(5 as bigint), 6, null, 2, 3])) t(k)";
+        assertQuery(sql, "values array[cast(5 as bigint), cast(11 as bigint), cast(null as bigint), cast(null as bigint), cast(null as bigint)]");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(null as bigint), 6, null, 2, 3])) t(k)";
+        assertQuery(sql, "values array[cast(null as bigint), cast(null as bigint), cast(null as bigint), cast(null as bigint), cast(null as bigint)]");
+
+        // real
+        sql = "select array_cum_sum(k) from (values (array[cast(null as real), 6, null, 2, 3])) t(k)";
+        assertQuery(sql, "values array[cast(null as real), cast(null as real), cast(null as real), cast(null as real), cast(null as real)]");
+
+        MaterializedResult raw = computeActual("SELECT array_cum_sum(k) FROM (values (ARRAY [cast(5.1 as real), 6.1, 0.5]), (ARRAY[]), (CAST(NULL AS array(real))), " +
+                "(ARRAY [cast(null as real), 6.1, 0.5]), (ARRAY [cast(2.5 as real), 6.1, null, 3.2])) t(k)");
+        List<MaterializedRow> rowList = raw.getMaterializedRows();
+        List<Float> actualFloat = (List<Float>) rowList.get(0).getField(0);
+        List<Float> expectedFloat = ImmutableList.of(5.1f, 11.2f, 11.7f);
+        for (int i = 0; i < actualFloat.size(); ++i) {
+            assertTrue(actualFloat.get(i) > expectedFloat.get(i) - 1e-5 && actualFloat.get(i) < expectedFloat.get(i) + 1e-5);
+        }
+
+        actualFloat = (List<Float>) rowList.get(1).getField(0);
+        assertTrue(actualFloat.isEmpty());
+
+        actualFloat = (List<Float>) rowList.get(2).getField(0);
+        assertTrue(actualFloat == null);
+
+        actualFloat = (List<Float>) rowList.get(3).getField(0);
+        for (int i = 0; i < actualFloat.size(); ++i) {
+            assertTrue(actualFloat.get(i) == null);
+        }
+
+        actualFloat = (List<Float>) rowList.get(4).getField(0);
+        expectedFloat = Arrays.asList(2.5f, 8.6f, null, null);
+        for (int i = 0; i < 2; ++i) {
+            assertTrue(actualFloat.get(i) > expectedFloat.get(i) - 1e-5 && actualFloat.get(i) < expectedFloat.get(i) + 1e-5);
+        }
+        for (int i = 2; i < actualFloat.size(); ++i) {
+            assertTrue(actualFloat.get(i) == null);
+        }
+
+        // double
+        raw = computeActual("SELECT array_cum_sum(k) FROM (values (ARRAY [cast(5.1 as double), 6.1, 0.5]), (ARRAY[]), (CAST(NULL AS array(double))), " +
+                "(ARRAY [cast(null as double), 6.1, 0.5]), (ARRAY [cast(5.1 as double), 6.1, null, 3.2])) t(k)");
+        rowList = raw.getMaterializedRows();
+        List<Double> actualDouble = (List<Double>) rowList.get(0).getField(0);
+        List<Double> expectedDouble = ImmutableList.of(5.1, 11.2, 11.7);
+        for (int i = 0; i < actualDouble.size(); ++i) {
+            assertTrue(actualDouble.get(i) > expectedDouble.get(i) - 1e-5 && actualDouble.get(i) < expectedDouble.get(i) + 1e-5);
+        }
+
+        actualDouble = (List<Double>) rowList.get(1).getField(0);
+        assertTrue(actualDouble.isEmpty());
+
+        actualDouble = (List<Double>) rowList.get(2).getField(0);
+        assertTrue(actualDouble == null);
+
+        actualDouble = (List<Double>) rowList.get(3).getField(0);
+        for (int i = 0; i < actualDouble.size(); ++i) {
+            assertTrue(actualDouble.get(i) == null);
+        }
+
+        actualDouble = (List<Double>) rowList.get(4).getField(0);
+        expectedDouble = Arrays.asList(5.1, 11.2, null, null);
+        for (int i = 0; i < 2; ++i) {
+            assertTrue(actualDouble.get(i) > expectedDouble.get(i) - 1e-5 && actualDouble.get(i) < expectedDouble.get(i) + 1e-5);
+        }
+        for (int i = 2; i < actualDouble.size(); ++i) {
+            assertTrue(actualDouble.get(i) == null);
+        }
+
+        // decimal
+        sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, 0]), (ARRAY[]), (CAST(NULL AS array(decimal)))) t(k)";
+        assertQuery(sql, "values array[cast(5.1 as decimal), cast(11.1 as decimal), cast(11.1 as decimal)], array[], null");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, null, 3]), (array[cast(null as decimal(38, 1)), 6, null, 3])) t(k)";
+        assertQuery(sql, "values array[cast(5.1 as decimal), cast(11.1 as decimal), cast(null as decimal), cast(null as decimal)], " +
+                "array[cast(null as decimal), cast(null as decimal), cast(null as decimal), cast(null as decimal)]");
+
+        // varchar
+        sql = "select array_cum_sum(k) from (values (array[cast('5.1' as varchar), '6', '0']), (ARRAY[]), (CAST(NULL AS array(varchar)))) t(k)";
+        assertQueryFails(sql, ".*cannot be applied to.*");
+
+        sql = "select array_cum_sum(k) from (values (array[cast(null as varchar), '6', '0'])) t(k)";
+        assertQueryFails(sql, ".*cannot be applied to.*");
     }
 }


### PR DESCRIPTION
Returns the array whose elements are the cumulative sum of the input array, i.e. result[i] = input[1]+input[2]+...+input[i]. If there there is null elements in the array, the cumulative sum at and after the element is null.

### Test plan - (Please fill in how you tested your changes)

Add unit tests

```
== RELEASE NOTES ==

General Changes
* Add a new UDF `array_cum_sum` to return the array whose elements are the cumulative sum of the input array
```
