### PR TITLE
[native]Fix presto exchange source peak memory usage stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -65,7 +65,7 @@ void PeriodicTaskManager::start() {
   }
   if (taskManager_ != nullptr) {
     addTaskStatsTask();
-    addTaskCleanupTask();
+    addOldTaskCleanupTask();
   }
   if (memoryAllocator_ != nullptr) {
     addMemoryAllocatorStatsTask();
@@ -154,15 +154,15 @@ void PeriodicTaskManager::addTaskStatsTask() {
       "task_counters");
 }
 
-void PeriodicTaskManager::updateTaskCleanUp() {
+void PeriodicTaskManager::cleanupOldTask() {
   // Report the number of tasks and drivers in the system.
   if (taskManager_ != nullptr) {
     taskManager_->cleanOldTasks();
   }
 }
-void PeriodicTaskManager::addTaskCleanupTask() {
+void PeriodicTaskManager::addOldTaskCleanupTask() {
   scheduler_.addFunction(
-      [this]() { updateTaskCleanUp(); },
+      [this]() { cleanupOldTask(); },
       std::chrono::microseconds{kTaskPeriodCleanOldTasks},
       "clean_old_tasks");
 }
@@ -194,9 +194,8 @@ void PeriodicTaskManager::updatePrestoExchangeSourceMemoryStats() {
   int64_t peakQueuedMemoryBytes{0};
   PrestoExchangeSource::getMemoryUsage(
       currQueuedMemoryBytes, peakQueuedMemoryBytes);
-  REPORT_ADD_STAT_VALUE(
-      kCounterExchangeSourceQueuedBytes, currQueuedMemoryBytes);
-  REPORT_ADD_STAT_VALUE(
+  PrestoExchangeSource::resetPeakMemoryUsage();
+  REPORT_ADD_HISTOGRAM_VALUE(
       kCounterExchangeSourcePeakQueuedBytes, peakQueuedMemoryBytes);
 }
 

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -77,8 +77,8 @@ class PeriodicTaskManager {
   void addTaskStatsTask();
   void updateTaskStats();
 
-  void addTaskCleanupTask();
-  void updateTaskCleanUp();
+  void addOldTaskCleanupTask();
+  void cleanupOldTask();
 
   void addMemoryAllocatorStatsTask();
   void updateMemoryAllocatorStats();

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -370,7 +370,11 @@ void PrestoExchangeSource::getMemoryUsage(
     int64_t& currentBytes,
     int64_t& peakBytes) {
   currentBytes = currQueuedMemoryBytes();
-  peakBytes = peakQueuedMemoryBytes();
+  peakBytes = std::max<int64_t>(currentBytes, peakQueuedMemoryBytes());
+}
+
+void PrestoExchangeSource::resetPeakMemoryUsage() {
+  peakQueuedMemoryBytes() = currQueuedMemoryBytes().load();
 }
 
 void PrestoExchangeSource::testingClearMemoryUsage() {

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -58,6 +58,12 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   /// PrestoExchangeSource.
   static void getMemoryUsage(int64_t& currentBytes, int64_t& peakBytes);
 
+  /// Invoked to reset the node-wise peak memory usage back to the current
+  /// memory usage in PrestoExchangeSource. Instead of getting all time peak,
+  /// this can be useful when tracking the peak within some fixed time
+  /// intervals.
+  static void resetPeakMemoryUsage();
+
   /// Used by test to clear the node-wise memory usage tracking.
   static void testingClearMemoryUsage();
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -102,10 +102,12 @@ void registerPrestoCppCounters() {
       facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMappedMemoryRawAllocBytesLarge, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterExchangeSourceQueuedBytes, facebook::velox::StatType::AVG);
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterExchangeSourcePeakQueuedBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
+      kCounterExchangeSourcePeakQueuedBytes,
+      (1024 * 1024), // bucket unit: 1MB
+      0,
+      (62l * 1024 * 1024 * 1024), // max bucket size: 62GB
+      100);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -36,15 +36,15 @@ constexpr folly::StringPiece kCounterNumHTTPRequestError{
 constexpr folly::StringPiece kCounterHTTPRequestLatencyMs{
     "presto_cpp.http_request_latency_ms"};
 
-// Number of http client onBody calls in PrestoExchangeSource.
+/// Number of http client onBody calls in PrestoExchangeSource.
 constexpr folly::StringPiece kCounterHttpClientPrestoExchangeNumOnBody{
     "presto_cpp.http.client.presto_exchange_source.num_on_body"};
-// Received IOBuf chain byte size in http client onBody call from
-// PrestoExchangeSource.
+/// Received IOBuf chain byte size in http client onBody call from
+/// PrestoExchangeSource.
 constexpr folly::StringPiece kCounterHttpClientPrestoExchangeOnBodyBytes{
     "presto_cpp.http.client.presto_exchange_source.on_body_bytes"};
 
-// SerializedPage size in bytes from PrestoExchangeSource.
+/// SerializedPage size in bytes from PrestoExchangeSource.
 constexpr folly::StringPiece kCounterPrestoExchangeSerializedPageSize{
     "presto_cpp.presto_exchange_source.serialized_page_size"};
 
@@ -71,155 +71,152 @@ constexpr folly::StringPiece kCounterNumRunningDrivers{
 constexpr folly::StringPiece kCounterNumBlockedDrivers{
     "presto_cpp.num_blocked_drivers"};
 
-// Number of total PartitionedOutputBuffer managed by all
-// PartitionedOutputBufferManager
+/// Number of total PartitionedOutputBuffer managed by all
+/// PartitionedOutputBufferManager
 constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{
     "presto_cpp.num_partitioned_output_buffer"};
-// Latency in millisecond of the get data call of a
-// PartitionedOutputBufferManager.
+/// Latency in millisecond of the get data call of a
+/// PartitionedOutputBufferManager.
 constexpr folly::StringPiece kCounterPartitionedOutputBufferGetDataLatencyMs{
     "presto_cpp.partitioned_output_buffer_get_data_latency_ms"};
 
-// ================== OS Counters =================
+/// ================== OS Counters =================
 
-// User CPU time of the presto_server process in microsecond since the process
-// start.
+/// User CPU time of the presto_server process in microsecond since the process
+/// start.
 constexpr folly::StringPiece kCounterOsUserCpuTimeMicros{
     "presto_cpp.os_user_cpu_time_micros"};
-// System CPU time of the presto_server process in microsecond since the process
-// start.
+/// System CPU time of the presto_server process in microsecond since the
+/// process start.
 constexpr folly::StringPiece kCounterOsSystemCpuTimeMicros{
     "presto_cpp.os_system_cpu_time_micros"};
-// Total number of soft page faults of the presto_server process in microsecond
-// since the process start.
+/// Total number of soft page faults of the presto_server process in microsecond
+/// since the process start.
 constexpr folly::StringPiece kCounterOsNumSoftPageFaults{
     "presto_cpp.os_num_soft_page_faults"};
-// Total number of hard page faults of the presto_server process in microsecond
-// since the process start.
+/// Total number of hard page faults of the presto_server process in microsecond
+/// since the process start.
 constexpr folly::StringPiece kCounterOsNumHardPageFaults{
     "presto_cpp.os_num_hard_page_faults"};
-// Total number of voluntary context switches in the presto_server process.
+/// Total number of voluntary context switches in the presto_server process.
 constexpr folly::StringPiece kCounterOsNumVoluntaryContextSwitches{
     "presto_cpp.os_num_voluntary_context_switches"};
-// Total number of involuntary context switches in the presto_server process.
+/// Total number of involuntary context switches in the presto_server process.
 constexpr folly::StringPiece kCounterOsNumForcedContextSwitches{
     "presto_cpp.os_num_forced_context_switches"};
 
-// ================== Memory Counters =================
+/// ================== Memory Counters =================
 
-// Number of bytes of memory MappedMemory currently maps (RSS). It also includes
-// memory that was freed and currently not in use.
+/// Number of bytes of memory MappedMemory currently maps (RSS). It also
+/// includes memory that was freed and currently not in use.
 constexpr folly::StringPiece kCounterMappedMemoryBytes{
     "presto_cpp.mapped_memory_bytes"};
-// Number of bytes of memory MappedMemory currently allocates. Memories in use
+/// Number of bytes of memory MappedMemory currently allocates. Memories in use
 constexpr folly::StringPiece kCounterAllocatedMemoryBytes{
     "presto_cpp.allocated_memory_bytes"};
-// Number of bytes currently allocated from MappedMemory directly from raw
-// allocateBytes() interface, and internally allocated by malloc. Only small
-// chunks of memory are delegated to malloc
+/// Number of bytes currently allocated from MappedMemory directly from raw
+/// allocateBytes() interface, and internally allocated by malloc. Only small
+/// chunks of memory are delegated to malloc
 constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesSmall{
     "presto_cpp.mapped_memory_raw_alloc_bytes_small"};
-// Number of bytes currently allocated from MappedMemory directly from raw
-// allocateBytes() interface, and internally allocated using SizeClass that are
-// managed by MappedMemory. Only chunks of memory that are large enough to be
-// efficiently fitted in the smallest SizeClass and not too large that even
-// largest SizeClass cannot accommodate, are counted towards this counter.
+/// Number of bytes currently allocated from MappedMemory directly from raw
+/// allocateBytes() interface, and internally allocated using SizeClass that are
+/// managed by MappedMemory. Only chunks of memory that are large enough to be
+/// efficiently fitted in the smallest SizeClass and not too large that even
+/// largest SizeClass cannot accommodate, are counted towards this counter.
 constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesSizeClass{
     "presto_cpp.mapped_memory_raw_alloc_bytes_size_class"};
-// Number of bytes currently allocated from MappedMemory directly from raw
-// allocateBytes() interface, and internally allocated using SizeClass that are
-// managed by MappedMemory. Only chunks of memory that are too large that even
-// largest SizeClass cannot accommodate, are counted towards this counter.
+/// Number of bytes currently allocated from MappedMemory directly from raw
+/// allocateBytes() interface, and internally allocated using SizeClass that are
+/// managed by MappedMemory. Only chunks of memory that are too large that even
+/// largest SizeClass cannot accommodate, are counted towards this counter.
 constexpr folly::StringPiece kCounterMappedMemoryRawAllocBytesLarge{
     "presto_cpp.mapped_memory_raw_alloc_bytes_large"};
-/// Number of bytes currently queued in PrestoExchangeSource waiting for
-/// consume.
-constexpr folly::StringPiece kCounterExchangeSourceQueuedBytes{
-    "presto_cpp.exchange_source_queued_bytes"};
+
 /// Peak number of bytes queued in PrestoExchangeSource waiting for consume.
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
 
-// ================== Cache Counters ==================
+/// ================== Cache Counters ==================
 
-// Total number of cache entries.
+/// Total number of cache entries.
 constexpr folly::StringPiece kCounterMemoryCacheNumEntries{
     "presto_cpp.memory_cache_num_entries"};
-// Total number of cache entries that do not cache anything.
+/// Total number of cache entries that do not cache anything.
 constexpr folly::StringPiece kCounterMemoryCacheNumEmptyEntries{
     "presto_cpp.memory_cache_num_empty_entries"};
-// Total number of cache entries that are pinned for shared access.
+/// Total number of cache entries that are pinned for shared access.
 constexpr folly::StringPiece kCounterMemoryCacheNumSharedEntries{
     "presto_cpp.memory_cache_num_shared_entries"};
-// Total number of cache entries that are pinned for exclusive access.
+/// Total number of cache entries that are pinned for exclusive access.
 constexpr folly::StringPiece kCounterMemoryCacheNumExclusiveEntries{
     "presto_cpp.memory_cache_num_exclusive_entries"};
-// Total number of cache entries that are being or have been prefetched but have
-// not been hit.
+/// Total number of cache entries that are being or have been prefetched but
+/// have not been hit.
 constexpr folly::StringPiece kCounterMemoryCacheNumPrefetchedEntries{
     "presto_cpp.memory_cache_num_prefetched_entries"};
-// Total number of bytes of the cached data that is much smaller than a
-// 'MappedMemory' page (AsyncDataCacheEntry::kTinyDataSize).
+/// Total number of bytes of the cached data that is much smaller than a
+/// 'MappedMemory' page (AsyncDataCacheEntry::kTinyDataSize).
 constexpr folly::StringPiece kCounterMemoryCacheTotalTinyBytes{
     "presto_cpp.memory_cache_total_tiny_bytes"};
-// Total number of bytes of the cached data excluding
-// 'kCounterMemoryCacheTotalTinyBytes'.
+/// Total number of bytes of the cached data excluding
+/// 'kCounterMemoryCacheTotalTinyBytes'.
 constexpr folly::StringPiece kCounterMemoryCacheTotalLargeBytes{
     "presto_cpp.memory_cache_total_large_bytes"};
-// Total unused capacity bytes in 'kCounterMemoryCacheTotalTinyBytes'.
+/// Total unused capacity bytes in 'kCounterMemoryCacheTotalTinyBytes'.
 constexpr folly::StringPiece kCounterMemoryCacheTotalTinyPaddingBytes{
     "presto_cpp.memory_cache_total_tiny_padding_bytes"};
-// Total unused capacity bytes in 'kCounterMemoryCacheTotalLargeBytes'.
+/// Total unused capacity bytes in 'kCounterMemoryCacheTotalLargeBytes'.
 constexpr folly::StringPiece kCounterMemoryCacheTotalLargePaddingBytes{
     "presto_cpp.memory_cache_total_large_padding_bytes"};
-// Total bytes of cache entries in prefetch state.
+/// Total bytes of cache entries in prefetch state.
 constexpr folly::StringPiece kCounterMemoryCacheTotalPrefetchBytes{
     "presto_cpp.memory_cache_total_prefetched_bytes"};
-// Sum of scores of evicted entries. This serves to infer an average lifetime
-// for entries in cache.
+/// Sum of scores of evicted entries. This serves to infer an average lifetime
+/// for entries in cache.
 constexpr folly::StringPiece kCounterMemoryCacheSumEvictScore{
     "presto_cpp.memory_cache_sum_evict_score"};
-// Cumulated number of hits (saved IO). The first hit to a prefetched entry does
-// not count.
+/// Cumulated number of hits (saved IO). The first hit to a prefetched entry
+/// does not count.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeHit{
     "presto_cpp.memory_cache_num_cumulative_hit"};
-// Number of hits (saved IO) since last counter retrieval. The first hit to a
-// prefetched entry does not count.
+/// Number of hits (saved IO) since last counter retrieval. The first hit to a
+/// prefetched entry does not count.
 constexpr folly::StringPiece kCounterMemoryCacheNumHit{
     "presto_cpp.memory_cache_num_hit"};
-// Cumulated number of new entries created.
+/// Cumulated number of new entries created.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeNew{
     "presto_cpp.memory_cache_num_cumulative_new"};
-// Number of new entries created since last counter retrieval.
+/// Number of new entries created since last counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumNew{
     "presto_cpp.memory_cache_num_new"};
-// Cumulated number of times a valid entry was removed in order to make space.
+/// Cumulated number of times a valid entry was removed in order to make space.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvict{
     "presto_cpp.memory_cache_num_cumulative_evict"};
-// Number of times a valid entry was removed in order to make space, since last
-// counter retrieval.
+/// Number of times a valid entry was removed in order to make space, since last
+/// counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumEvict{
     "presto_cpp.memory_cache_num_evict"};
-// Cumulated number of entries considered for evicting.
+/// Cumulated number of entries considered for evicting.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvictChecks{
     "presto_cpp.memory_cache_num_cumulative_evict_checks"};
-// Number of entries considered for evicting, since last counter retrieval.
+/// Number of entries considered for evicting, since last counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumEvictChecks{
     "presto_cpp.memory_cache_num_evict_checks"};
-// Cumulated number of times a user waited for an entry to transit from
-// exclusive to shared mode.
+/// Cumulated number of times a user waited for an entry to transit from
+/// exclusive to shared mode.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeWaitExclusive{
     "presto_cpp.memory_cache_num_cumulative_wait_exclusive"};
-// Number of times a user waited for an entry to transit from exclusive to
-// shared mode, since last counter retrieval.
+/// Number of times a user waited for an entry to transit from exclusive to
+/// shared mode, since last counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumWaitExclusive{
     "presto_cpp.memory_cache_num_wait_exclusive"};
-// Cumulative clocks spent in allocating or freeing memory for backing cache
-// entries.
+/// Cumulative clocks spent in allocating or freeing memory for backing cache
+/// entries.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAllocClocks{
     "presto_cpp.memory_cache_num_cumulative_alloc_clocks"};
-// Clocks spent in allocating or freeing memory for backing cache
-// entries, since last counter retrieval
+/// Clocks spent in allocating or freeing memory for backing cache entries,
+/// since last counter retrieval
 constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
     "presto_cpp.memory_cache_num_alloc_clocks"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadEntries{
@@ -253,9 +250,9 @@ constexpr folly::StringPiece kCounterSsdCacheCumulativeReadSsdErrors{
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadCheckpointErrors{
     "presto_cpp.ssd_cache_cumulative_read_checkpoint_errors"};
 
-// ================== HiveConnector Counters ==================
-// Format template strings use 'constexpr std::string_view' to be 'fmt::format'
-// compatible.
+/// ================== HiveConnector Counters ==================
+/// Format template strings use 'constexpr std::string_view' to be 'fmt::format'
+/// compatible.
 constexpr std::string_view kCounterHiveFileHandleCacheNumElementsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_elements"};
 constexpr std::string_view kCounterHiveFileHandleCachePinnedSizeFormat{


### PR DESCRIPTION
The peak memory usage should be reset each time periodic task
manager reports, otherwise the peak usage might not seems meaningful
as the current memory usage changes over the time. Also change
the peak memory usage to percentile with 100 to collect the max during
each stats collection interval.

```
== NO RELEASE NOTE ==
```
