### PR TITLE
Add optimization to cross join with array contains filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -271,6 +271,7 @@ public final class SystemSessionProperties
     public static final String SIMPLIFY_PLAN_WITH_EMPTY_INPUT = "simplify_plan_with_empty_input";
     public static final String PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN = "push_down_filter_expression_evaluation_through_cross_join";
     public static final String REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN = "rewrite_cross_join_or_to_inner_join";
+    public static final String REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN = "rewrite_cross_join_array_contains_to_inner_join";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1562,6 +1563,11 @@ public final class SystemSessionProperties
                         "Rewrite cross join with or filter to inner join",
                         featuresConfig.isRewriteCrossJoinWithOrFilterToInnerJoin(),
                         false),
+                booleanProperty(
+                        REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN,
+                        "Rewrite cross join with array contains filter to inner join",
+                        featuresConfig.isRewriteCrossJoinWithArrayContainsFilterToInnerJoin(),
+                        false),
                 new PropertyMetadata<>(
                         JOINS_NOT_NULL_INFERENCE_STRATEGY,
                         format("Set the strategy used NOT NULL filter inference on Join Nodes. Options are: %s",
@@ -2640,5 +2646,10 @@ public final class SystemSessionProperties
     public static boolean isRewriteCrossJoinOrToInnerJoinEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN, Boolean.class);
+    }
+
+    public static boolean isRewriteCrossJoinArrayContainsToInnerJoinEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -263,6 +263,7 @@ public class FeaturesConfig
     private boolean simplifyPlanWithEmptyInput = true;
     private PushDownFilterThroughCrossJoinStrategy pushDownFilterExpressionEvaluationThroughCrossJoin = PushDownFilterThroughCrossJoinStrategy.REWRITTEN_TO_INNER_JOIN;
     private boolean rewriteCrossJoinWithOrFilterToInnerJoin = true;
+    private boolean rewriteCrossJoinWithArrayContainsFilterToInnerJoin = true;
     private JoinNotNullInferenceStrategy joinNotNullInferenceStrategy = NONE;
 
     private boolean preProcessMetadataCalls;
@@ -2592,6 +2593,19 @@ public class FeaturesConfig
     public FeaturesConfig setRewriteCrossJoinWithOrFilterToInnerJoin(boolean rewriteCrossJoinWithOrFilterToInnerJoin)
     {
         this.rewriteCrossJoinWithOrFilterToInnerJoin = rewriteCrossJoinWithOrFilterToInnerJoin;
+        return this;
+    }
+
+    public boolean isRewriteCrossJoinWithArrayContainsFilterToInnerJoin()
+    {
+        return this.rewriteCrossJoinWithArrayContainsFilterToInnerJoin;
+    }
+
+    @Config("optimizer.rewrite-cross-join-with-array-contains-filter-to-inner-join")
+    @ConfigDescription("Enable optimization to rewrite cross join with array contains filter to inner join")
+    public FeaturesConfig setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(boolean rewriteCrossJoinWithArrayContainsFilterToInnerJoin)
+    {
+        this.rewriteCrossJoinWithArrayContainsFilterToInnerJoin = rewriteCrossJoinWithArrayContainsFilterToInnerJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregation
 import com.facebook.presto.sql.planner.iterative.rule.AddNotNullFiltersToJoinNode;
 import com.facebook.presto.sql.planner.iterative.rule.CombineApproxPercentileFunctions;
 import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
+import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithArrayContainsToInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithOrFilterToInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarLambdaExpression;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
@@ -446,7 +447,8 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
                                 new PushDownFilterExpressionEvaluationThroughCrossJoin(metadata.getFunctionAndTypeManager()),
-                                new CrossJoinWithOrFilterToInnerJoin(metadata.getFunctionAndTypeManager()))),
+                                new CrossJoinWithOrFilterToInnerJoin(metadata.getFunctionAndTypeManager()),
+                                new CrossJoinWithArrayContainsToInnerJoin(metadata.getFunctionAndTypeManager()))),
                 new KeyBasedSampler(metadata, sqlParser),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithArrayContainsToInnerJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithArrayContainsToInnerJoin.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlannerUtils;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteCrossJoinArrayContainsToInnerJoinEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Inner join with contains function inside join clause will be run as cross join with filter.
+ * When the join condition has pattern of contains(array, element), we can rewrite it to a inner join. For example:
+ * <pre>
+ * - Filter contains(l_array_key, r_key)
+ *      - Cross join
+ *          - scan l
+ *          - scan r
+ * </pre>
+ * into:
+ * <pre>
+ *     - Join
+ *          field = r_key
+ *          - Unnest
+ *              field <- unnest distinct_array
+ *              - project
+ *                  distinct_array := array_distinct(l_array_key)
+ *                  - scan l
+ *                      l_array_key
+ *              - scan r
+ *                  r_key
+ * </pre>
+ */
+public class CrossJoinWithArrayContainsToInnerJoin
+        implements Rule<FilterNode>
+{
+    private static final String CONTAINS_FUNCTION_NAME = "presto.default.contains";
+    private static final List<Type> SUPPORTED_JOIN_KEY_TYPE = ImmutableList.of(BIGINT, INTEGER, VARCHAR, DATE);
+    private static final Capture<JoinNode> CHILD = newCapture();
+    private static final Pattern<FilterNode> PATTERN = filter()
+            .with(source().matching(join().matching(x -> x.getType().equals(JoinNode.Type.INNER) && x.getCriteria().isEmpty()).capturedAs(CHILD)));
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public CrossJoinWithArrayContainsToInnerJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    public static RowExpression getCandidateArrayContainsExpression(RowExpression filterPredicate, List<VariableReferenceExpression> leftInput, List<VariableReferenceExpression> rightInput)
+    {
+        List<RowExpression> andConjuncts = extractConjuncts(filterPredicate);
+        for (RowExpression conjunct : andConjuncts) {
+            if (isValidArrayContainsFilter(conjunct, leftInput, rightInput)) {
+                return conjunct;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isValidArrayContainsFilter(RowExpression filterExpression, List<VariableReferenceExpression> left, List<VariableReferenceExpression> right)
+    {
+        if (filterExpression instanceof CallExpression) {
+            CallExpression callExpression = (CallExpression) filterExpression;
+            if (callExpression.getFunctionHandle().getName().equals(CONTAINS_FUNCTION_NAME)) {
+                RowExpression array = callExpression.getArguments().get(0);
+                RowExpression element = callExpression.getArguments().get(1);
+                checkState(array.getType() instanceof ArrayType && ((ArrayType) array.getType()).getElementType().equals(element.getType()));
+                return (SUPPORTED_JOIN_KEY_TYPE.contains(element.getType())) && ((left.contains(array) && right.contains(element)) || (right.contains(array) && left.contains(element)));
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRewriteCrossJoinArrayContainsToInnerJoinEnabled(session);
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        JoinNode joinNode = captures.get(CHILD);
+        if (!(joinNode.getType().equals(JoinNode.Type.INNER) && joinNode.getCriteria().isEmpty())) {
+            return Result.empty();
+        }
+        List<VariableReferenceExpression> leftInput = joinNode.getLeft().getOutputVariables();
+        List<VariableReferenceExpression> rightInput = joinNode.getRight().getOutputVariables();
+        RowExpression filterExpression = node.getPredicate();
+        RowExpression arrayContainsExpression = getCandidateArrayContainsExpression(filterExpression, leftInput, rightInput);
+        if (arrayContainsExpression == null) {
+            return Result.empty();
+        }
+        List<RowExpression> andConjuncts = extractConjuncts(filterExpression);
+        List<RowExpression> remainingConjuncts = andConjuncts.stream().filter(x -> !x.equals(arrayContainsExpression)).collect(toImmutableList());
+
+        VariableReferenceExpression array = (VariableReferenceExpression) ((CallExpression) arrayContainsExpression).getArguments().get(0);
+        VariableReferenceExpression element = (VariableReferenceExpression) ((CallExpression) arrayContainsExpression).getArguments().get(1);
+        boolean arrayAtLeftInput = leftInput.contains(array);
+        PlanNode inputWithArray = arrayAtLeftInput ? joinNode.getLeft() : joinNode.getRight();
+
+        CallExpression arrayDistinct = call(functionAndTypeManager, "array_distinct", new ArrayType(element.getType()), array);
+        VariableReferenceExpression arrayDistinctVariable = context.getVariableAllocator().newVariable(arrayDistinct);
+        PlanNode project = PlannerUtils.addProjections(inputWithArray, context.getIdAllocator(), ImmutableMap.of(arrayDistinctVariable, arrayDistinct));
+        VariableReferenceExpression unnestVariable = context.getVariableAllocator().newVariable("field", element.getType());
+        UnnestNode unnest = new UnnestNode(inputWithArray.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                project,
+                project.getOutputVariables(),
+                ImmutableMap.of(arrayDistinctVariable, ImmutableList.of(unnestVariable)),
+                Optional.empty());
+
+        JoinNode.EquiJoinClause equiJoinClause = arrayAtLeftInput ? new JoinNode.EquiJoinClause(unnestVariable, element) : new JoinNode.EquiJoinClause(element, unnestVariable);
+
+        JoinNode newJoinNode = new JoinNode(joinNode.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                joinNode.getType(),
+                arrayAtLeftInput ? unnest : joinNode.getLeft(),
+                arrayAtLeftInput ? joinNode.getRight() : unnest,
+                ImmutableList.of(equiJoinClause),
+                joinNode.getOutputVariables(),
+                joinNode.getFilter(),
+                Optional.empty(),
+                Optional.empty(),
+                joinNode.getDistributionType(),
+                joinNode.getDynamicFilters());
+
+        if (!remainingConjuncts.isEmpty()) {
+            return Result.ofPlanNode(new FilterNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), newJoinNode, and(remainingConjuncts)));
+        }
+
+        return Result.ofPlanNode(newJoinNode);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -232,7 +232,8 @@ public class TestFeaturesConfig
                 .setSimplifyPlanWithEmptyInput(true)
                 .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.REWRITTEN_TO_INNER_JOIN)
                 .setDefaultJoinSelectivityCoefficient(0)
-                .setRewriteCrossJoinWithOrFilterToInnerJoin(true));
+                .setRewriteCrossJoinWithOrFilterToInnerJoin(true)
+                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(true));
     }
 
     @Test
@@ -412,6 +413,7 @@ public class TestFeaturesConfig
                 .put("optimizer.simplify-plan-with-empty-input", "false")
                 .put("optimizer.push-down-filter-expression-evaluation-through-cross-join", "DISABLED")
                 .put("optimizer.rewrite-cross-join-with-or-filter-to-inner-join", "false")
+                .put("optimizer.rewrite-cross-join-with-array-contains-filter-to-inner-join", "false")
                 .put("optimizer.default-join-selectivity-coefficient", "0.5")
                 .build();
 
@@ -590,7 +592,8 @@ public class TestFeaturesConfig
                 .setSimplifyPlanWithEmptyInput(false)
                 .setDefaultJoinSelectivityCoefficient(0.5)
                 .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.DISABLED)
-                .setRewriteCrossJoinWithOrFilterToInnerJoin(false);
+                .setRewriteCrossJoinWithOrFilterToInnerJoin(false)
+                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -57,13 +57,13 @@ public class OptimizerAssert
 {
     private final Metadata metadata;
     private final TestingStatsCalculator statsCalculator;
-    private final Session session;
     private final PlanOptimizer optimizer;
     private final PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final LocalQueryRunner queryRunner;
 
+    private Session session;
     private TypeProvider types;
     private PlanNode plan;
 
@@ -76,6 +76,19 @@ public class OptimizerAssert
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.accessControl = requireNonNull(accessControl, "access control is null");
         this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
+    }
+
+    public OptimizerAssert setSystemProperty(String key, String value)
+    {
+        return withSession(Session.builder(session)
+                .setSystemProperty(key, value)
+                .build());
+    }
+
+    public OptimizerAssert withSession(Session session)
+    {
+        this.session = session;
+        return this;
     }
 
     public OptimizerAssert on(Function<PlanBuilder, PlanNode> planProvider)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCrossJoinWithArrayContainsToInnerJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCrossJoinWithArrayContainsToInnerJoin.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unnest;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestCrossJoinWithArrayContainsToInnerJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testTriggerForBigInt()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT))),
+                                    p.values(p.variable("right_k1"))));
+                })
+                .matches(
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(equiJoinClause("field", "right_k1")),
+                                unnest(
+                                        ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                        project(
+                                                ImmutableMap.of("array_distinct", expression("array_distinct(left_array_k1)")),
+                                                values("left_array_k1"))),
+                                values("right_k1")));
+    }
+
+    @Test
+    public void testTriggerForBigIntArrayRightSide()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("right_array_k1", new ArrayType(BIGINT));
+                    return p.filter(
+                            p.rowExpression("contains(right_array_k1, left_k1)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1")),
+                                    p.values(p.variable("right_array_k1", new ArrayType(BIGINT)))));
+                })
+                .matches(
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(equiJoinClause("left_k1", "field")),
+                                values("left_k1"),
+                                unnest(
+                                        ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                        project(
+                                                ImmutableMap.of("array_distinct", expression("array_distinct(right_array_k1)")),
+                                                values("right_array_k1")))));
+    }
+
+    @Test
+    public void testMultipleArrayContainsConditions()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_array_k2", new ArrayType(BIGINT));
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1) and contains(right_array_k2, left_k2)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT)), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_array_k2", new ArrayType(BIGINT)))));
+                })
+                .matches(
+                        filter(
+                                "contains(right_array_k2, left_k2)",
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("field", "right_k1")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(left_array_k1)")),
+                                                        values("left_array_k1", "left_k2"))),
+                                        values("right_k1", "right_array_k2"))));
+    }
+
+    @Test
+    public void testMultipleInvalidArrayContainsConditions()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_array_k2", new ArrayType(BIGINT));
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1) or contains(right_array_k2, left_k2)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT)), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_array_k2", new ArrayType(BIGINT)))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerForDouble()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(DOUBLE));
+                    p.variable("right_k1", DOUBLE);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(DOUBLE))),
+                                    p.values(p.variable("right_k1", DOUBLE))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testArrayContainsWithCast()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, CAST(right_k1 AS BIGINT))"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", new ArrayType(BIGINT))),
+                                    p.values(p.variable("right_k1", VARCHAR))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testArrayContainsWithCastBothRules()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, CAST(right_k1 AS BIGINT))"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT))),
+                                    p.values(p.variable("right_k1", VARCHAR))));
+                })
+                .matches(
+                        project(
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("field", "cast_r")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(left_array_k1)")),
+                                                        values("left_array_k1"))),
+                                        project(
+                                                ImmutableMap.of("cast_r", expression("CAST(right_k1 AS bigint)")),
+                                                values("right_k1")))));
+    }
+
+    @Test
+    public void testArrayContainsWithCastBothRules2()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", VARCHAR);
+                    return p.filter(
+                            p.rowExpression("contains(CAST(left_array_k1 AS ARRAY<VARCHAR>), right_k1)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT))),
+                                    p.values(p.variable("right_k1", VARCHAR))));
+                })
+                .matches(
+                        project(
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("field", "right_k1")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(cast_array)")),
+                                                        project(
+                                                                ImmutableMap.of("cast_array", expression("cast(left_array_k1 as array<varchar>)")),
+                                                                values("left_array_k1")))),
+                                        values("right_k1"))));
+    }
+
+    @Test
+    public void testArrayContainsWithCastBothRulesArrayRightSide()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_k1", VARCHAR);
+                    p.variable("right_array_k1", new ArrayType(BIGINT));
+                    return p.filter(
+                            p.rowExpression("contains(right_array_k1, CAST(left_k1 AS BIGINT))"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", VARCHAR)),
+                                    p.values(p.variable("right_array_k1", new ArrayType(BIGINT)))));
+                })
+                .matches(
+                        project(
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("cast_l", "field")),
+                                        project(
+                                                ImmutableMap.of("cast_l", expression("CAST(left_k1 AS bigint)")),
+                                                values("left_k1")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(right_array_k1)")),
+                                                        values("right_array_k1"))))));
+    }
+
+    @Test
+    public void testArrayContainsWithCoalesceBothRules()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", VARCHAR);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, coalesce(CAST(right_k1 AS BIGINT), right_k2))"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT))),
+                                    p.values(p.variable("right_k1", VARCHAR), p.variable("right_k2", BIGINT))));
+                })
+                .matches(
+                        project(
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("field", "expr")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(left_array_k1)")),
+                                                        values("left_array_k1"))),
+                                        project(
+                                                ImmutableMap.of("expr", expression("COALESCE(CAST(right_k1 AS bigint), right_k2)")),
+                                                values("right_k1", "right_k2")))));
+    }
+
+    @Test
+    public void testArrayContainsWithCoalesceBothRulesArrayOnRight()
+    {
+        tester().assertThat(
+                ImmutableSet.of(
+                        new PushDownFilterExpressionEvaluationThroughCrossJoin(getFunctionManager()),
+                        new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager())))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("right_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k1", VARCHAR);
+                    p.variable("left_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(right_array_k1, coalesce(CAST(left_k1 AS BIGINT), left_k2))"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1", VARCHAR), p.variable("left_k2", BIGINT)),
+                                    p.values(p.variable("right_array_k1", new ArrayType(BIGINT)))));
+                })
+                .matches(
+                        project(
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("expr", "field")),
+                                        project(
+                                                ImmutableMap.of("expr", expression("COALESCE(CAST(left_k1 AS bigint), left_k2)")),
+                                                values("left_k1", "left_k2")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(right_array_k1)")),
+                                                        values("right_array_k1"))))));
+    }
+
+    @Test
+    public void testConditionWithAnd()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1) and left_k2+right_k2 > 10"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT)), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                })
+                .matches(
+                        filter(
+                                "left_k2+right_k2 > 10",
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("field", "right_k1")),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(left_array_k1)")),
+                                                        values("left_array_k1", "left_k2"))),
+                                        values("right_k1", "right_k2"))));
+    }
+
+    @Test
+    public void testConditionWithAndArrayOnRight()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("right_array_k1", new ArrayType(BIGINT));
+                    p.variable("right_k2", BIGINT);
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(right_array_k1, left_k1) and right_k2+left_k2 > 10"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_array_k1", new ArrayType(BIGINT)), p.variable("right_k2"))));
+                })
+                .matches(
+                        filter(
+                                "right_k2+left_k2 > 10",
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("left_k1", "field")),
+                                        values("left_k1", "left_k2"),
+                                        unnest(
+                                                ImmutableMap.of("array_distinct", ImmutableList.of("field")),
+                                                project(
+                                                        ImmutableMap.of("array_distinct", expression("array_distinct(right_array_k1)")),
+                                                        values("right_array_k1", "right_k2"))))));
+    }
+
+    @Test
+    public void testNonMatchingCondition()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, right_k1) or left_k2+right_k2 > 10"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT)), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNonMatchingCondition2()
+    {
+        tester().assertThat(new CrossJoinWithArrayContainsToInnerJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .on(p ->
+                {
+                    p.variable("left_array_k1", new ArrayType(BIGINT));
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("contains(left_array_k1, left_k2)"),
+                            p.join(JoinNode.Type.INNER,
+                                    p.values(p.variable("left_array_k1", new ArrayType(BIGINT)), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2"))));
+                }).doesNotFire();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -67,6 +67,7 @@ import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_T
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.SIMPLIFY_PLAN_WITH_EMPTY_INPUT;
 import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
@@ -6813,5 +6814,89 @@ public abstract class AbstractTestQueries
         errorMessage = ".*Column 'name1' cannot be resolved";
         assertQueryFails(query, errorMessage);
         assertQueryFails(enablePreProcessMetadataCalls, query, errorMessage);
+    }
+
+    @Test
+    public void testCrossJoinWithArrayContainsCondition()
+    {
+        Session enableOptimization = Session.builder(getSession())
+                .setSystemProperty(PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN, "REWRITTEN_TO_INNER_JOIN")
+                .setSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, "true")
+                .build();
+
+        String sql = "with t1 as (select * from (values (array[1, 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, 1, 3], 10), (array[4, 4, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, null, 3], 10), (array[4, null, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (null, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k) and t1.k > 10";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b')");
+
+        sql = "with t1 as (select * from (values (array[1, 2, 3], 1), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k) or t1.k = t2.k";
+        assertQuery(enableOptimization, sql, "values (1, 1, 'a'), (11, 4, 'b')");
+
+        sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from t1 join orders o on contains(t1.orderkey, o.orderkey) where o.totalprice < 2000";
+        // Because the UDF has different names in H2, which is `array_contains`
+        String h2Sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from t1 join orders o on array_contains(t1.orderkey, o.orderkey) where o.totalprice < 2000";
+        assertQuery(enableOptimization, sql, h2Sql);
+
+        sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from t1 join orders o on contains(t1.orderkey, o.orderkey) and t1.partkey < o.orderkey where o.totalprice < 2000";
+        h2Sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from t1 join orders o on array_contains(t1.orderkey, o.orderkey) and t1.partkey < o.orderkey where o.totalprice < 2000";
+        assertQuery(enableOptimization, sql, h2Sql);
+
+        // Arrray on build side
+        sql = "with t1 as (select * from (values (array[1, 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t2 join t1 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, 1, 3], 10), (array[4, 4, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t2 join t1 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, null, 3], 10), (array[4, null, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (null, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t2 join t1 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[1, 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t2 join t1 on contains(t1.arr, t2.k) and t1.k > 10";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b')");
+
+        sql = "with t1 as (select * from (values (array[1, 2, 3], 1), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (1, 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t2 join t1 on contains(t1.arr, t2.k) or t1.k = t2.k";
+        assertQuery(enableOptimization, sql, "values (1, 1, 'a'), (11, 4, 'b')");
+
+        sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from t1 join orders o on contains(t1.orderkey, o.orderkey) where o.totalprice < 2000";
+        h2Sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from orders o join t1 on array_contains(t1.orderkey, o.orderkey) where o.totalprice < 2000";
+        assertQuery(enableOptimization, sql, h2Sql);
+
+        sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from orders o join t1 on contains(t1.orderkey, o.orderkey) and t1.partkey < o.orderkey where o.totalprice < 2000";
+        h2Sql = "with t1 as (select array_agg(orderkey) orderkey, partkey from lineitem l where l.quantity < 5 group by partkey) " +
+                "select t1.partkey, o.orderkey, o.totalprice from orders o join t1 on array_contains(t1.orderkey, o.orderkey) and t1.partkey < o.orderkey where o.totalprice < 2000";
+        assertQuery(enableOptimization, sql, h2Sql);
+
+        // Element type and array type does not match
+        sql = "with t1 as (select * from (values (array[cast(1 as bigint), 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (cast(1 as integer), 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+
+        sql = "with t1 as (select * from (values (array[cast(1 as integer), 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (cast(1 as bigint), 'a'), (4, 'b')) t(k, v)) " +
+                "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
+        assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
     }
 }


### PR DESCRIPTION
Add an optimization rule to optimize cross join with array contains filter to inner join.
For example, queries like 
`select t1.array, t2.k from t1 join t2 on contains(t1.array, t2.k)` 
can be rewritten to 
```
with newt1 as (select * from t1 cross join unnest(array_distinct(t1.array)) t(newk)) 
select array, k from newt1 join t2 on newk = k;
```

### Test plan - (Please fill in how you tested your changes)

Add unit tests. And verifier runs ([r1](https://www.internalfb.com/intern/presto/verifier/results/?test_id=113338), [r2](https://www.internalfb.com/intern/presto/verifier/results/?test_id=113354), [r3](https://our.internmc.facebook.com/intern/presto/verifier/results/?test_id=113962))

```
== RELEASE NOTES ==

General Changes
* Add an optimization to optimize cross join with array contains filter, it's controlled by session parameter `rewrite_cross_join_array_contains_to_inner_join`
```
