### PR TITLE
Fixing Schema variable support in resource group static selector

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
@@ -75,7 +75,7 @@ public class StaticSelector
         this.schema = requireNonNull(schema, "schema is null");
         this.group = requireNonNull(group, "group is null");
 
-        HashSet<String> variableNames = new HashSet<>(ImmutableList.of(USER_VARIABLE, SOURCE_VARIABLE));
+        HashSet<String> variableNames = new HashSet<>(ImmutableList.of(USER_VARIABLE, SOURCE_VARIABLE, SCHEMA_VARIABLE));
         userRegex.ifPresent(u -> addNamedGroups(u, variableNames));
         sourceRegex.ifPresent(s -> addNamedGroups(s, variableNames));
         this.variableNames = ImmutableSet.copyOf(variableNames);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
@@ -102,7 +102,7 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of("schema1"),
-                new ResourceGroupIdTemplate("global.schema1"));
+                new ResourceGroupIdTemplate("global.${SCHEMA}"));
         assertEquals(selector.match(newSelectionCriteria("userA", null, "schema1", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
         assertEquals(selector.match(newSelectionCriteria("userB", "source", "schema2", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES)), Optional.empty());
         assertEquals(selector.match(newSelectionCriteria("userA", null, "schema1", ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));


### PR DESCRIPTION
Due to a validation check in StaticSelector, resource group was not supporting ${SCHEMA} in resource group name. Fixing it as part of the PR.

Test plan - Fixed existing unit test to verify it correctly.

```
== RELEASE NOTES ==

General Changes
* Fixing schema support in resource group static selector

