### PR TITLE
Add optional jmx plugin to HiveQueryRunner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,6 +583,12 @@
 
             <dependency>
                 <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-jmx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-main</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -421,6 +421,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for benchmark -->
         <dependency>
             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
This PR adds optional JMX plugin to HiveQueryRunner, which can be used to monitor metrics during features development, e.g. caching.
```
== NO RELEASE NOTE ==
```
