### PR TITLE
[native pos] Check splits for batch tasks

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -140,6 +140,7 @@ class PrestoServer {
 
   std::unique_ptr<http::HttpServer> httpServer_;
   std::unique_ptr<SignalHandler> signalHandler_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<TaskManager> taskManager_;
   std::unique_ptr<TaskResource> taskResource_;
   std::atomic<NodeState> nodeState_{NodeState::ACTIVE};

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -57,14 +57,13 @@ class TaskManager {
 
   std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
       const protocol::TaskId& taskId,
-      velox::core::PlanFragment planFragment,
-      const std::vector<protocol::TaskSource>& sources,
-      const protocol::OutputBuffers& outputBuffers,
-      std::unordered_map<std::string, std::string>&& configStrings,
-      std::unordered_map<
-          std::string,
-          std::unordered_map<std::string, std::string>>&&
-          connectorConfigStrings);
+      const protocol::TaskUpdateRequest& updateRequest,
+      const velox::core::PlanFragment& planFragment);
+
+  std::unique_ptr<protocol::TaskInfo> createOrUpdateBatchTask(
+      const protocol::TaskId& taskId,
+      const protocol::BatchTaskUpdateRequest& batchUpdateRequest,
+      const velox::core::PlanFragment& planFragment);
 
   // Iterates through a map of resultRequests and fetches data from
   // buffer manager. This method uses the getData() global call to fetch
@@ -148,6 +147,17 @@ class TaskManager {
   static constexpr folly::StringPiece kSessionTimezone{"session_timezone"};
 
  private:
+  std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
+      const protocol::TaskId& taskId,
+      const velox::core::PlanFragment& planFragment,
+      const std::vector<protocol::TaskSource>& sources,
+      const protocol::OutputBuffers& outputBuffers,
+      std::unordered_map<std::string, std::string>&& configStrings,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::string>>&&
+          connectorConfigStrings);
+
   std::shared_ptr<PrestoTask> findOrCreateTask(const protocol::TaskId& taskId);
 
   std::shared_ptr<PrestoTask> findOrCreateTaskLocked(

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/PrestoTask.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
@@ -37,10 +38,11 @@ TEST_F(PrestoTaskTest, basicTaskId) {
 }
 
 TEST_F(PrestoTaskTest, malformedTaskId) {
-  ASSERT_THROW(PrestoTaskId(""), std::invalid_argument);
-  ASSERT_THROW(
-      PrestoTaskId("20201107_130540_00011_wrpkw."), std::invalid_argument);
-  ASSERT_THROW(PrestoTaskId("q.1.2"), std::invalid_argument);
+  VELOX_ASSERT_THROW(PrestoTaskId(""), "Malformed task ID: ");
+  VELOX_ASSERT_THROW(
+      PrestoTaskId("20201107_130540_00011_wrpkw."),
+      "Malformed task ID: 20201107_130540_00011_wrpkw.");
+  VELOX_ASSERT_THROW(PrestoTaskId("q.1.2"), "Malformed task ID: q.1.2");
 }
 
 TEST_F(PrestoTaskTest, runtimeMetricConversion) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -14,6 +14,7 @@
 #pragma once
 #include <folly/Conv.h>
 #include <string>
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto {
 class PrestoTaskId {
@@ -55,7 +56,7 @@ class PrestoTaskId {
   int nextDot(const std::string& taskId, int start) {
     auto pos = taskId.find(".", start);
     if (pos == std::string::npos) {
-      throw std::invalid_argument("Malformed task ID: " + taskId);
+      VELOX_USER_FAIL("Malformed task ID: {}", taskId);
     }
     return pos;
   }


### PR DESCRIPTION
Presto-on-Spark is expected to specify all splits at once along with
no-more-splits flag. Verify that all plan nodes that require splits have
received splits and no-more-splits flag. This check helps prevent hard-to-debug
query hangs caused by Velox Task waiting for splits that never arrive.

```
== NO RELEASE NOTE ==
```
