### PR TITLE
[native] Add additional cast to NULL_IF is argument types are different

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -830,6 +830,13 @@ public final class SqlToRowExpressionTranslator
             RowExpression first = process(node.getFirst(), context);
             RowExpression second = process(node.getSecond(), context);
 
+            if (!second.getType().equals(first.getType())) {
+                second = call(
+                        getSourceLocation(node),
+                        CAST.name(),
+                        functionAndTypeResolver.lookupCast(CAST.name(), second.getType(), first.getType()),
+                        first.getType(), second);
+            }
             return specialForm(getSourceLocation(node), NULL_IF, getType(node), first, second);
         }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -244,6 +244,11 @@ public abstract class AbstractTestNativeGeneralQueries
     @Test
     public void testCast()
     {
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
         assertQuery("SELECT CAST(linenumber as TINYINT), CAST(linenumber AS SMALLINT), "
                 + "CAST(linenumber AS INTEGER), CAST(linenumber AS BIGINT), CAST(quantity AS REAL), "
                 + "CAST(orderkey AS DOUBLE), CAST(orderkey AS VARCHAR) FROM lineitem");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -48,10 +48,6 @@ public class TestPrestoSparkNativeGeneralQueries
 
     @Override
     @Ignore
-    public void testCast() {}
-
-    @Override
-    @Ignore
     public void testCatalogWithCacheEnabled() {}
 
     @Override


### PR DESCRIPTION
Add additional cast to NULL_IF if the argument type of first and second are different.
```
== NO RELEASE NOTE ==
```
