### PR TITLE
Fix bind expression conversion

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -475,15 +475,13 @@ TypedExprPtr convertBindExpr(const std::vector<TypedExprPtr>& args) {
   VELOX_CHECK(lambda, "Last argument of a BIND must be a lambda expression");
 
   // replace first N arguments of the lambda with bind variables
-  std::unordered_map<std::string, std::string> mapping;
+  std::unordered_map<std::string, TypedExprPtr> mapping;
   mapping.reserve(args.size() - 1);
 
   const auto& signature = lambda->signature();
 
   for (auto i = 0; i < args.size() - 1; i++) {
-    const auto& field =
-        std::dynamic_pointer_cast<const FieldAccessTypedExpr>(args[i]);
-    mapping.insert({signature->nameOf(i), field->name()});
+    mapping.insert({signature->nameOf(i), args[i]});
   }
 
   auto numArgsLeft = signature->size() - (args.size() - 1);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1010,6 +1010,16 @@ public abstract class AbstractTestNativeGeneralQueries
         }
     }
 
+    @Test
+    public void testLambda()
+    {
+        assertQuery("select transform(x, i->i*y) from (select x, y*y as y from (values row(array[1], 2)) t(x, y))");
+
+        // test nested lambda
+        assertQuery("select transform(transform(x, i->i*z), i->i*y) from (select x, y*y as y, z*z as z from (values row(array[1], 2, 3)) t(x, y, z))");
+        assertQuery("select transform(x, i->transform(i, j->j*y)) from (select x, y*y as y from (values row(array[array[1]], 2)) t(x, y))");
+    }
+
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/5016

Issue: https://github.com/prestodb/presto/issues/19589

Let's rework the rewriteNames() api. This is used to replace names in an expression. Consider expression:

BIND((field_0) * (field_0), (expr_17, expr) -> (expr) * (expr_17)))

BIND is just a syntactic sugar, that is needed by Presto. This is evaluated as

expr -> (expr) * ((field_0) * (field_0))

So our mapping needs to be string -> Expression instead of string -> string.

Also we should not rewrite things like dereferences(x in a.x), and names(x in ROW(x int)). We previously did this and that is unsound.

diff-train-skip-merge

Reviewed By: laithsakka

Differential Revision: D46031146

