### PR TITLE
[native] Enable native-specific Circle CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,114 +10,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 version: 2.1
+
+setup: true
+
+orbs:
+  path-filtering: circleci/path-filtering@0.1.5
+
 workflows:
-  version: 2
-  dist-compile:
+  always-run:
     jobs:
-      - linux-build
-      - linux-parquet-S3-build
-      - format-check
-      - header-check
-
-executors:
-  build:
-    docker:
-      - image: prestocpp/prestocpp-avx-centos:kpai-20221018
-    resource_class: 2xlarge
-    environment:
-      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
-      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
-      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
-      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
-  check:
-    docker:
-      - image: prestocpp/velox-check:mikesh-20210609
-
-jobs:
-  linux-build:
-    executor: build
-    steps:
-      - checkout
-      - run:
-          name: "Update velox"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
-      - run:
-          name: Build
-          command: |
-            source /opt/rh/gcc-toolset-9/enable
-            cd presto-native-execution
-            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DPRESTO_ENABLE_PARQUET=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ninja -C _build/debug -j 8
-      - run:
-          name: 'Run Unit Tests'
-          command: |
-            cd presto-native-execution/_build/debug
-            ctest -j 8 -VV --output-on-failure --exclude-regex velox.*
-      - run:
-          name: 'Maven Install'
-          command: |
-            export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-            ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
-      - run:
-          name: 'Run e2e tests'
-          command: |
-            export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
-            export TEMP_PATH="/tmp"
-            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
-
-  linux-parquet-S3-build:
-    executor: build
-    steps:
-      - checkout
-      - run:
-          name: "Update velox submodule"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
-      - run:
-          name: "Install S3 adapter dependencies"
-          command: |
-            mkdir -p ${HOME}/adapter-deps/install
-            source /opt/rh/gcc-toolset-9/enable
-            set -xu
-            cd presto-native-execution
-            DEPENDENCY_DIR=${HOME}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./velox/scripts/setup-adapters.sh
-      - run:
-          name: Build
-          command: |
-            source /opt/rh/gcc-toolset-9/enable
-            cd presto-native-execution
-            cmake -B _build/release -GNinja -DAWSSDK_ROOT_DIR=${HOME}/adapter-deps/install -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Release -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ninja -C _build/release -j 8
-
-  format-check:
-    executor: check
-    steps:
-      - checkout
-      - run:
-          name: "Update velox"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
-      - run:
-          name: Check formatting
-          command: |
-            cd presto-native-execution
-            make format-check
-
-  header-check:
-    executor: check
-    steps:
-      - checkout
-      - run:
-          name: "Update velox"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
-      - run:
-          name: "Check license headers"
-          command: |
-            cd presto-native-execution
-            make header-check
+      - path-filtering/filter:
+          name: check-updated-files
+          # 3-column, whitespace-delimited mapping. One mapping per line
+          # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
+          mapping: |
+            presto-native-execution/.* run_native_specific_jobs true
+          base-revision: master
+          config-path: .circleci/continue_config.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,133 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+version: 2.1
+
+parameters:
+  run_native_specific_jobs:
+    type: boolean
+    default: false
+
+workflows:
+  version: 2
+  dist-compile:
+    jobs:
+      - linux-build
+
+  conditionals:
+    when: << pipeline.parameters.run_native_specific_jobs >>
+    jobs:
+      - format-check
+      - header-check
+      - linux-parquet-S3-build
+
+executors:
+  build:
+    docker:
+      - image: prestocpp/prestocpp-avx-centos:kpai-20221018
+    resource_class: 2xlarge
+    environment:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+  check:
+    docker:
+      - image: prestocpp/velox-check:mikesh-20210609
+
+jobs:
+  linux-build:
+    executor: build
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: Build
+          command: |
+            source /opt/rh/gcc-toolset-9/enable
+            cd presto-native-execution
+            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DPRESTO_ENABLE_PARQUET=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            ninja -C _build/debug -j 8
+      - run:
+          name: 'Run Unit Tests'
+          command: |
+            cd presto-native-execution/_build/debug
+            ctest -j 8 -VV --output-on-failure --exclude-regex velox.*
+      - run:
+          name: 'Maven Install'
+          command: |
+            export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+            ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
+      - run:
+          name: 'Run e2e tests'
+          command: |
+            export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+            export TEMP_PATH="/tmp"
+            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+
+  linux-parquet-S3-build:
+    executor: build
+    steps:
+      - checkout
+      - run:
+          name: "Update velox submodule"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: "Install S3 adapter dependencies"
+          command: |
+            mkdir -p ${HOME}/adapter-deps/install
+            source /opt/rh/gcc-toolset-9/enable
+            set -xu
+            cd presto-native-execution
+            DEPENDENCY_DIR=${HOME}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./velox/scripts/setup-adapters.sh
+      - run:
+          name: Build
+          command: |
+            source /opt/rh/gcc-toolset-9/enable
+            cd presto-native-execution
+            cmake -B _build/release -GNinja -DAWSSDK_ROOT_DIR=${HOME}/adapter-deps/install -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Release -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            ninja -C _build/release -j 8
+
+  format-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: Check formatting
+          command: |
+            cd presto-native-execution
+            make format-check
+
+  header-check:
+    executor: check
+    steps:
+      - checkout
+      - run:
+          name: "Update velox"
+          command: |
+            cd presto-native-execution
+            make velox-submodule
+      - run:
+          name: "Check license headers"
+          command: |
+            cd presto-native-execution
+            make header-check


### PR DESCRIPTION
Run some circle ci jobs only for native-specific PRs which include:
* format check
* header check
* parquet S3 build
Those runs (including macos runs which will be added later) are not necessary for Java changes.

Test plan - Make sure all circle ci runs are green

```
== NO RELEASE NOTE ==
```
