### PR TITLE
[native pos] Implement replicate-null-and-any in PartitionAndSerializeOperator

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
   velox_exec
   velox_memory
   velox_exec
+  gmock
   gtest
   ${ANTLR4_RUNTIME}
   gtest_main)

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -25,8 +25,9 @@ namespace facebook::presto::operators {
 std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)>
 addPartitionAndSerializeNode(
     uint32_t numPartitions,
+    bool replicateNullsAndAny,
     const std::vector<std::string>& serializedColumns) {
-  return [numPartitions, &serializedColumns](
+  return [numPartitions, &serializedColumns, replicateNullsAndAny](
              core::PlanNodeId nodeId,
              core::PlanNodePtr source) -> core::PlanNodePtr {
     std::vector<core::TypedExprPtr> keys{
@@ -49,6 +50,7 @@ addPartitionAndSerializeNode(
         numPartitions,
         serializedType,
         std::move(source),
+        replicateNullsAndAny,
         std::make_shared<exec::HashPartitionFunctionSpec>(
             inputType, exec::toChannels(inputType, keys)));
   };

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -21,8 +21,10 @@ namespace facebook::presto::operators {
 
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
+
 addPartitionAndSerializeNode(
     uint32_t numPartitions,
+    bool replicateNullsAndAny,
     const std::vector<std::string>& serializedColumns = {});
 
 std::function<

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -70,7 +70,7 @@ TEST_F(PlanNodeSerdeTest, partitionAndSerializeNode) {
   auto plan = exec::test::PlanBuilder()
                   .values(data_, true)
                   .addNode(addPartitionAndSerializeNode(
-                      4, reverseColumns(asRowType(data_[0]->type()))))
+                      4, false, reverseColumns(asRowType(data_[0]->type()))))
                   .localPartition({})
                   .planNode();
   testSerde(plan);
@@ -96,7 +96,7 @@ TEST_F(PlanNodeSerdeTest, shuffleWriteNode) {
       fmt::format(kTestShuffleInfoFormat, numPartitions, 1 << 20);
   auto plan = exec::test::PlanBuilder()
                   .values(data_, true)
-                  .addNode(addPartitionAndSerializeNode(numPartitions))
+                  .addNode(addPartitionAndSerializeNode(numPartitions, false))
                   .localPartition({})
                   .addNode(addShuffleWriteNode(shuffleName, shuffleInfo))
                   .planNode();

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2179,10 +2179,6 @@ velox::core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
       !partitionedOutputNode->isBroadcast(),
       "Broadcast shuffle is not supported");
 
-  VELOX_USER_CHECK(
-      !partitionedOutputNode->isReplicateNullsAndAny(),
-      "Replicate-nulls-and-any shuffle mode is not supported.");
-
   // If the serializedShuffleWriteInfo is not nullptr, it means this fragment
   // ends with a shuffle stage. We convert the PartitionedOutputNode to a
   // chain of following nodes:
@@ -2206,6 +2202,7 @@ velox::core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
           partitionedOutputNode->numPartitions(),
           partitionedOutputNode->outputType(),
           partitionedOutputNode->sources()[0],
+          partitionedOutputNode->isReplicateNullsAndAny(),
           partitionedOutputNode->partitionFunctionSpecPtr());
 
   planFragment.planNode = std::make_shared<operators::ShuffleWriteNode>(

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -69,10 +69,6 @@ public class TestPrestoSparkNativeTpchQueries
 
     @Override
     @Ignore
-    public void testTpchQ20() {}
-
-    @Override
-    @Ignore
     public void testTpchQ21() {}
 
     @Override


### PR DESCRIPTION
Implement replicate-null-and-any in PartitionAndSerializeOperator.

This unblocks a number of join queries from running on native presto-on-spark.

I will share a new PR with better memory handling on null skewed join.
```
== NO RELEASE NOTE ==
```
