### PR TITLE
[native pos] Enable tests relying on replicate-null-and-any

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spark;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.nativeworker.AbstractTestNativeJoinQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
@@ -57,16 +56,7 @@ public class TestPrestoSparkNativeJoinQueries
     }
 
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
-
-    // Semi and anti joins require support for replicate-nulls-and-any mode in shuffle.
-    @Override
-    @Ignore
-    public void testAntiJoin(Session joinTypeSession) {}
-
-    @Override
-    @Ignore
-    public void testSemiJoin(Session joinTypeSession) {}
-
+    // Cross join requires broadcast join
     @Override
     @Ignore
     public void testCrossJoin() {}

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -42,6 +42,7 @@ public class TestPrestoSparkNativeTpchQueries
     }
 
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+    // Following tests require broadcast join
     @Override
     @Ignore
     public void testTpchQ7() {}
@@ -57,11 +58,6 @@ public class TestPrestoSparkNativeTpchQueries
     @Override
     @Ignore
     public void testTpchQ15() {}
-
-    // Requires support for replicate-nulls-and-any shuffle mode.
-    @Override
-    @Ignore
-    public void testTpchQ16() {}
 
     @Override
     @Ignore


### PR DESCRIPTION
Replicate null and any partition strategy was implemented in #19698, enable all tests which were earlier failing due to missing functionality.

```
== NO RELEASE NOTE ==
```
