### PR TITLE
[native] Refactor rest of periodic manager.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -72,10 +72,19 @@ class PeriodicTaskManager {
 
  private:
   void addExecutorStatsTask();
+  void updateExecutorStats();
+
   void addTaskStatsTask();
+  void updateTaskStats();
+
   void addTaskCleanupTask();
+  void updateTaskCleanUp();
+
   void addMemoryAllocatorStatsTask();
+  void updateMemoryAllocatorStats();
+
   void addPrestoExchangeSourceMemoryStatsTask();
+  void updatePrestoExchangeSourceMemoryStats();
 
   void addCacheStatsUpdateTask();
   void updateCacheStats();


### PR DESCRIPTION
PeriodicManager schedules tasks to collect counters over a specific interval. Current design puts a lamdba function for such work which often gets bigger and also requires capturing private variable. We want to have a update function that will allow to encapsulate the update tasks. We have done two such changes already (https://github.com/prestodb/presto/pull/19694 and https://github.com/prestodb/presto/pull/19674). This PR converts all such lambda functions into update tasks.

```
== NO RELEASE NOTE ==
```
