### PR TITLE
[native] Let PrestoServer own Announcer

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -100,10 +100,6 @@ Announcer::Announcer(
       clientCertAndKeyPath_(clientCertAndKeyPath),
       ciphers_(ciphers) {}
 
-Announcer::~Announcer() {
-  stop();
-}
-
 void Announcer::start() {
   eventBaseThread_.start("Announcer");
   stopped_ = false;

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -35,7 +35,7 @@ class Announcer {
       const std::string& clientCertAndKeyPath = "",
       const std::string& ciphers = "");
 
-  ~Announcer();
+  ~Announcer() = default;
 
   void start();
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -56,6 +56,7 @@ namespace facebook::presto {
 // Three states our server can be in.
 enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };
 
+class Announcer;
 class SignalHandler;
 class TaskManager;
 class TaskResource;
@@ -157,6 +158,7 @@ class PrestoServer {
 
   std::unique_ptr<http::HttpServer> httpServer_;
   std::unique_ptr<SignalHandler> signalHandler_;
+  std::unique_ptr<Announcer> announcer_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<TaskManager> taskManager_;
   std::unique_ptr<TaskResource> taskResource_;


### PR DESCRIPTION
Let Announcer be part of PrestoServer and graceful shutdown logic procedure.
```
== NO RELEASE NOTE ==
```
