### PR TITLE
[native] Make PrestoTaskId backward compatible

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -38,6 +38,16 @@ TEST_F(PrestoTaskTest, basicTaskId) {
   EXPECT_EQ(id.attemptNumber(), 4);
 }
 
+TEST_F(PrestoTaskTest, legacyTaskId) {
+  PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3");
+
+  EXPECT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
+  EXPECT_EQ(id.stageId(), 1);
+  EXPECT_EQ(id.stageExecutionId(), 2);
+  EXPECT_EQ(id.id(), 3);
+  EXPECT_EQ(id.attemptNumber(), 0);
+}
+
 TEST_F(PrestoTaskTest, malformedTaskId) {
   VELOX_ASSERT_THROW(PrestoTaskId(""), "Malformed task ID: ");
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
Currently, because of #19649 TaskId is expected to have 5 parts. The 5th part - attemptNumber - is a new addition. For production use-cases, there is no issue as Java and CPP process will use newer code. But for testing use-cases, for presto-on-spark, this backward incompatibility will cause errors. This PR enhances the parsing logic so that the CPP code is compatible with older Java code. We should be able to remove this special handling once both java and cpp have caught up to latest version in all non-prod systems
