### PR TITLE
[native] Migrate presto-native-execution CI to CircleCI [first phase]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,15 @@ workflows:
   dist-compile:
     jobs:
       - linux-build
+      - linux-parquet-S3-build
+      - format-check
+      - header-check
 
 executors:
   build:
     docker:
-      - image : prestocpp/velox-avx-circleci:kpai-20221017
-    resource_class: xlarge
+      - image : prestocpp/prestocpp-avx-centos:kpai-20221018
+    resource_class: 2xlarge
     environment:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
@@ -40,3 +43,81 @@ jobs:
           command: |
             cd presto-native-execution
             make velox-submodule
+      - run:
+          name: Build
+          command: |
+            source /opt/rh/gcc-toolset-9/enable
+            cd presto-native-execution
+            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            ninja -C _build/debug -j 8
+      - run:
+          name: 'Run Unit Tests'
+          command: |
+            cd presto-native-execution/_build/debug
+            ctest -j 8 -VV --output-on-failure --exclude-regex velox.*
+      - run:
+          name: 'Maven Install'
+          command: |
+            export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+            ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
+      - run:
+          name: 'Run e2e tests'
+          command: |
+            export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+            export TEMP_PATH="/tmp"
+            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+
+  linux-parquet-S3-build:
+    executor: build
+    steps:
+      - checkout
+      - run:
+          name: "Update velox submodule"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: "Install S3 adapter dependencies"
+          command: |
+            mkdir -p ${HOME}/adapter-deps/install
+            source /opt/rh/gcc-toolset-9/enable
+            set -xu
+            cd presto-native-execution
+            DEPENDENCY_DIR=${HOME}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./velox/scripts/setup-adapters.sh
+      - run:
+          name: Build
+          command: |
+            source /opt/rh/gcc-toolset-9/enable
+            cd presto-native-execution
+            cmake -B _build/release -GNinja -DAWSSDK_ROOT_DIR=${HOME}/adapter-deps/install -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Release -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            ninja -C _build/release -j 8
+
+  format-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: Check formatting
+          command: |
+            cd presto-native-execution
+            make format-check
+
+  header-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: "Check license headers"
+          command: |
+            cd presto-native-execution
+            make header-check


### PR DESCRIPTION
Migrate presto-native-execution CI to CircleCI from presto-native.yml which is the common runs for all PR trying to get merged into master. We will have a separate one for those native-specific runs including MacOS runs. 

The build time improves quite a lot from 1.5 hours to just 13 minutes. See an example here: https://app.circleci.com/pipelines/github/prestodb/presto/2778/workflows/133a7b10-db26-4473-b1d0-23e15cf743cc/jobs/3533
- build + ut takes around 13 minutes.
- e2e takes 1h12m which is almost the same as github action runs. The reason is we are running test serially so it does take advantage of the powerful runner circle ci provide. We will try to optimize it later after all runs have been migrated.

We change the e2e run to use one mvn command (instead of running each test class in its own command) but the e2e tests still take 1+ hours pretty much the same as github actions. I'd suppose that's because the run in e2e is serial. As we add more test cases, it gets slower and slower. Let's keep it as is for mow and try to optimize it later.

In the mean time, we keep the runs in github action to observe how the circleci run performs compared with existing ones for a couple of days before we can remove the github actions run.

Test plan:
Make sure all circle ci runs are green