### PR TITLE
Update Iceberg from 1.2.1 to 1.3.0

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>1.2.1</dep.iceberg.version>
-        <dep.nessie.version>0.51.1</dep.nessie.version>
+        <dep.iceberg.version>1.3.0</dep.iceberg.version>
+        <dep.nessie.version>0.59.0</dep.nessie.version>
     </properties>
 
     <dependencies>

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -27,7 +27,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.44.0";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.59.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

Iceberg Changes
* Update Iceberg from 1.2.1 to 1.3.0
```
We just released Iceberg 1.3.0 that contains numerous improvements and bug fixes. Release notes can be found [here](https://iceberg.apache.org/releases/#130-release).
