### PR TITLE
[native pos] Extract plan node creation functions

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -9,6 +9,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_library(presto_operators_plan_builder PlanBuilder.cpp)
+
+target_link_libraries(presto_operators_plan_builder velox_core)
+
 add_executable(presto_operators_test PlanNodeSerdeTest.cpp
                                      UnsafeRowShuffleTest.cpp)
 
@@ -16,6 +20,7 @@ add_test(presto_operators_test presto_operators_test)
 
 target_link_libraries(
   presto_operators_test
+  presto_operators_plan_builder
   presto_operators
   presto_protocol
   presto_type_converter

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/operators/tests/PlanBuilder.h"
+#include "presto_cpp/main/operators/PartitionAndSerialize.h"
+#include "presto_cpp/main/operators/ShuffleRead.h"
+#include "presto_cpp/main/operators/ShuffleWrite.h"
+#include "velox/exec/HashPartitionFunction.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+
+namespace facebook::presto::operators {
+
+std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)>
+addPartitionAndSerializeNode(uint32_t numPartitions) {
+  return [numPartitions](
+             core::PlanNodeId nodeId,
+             core::PlanNodePtr source) -> core::PlanNodePtr {
+    std::vector<core::TypedExprPtr> keys;
+    keys.push_back(
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"));
+    const auto inputType = source->outputType();
+    return std::make_shared<PartitionAndSerializeNode>(
+        nodeId,
+        keys,
+        numPartitions,
+        ROW({"p", "d"}, {INTEGER(), VARBINARY()}),
+        std::move(source),
+        std::make_shared<exec::HashPartitionFunctionSpec>(
+            inputType, exec::toChannels(inputType, keys)));
+  };
+}
+
+std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleReadNode(
+    velox::RowTypePtr& outputType) {
+  return [&outputType](
+             PlanNodeId nodeId, PlanNodePtr /* source */) -> PlanNodePtr {
+    return std::make_shared<ShuffleReadNode>(nodeId, outputType);
+  };
+}
+
+std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleWriteNode(
+    const std::string& shuffleName,
+    const std::string& serializedWriteInfo) {
+  return [&shuffleName, &serializedWriteInfo](
+             PlanNodeId nodeId, PlanNodePtr source) -> PlanNodePtr {
+    return std::make_shared<ShuffleWriteNode>(
+        nodeId, shuffleName, serializedWriteInfo, std::move(source));
+  };
+}
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::presto::operators {
+
+// Helper functions to use with PlanBuilder::addNode.
+
+std::function<
+    velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
+addPartitionAndSerializeNode(uint32_t numPartitions);
+
+std::function<
+    velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
+addShuffleReadNode(velox::RowTypePtr& outputType);
+
+std::function<
+    velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
+addShuffleWriteNode(
+    const std::string& shuffleName,
+    const std::string& serializedWriteInfo);
+
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -13,12 +13,9 @@
  */
 #include <gtest/gtest.h>
 
-#include "presto_cpp/main/operators/PartitionAndSerialize.h"
-#include "presto_cpp/main/operators/ShuffleRead.h"
-#include "presto_cpp/main/operators/ShuffleWrite.h"
+#include "presto_cpp/main/operators/tests/PlanBuilder.h"
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "velox/core/PlanNode.h"
-#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/PartitionFunction.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -57,43 +54,6 @@ class PlanNodeSerdeTest : public testing::Test,
     auto copy =
         velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
     ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
-  }
-
-  auto addPartitionAndSerializeNode(uint32_t numPartitions) {
-    return [numPartitions](
-               core::PlanNodeId nodeId,
-               core::PlanNodePtr source) -> core::PlanNodePtr {
-      const auto outputType = source->outputType();
-      const std::vector<velox::core::TypedExprPtr> keys = {
-          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")};
-      return std::make_shared<PartitionAndSerializeNode>(
-          nodeId,
-          keys,
-          numPartitions,
-          ROW({"p", "d"}, {INTEGER(), VARBINARY()}),
-          std::move(source),
-          std::make_shared<HashPartitionFunctionSpec>(
-              outputType, std::vector<column_index_t>{0}));
-    };
-  }
-
-  auto addShuffleReadNode(velox::RowTypePtr& outputType) {
-    return [&outputType](
-               core::PlanNodeId nodeId,
-               core::PlanNodePtr /* source */) -> core::PlanNodePtr {
-      return std::make_shared<ShuffleReadNode>(nodeId, outputType);
-    };
-  }
-
-  auto addShuffleWriteNode(
-      const std::string& shuffleName,
-      const std::string& serializedWriteInfo) {
-    return [&shuffleName, &serializedWriteInfo](
-               core::PlanNodeId nodeId,
-               core::PlanNodePtr source) -> core::PlanNodePtr {
-      return std::make_shared<ShuffleWriteNode>(
-          nodeId, shuffleName, serializedWriteInfo, std::move(source));
-    };
   }
 
   std::vector<RowVectorPtr> data_;


### PR DESCRIPTION
Functions to add PartitionAndSerialize, ShuffleRead and ShuffleWrite plan nodes used to be duplicated in multiple tests. This change is to extract these into a shared PlanBuilder.h.

```
== NO RELEASE NOTE ==
```
