### PR TITLE
[native pos] Add virtual dtor to VeloxQueryPlanConverterBase

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -35,6 +35,8 @@ class VeloxQueryPlanConverterBase {
   explicit VeloxQueryPlanConverterBase(velox::memory::MemoryPool* pool)
       : pool_(pool), exprConverter_(pool) {}
 
+  virtual ~VeloxQueryPlanConverterBase() = default;
+
   virtual velox::core::PlanFragment toVeloxQueryPlan(
       const protocol::PlanFragment& fragment,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,


### PR DESCRIPTION
presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h:33:7: error: 'facebook::presto::VeloxQueryPlanConverterBase' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]

```
== NO RELEASE NOTE ==
```
