### PR TITLE
[Druid] Use a different repository to download sigar artifacts

### DIFF
--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -16,6 +16,16 @@
         <dep.log4j.version>2.17.1</dep.log4j.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>sigar</id>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>


### PR DESCRIPTION
The old repository(repository.jboss.org) has been throwing 500 Internal Server Errors.

```
[ERROR] Failed to execute goal on project presto-druid: Could not resolve dependencies for project com.facebook.presto:presto-druid:presto-plugin:0.282-SNAPSHOT: Failed to collect dependencies at org.apache.druid:druid-processing:jar:0.19.0 -> org.apache.druid:druid-core:jar:0.19.0 -> org.hyperic:sigar:jar:1.6.5.132: Failed to read artifact descriptor for org.hyperic:sigar:jar:1.6.5.132: Could not transfer artifact org.hyperic:sigar:pom:1.6.5.132 from/to sigar (https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/): transfer failed for https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/org/hyperic/sigar/1.6.5.132/sigar-1.6.5.132.pom, status: 500 Internal Server Error -> [Help 1]
```

The new repository has been taken from the recent versions of druid. Since druid-24.0.0, the repository has been changed from  `https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/` to  `https://repository.mulesoft.org/nexus/content/repositories/public` (https://github.com/apache/druid/pull/12561)

Test plan 
Verified that after this change, we are able to download the sigar artifacts from the new repository and the build succeeds.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
