### PR TITLE
Fix bug with handling projections in payload join optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -276,7 +276,7 @@ public class PayloadJoinOptimizer
 
             PlanNode newChild = context.rewrite(child, context.get());
 
-            if (child.equals(newChild) || !context.get().needsPayloadRejoin()) {
+            if (child.equals(newChild)) {
                 return projectNode;
             }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1241,7 +1241,7 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT l.* FROM (select rand(100) as pk100 from (select orderkey+1 as ok1, * from lineitem_map) l left join orders o on (l.ok1 = o.orderkey+1)) l left join part p on (l.pk100=p.partkey)",
                 "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
                 "SELECT l.*, p.m3, p.m4 FROM (select * from lineitem_map where false) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select * from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)"
+                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)"
         };
 
         for (String query : nonOptimizableQueries) {
@@ -1284,6 +1284,6 @@ public abstract class AbstractTestDistributedQueries
 
     private String sanitizePlan(String explain)
     {
-        return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX");
+        return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX").replaceAll("Values => .*\n", "\n");
     }
 }


### PR DESCRIPTION
When visiting a project node, check if the child node was changed from the transformation. The check was incorrect and was missing cases where the payload was already reattached in the child project node.