### PR TITLE
[native]Fix ws file destruction issue and improve presto server logging

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -95,6 +95,9 @@ class PrestoServer {
   virtual std::vector<std::string> registerConnectors(
       const fs::path& configDirectoryPath);
 
+  /// Invoked by presto shutdown procedure to unregister connectors.
+  virtual void unregisterConnectors();
+
   virtual void registerShuffleInterfaceFactories();
 
   virtual void registerCustomOperators();


### PR DESCRIPTION
- Add to unregister connectors on shutdown to avoid the presto server
   crashes on shutdown caused by the destruction order.
- Add macro to simplify presto server startup and shutdown logging

```
== NO RELEASE NOTE ==
```
