### PR TITLE
Update deltalake instuctions

### DIFF
--- a/presto-docs/src/main/sphinx/connector/deltalake.rst
+++ b/presto-docs/src/main/sphinx/connector/deltalake.rst
@@ -80,7 +80,7 @@ table location in an S3 bucket named ``db-sa-datasets`` using Delta Lake connect
 .. code-block:: sql
 
     CREATE TABLE sales.apac.sales_data_new (dummyColumn INT)
-    WITH (external_location = 's3://db-sa-datasets/presto/sales_data_new');
+    WITH (external_location = 's3://db-sa-datasets/presto/sales_data_new', format = 'parquet');
 
 To register a partition Delta table in Hive metastore, use the ``CREATE TABLE`` same as above.
 Only ``external_location`` is required in the properties, no need to specify ``partitioned_by`` in


### PR DESCRIPTION
Delta only supports parquet, specify it in the table creation as not all presto deployments default to parquet.

Test plan - docs change

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.
