### PR TITLE
[TEST_ONLY] Remove maven cache to fix the disc full issue

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -83,23 +83,10 @@ jobs:
           # Delete static libraries
           rm `find ./ -name lib\*.a` 
 
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
-
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm,!presto-test-coverage'
+          ./mvnw install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
 
       - name: Run e2e tests
         run: |


### PR DESCRIPTION
Fix the out of disc space issue by removing caching for maven. Instead we build all dependents of presto-native-execution every time which only take around 2+ minutes. This will save us some space to avoid the disc full issue.

Test plan -
Make all CI runs are green