### PR TITLE
Add optimization to convert left join with null filter to semi join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -272,6 +272,7 @@ public final class SystemSessionProperties
     public static final String PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN = "push_down_filter_expression_evaluation_through_cross_join";
     public static final String REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN = "rewrite_cross_join_or_to_inner_join";
     public static final String REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN = "rewrite_cross_join_array_contains_to_inner_join";
+    public static final String REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN = "rewrite_left_join_null_filter_to_semi_join";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1579,7 +1580,12 @@ public final class SystemSessionProperties
                         featuresConfig.getJoinsNotNullInferenceStrategy(),
                         false,
                         value -> JoinNotNullInferenceStrategy.valueOf(((String) value).toUpperCase()),
-                        JoinNotNullInferenceStrategy::name));
+                        JoinNotNullInferenceStrategy::name),
+                booleanProperty(
+                        REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN,
+                        "Rewrite left join with is null check to semi join",
+                        featuresConfig.isLeftJoinNullFilterToSemiJoin(),
+                        false));
     }
 
     public static boolean isSpoolingOutputBufferEnabled(Session session)
@@ -2651,5 +2657,10 @@ public final class SystemSessionProperties
     public static boolean isRewriteCrossJoinArrayContainsToInnerJoinEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN, Boolean.class);
+    }
+
+    public static boolean isRewriteLeftJoinNullFilterToSemiJoinEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -265,6 +265,7 @@ public class FeaturesConfig
     private boolean rewriteCrossJoinWithOrFilterToInnerJoin = true;
     private boolean rewriteCrossJoinWithArrayContainsFilterToInnerJoin = true;
     private JoinNotNullInferenceStrategy joinNotNullInferenceStrategy = NONE;
+    private boolean leftJoinNullFilterToSemiJoin = true;
 
     private boolean preProcessMetadataCalls;
 
@@ -2606,6 +2607,19 @@ public class FeaturesConfig
     public FeaturesConfig setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(boolean rewriteCrossJoinWithArrayContainsFilterToInnerJoin)
     {
         this.rewriteCrossJoinWithArrayContainsFilterToInnerJoin = rewriteCrossJoinWithArrayContainsFilterToInnerJoin;
+        return this;
+    }
+
+    public boolean isLeftJoinNullFilterToSemiJoin()
+    {
+        return this.leftJoinNullFilterToSemiJoin;
+    }
+
+    @Config("optimizer.rewrite-left-join-with-null-filter-to-semi-join")
+    @ConfigDescription("Rewrite left join with is null check to semi join")
+    public FeaturesConfig setLeftJoinNullFilterToSemiJoin(boolean leftJoinNullFilterToSemiJoin)
+    {
+        this.leftJoinNullFilterToSemiJoin = leftJoinNullFilterToSemiJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -44,6 +44,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregati
 import com.facebook.presto.sql.planner.iterative.rule.ImplementOffset;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.InlineSqlFunctions;
+import com.facebook.presto.sql.planner.iterative.rule.LeftJoinNullFilterToSemiJoin;
 import com.facebook.presto.sql.planner.iterative.rule.MergeDuplicateAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.MergeFilters;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
@@ -449,6 +450,11 @@ public class PlanOptimizers
                                 new PushDownFilterExpressionEvaluationThroughCrossJoin(metadata.getFunctionAndTypeManager()),
                                 new CrossJoinWithOrFilterToInnerJoin(metadata.getFunctionAndTypeManager()),
                                 new CrossJoinWithArrayContainsToInnerJoin(metadata.getFunctionAndTypeManager()))),
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new LeftJoinNullFilterToSemiJoin(metadata.getFunctionAndTypeManager()))),
                 new KeyBasedSampler(metadata, sqlParser),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
@@ -53,13 +53,13 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.and;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractDisjuncts;
 import static com.facebook.presto.matching.Capture.newCapture;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.coalesceNullToFalse;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
 import static com.facebook.presto.sql.relational.Expressions.not;
@@ -301,11 +301,6 @@ public class CrossJoinWithOrFilterToInnerJoin
         identity.putAll(filterNode.getOutputVariables().stream().collect(toImmutableMap(x -> x, x -> x)));
         ProjectNode projectUnusedOutput = new ProjectNode(context.getIdAllocator().getNextId(), newFilterNode, identity.build());
         return Result.ofPlanNode(projectUnusedOutput);
-    }
-
-    private SpecialFormExpression coalesceNullToFalse(RowExpression rowExpression)
-    {
-        return new SpecialFormExpression(rowExpression.getSourceLocation(), COALESCE, BOOLEAN, rowExpression, constant(false, BOOLEAN));
     }
 
     private static class RewrittenJoinInput

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LeftJoinNullFilterToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LeftJoinNullFilterToSemiJoin.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteLeftJoinNullFilterToSemiJoinEnabled;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.VariablesExtractor.extractAll;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.Expressions.coalesceNullToFalse;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.not;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.function.Function.identity;
+
+/**
+ * Rewrite Left Join with is null check on right join key to semi join, when other output from right input is not used.
+ * <pre>
+ *     - Filter
+ *          r.k is null
+ *          - Left Join
+ *              l.k = r.k
+ *              - Scan l
+ *                  k
+ *              - Scan r
+ *                  k
+ * </pre>
+ * to
+ * <pre>
+ *     - Project
+ *          l.k := l.k
+ *          r.k := NULL
+ *          - Filter
+ *              not(coalesce(semiJoinOutput, false))
+ *              - Semi Join
+ *                  source: l.k
+ *                  filter source: r.k
+ *                  filter output: semiJoinOutput
+ *                  - scan l
+ *                      k
+ *                  - scan r
+ *                      k
+ * </pre>
+ */
+public class LeftJoinNullFilterToSemiJoin
+        implements Rule<FilterNode>
+{
+    private static final Capture<JoinNode> CHILD = newCapture();
+    private static final Pattern<FilterNode> PATTERN = filter().with(source().matching(join().matching(x -> x.getType().equals(JoinNode.Type.LEFT)
+            && x.getCriteria().size() == 1 && !x.getFilter().isPresent() && x.getDynamicFilters().isEmpty()).capturedAs(CHILD)));
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public LeftJoinNullFilterToSemiJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRewriteLeftJoinNullFilterToSemiJoinEnabled(session);
+    }
+
+    private boolean isRightKeyNullExpression(RowExpression expression, VariableReferenceExpression rightKey)
+    {
+        return expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm().equals(SpecialFormExpression.Form.IS_NULL)
+                && ((SpecialFormExpression) expression).getArguments().get(0).equals(rightKey);
+    }
+
+    @Override
+    public Result apply(FilterNode filterNode, Captures captures, Context context)
+    {
+        JoinNode joinNode = captures.get(CHILD);
+        VariableReferenceExpression rightKey = joinNode.getCriteria().get(0).getRight();
+        VariableReferenceExpression leftKey = joinNode.getCriteria().get(0).getLeft();
+        // if output other than join key from right side are used, cannot rewrite
+        if (joinNode.getOutputVariables().stream().anyMatch(x -> joinNode.getRight().getOutputVariables().contains(x) && !x.equals(rightKey))) {
+            return Result.empty();
+        }
+
+        List<RowExpression> andConjuncts = extractConjuncts(filterNode.getPredicate());
+        List<RowExpression> rightKeyNull = andConjuncts.stream().filter(x -> isRightKeyNullExpression(x, rightKey)).collect(toImmutableList());
+        // if no null check just return
+        if (rightKeyNull.isEmpty()) {
+            return Result.empty();
+        }
+        List<RowExpression> remainingConjunct = andConjuncts.stream().filter(x -> !rightKeyNull.contains(x)).collect(toImmutableList());
+        List<VariableReferenceExpression> variablesInRemainingConjuncts = remainingConjunct.stream().flatMap(x -> extractAll(x).stream()).collect(toImmutableList());
+        // Variables from right side referred in other expressions, not only null check.
+        if (variablesInRemainingConjuncts.stream().anyMatch(x -> joinNode.getRight().getOutputVariables().contains(x))) {
+            return Result.empty();
+        }
+
+        VariableReferenceExpression semiJoinOutput = context.getVariableAllocator().newVariable("semiJoinOutput", BOOLEAN);
+        SemiJoinNode semiJoinNode = new SemiJoinNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), joinNode.getLeft(), joinNode.getRight(),
+                leftKey, rightKey, semiJoinOutput, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableMap.of());
+        RowExpression filterExpression = not(functionAndTypeManager, coalesceNullToFalse(semiJoinOutput));
+        FilterNode semiFilterNode = new FilterNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), semiJoinNode, filterExpression);
+        Map<VariableReferenceExpression, RowExpression> outputAssignments =
+                filterNode.getOutputVariables().stream().collect(toImmutableMap(identity(), x -> x.equals(rightKey) ? constantNull(rightKey.getType()) : x));
+        PlanNode planNode = new ProjectNode(context.getIdAllocator().getNextId(), semiFilterNode, Assignments.builder().putAll(outputAssignments).build());
+        if (!remainingConjunct.isEmpty()) {
+            planNode = new FilterNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), planNode, and(remainingConjunct));
+        }
+        return Result.ofPlanNode(planNode);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -93,6 +94,11 @@ public final class Expressions
     public static boolean isComparison(CallExpression callExpression)
     {
         return COMPARISON_FUNCTIONS.contains(callExpression.getFunctionHandle().getName());
+    }
+
+    public static SpecialFormExpression coalesceNullToFalse(RowExpression rowExpression)
+    {
+        return new SpecialFormExpression(rowExpression.getSourceLocation(), COALESCE, BOOLEAN, rowExpression, constant(false, BOOLEAN));
     }
 
     public static CallExpression not(FunctionAndTypeManager functionAndTypeManager, RowExpression rowExpression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -233,7 +233,8 @@ public class TestFeaturesConfig
                 .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.REWRITTEN_TO_INNER_JOIN)
                 .setDefaultJoinSelectivityCoefficient(0)
                 .setRewriteCrossJoinWithOrFilterToInnerJoin(true)
-                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(true));
+                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(true)
+                .setLeftJoinNullFilterToSemiJoin(true));
     }
 
     @Test
@@ -415,6 +416,7 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-cross-join-with-or-filter-to-inner-join", "false")
                 .put("optimizer.rewrite-cross-join-with-array-contains-filter-to-inner-join", "false")
                 .put("optimizer.default-join-selectivity-coefficient", "0.5")
+                .put("optimizer.rewrite-left-join-with-null-filter-to-semi-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -593,7 +595,8 @@ public class TestFeaturesConfig
                 .setDefaultJoinSelectivityCoefficient(0.5)
                 .setPushDownFilterExpressionEvaluationThroughCrossJoin(PushDownFilterThroughCrossJoinStrategy.DISABLED)
                 .setRewriteCrossJoinWithOrFilterToInnerJoin(false)
-                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(false);
+                .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(false)
+                .setLeftJoinNullFilterToSemiJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLeftJoinNullFilterToSemiJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLeftJoinNullFilterToSemiJoin.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestLeftJoinNullFilterToSemiJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testTrigger()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        "not(COALESCE(semijoinoutput, false))",
+                                        semiJoin(
+                                                "left_k1",
+                                                "right_k1",
+                                                "semijoinoutput",
+                                                values("left_k1", "left_k2"),
+                                                values("right_k1")))));
+    }
+
+    @Test
+    public void testNotTriggerWithFilter()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    p.rowExpression("left_k2 > 10"),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerNotNull()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is not null"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerOtherOutputUsed()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    p.variable("right_k2", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1"), p.variable("right_k2")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerOutputUsedInFilter()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null or right_k1 > 2"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerOutputUsedInFilter2()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null and right_k1 > 2"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNotTriggerOtherOutputUsedInFilter()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null or left_k2 > 2"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testTriggerForFilterWithAnd()
+    {
+        tester().assertThat(new LeftJoinNullFilterToSemiJoin(getMetadata().getFunctionAndTypeManager()))
+                .on(p ->
+                {
+                    p.variable("left_k1", BIGINT);
+                    p.variable("left_k2", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.filter(
+                            p.rowExpression("right_k1 is null and left_k2 > 2"),
+                            p.join(JoinNode.Type.LEFT,
+                                    p.values(p.variable("left_k1"), p.variable("left_k2")),
+                                    p.values(p.variable("right_k1")),
+                                    new JoinNode.EquiJoinClause(p.variable("left_k1"), p.variable("right_k1"))));
+                })
+                .matches(
+                        filter(
+                                "left_k2 > 2",
+                                project(
+                                        filter(
+                                                "not(COALESCE(semijoinoutput, false))",
+                                                semiJoin(
+                                                        "left_k1",
+                                                        "right_k1",
+                                                        "semijoinoutput",
+                                                        values("left_k1", "left_k2"),
+                                                        values("right_k1"))))));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_N
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN;
+import static com.facebook.presto.SystemSessionProperties.REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN;
 import static com.facebook.presto.SystemSessionProperties.SIMPLIFY_PLAN_WITH_EMPTY_INPUT;
 import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -6898,5 +6899,68 @@ public abstract class AbstractTestQueries
         sql = "with t1 as (select * from (values (array[cast(1 as integer), 2, 3], 10), (array[4, 5, 6], 11)) t(arr, k)), t2 as (select * from (values (cast(1 as bigint), 'a'), (4, 'b')) t(k, v)) " +
                 "select t1.k, t2.k, t2.v from t1 join t2 on contains(t1.arr, t2.k)";
         assertQuery(enableOptimization, sql, "values (11, 4, 'b'), (10, 1, 'a')");
+    }
+
+    @Test
+    public void testLeftJoinNullFilterToSemiJoin()
+    {
+        Session enableOptimization = Session.builder(getSession())
+                .setSystemProperty(REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN, "true")
+                .build();
+
+        String sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 3, 3");
+
+        // null in both sides
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2, null) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 3, 3, null");
+
+        // null in right side
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2, null) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 3, 3");
+
+        // null in left side
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 3, 3, null");
+
+        // right key also in output
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.*, t2.k from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values (3, null), (3, null)");
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2, null) t(k)) select t1.*, t2.k from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values (3, null), (3, null), (null, null)");
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2, null) t(k)) select t1.*, t2.k from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values (3, null), (3, null)");
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.*, t2.k from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values (3, null), (3, null), (null, null)");
+
+        // Empty right input
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k) where k > 3) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 1, 1, 2, 2, 3, 3");
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2, null) t(k) where k > 3) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 1, 1, 2, 2, 3, 3, null");
+
+        // join filter on left side
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k and t1.k < 2 where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 2, 2, 3, 3");
+
+        // join filter on right side
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k and t2.k < 2 where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 3, 3, 2, 2");
+
+        // join filter on both side
+        sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k and t1.k+t2.k > 2 where t2.k is null";
+        assertQuery(enableOptimization, sql, "values 1, 1, 3, 3");
+
+        // rewrite with tpch dataset
+        sql = "with t as (select orderkey from orders where custkey%5=1) select l.orderkey, l.partkey, l.quantity from lineitem l left join t on l.orderkey = t.orderkey where t.orderkey is null";
+        assertQuery(enableOptimization, sql);
+
+        // filter in where
+        sql = "with t as (select orderkey from orders where custkey%5=1) select l.orderkey, l.partkey, l.quantity from lineitem l left join t on l.orderkey = t.orderkey where t.orderkey is null and l.suppkey%5=1";
+        assertQuery(enableOptimization, sql);
+
+        // filter in on condition
+        sql = "with t as (select orderkey from orders where custkey%5=1) select l.orderkey, l.partkey, l.quantity from lineitem l left join t on l.orderkey = t.orderkey and l.suppkey%5=1 where t.orderkey is null";
+        assertQuery(enableOptimization, sql);
     }
 }


### PR DESCRIPTION
For queries like select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null, it can be rewritten with semi join, which is more efficient.

### Test plan - (Please fill in how you tested your changes)

Add unit test

```
== RELEASE NOTES ==

General Changes
* Add a query optimization to rewrite left join with null check on right join key with semi join. It's controlled by session property `rewrite_left_join_null_filter_to_semi_join`
```
