### PR TITLE
[native] Adding BaseVeloxQueryConfig.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -139,6 +139,8 @@ void PrestoServer::run() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
+    // Create velox query config after we initialized system config.
+    BaseVeloxQueryConfig::instance();
 
     httpPort = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -38,6 +38,10 @@ class PrestoServerOperations {
   static std::string systemConfigOperation(
       const ServerOperation& op,
       proxygen::HTTPMessage* message);
+
+  static std::string veloxQueryConfigOperation(
+      const ServerOperation& op,
+      proxygen::HTTPMessage* message);
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -36,12 +36,14 @@ const folly::F14FastMap<std::string, ServerOperation::Target>
     ServerOperation::kTargetLookup{
         {"connector", ServerOperation::Target::kConnector},
         {"systemConfig", ServerOperation::Target::kSystemConfig},
+        {"veloxQueryConfig", ServerOperation::Target::kVeloxQueryConfig},
     };
 
 const folly::F14FastMap<ServerOperation::Target, std::string>
     ServerOperation::kReverseTargetLookup{
         {ServerOperation::Target::kConnector, "connector"},
         {ServerOperation::Target::kSystemConfig, "systemConfig"},
+        {ServerOperation::Target::kVeloxQueryConfig, "veloxQueryConfig"},
     };
 
 ServerOperation::Target ServerOperation::targetFromString(

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -24,6 +24,7 @@ struct ServerOperation {
   enum class Target {
     kConnector,
     kSystemConfig,
+    kVeloxQueryConfig,
   };
 
   /// The action this operation is trying to take

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -260,8 +260,12 @@ void TaskManager::getDataForResultRequests(
 namespace {
 std::unordered_map<std::string, std::string> toConfigs(
     const protocol::SessionRepresentation& session) {
-  auto configs = std::unordered_map<std::string, std::string>(
-      session.systemProperties.begin(), session.systemProperties.end());
+  // Use base velox query config as the starting point and add Presto session
+  // properties on top of it.
+  auto configs = BaseVeloxQueryConfig::instance()->values();
+  for (const auto& it : session.systemProperties) {
+    configs[it.first] = it.second;
+  }
 
   // If there's a timeZoneKey, convert to timezone name and add to the
   // configs. Throws if timeZoneKey can't be resolved.

--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "presto_cpp/main/common/Configs.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/QueryConfig.h"
+
+namespace facebook::presto::test {
+
+using namespace velox;
+
+class BaseVeloxQueryConfigTest : public testing::Test {
+ protected:
+  void setUpSystemConfig(bool isMutable) {
+    std::unordered_map<std::string, std::string> properties;
+    if (isMutable) {
+      properties[std::string{SystemConfig::kMutableConfig}] = "true";
+    }
+
+    SystemConfig::instance()->initialize(
+        std::make_unique<core::MemConfig>(std::move(properties)));
+
+    propName = std::string{core::QueryConfig::kSessionTimezone};
+  }
+
+  std::string propName;
+};
+
+TEST_F(BaseVeloxQueryConfigTest, defaultConfig) {
+  setUpSystemConfig(false);
+  auto cfg = std::make_unique<BaseVeloxQueryConfig>();
+
+  ASSERT_FALSE(cfg->isMutable());
+  ASSERT_FALSE(cfg->getValue(propName).has_value());
+  ASSERT_THROW(cfg->setValue(propName, "TZ1"), VeloxException);
+}
+
+TEST_F(BaseVeloxQueryConfigTest, mutableConfig) {
+  setUpSystemConfig(true);
+  auto cfg = std::make_unique<BaseVeloxQueryConfig>();
+
+  ASSERT_TRUE(cfg->isMutable());
+  ASSERT_FALSE(cfg->getValue(propName).has_value());
+  auto ret = cfg->setValue(propName, "TZ1");
+  ASSERT_EQ(folly::Optional<std::string>{}, ret);
+  ASSERT_EQ(folly::Optional<std::string>{"TZ1"}, ret = cfg->getValue(propName));
+}
+
+} // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -9,7 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(presto_common_test CommonTest.cpp SystemConfigTest.cpp)
+add_executable(presto_common_test CommonTest.cpp SystemConfigTest.cpp
+        BaseVeloxQueryConfigTest.cpp)
 
 add_test(presto_common_test presto_common_test)
 


### PR DESCRIPTION
This allows to use "v1/operation" end point to change default values of
Velox's QueryConfig.
```
curl "127.0.0.1:7777/v1/operation/veloxQueryConfig/setProperty?name=preferred_output_batch_bytes&value=1024"
curl "127.0.0.1:7777/v1/operation/veloxQueryConfig/getProperty?name=preferred_output_batch_bytes"
```

Test plan - New test. Local mac runs.

```
== NO RELEASE NOTE ==
```
