### PR TITLE
[native] Refactor cleanOldTasks() in TaskManager

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -67,7 +67,7 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumTasksFailed, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterNumZombieTasks, facebook::velox::StatType::AVG);
+      kCounterNumZombieVeloxTasks, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumZombiePrestoTasks, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -62,8 +62,8 @@ constexpr folly::StringPiece kCounterNumTasksAborted{
     "presto_cpp.num_tasks_aborted"};
 constexpr folly::StringPiece kCounterNumTasksFailed{
     "presto_cpp.num_tasks_failed"};
-constexpr folly::StringPiece kCounterNumZombieTasks{
-    "presto_cpp.num_zombie_tasks"};
+constexpr folly::StringPiece kCounterNumZombieVeloxTasks{
+    "presto_cpp.num_zombie_velox_tasks"};
 constexpr folly::StringPiece kCounterNumZombiePrestoTasks{
     "presto_cpp.num_zombie_presto_tasks"};
 constexpr folly::StringPiece kCounterNumRunningDrivers{


### PR DESCRIPTION
In cleanOldTasks() a copy of taskMap is made to reduce locking time. The purpose of the copy is for iterating and finding the tasks eligible to delete. However the copy lives till the end of the method, holding shared_ptr of already "deleted" PrestoTask (deleted through taskMap_.wlock()->erase()). Though this won't cause functionality issues, it introduces troubles while debugging crash stack. When destruction order of PrestoTask is invoked, we expect it to be at the site of erase() call instead of at the end of the method. Also it does not align with the log lines "Cleaned old task" when it really has not cleaned it. 
```
== NO RELEASE NOTE ==
```
