### PR TITLE
[native] Convert [TopN]RowNumberNode to WindowNode

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -149,6 +149,16 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);
 
+  std::shared_ptr<const velox::core::WindowNode> toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::RowNumberNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
+  std::shared_ptr<const velox::core::WindowNode> toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::TopNRowNumberNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
   std::vector<velox::core::FieldAccessTypedExprPtr> toVeloxExprs(
       const std::vector<protocol::VariableReferenceExpression>& variables);
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -110,9 +110,7 @@ public abstract class AbstractTestNativeWindowQueries
     @Test
     public void testRowNumberWithFilter()
     {
-        assertQueryFails("SELECT * FROM (SELECT row_number() over() rn, * from orders) WHERE rn = 1",
-                " Unknown plan node type com.facebook.presto.sql.planner.plan.RowNumberNode");
-        assertQueryFails("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey) rn, * from orders) WHERE rn = 1",
-                " Unknown plan node type com.facebook.presto.sql.planner.plan.TopNRowNumberNode");
+        assertQuery("SELECT sum(rn) FROM (SELECT row_number() over() rn, * from orders) WHERE rn = 10");
+        assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey) rn, * from orders) WHERE rn = 1");
     }
 }


### PR DESCRIPTION
Velox doesn't support [TopN]RowNumberNodes yet. Convert these to WindowNode which is less efficient, but still correct.

```
== NO RELEASE NOTE ==
```
