### PR TITLE
[native] Disambiguate QueryCtx constructor calls.

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -371,7 +371,8 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       const std::string& taskId,
       core::PlanNodePtr planNode,
       int destination) {
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        executor_.get(), std::make_shared<velox::core::MemConfig>());
     core::PlanFragment planFragment{planNode};
     return exec::Task::create(
         taskId, std::move(planFragment), destination, std::move(queryCtx));

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -14,8 +14,9 @@
 #include <gtest/gtest.h>
 #include "presto_cpp/main/QueryContextManager.h"
 
-using namespace facebook::velox;
-using namespace facebook::presto;
+namespace facebook::presto {
+
+using namespace velox;
 
 namespace {
 void verifyQueryCtxCache(
@@ -40,7 +41,8 @@ TEST(QueryContextCacheTest, basic) {
 
   for (int i = 0; i < 16; ++i) {
     auto queryId = fmt::format("query-{}", i);
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        (folly::Executor*)nullptr, std::make_shared<core::MemConfig>());
     queryCtxs[queryId] = queryCtx;
     queryContextCache.insert(queryId, queryCtx);
   }
@@ -69,7 +71,8 @@ TEST(QueryContextCacheTest, eviction) {
 
   for (int i = 0; i < 8; ++i) {
     auto queryId = fmt::format("query-{}", i);
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        (folly::Executor*)nullptr, std::make_shared<core::MemConfig>());
     queryCtxs[queryId] = queryCtx;
     queryContextCache.insert(queryId, queryCtx);
   }
@@ -88,7 +91,8 @@ TEST(QueryContextCacheTest, eviction) {
   // Insert 4 more query ctxs
   for (int i = 8; i < 12; ++i) {
     auto queryId = fmt::format("query-{}", i);
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        (folly::Executor*)nullptr, std::make_shared<core::MemConfig>());
     queryCtxs[queryId] = queryCtx;
     queryContextCache.insert(queryId, queryCtx);
   }
@@ -101,7 +105,8 @@ TEST(QueryContextCacheTest, eviction) {
   // Ensure that cache expands if all the queries in cache are alive.
   for (int i = 12; i < 20; ++i) {
     auto queryId = fmt::format("query-{}", i);
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        (folly::Executor*)nullptr, std::make_shared<core::MemConfig>());
     queryCtxs[queryId] = queryCtx;
     queryContextCache.insert(queryId, queryCtx);
   }
@@ -117,3 +122,4 @@ TEST(QueryContextCacheTest, eviction) {
   verifyQueryCtxCache(queryContextCache, queryCtxs, 0, 20);
   EXPECT_EQ(queryContextCache.size(), 0);
 }
+} // namespace facebook::presto


### PR DESCRIPTION
Disambiguate QueryCtx constructor calls, so when new constructor is introduced
in Velox, the build wouldn't fail and we can then adopt the new constructor and
remove the old one in Velox.

```
== NO RELEASE NOTE ==
```
