### PR TITLE
[native] Fix tpch connector unit test for presto on spark native

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchConnectorQueries.java
@@ -20,26 +20,29 @@ import org.testng.annotations.Test;
 public abstract class AbstractTestNativeTpchConnectorQueries
         extends AbstractTestQueryFramework
 {
-    private Session tpchStandardTiny()
+    @Override
+    public Session getSession()
     {
-        return Session.builder(getSession()).setCatalog("tpchstandard").setSchema("tiny").build();
+        return Session.builder(super.getSession()).setCatalog("tpchstandard").setSchema("tiny").build();
     }
 
     @Test
-    public void testMissingTpchConnector()
+    public abstract void testMissingTpchConnector();
+
+    protected void testMissingTpchConnector(String expectedErrorMessageRegExp)
     {
         Session session = Session.builder(getSession())
                 .setCatalog("tpch")
                 .setSchema("tiny")
                 .build();
         // No tpch catalog exists in the native worker.
-        assertQueryFails(session, "SELECT * FROM nation", "No nodes available to run query");
+        assertQueryFails(session, "SELECT * FROM nation", expectedErrorMessageRegExp);
     }
 
     @Test
     public void testTpchTinyTables()
     {
-        Session session = tpchStandardTiny();
+        Session session = getSession();
 
         assertQuery(session, "SELECT count(*) FROM customer");
         assertQuery(session, "SELECT count(*) FROM lineitem");
@@ -68,9 +71,7 @@ public abstract class AbstractTestNativeTpchConnectorQueries
     @Test
     public void testTpchDateFilter()
     {
-        Session session = tpchStandardTiny();
-
-        assertQuery(session, "select count(*) as l_count from lineitem where " +
+        assertQuery("select count(*) as l_count from lineitem where " +
                 "l_shipdate >= date '1994-01-01' and l_shipdate < date '1994-01-01' + interval '1' year");
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchConnectorQueries.java
@@ -20,14 +20,22 @@ public class TestPrestoNativeTpchConnectorQueries
         extends AbstractTestNativeTpchConnectorQueries
 {
     @Override
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
     }
 
     @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
     {
         return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    public void testMissingTpchConnector()
+    {
+        super.testMissingTpchConnector("No nodes available to run query");
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager;
 import com.facebook.presto.spark.execution.NativeExecutionModule;
+import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
@@ -101,27 +102,42 @@ public class PrestoSparkNativeQueryRunnerUtils
         return builder.build();
     }
 
-    public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner()
+    public static PrestoSparkQueryRunner createHiveRunner()
     {
-        PrestoSparkQueryRunner queryRunner = createPrestoSparkNativeQueryRunner(
-                Optional.of(getBaseDataPath()),
-                getNativeExecutionSessionConfigs(),
-                getNativeExecutionShuffleConfigs(),
-                ImmutableList.of(new NativeExecutionModule()));
+        PrestoSparkQueryRunner queryRunner = createRunner("hive", new NativeExecutionModule());
         setupJsonFunctionNamespaceManager(queryRunner);
 
-        // Increases log level to reduce log spamming while running test.
-        customizeLogging();
         return queryRunner;
     }
 
-    public static PrestoSparkQueryRunner createPrestoSparkNativeQueryRunner(Optional<Path> baseDir, Map<String, String> additionalConfigProperties, Map<String, String> additionalSparkProperties, ImmutableList<Module> nativeModules)
+    private static PrestoSparkQueryRunner createRunner(String defaultCatalog, NativeExecutionModule nativeExecutionModule)
+    {
+        // Increases log level to reduce log spamming while running test.
+        customizeLogging();
+        return createRunner(
+                defaultCatalog,
+                Optional.of(getBaseDataPath()),
+                getNativeExecutionSessionConfigs(),
+                getNativeExecutionShuffleConfigs(),
+                ImmutableList.of(nativeExecutionModule));
+    }
+
+    // Similar to createPrestoSparkNativeQueryRunner, but with custom connector config and without jsonFunctionNamespaceManager
+    public static PrestoSparkQueryRunner createTpchRunner()
+    {
+        return createRunner(
+                "tpchstandard",
+                new NativeExecutionModule(
+                        Optional.of(new NativeExecutionConnectorConfig().setConnectorName("tpch"))));
+    }
+
+    public static PrestoSparkQueryRunner createRunner(String defaultCatalog, Optional<Path> baseDir, Map<String, String> additionalConfigProperties, Map<String, String> additionalSparkProperties, ImmutableList<Module> nativeModules)
     {
         ImmutableMap.Builder<String, String> configBuilder = ImmutableMap.builder();
         configBuilder.putAll(getNativeWorkerSystemProperties()).putAll(additionalConfigProperties);
 
         PrestoSparkQueryRunner queryRunner = new PrestoSparkQueryRunner(
-                "hive",
+                defaultCatalog,
                 configBuilder.build(),
                 getNativeWorkerHiveProperties(),
                 additionalSparkProperties,

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
@@ -23,7 +23,7 @@ public class TestPrestoSparkNativeAggregations
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
@@ -23,7 +23,7 @@ public class TestPrestoSparkNativeArrayFunctionQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
@@ -23,7 +23,7 @@ public class TestPrestoSparkNativeBitwiseFunctionQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -24,7 +24,7 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
@@ -24,7 +24,7 @@ public class TestPrestoSparkNativeJoinQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -24,7 +24,7 @@ public class TestPrestoSparkNativeSimpleQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark;
 import com.facebook.presto.nativeworker.AbstractTestNativeTpchConnectorQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.testng.annotations.Ignore;
 
 public class TestPrestoSparkNativeTpchConnectorQueries
         extends AbstractTestNativeTpchConnectorQueries
@@ -24,7 +23,7 @@ public class TestPrestoSparkNativeTpchConnectorQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createTpchRunner();
     }
 
     @Override
@@ -41,16 +40,9 @@ public class TestPrestoSparkNativeTpchConnectorQueries
         PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
     }
 
-    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
-    @Ignore
-    public void testMissingTpchConnector() {}
-
-    @Override
-    @Ignore
-    public void testTpchDateFilter() {}
-
-    @Override
-    @Ignore
-    public void testTpchTinyTables() {}
+    public void testMissingTpchConnector()
+    {
+        super.testMissingTpchConnector(".*Catalog tpch does not exist*");
+    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -24,7 +24,7 @@ public class TestPrestoSparkNativeTpchQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
@@ -23,7 +23,7 @@ public class TestPrestoSparkNativeWindowQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createPrestoSparkNativeQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -269,7 +269,8 @@ public class NativeExecutionProcess
         return absolutePath.getAbsolutePath();
     }
 
-    private List<String> getLaunchCommand() throws IOException
+    private List<String> getLaunchCommand()
+            throws IOException
     {
         String executablePath = getProcessWorkingPath(SystemSessionProperties.getNativeExecutionExecutablePath(session));
         String programArgs = SystemSessionProperties.getNativeExecutionProgramArguments(session);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConnectorConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConnectorConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 /**
  * This config class corresponds to catalog/<catalog-name>.properties for native execution process. Properties inside will be used in PrestoServer.cpp
+ * Currently, presto-on-spark native only supports querying 1 catalog in a single spark session.
  */
 public class NativeExecutionConnectorConfig
 {


### PR DESCRIPTION
Register tpchstandard catalog and fix missing connector expected message.
Allow injecting custom NativeExecutionConnectorConfig to NativeExecutionModule 
to override connector name which otherwise defaults to hive.



```
== NO RELEASE NOTE ==
```
