### PR TITLE
[native] Catch exception when creating error PrestoTask

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -201,8 +201,16 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
         } catch (const velox::VeloxException& e) {
           // Creating an empty task, putting errors inside so that next status
           // fetch from coordinator will catch the error and well categorize it.
-          taskInfo = taskManager_.createOrUpdateErrorTask(
-              taskId, std::current_exception());
+          try {
+            taskInfo = taskManager_.createOrUpdateErrorTask(
+                taskId, std::current_exception());
+          } catch (const velox::VeloxUserError& e) {
+            http::sendErrorResponse(downstream, e.what());
+            return;
+          } catch (const std::exception& e) {
+            http::sendErrorResponse(downstream, e.what());
+            return;
+          }
         } catch (const std::exception& e) {
           http::sendErrorResponse(downstream, e.what());
           return;


### PR DESCRIPTION
Currently when error happens while creating a PrestoTask, we catch and create an error PrestoTask. But while creating an error PrestoTask we do not handle exceptions, causing servers to crash.
```
== NO RELEASE NOTE ==
```
