### PR TITLE
Use mtime and path as cacheIdentifier

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingFileSystem.java
@@ -86,7 +86,9 @@ public class AlluxioCachingFileSystem
                     .setPath(path.toString())
                     .setFolder(false)
                     .setLength(hiveFileContext.getFileSize().getAsLong());
-            String cacheIdentifier = md5().hashString(path.toString(), UTF_8).toString();
+            // Use a combination of the last modification time and path
+            // so that caching is automatically invalidated when a file is modified.
+            String cacheIdentifier = md5().hashString(hiveFileContext.getModificationTime() + path.toString(), UTF_8).toString();
             // CacheContext is the mechanism to pass the cache related context to the source filesystem
             CacheContext cacheContext = PrestoCacheContext.build(cacheIdentifier, hiveFileContext, cacheQuotaEnabled);
             URIStatus uriStatus = new URIStatus(info, cacheContext);


### PR DESCRIPTION
When a file is modified, we can perceive that the file has changed, but the local cached data does not automatically become invalid. This can result in errors when reading the file. Taking ORC files as an example, an error similar to the following may occur: 
```
Query 20230529_082458_00000_qjykh failed: Error opening Hive split hdfs://xxx:8020/xxx.orc (offset=0, length=17261): Malformed ORC file. Invalid postscript [hdfs://xxx:8020/xxx.orc]
```

```
== RELEASE NOTES ==

Hive Changes
* Use mtime and path as cacheIdentifier rather than path.
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
