### PR TITLE
Log average bootstrap time for presto on spark executors in millisecond

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -27,6 +27,7 @@ import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -124,8 +125,10 @@ public class PrestoSparkInjectorFactory
         this.isForTesting = isForTesting;
     }
 
-    public Injector create()
+    public Injector create(PrestoSparkBootstrapTimer bootstrapTimer)
     {
+        bootstrapTimer.beginInjectorCreation();
+
         // TODO: migrate docker containers to a newer JVM, then re-enable it
         // verifyJvmRequirements();
         verifySystemTimeIsReasonable();
@@ -169,15 +172,20 @@ public class PrestoSparkInjectorFactory
 
         app.setRequiredConfigurationProperties(ImmutableMap.copyOf(requiredProperties));
 
+        bootstrapTimer.beginInjectorInitialization();
         Injector injector = app.initialize();
+        bootstrapTimer.endInjectorInitialization();
 
         try {
+            bootstrapTimer.beginSharedModulesLoading();
             injector.getInstance(PluginManager.class).loadPlugins();
             injector.getInstance(StaticCatalogStore.class).loadCatalogs(catalogProperties);
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             eventListenerProperties.ifPresent(properties -> injector.getInstance(EventListenerManager.class).loadConfiguredEventListener(properties));
+            bootstrapTimer.endSharedModulesLoading();
 
+            bootstrapTimer.beginNonTestingModulesLoading();
             if (!isForTesting) {
                 if (accessControlProperties.isPresent()) {
                     injector.getInstance(AccessControlManager.class).loadSystemAccessControl(accessControlProperties.get());
@@ -193,7 +201,9 @@ public class PrestoSparkInjectorFactory
                     injector.getInstance(TempStorageManager.class).loadTempStorages();
                 }
             }
+            bootstrapTimer.endNonTestingModulesLoading();
 
+            bootstrapTimer.beginDriverModulesLoading();
             if ((sparkProcessType.equals(DRIVER))) {
                 if (sessionPropertyConfigurationProperties.isPresent()) {
                     injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager(sessionPropertyConfigurationProperties.get());
@@ -212,11 +222,12 @@ public class PrestoSparkInjectorFactory
                     injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
                 }
             }
+            bootstrapTimer.endDriverModulesLoading();
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
-
+        bootstrapTimer.endInjectorCreation();
         return injector;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -526,7 +526,8 @@ public class PrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            Optional<RetryExecutionStrategy> retryExecutionStrategy)
+            Optional<RetryExecutionStrategy> retryExecutionStrategy,
+            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
     {
         PrestoSparkConfInitializer.checkInitialized(sparkContext);
 
@@ -694,7 +695,8 @@ public class PrestoSparkQueryExecutionFactory
                             planFragmenter,
                             metadata,
                             partitioningProviderManager,
-                            historyBasedPlanStatisticsTracker);
+                            historyBasedPlanStatisticsTracker,
+                            bootstrapMetricsCollector);
                 }
                 else {
                     return new PrestoSparkAdaptiveQueryExecution(
@@ -732,7 +734,8 @@ public class PrestoSparkQueryExecutionFactory
                             planFragmenter,
                             metadata,
                             partitioningProviderManager,
-                            historyBasedPlanStatisticsTracker);
+                            historyBasedPlanStatisticsTracker,
+                            bootstrapMetricsCollector);
                 }
             }
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -157,7 +157,8 @@ public class PrestoSparkAdaptiveQueryExecution
             PrestoSparkPlanFragmenter planFragmenter,
             Metadata metadata,
             PartitioningProviderManager partitioningProviderManager,
-            HistoryBasedPlanStatisticsTracker historyBasedPlanStatisticsTracker)
+            HistoryBasedPlanStatisticsTracker historyBasedPlanStatisticsTracker,
+            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
     {
         super(
                 sparkContext,
@@ -194,7 +195,8 @@ public class PrestoSparkAdaptiveQueryExecution
                 planFragmenter,
                 metadata,
                 partitioningProviderManager,
-                historyBasedPlanStatisticsTracker);
+                historyBasedPlanStatisticsTracker,
+                bootstrapMetricsCollector);
 
         this.iterativePlanFragmenter = createIterativePlanFragmenter();
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
@@ -113,7 +113,8 @@ public class PrestoSparkStaticQueryExecution
             PrestoSparkPlanFragmenter planFragmenter,
             Metadata metadata,
             PartitioningProviderManager partitioningProviderManager,
-            HistoryBasedPlanStatisticsTracker historyBasedPlanStatisticsTracker)
+            HistoryBasedPlanStatisticsTracker historyBasedPlanStatisticsTracker,
+            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
     {
         super(
                 sparkContext,
@@ -150,7 +151,8 @@ public class PrestoSparkStaticQueryExecution
                 planFragmenter,
                 metadata,
                 partitioningProviderManager,
-                historyBasedPlanStatisticsTracker);
+                historyBasedPlanStatisticsTracker,
+                bootstrapMetricsCollector);
     }
 
     @Override

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -47,6 +47,7 @@ import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecutionFactory;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutorFactory;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkConfInitializer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFailure;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
@@ -115,6 +116,7 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.base.Ticker.systemTicker;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -302,7 +304,7 @@ public class PrestoSparkQueryRunner
                 moduleBuilder.build(),
                 true);
 
-        Injector injector = injectorFactory.create();
+        Injector injector = injectorFactory.create(new PrestoSparkBootstrapTimer(systemTicker(), false));
 
         defaultSession = testSessionBuilder(injector.getInstance(SessionPropertyManager.class))
                 .setCatalog(defaultCatalog)
@@ -573,7 +575,8 @@ public class PrestoSparkQueryRunner
                 new TestingPrestoSparkTaskExecutorFactoryProvider(instanceId),
                 Optional.empty(),
                 Optional.empty(),
-                retryExecutionStrategy);
+                retryExecutionStrategy,
+                Optional.empty());
         return execution;
     }
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -23,6 +23,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.spark.classloader_interface;
 
 import org.apache.spark.SparkContext;
+import org.apache.spark.util.CollectionAccumulator;
 
+import java.util.Map;
 import java.util.Optional;
 
 public interface IPrestoSparkQueryExecutionFactory
@@ -30,5 +32,6 @@ public interface IPrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            Optional<RetryExecutionStrategy> retryExecutionStrategy);
+            Optional<RetryExecutionStrategy> retryExecutionStrategy,
+            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector);
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkServiceFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkServiceFactory.java
@@ -15,5 +15,5 @@ package com.facebook.presto.spark.classloader_interface;
 
 public interface IPrestoSparkServiceFactory
 {
-    IPrestoSparkService createService(SparkProcessType sparkProcessType, PrestoSparkConfiguration configuration);
+    IPrestoSparkService createService(SparkProcessType sparkProcessType, PrestoSparkConfiguration configuration, PrestoSparkBootstrapTimer timer);
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkBootstrapTimer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkBootstrapTimer.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import com.google.common.base.Ticker;
+import io.airlift.units.Duration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.units.Duration.succinctNanos;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkBootstrapTimer
+{
+    private final Ticker ticker;
+    private final boolean isExecutor;
+
+    private final AtomicReference<Long> beginRunnerServiceCreation = new AtomicReference<>();
+    private final AtomicReference<Duration> endRunnerServiceCreation = new AtomicReference<>();
+    private final AtomicReference<Long> beginPrestoSparkServiceCreation = new AtomicReference<>();
+    private final AtomicReference<Duration> endPrestoSparkServiceCreation = new AtomicReference<>();
+    private final AtomicReference<Long> beginInjectorCreation = new AtomicReference<>();
+    private final AtomicReference<Duration> endInjectorCreation = new AtomicReference<>();
+    private final AtomicReference<Long> beginInjectorInitialization = new AtomicReference<>();
+    private final AtomicReference<Duration> endInjectorInitialization = new AtomicReference<>();
+    private final AtomicReference<Long> beginSharedModulesLoading = new AtomicReference<>();
+    private final AtomicReference<Duration> endSharedModulesLoading = new AtomicReference<>();
+    private final AtomicReference<Long> beginNonTestingModulesLoading = new AtomicReference<>();
+    private final AtomicReference<Duration> endNonTestingModulesLoading = new AtomicReference<>();
+    private final AtomicReference<Long> beginDriverModulesLoading = new AtomicReference<>();
+    private final AtomicReference<Duration> endDriverModulesLoading = new AtomicReference<>();
+
+    public PrestoSparkBootstrapTimer(Ticker ticker, boolean isExecutor)
+    {
+        this.ticker = requireNonNull(ticker, "PrestoSparkBootstrapTimer ticker is null");
+        this.isExecutor = isExecutor;
+    }
+
+    public Map<String, Long> exportBootstrapDurations()
+    {
+        Map<String, Long> output = new HashMap<>();
+        output.put("RunnerServiceCreationDurationMS",
+                (endRunnerServiceCreation.get() != null) ? endRunnerServiceCreation.get().toMillis() : 0);
+        output.put("PrestoSparkServiceCreationDurationMS",
+                (endPrestoSparkServiceCreation.get() != null) ? endPrestoSparkServiceCreation.get().toMillis() : 0);
+        output.put("RunnerServiceCreationDurationMS",
+                (endRunnerServiceCreation.get() != null) ? endRunnerServiceCreation.get().toMillis() : 0);
+        output.put("InjectorCreationDurationMS",
+                (endInjectorCreation.get() != null) ? endInjectorCreation.get().toMillis() : 0);
+        output.put("InjectorInitializationDurationMS",
+                (endInjectorInitialization.get() != null) ? endInjectorCreation.get().toMillis() : 0);
+        output.put("InjectorInitializationDurationMS",
+                (endInjectorInitialization.get() != null) ? endInjectorCreation.get().toMillis() : 0);
+        output.put("SharedModulesLoadingDurationMS",
+                (endSharedModulesLoading.get() != null) ? endSharedModulesLoading.get().toMillis() : 0);
+        output.put("NonTestingModulesLoadingDurationMS",
+                (endNonTestingModulesLoading.get() != null) ? endNonTestingModulesLoading.get().toMillis() : 0);
+        output.put("DriverModulesLoadingDurationMS",
+                (endDriverModulesLoading.get() != null) ? endDriverModulesLoading.get().toMillis() : 0);
+        return output;
+    }
+
+    public boolean isExecutorBootstrap()
+    {
+        return isExecutor;
+    }
+
+    private static Duration nanosSince(AtomicReference<Long> start, long end)
+    {
+        Long startNanos = start.get();
+        if (startNanos == null) {
+            throw new IllegalStateException("Start time not set");
+        }
+        return nanosSince(startNanos, end);
+    }
+
+    private static Duration nanosSince(long start, long now)
+    {
+        return succinctNanos(max(0, now - start));
+    }
+
+    // Runner
+    public void beginRunnerServiceCreation()
+    {
+        beginRunnerServiceCreation.compareAndSet(null, ticker.read());
+    }
+
+    public void endRunnerServiceCreation()
+    {
+        endRunnerServiceCreation.compareAndSet(null, nanosSince(beginRunnerServiceCreation, ticker.read()));
+    }
+
+    public void beginPrestoSparkServiceCreation()
+    {
+        beginPrestoSparkServiceCreation.compareAndSet(null, ticker.read());
+    }
+
+    public void endPrestoSparkServiceCreation()
+    {
+        endPrestoSparkServiceCreation.compareAndSet(null, nanosSince(beginPrestoSparkServiceCreation, ticker.read()));
+    }
+
+    public void beginInjectorCreation()
+    {
+        beginInjectorCreation.compareAndSet(null, ticker.read());
+    }
+
+    public void endInjectorCreation()
+    {
+        endInjectorCreation.compareAndSet(null, nanosSince(beginInjectorCreation, ticker.read()));
+    }
+
+    public void beginInjectorInitialization()
+    {
+        beginInjectorInitialization.compareAndSet(null, ticker.read());
+    }
+
+    public void endInjectorInitialization()
+    {
+        endInjectorInitialization.compareAndSet(null, nanosSince(beginInjectorInitialization, ticker.read()));
+    }
+
+    public void beginSharedModulesLoading()
+    {
+        beginSharedModulesLoading.compareAndSet(null, ticker.read());
+    }
+
+    public void endSharedModulesLoading()
+    {
+        endSharedModulesLoading.compareAndSet(null, nanosSince(beginSharedModulesLoading, ticker.read()));
+    }
+
+    public void beginNonTestingModulesLoading()
+    {
+        beginNonTestingModulesLoading.compareAndSet(null, ticker.read());
+    }
+
+    public void endNonTestingModulesLoading()
+    {
+        endNonTestingModulesLoading.compareAndSet(null, nanosSince(beginNonTestingModulesLoading, ticker.read()));
+    }
+
+    public void beginDriverModulesLoading()
+    {
+        beginDriverModulesLoading.compareAndSet(null, ticker.read());
+    }
+
+    public void endDriverModulesLoading()
+    {
+        endDriverModulesLoading.compareAndSet(null, nanosSince(beginDriverModulesLoading, ticker.read()));
+    }
+}


### PR DESCRIPTION
## Log average bootstrap time for presto on spark executor in millisecond

Track the Presto on Spark executors bootstrap duration for latency analysis breakdown.  
* New timer class is being added to record bootstrap module start and end time with durations and collected by Spark Accumulator.
* Break bootstrap steps into mainly 5 segments 
* Calculate average duration after query complete and print out along with results

Test plan: 
* End to end example query run
```
Average executor bootstrap durations in milliseconds:
DriverModulesLoadingDurationMS: 0.0
SharedModulesLoadingDurationMS: 14757.0
PrestoSparkServiceCreationDurationMS: 21532.0
InjectorCreationDurationMS: 21502.0
InjectorInitializationDurationMS: 21502.0
NonTestingModulesLoadingDurationMS: 1408.0
RunnerServiceCreationDurationMS: 21641.0
```


```
== NO RELEASE NOTE ==
```
