### PR TITLE
Update Joda to 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>1.33</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.10.8</dep.joda.version>
+        <dep.joda.version>2.12.2</dep.joda.version>
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2237,3 +2237,6 @@
 2228 Europe/Saratov
 2229 Asia/Qostanay
 2230 America/Nuuk
+2231 Pacific/Kanton
+2232 Europe/Kyiv
+2233 America/Ciudad_Juarez

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -216,7 +216,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), 6334606028834602490L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), 4825838578917475630L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -67,29 +67,6 @@ public class TestTimeZoneUtils
                 continue;
             }
 
-            if (zoneId.equals("Pacific/Kanton")) {
-                // TODO: remove Once Joda version supports this Timezone.
-                // JDK supported this timezone, but not Joda and was resulting in the test failure.
-                // https://www.joda.org/joda-time/timezones.html
-                continue;
-            }
-
-            if (zoneId.equals("Europe/Kyiv")) {
-                // TODO: remove Once this recently renamed Timezone is supported.
-                // Europe/Kiev was renamed to Europe/Kyiv.
-                // https://www.oracle.com/java/technologies/tzdata-versions.html
-                // Likely need to wait for Joda to supported this renamed timezone.
-                // https://www.joda.org/joda-time/timezones.html
-                continue;
-            }
-
-            if (zoneId.equals("America/Ciudad_Juarez")) {
-                // TODO: remove Once this new Timezone is supported.
-                // This is included in 2022g release of the tz code and data.
-                // https://mm.icann.org/pipermail/tz-announce/2022-November/000076.html
-                continue;
-            }
-
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));
 


### PR DESCRIPTION
Fixes #19819

Add Pacific/Kanton, Europe/Kyiv, America/Ciudad_Juarez time zone

Cherrypick of https://github.com/trinodb/trino/pull/10679 
Cherrypick of https://github.com/trinodb/trino/pull/14684 
Cherrypick of https://github.com/trinodb/trino/pull/15754

Test plan - Unit tests

```
== RELEASE NOTES ==

General Changes
* Update Joda to 2.12.2.  Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data.
