### PR TITLE
Remove additional update check for coordinator discoverer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -214,8 +214,7 @@ void PrestoServer::run() {
 
   initializeCoordinatorDiscoverer();
   std::unique_ptr<Announcer> announcer;
-  if (coordinatorDiscoverer_ != nullptr &&
-      !coordinatorDiscoverer_->updateAddress().empty()) {
+  if (coordinatorDiscoverer_ != nullptr) {
     announcer = std::make_unique<Announcer>(
         address_,
         httpsPort.has_value(),


### PR DESCRIPTION
Summary: Additional updateAddress() call will potentially throw. And there is no exception handling of that throwing, leading to server crash. This can happen sometimes depending on if smc initialization is done first of that updateAddress() call is done first.

Differential Revision: D46299394

