### PR TITLE
[native] Disable testUnionAll in presto-on-spark native test

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -44,6 +44,10 @@ public class TestPrestoSparkNativeGeneralQueries
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore
+    public void testUnionAll() {}
+
+    @Override
+    @Ignore
     public void testBucketedExecution() {}
 
     @Override


### PR DESCRIPTION
The test currently failed on `VeloxRuntimeError: type_->kindEquals(vector.type()) Type mismatch: VARCHAR vs. INTEGER`. It's been tracking in [#19665](https://github.com/prestodb/presto/issues/19665)



```
== NO RELEASE NOTE ==
```
