### PR TITLE
Skip runtime stats from running task info

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -132,4 +132,6 @@ protocol::RuntimeMetric toRuntimeMetric(
     const std::string& name,
     const facebook::velox::RuntimeMetric& metric);
 
+bool isFinalState(protocol::TaskState state);
+
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -66,18 +66,6 @@ static void maybeSetupTaskSpillDirectory(
   }
 }
 
-bool isFinalState(protocol::TaskState state) {
-  switch (state) {
-    case protocol::TaskState::FINISHED:
-    case protocol::TaskState::FAILED:
-    case protocol::TaskState::ABORTED:
-    case protocol::TaskState::CANCELED:
-      return true;
-    default:
-      return false;
-  }
-}
-
 // Keep outstanding Promises in RequestHandler's state itself.
 //
 // If the promise is not fulfilled yet, resetting promiseHolder will

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -231,6 +231,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kQueryMaxMemoryPerNode, "4GB"),
           STR_PROP(kEnableMemoryLeakCheck, "true"),
           NONE_PROP(kRemoteFunctionServerThriftPort),
+          STR_PROP(kSkipRuntimeStatsInRunningTaskInfo, "true"),
       };
 }
 
@@ -409,6 +410,10 @@ uint64_t SystemConfig::queryMaxMemoryPerNode() const {
 
 bool SystemConfig::enableMemoryLeakCheck() const {
   return optionalProperty<bool>(kEnableMemoryLeakCheck).value();
+}
+
+bool SystemConfig::skipRuntimeStatsInRunningTaskInfo() const {
+  return optionalProperty<bool>(kSkipRuntimeStatsInRunningTaskInfo).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -230,6 +230,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kRemoteFunctionServerThriftPort{
       "remote-function-server.thrift.port"};
 
+  static constexpr std::string_view kSkipRuntimeStatsInRunningTaskInfo{
+      "skip-runtime-stats-in-running-task-info"};
+
   SystemConfig();
 
   static SystemConfig* instance();
@@ -332,6 +335,8 @@ class SystemConfig : public ConfigBase {
   uint64_t queryMaxMemoryPerNode() const;
 
   bool enableMemoryLeakCheck() const;
+
+  bool skipRuntimeStatsInRunningTaskInfo() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
Add a system config skip-runtime-stats-in-running-task-info, with
default value true. When it is true, do not include runtime stats
in the payload of a task in running state for the endpoint taskInfo.

Also do more modualization of the function
PrestoTask::updateInfoLocked().
