### PR TITLE
Track applicable optimizations that were disabled with a flag

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -237,6 +237,7 @@ public final class SystemSessionProperties
     public static final String EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY = "exceeded_memory_limit_heap_dump_file_directory";
     public static final String DISTRIBUTED_TRACING_MODE = "distributed_tracing_mode";
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
+    public static final String VERBOSE_OPTIMIZER_INFO_ENABLED = "verbose_optimizer_info_enabled";
     public static final String STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED = "streaming_for_partial_aggregation_enabled";
     public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
     public static final String HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD = "hyperloglog_standard_error_warning_threshold";
@@ -1291,6 +1292,11 @@ public final class SystemSessionProperties
                         VERBOSE_RUNTIME_STATS_ENABLED,
                         "Enable logging all runtime stats",
                         featuresConfig.isVerboseRuntimeStatsEnabled(),
+                        false),
+                booleanProperty(
+                        VERBOSE_OPTIMIZER_INFO_ENABLED,
+                        "Enable logging of verbose information about applied optimizations",
+                        featuresConfig.isVerboseOptimizerInfoEnabled(),
                         false),
                 booleanProperty(
                         STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED,
@@ -2458,6 +2464,11 @@ public final class SystemSessionProperties
     public static boolean isVerboseRuntimeStatsEnabled(Session session)
     {
         return session.getSystemProperty(VERBOSE_RUNTIME_STATS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isVerboseOptimizerInfoEnabled(Session session)
+    {
+        return session.getSystemProperty(VERBOSE_OPTIMIZER_INFO_ENABLED, Boolean.class);
     }
 
     public static boolean isLeafNodeLimitEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
@@ -26,11 +26,13 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -42,6 +44,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getQueryAnalyzerTimeout;
 import static com.facebook.presto.SystemSessionProperties.isPrintStatsForNonJoinQuery;
+import static com.facebook.presto.SystemSessionProperties.isVerboseOptimizerInfoEnabled;
 import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_PLANNING_TIMEOUT;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED;
@@ -105,11 +108,13 @@ public class Optimizer
                     throw new PrestoException(QUERY_PLANNING_TIMEOUT, String.format("The query optimizer exceeded the timeout of %s.", getQueryAnalyzerTimeout(session).toString()));
                 }
                 long start = System.nanoTime();
-                root = optimizer.optimize(root, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
-                requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
+                PlanNode newRoot = optimizer.optimize(root, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+                requireNonNull(newRoot, format("%s returned a null plan", optimizer.getClass().getName()));
                 if (enableVerboseRuntimeStats) {
                     session.getRuntimeStats().addMetricValue(String.format("optimizer%sTimeNanos", optimizer.getClass().getSimpleName()), NANO, System.nanoTime() - start);
                 }
+                collectOptimizerInformation(optimizer, root, newRoot);
+                root = newRoot;
             }
         }
 
@@ -132,5 +137,23 @@ public class Optimizer
             return StatsAndCosts.create(root, statsProvider, costProvider);
         }
         return StatsAndCosts.empty();
+    }
+
+    private void collectOptimizerInformation(PlanOptimizer optimizer, PlanNode oldNode, PlanNode newNode)
+    {
+        if (optimizer instanceof IterativeOptimizer) {
+            // iterative optimizers do their own recording of what rules got triggered
+            return;
+        }
+
+        boolean isTriggered = (oldNode != newNode);
+        boolean isApplicable =
+                isTriggered ||
+                !optimizer.isEnabled(session) && isVerboseOptimizerInfoEnabled(session) &&
+                        optimizer.isApplicable(oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+
+        if (isTriggered || isApplicable) {
+            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(optimizer.getClass().getSimpleName(), isTriggered, Optional.of(isApplicable)));
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -234,6 +234,7 @@ public class FeaturesConfig
     private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
     private String analyzerType = "BUILTIN";
     private boolean verboseRuntimeStatsEnabled;
+    private boolean verboseOptimizerInfoEnabled;
 
     private boolean streamingForPartialAggregationEnabled;
     private boolean preferMergeJoinForSortedInputs;
@@ -2203,6 +2204,11 @@ public class FeaturesConfig
     public boolean isVerboseRuntimeStatsEnabled()
     {
         return verboseRuntimeStatsEnabled;
+    }
+
+    public boolean isVerboseOptimizerInfoEnabled()
+    {
+        return verboseOptimizerInfoEnabled;
     }
 
     @Config("verbose-runtime-stats-enabled")

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -93,10 +93,23 @@ public class HashGenerationOptimizer
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
+    private boolean isEnabledForTesting;
 
     public HashGenerationOptimizer(FunctionAndTypeManager functionAndTypeManager)
     {
         this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionManager is null");
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || SystemSessionProperties.isOptimizeHashGenerationEnabled(session);
     }
 
     @Override
@@ -107,7 +120,7 @@ public class HashGenerationOptimizer
         requireNonNull(types, "types is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
-        if (SystemSessionProperties.isOptimizeHashGenerationEnabled(session)) {
+        if (isEnabled(session)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, functionAndTypeManager).accept(plan, new HashComputationSet());
             return result.getNode();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -44,10 +44,23 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
     private static final Set<Class<? extends PlanNode>> LIMITING_NODES =
             ImmutableSet.of(TopNNode.class, LimitNode.class, DistinctLimitNode.class, TopNRowNumberNode.class);
     private final StatsCalculator statsCalculator;
+    private boolean isEnabledForTesting;
 
     public HistoricalStatisticsEquivalentPlanMarkingOptimizer(StatsCalculator statsCalculator)
     {
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || useHistoryBasedPlanStatisticsEnabled(session) || trackHistoryBasedPlanStatisticsEnabled(session);
     }
 
     @Override
@@ -59,7 +72,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (!useHistoryBasedPlanStatisticsEnabled(session) && !trackHistoryBasedPlanStatisticsEnabled(session)) {
+        if (!isEnabled(session)) {
             return plan;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
@@ -40,11 +40,24 @@ public class MergeJoinForSortedInputOptimizer
 {
     private final Metadata metadata;
     private final SqlParser parser;
+    private boolean isEnabledForTesting;
 
     public MergeJoinForSortedInputOptimizer(Metadata metadata, SqlParser parser)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.parser = requireNonNull(parser, "parser is null");
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isGroupedExecutionEnabled(session) && preferMergeJoinForSortedInputs(session);
     }
 
     @Override
@@ -55,7 +68,7 @@ public class MergeJoinForSortedInputOptimizer
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (isGroupedExecutionEnabled(session) && preferMergeJoinForSortedInputs(session)) {
+        if (isEnabled(session)) {
             return SimplePlanRewriter.rewriteWith(new MergeJoinForSortedInputOptimizer.Rewriter(variableAllocator, idAllocator, metadata, session), plan, null);
         }
         return plan;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -90,6 +90,7 @@ public class MergePartialAggregationsWithFilter
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
+    private boolean isEnabledForTesting;
 
     public MergePartialAggregationsWithFilter(FunctionAndTypeManager functionAndTypeManager)
     {
@@ -97,9 +98,21 @@ public class MergePartialAggregationsWithFilter
     }
 
     @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isMergeAggregationsWithAndWithoutFilter(session);
+    }
+
+    @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (isMergeAggregationsWithAndWithoutFilter(session)) {
+        if (isEnabled(session)) {
             return SimplePlanRewriter.rewriteWith(new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager), plan, new Context());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -83,6 +83,7 @@ public class OptimizeMixedDistinctAggregations
 {
     private final Metadata metadata;
     private final StandardFunctionResolution functionResolution;
+    private boolean isEnabledForTesting;
 
     public OptimizeMixedDistinctAggregations(Metadata metadata)
     {
@@ -91,9 +92,21 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isOptimizeDistinctAggregationEnabled(session);
+    }
+
+    @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (isOptimizeDistinctAggregationEnabled(session)) {
+        if (isEnabled(session)) {
             return SimplePlanRewriter.rewriteWith(new Optimizer(idAllocator, variableAllocator, metadata, functionResolution), plan, Optional.empty());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -122,6 +122,7 @@ public class PayloadJoinOptimizer
         implements PlanOptimizer
 {
     private final Metadata metadata;
+    private boolean isEnabledForTesting;
 
     public PayloadJoinOptimizer(Metadata metadata)
     {
@@ -141,9 +142,16 @@ public class PayloadJoinOptimizer
         return plan;
     }
 
-    private boolean isEnabled(Session session)
+    @Override
+    public void setEnabledForTesting(boolean isSet)
     {
-        return isOptimizePayloadJoins(session);
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isOptimizePayloadJoins(session);
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
@@ -28,4 +28,35 @@ public interface PlanOptimizer
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector);
+
+    default boolean isEnabled(Session session)
+    {
+        return true;
+    }
+
+    default void setEnabledForTesting(boolean isSet)
+    {
+        return;
+    }
+
+    default boolean isApplicable(PlanNode plan,
+            Session session,
+            TypeProvider types,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator,
+            WarningCollector warningCollector)
+    {
+        setEnabledForTesting(true);
+
+        boolean isApplicable = false;
+        try {
+            // wrap in try/catch block in case optimization throws an error
+            PlanNode newPlan = optimize(plan, session, types, variableAllocator, idAllocator, warningCollector);
+            isApplicable = !plan.equals(newPlan);
+        }
+        finally {
+            setEnabledForTesting(false);
+            return isApplicable;
+        }
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java.orig
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java.orig
@@ -89,24 +89,10 @@ public class PrefilterForLimitingAggregation
 {
     private final Metadata metadata;
     private final StatsCalculator statsCalculator;
-    private boolean isEnabledForTesting;
-
     public PrefilterForLimitingAggregation(Metadata metadata, StatsCalculator statsCalculator)
     {
         this.metadata = metadata;
         this.statsCalculator = statsCalculator;
-    }
-
-    @Override
-    public void setEnabledForTesting(boolean isSet)
-    {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || SystemSessionProperties.isPrefilterForGroupbyLimit(session);
     }
 
     @Override
@@ -118,7 +104,7 @@ public class PrefilterForLimitingAggregation
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector)
     {
-        if (isEnabled(session)) {
+        if (SystemSessionProperties.isPrefilterForGroupbyLimit(session)) {
             return SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata, types, statsCalculator, idAllocator, variableAllocator), plan);
         }
 
@@ -203,8 +189,12 @@ public class PrefilterForLimitingAggregation
             }
 
             PlanNode originalSource = aggregationNode.getSource();
-            PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, keys, new HashMap<>());
+<<<<<<< HEAD
+            PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, keys, ImmutableMap.of());
             // TODO(kaikalur): See if timetout can be done in a cleaner way in the middle tier
+=======
+            PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, keys, new HashMap<>());
+>>>>>>> efe19190ab (Optimize joins over tables with map columns)
             DistinctLimitNode timedDistinctLimitNode = new DistinctLimitNode(
                     Optional.empty(),
                     idAllocator.getNextId(),
@@ -224,7 +214,7 @@ public class PrefilterForLimitingAggregation
 
             VariableReferenceExpression mapAggVariable = variableAllocator.newVariable("expr", mapType);
             PlanNode crossJoinRhs = addAggregation(rightProjectNode, functionAndTypeManager, idAllocator, variableAllocator, "MAP_AGG", mapType, ImmutableList.of(), mapAggVariable, rightProjectNode.getOutputVariables().get(0), rightProjectNode.getOutputVariables().get(1));
-            PlanNode crossJoinLhs = addProjections(originalSource, idAllocator, variableAllocator, ImmutableList.of(leftHashExpression), ImmutableList.of());
+            PlanNode crossJoinLhs = addProjections(originalSource, idAllocator, variableAllocator, ImmutableList.of(leftHashExpression));
             ImmutableList.Builder<VariableReferenceExpression> crossJoinOutput = ImmutableList.builder();
 
             crossJoinOutput.addAll(crossJoinLhs.getOutputVariables());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -89,10 +89,23 @@ public class PushdownSubfields
         implements PlanOptimizer
 {
     private final Metadata metadata;
+    private boolean isEnabledForTesting;
 
     public PushdownSubfields(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isPushdownSubfieldsEnabled(session);
     }
 
     @Override
@@ -102,7 +115,7 @@ public class PushdownSubfields
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
 
-        if (!isPushdownSubfieldsEnabled(session)) {
+        if (!isEnabled(session)) {
             return plan;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
@@ -54,10 +54,24 @@ import static java.util.Objects.requireNonNull;
 public class RemoveRedundantDistinctAggregation
         implements PlanOptimizer
 {
+    private boolean isEnabledForTesting;
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isRemoveRedundantDistinctAggregationEnabled(session);
+    }
+
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (isRemoveRedundantDistinctAggregationEnabled(session)) {
+        if (isEnabled(session)) {
             PlanWithProperties result = new RemoveRedundantDistinctAggregation.Rewriter().accept(plan);
             return result.getNode();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
@@ -87,10 +87,23 @@ public class RewriteIfOverAggregation
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
+    private boolean isEnabledForTesting;
 
     public RewriteIfOverAggregation(FunctionAndTypeManager functionAndTypeManager)
     {
         this.functionAndTypeManager = functionAndTypeManager;
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isOptimizeConditionalAggregationEnabled(session);
     }
 
     @Override
@@ -101,7 +114,7 @@ public class RewriteIfOverAggregation
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector)
     {
-        if (isOptimizeConditionalAggregationEnabled(session)) {
+        if (isEnabled(session)) {
             return SimplePlanRewriter.rewriteWith(
                     new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager)), plan, ImmutableMap.of());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -102,10 +102,24 @@ import static java.util.function.Function.identity;
 public class SimplifyPlanWithEmptyInput
         implements PlanOptimizer
 {
+    private boolean isEnabledForTesting;
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isSimplifyPlanWithEmptyInputEnabled(session);
+    }
+
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (isSimplifyPlanWithEmptyInputEnabled(session)) {
+        if (isEnabled(session)) {
             Rewriter rewriter = new Rewriter(idAllocator);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(rewriter, plan);
             if (rewriter.isPlanChanged()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -122,6 +122,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.isVerboseOptimizerInfoEnabled;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.expressions.DynamicFilters.extractDynamicFilters;
@@ -180,7 +181,7 @@ public class PlanPrinter
                 .mapToLong(planNode -> planNode.getPlanNodeScheduledTime().toMillis())
                 .sum(), MILLISECONDS));
 
-        this.representation = new PlanRepresentation(planRoot, types, totalCpuTime, totalScheduledTime);
+        this.representation = new PlanRepresentation(planRoot, types, totalCpuTime, totalScheduledTime, session.getOptimizerInformationCollector().getOptimizationInfo());
 
         RowExpressionFormatter rowExpressionFormatter = new RowExpressionFormatter(functionAndTypeManager);
         ConnectorSession connectorSession = requireNonNull(session, "session is null").toConnectorSession();
@@ -190,9 +191,9 @@ public class PlanPrinter
         planRoot.accept(visitor, null);
     }
 
-    public String toText(boolean verbose, int level)
+    public String toText(boolean verbose, int level, boolean verboseOptimizerInfo)
     {
-        return new TextRenderer(verbose, level).render(representation);
+        return new TextRenderer(verbose, level, verboseOptimizerInfo).render(representation);
     }
 
     public String toJson()
@@ -209,7 +210,13 @@ public class PlanPrinter
 
     public static String textLogicalPlan(PlanNode plan, TypeProvider types, StatsAndCosts estimatedStatsAndCosts, FunctionAndTypeManager functionAndTypeManager, Session session, int level)
     {
-        return new PlanPrinter(plan, types, Optional.empty(), estimatedStatsAndCosts, Optional.empty(), functionAndTypeManager, session).toText(false, level);
+        return new PlanPrinter(plan, types,
+                Optional.empty(),
+                estimatedStatsAndCosts,
+                Optional.empty(),
+                functionAndTypeManager,
+                session)
+                .toText(false, level, isVerboseOptimizerInfoEnabled(session));
     }
 
     public static String textLogicalPlan(
@@ -235,7 +242,7 @@ public class PlanPrinter
             int level,
             boolean verbose)
     {
-        return new PlanPrinter(plan, types, stageExecutionStrategy, estimatedStatsAndCosts, stats, functionAndTypeManager, session).toText(verbose, level);
+        return new PlanPrinter(plan, types, stageExecutionStrategy, estimatedStatsAndCosts, stats, functionAndTypeManager, session).toText(verbose, level, isVerboseOptimizerInfoEnabled(session));
     }
 
     public static String textDistributedPlan(StageInfo outputStageInfo, FunctionAndTypeManager functionAndTypeManager, Session session, boolean verbose)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.sql.planner.planPrinter;
 
+import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.TypeProvider;
 import io.airlift.units.Duration;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,13 +34,15 @@ class PlanRepresentation
     private final TypeProvider types;
 
     private final Map<PlanNodeId, NodeRepresentation> nodeInfo = new HashMap<>();
+    private final List<PlanOptimizerInformation> planOptimizerInfo;
 
-    public PlanRepresentation(PlanNode root, TypeProvider types, Optional<Duration> totalCpuTime, Optional<Duration> totalScheduledTime)
+    public PlanRepresentation(PlanNode root, TypeProvider types, Optional<Duration> totalCpuTime, Optional<Duration> totalScheduledTime, List<PlanOptimizerInformation> planOptimizerInfo)
     {
         this.root = requireNonNull(root, "root is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
         this.types = requireNonNull(types, "types is null");
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
+        this.planOptimizerInfo = requireNonNull(planOptimizerInfo, "planOptimizerInfo is null");
     }
 
     public NodeRepresentation getRoot()
@@ -77,5 +81,10 @@ class PlanRepresentation
         if (previous != null) {
             throw new IllegalStateException(String.format("Duplicate node ID %s: %s vs. %s", node.getId(), previous.getName(), node.getName()));
         }
+    }
+
+    public List<PlanOptimizerInformation> getPlanOptimizerInfo()
+    {
+        return planOptimizerInfo;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
@@ -87,7 +87,8 @@ public class TestJsonRenderer
                 root,
                 TypeProvider.viewOf(VARIABLE_ALLOCATOR.getVariables()),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     private NodeRepresentation getNodeRepresentation(PlanNode root, List<PlanNodeId> planNodeIds)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestVerboseOptimizerInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestVerboseOptimizerInfo.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_PAYLOAD_JOINS;
+import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertTrue;
+
+public class TestVerboseOptimizerInfo
+        extends AbstractTestQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return createLocalQueryRunner();
+    }
+
+    public static LocalQueryRunner createLocalQueryRunner()
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        // add the tpch catalog
+        // local queries run directly against the generator
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.of());
+
+        localQueryRunner.getMetadata().registerBuiltInFunctions(CUSTOM_FUNCTIONS);
+
+        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
+        sessionPropertyManager.addConnectorSessionProperties(new ConnectorId(TESTING_CATALOG), TEST_CATALOG_PROPERTIES);
+
+        return localQueryRunner;
+    }
+
+    @Test
+    public void testApplicableOptimizers()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty("verbose_optimizer_info_enabled", "true")
+                .build();
+        String query = "SELECT o.orderkey FROM part p, orders o, lineitem l WHERE p.partkey = l.partkey AND l.orderkey = o.orderkey AND p.partkey <> o.orderkey AND p.name < l.comment";
+        MaterializedResult materializedResult = computeActual(session, "explain " + query);
+        String explain = (String) getOnlyElement(materializedResult.getOnlyColumnAsSet());
+
+        checkOptimizerInfo(explain, true, ImmutableList.of("PruneCrossJoinColumns"));
+        checkOptimizerInfo(explain, false, ImmutableList.of("AddNotNullFiltersToJoinNode"));
+
+        String payloadJoinQuery = "SELECT l.* FROM (select *, map(ARRAY[1,3], ARRAY[2,4]) as m1 from lineitem) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)";
+        materializedResult = computeActual(session, "explain " + payloadJoinQuery);
+        String explainPayloadJoinQuery = (String) getOnlyElement(materializedResult.getOnlyColumnAsSet());
+
+        checkOptimizerInfo(explainPayloadJoinQuery, false, ImmutableList.of("PayloadJoinOptimizer"));
+
+        Session sessionWithPayload = Session.builder(session)
+                .setSystemProperty(OPTIMIZE_PAYLOAD_JOINS, "true")
+                .build();
+        materializedResult = computeActual(sessionWithPayload, "explain " + payloadJoinQuery);
+        explainPayloadJoinQuery = (String) getOnlyElement(materializedResult.getOnlyColumnAsSet());
+
+        checkOptimizerInfo(explainPayloadJoinQuery, true, ImmutableList.of("PayloadJoinOptimizer"));
+    }
+
+    private void checkOptimizerInfo(String explain, boolean checkTriggered, List<String> optimizers)
+    {
+        String regex = checkTriggered ? "Triggered optimizers.*" : "Applicable optimizers.*";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(explain);
+        assertTrue(matcher.find());
+
+        String optimizerInfo = matcher.group();
+        for (String opt : optimizers) {
+            assertTrue(optimizerInfo.contains(opt));
+        }
+    }
+}


### PR DESCRIPTION
This PR extends previous [change](https://github.com/prestodb/presto/commit/e2f5ad57fef87dd67412cc53181a5e1ab97fc429#diff-53a59072e713641cbf93aed58413dbe55e2b646005db67e88a0bb118a9c4c716), which tracked which rule-based optimizations triggered for a query in the following shape:
```
RemoveRedundantIdentityProjections(triggered: true, applicable: true)
PruneTableScanColumns(triggered: true, applicable: true)
...
```

This PR adds the following:
- also track plan optimizers (and not just rule-based optimizers)
- track which optimizers were applicable but did not trigger because they are disabled by a flag:
```
PayloadJoinOptimizer(triggered: false, applicable: true)
```
- adds info about triggered and applicable optimizers to EXPLAIN output, e.g.:
```
presto:tpch> explain SELECT l.* FROM lineitem_map l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1);
                                                                                                                                                                                 >
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct, shipmode, comm>
         Estimates: {rows: 135354 (24.12MB), cpu: 176007121.33, memory: 306000.00, network: 56242251.93}                                                                         >
     - RemoteStreamingExchange[GATHER] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:doubl>
             Estimates: {rows: 135354 (24.12MB), cpu: 176007121.33, memory: 306000.00, network: 56242251.93}                                                                     >
         - LeftJoin[("expr_11" = "expr_12")][$hashvalue, $hashvalue_93] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:d>
....                                                                                                >
 Triggered optimizers: [RemoveRedundantIdentityProjections, PruneTableScanColumns, PruneJoinColumns, PruneProjectColumns, PruneJoinChildrenColumns, ProjectRowExpressionRewrite, >
 Applicable optimizers: [AddNotNullFiltersToJoinNode, PayloadJoinOptimizer]
```
This information is only printed if the flag verbose_optimizer_info_enabled is true.
