### PR TITLE
[native] Create all tables when launching HiveExternalWorkerQueryRunner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
@@ -15,17 +15,25 @@ package com.facebook.presto.nativeworker;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.log.Logging;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 
 public class HiveExternalWorkerQueryRunner
 {
     private HiveExternalWorkerQueryRunner() {}
+
     public static void main(String[] args)
             throws Exception
     {
-        // You need to add "--user user" to your CLI for your queries to work
+        // You need to add "--user user" to your CLI for your queries to work.
         Logging.initialize();
 
+        // Create tables before launching distributed runner.
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
+        javaQueryRunner.close();
+
+        // Launch distributed runner.
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner();
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -45,6 +45,28 @@ public class NativeQueryRunnerUtils
                 .build();
     }
 
+    /**
+     * Creates all tables for local testing, except for bench tables.
+     * @param queryRunner
+     */
+    public static void createAllTables(QueryRunner queryRunner)
+    {
+        createLineitem(queryRunner);
+        createOrders(queryRunner);
+        createOrdersEx(queryRunner);
+        createOrdersHll(queryRunner);
+        createNation(queryRunner);
+        createPartitionedNation(queryRunner);
+        createBucketedCustomer(queryRunner);
+        createCustomer(queryRunner);
+        createPart(queryRunner);
+        createPartSupp(queryRunner);
+        createRegion(queryRunner);
+        createSupplier(queryRunner);
+        createEmptyTable(queryRunner);
+        createBucketedLineitemAndOrders(queryRunner);
+    }
+
     public static void createLineitem(QueryRunner queryRunner)
     {
         if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem")) {


### PR DESCRIPTION
Previously table creation upon launching HiveExternalWorkerQueryRunner is removed. We need to bring it back to facilitate local debugging.
```
== NO RELEASE NOTE ==
```
