### PR TITLE
[Native] Handle deserialization for row type block

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -910,6 +910,7 @@ public abstract class AbstractTestNativeGeneralQueries
     public void testRow()
     {
         assertQuery("SELECT cast(row(nationkey, regionkey) as row(a bigint, b bigint)) FROM nation");
+        assertQuery("SELECT row(name, null, cast(row(nationkey, regionkey) as row(a bigint, b bigint))) FROM nation");
     }
 
     private void assertQueryResultCount(String sql, int expectedResultCount)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -51,6 +51,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -251,6 +252,17 @@ public class TestingPrestoClient
                             e -> convertToRowValue(((MapType) type).getValueType(), e.getValue())));
         }
         else if (type instanceof RowType) {
+            if (value instanceof LinkedHashMap) {
+                // If value is an ordered map, use indexes instead of names.
+                List<Object> data = new ArrayList<>(((Map<String, Object>) value).values());
+                List<RowType.Field> fields = ((RowType) type).getFields();
+                List<Object> rowValues = new ArrayList<>();
+                for (int i = 0; i < fields.size(); i++) {
+                    rowValues.add(convertToRowValue(fields.get(i).getType(), data.get(i)));
+                }
+                return rowValues;
+            }
+
             Map<String, Object> data = (Map<String, Object>) value;
             RowType rowType = (RowType) type;
 


### PR DESCRIPTION
Block read currently doesn't handle complex type `ROW` properly, which causes queries as simple as `SELECT ROW('a', 'b')` to fail with `error: not a scalar type! kind: ROW`. This change adds the logic to read the block and construct a `RowVector` accordingly.

```
== NO RELEASE NOTE ==
```
