### PR TITLE
[native] Fix PartitionedOutput to PartitionAndSerialize node translation

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -77,9 +77,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testTopN() {}
-
-    // This test is flaky: https://github.com/prestodb/presto/issues/19665
-    @Override
-    @Ignore
-    public void testUnionAll() {}
 }


### PR DESCRIPTION
When we add extra projection to re-order the columns during PartitionedOutput to PartitionAndSerialize node translation, we also need to update the order of the partition keys accordingly in the PartitionFunctionSpec.

This PR will fix issue[#19665](https://github.com/prestodb/presto/issues/19665)

```
== NO RELEASE NOTE ==
```
