### PR TITLE
[native] Adding concept of registered config properties.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -16,6 +16,7 @@
 #include <gflags/gflags_declare.h>
 #include <glog/logging.h>
 #include "presto_cpp/main/PrestoServer.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/StatsReporter.h"
 
 DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
@@ -23,9 +24,10 @@ DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
 
+  PRESTO_STARTUP_LOG(INFO) << "Entering main()";
   facebook::presto::PrestoServer presto(FLAGS_etc_dir);
   presto.run();
-  LOG(INFO) << "SHUTDOWN: Exiting main()";
+  PRESTO_SHUTDOWN_LOG(INFO) << "Exiting main()";
 }
 
 // Initialize singleton for the reporter.

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -26,6 +26,7 @@
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Counters.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/connectors/hive/storage_adapters/FileSystems.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/http/filters/AccessLogFilter.h"
@@ -106,12 +107,6 @@ void enableChecksum() {
       });
 }
 
-#define PRESTO_STARTUP_LOG_PREFIX "[PRESTO_STARTUP] "
-#define PRESTO_STARTUP_LOG(severity) LOG(severity) << PRESTO_STARTUP_LOG_PREFIX
-
-#define PRESTO_SHUTDOWN_LOG_PREFIX "[PRESTO_SHUTDOWN] "
-#define PRESTO_SHUTDOWN_LOG(severity) \
-  LOG(severity) << PRESTO_SHUTDOWN_LOG_PREFIX
 } // namespace
 
 PrestoServer::PrestoServer(const std::string& configDirectoryPath)
@@ -135,6 +130,8 @@ void PrestoServer::run() {
   std::optional<int> httpsPort;
 
   try {
+    // Allow registering extra config properties before we load them from files.
+    registerExtraConfigProperties();
     systemConfig->initialize(
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -113,6 +113,11 @@ class PrestoServer {
 
   virtual void registerStatsCounters();
 
+  /// Invoked after creating global (singleton) config objects (SystemConfig and
+  /// NodeConfig) and before loading their properties from the file.
+  /// In the implementation any extra config properties can be registered.
+  virtual void registerExtraConfigProperties() {}
+
   /// Invoked to get the list of filters passed to the http server.
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
   getHttpServerFilters();

--- a/presto-native-execution/presto_cpp/main/SignalHandler.cpp
+++ b/presto-native-execution/presto_cpp/main/SignalHandler.cpp
@@ -15,6 +15,7 @@
 #include <folly/io/async/EventBaseManager.h>
 #include <csignal>
 #include "presto_cpp/main/PrestoServer.h"
+#include "presto_cpp/main/common/Utils.h"
 
 namespace facebook::presto {
 
@@ -26,7 +27,7 @@ SignalHandler::SignalHandler(PrestoServer* prestoServer)
 }
 
 void SignalHandler::signalReceived(int signum) noexcept {
-  LOG(INFO) << "SHUTDOWN: Received signal " << signum;
+  PRESTO_SHUTDOWN_LOG(INFO) << "Received signal " << signum;
   prestoServer_->stop();
 }
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -51,10 +51,12 @@ static void maybeSetupTaskSpillDirectory(
     const core::PlanFragment& planFragment,
     exec::Task& execTask) {
   const auto baseSpillPath = SystemConfig::instance()->spillerSpillPath();
-  if (!baseSpillPath.empty() &&
+  if (baseSpillPath.hasValue() &&
       planFragment.canSpill(execTask.queryCtx()->queryConfig())) {
     const auto taskSpillDirPath = TaskManager::buildTaskSpillDirectoryPath(
-        baseSpillPath, execTask.queryCtx()->queryId(), execTask.taskId());
+        baseSpillPath.value(),
+        execTask.queryCtx()->queryId(),
+        execTask.taskId());
     execTask.setSpillDirectory(taskSpillDirPath);
     // Create folder for the task spilling.
     auto fileSystem =

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -12,9 +12,17 @@
  * limitations under the License.
  */
 #pragma once
+#include <glog/logging.h>
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 
 namespace facebook::presto::util {
+
+#define PRESTO_STARTUP_LOG_PREFIX "[PRESTO_STARTUP] "
+#define PRESTO_STARTUP_LOG(severity) LOG(severity) << PRESTO_STARTUP_LOG_PREFIX
+
+#define PRESTO_SHUTDOWN_LOG_PREFIX "[PRESTO_SHUTDOWN] "
+#define PRESTO_SHUTDOWN_LOG(severity) \
+  LOG(severity) << PRESTO_SHUTDOWN_LOG_PREFIX
 
 protocol::DateTime toISOTimestamp(uint64_t timeMilli);
 

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 
-#include "presto_cpp/main/http/HttpServer.h"
 #include <algorithm>
+
 #include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/Utils.h"
+#include "presto_cpp/main/http/HttpServer.h"
 
 namespace facebook::presto::http {
 
@@ -255,7 +257,7 @@ void HttpServer::start(
 
   server_->bind(ipConfigs);
 
-  LOG(INFO) << "STARTUP: proxygen::HTTPServer::start()";
+  PRESTO_STARTUP_LOG(INFO) << "proxygen::HTTPServer::start()";
   server_->start(
       [&]() {
         if (onSuccess) {


### PR DESCRIPTION
- Adding concept of registered config properties and way to add extra ones.
- Using registered properties to store default values.
- Return default values as old values when altering properties at run time.

Test plan - Existing and added tests. Local run. Dev cluster run.

```
== NO RELEASE NOTE ==
```
