### PR TITLE
[native] Handle NULLIF without the need for specialForm

### DIFF
--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
@@ -199,7 +199,7 @@ public class TestDruidQueryBase
                 expression,
                 ImmutableMap.of(),
                 WarningCollector.NOOP);
-        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager.getFunctionAndTypeResolver(), session);
+        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager, session);
     }
 
     protected LimitNode limit(PlanBuilder pb, long count, PlanNode source)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -759,7 +759,7 @@ public class MaterializedViewQueryOptimizer
                     coercedMaybe,
                     coercedExpressionAnalysis.getExpressionTypes(),
                     ImmutableMap.of(),
-                    metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                    metadata.getFunctionAndTypeManager(),
                     session);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1495,7 +1495,7 @@ class StatementAnalyzer
                         viewQueryWhereClause,
                         analysis.getTypes(),
                         ImmutableMap.of(),
-                        functionAndTypeResolver,
+                        metadata.getFunctionAndTypeManager(),
                         session);
 
                 TupleDomain<String> viewQueryDomain = MaterializedViewUtils.getDomainFromFilter(session, domainTranslator, rowExpression);
@@ -2100,9 +2100,8 @@ class StatementAnalyzer
 
                 Window window = windowFunction.getWindow().get();
                 if (window.getOrderBy().filter(
-                        orderBy -> orderBy.getSortItems()
-                                .stream()
-                                .anyMatch(item -> item.getSortKey() instanceof Literal))
+                                orderBy -> orderBy.getSortItems().stream().anyMatch(
+                                        item -> item.getSortKey() instanceof Literal))
                         .isPresent()) {
                     if (isAllowWindowOrderByLiterals(session)) {
                         warningCollector.add(

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2099,10 +2099,7 @@ class StatementAnalyzer
                 }
 
                 Window window = windowFunction.getWindow().get();
-                if (window.getOrderBy().filter(
-                                orderBy -> orderBy.getSortItems().stream().anyMatch(
-                                        item -> item.getSortKey() instanceof Literal))
-                        .isPresent()) {
+                if (window.getOrderBy().filter(orderBy -> orderBy.getSortItems().stream().anyMatch(item -> item.getSortKey() instanceof Literal)).isPresent()) {
                     if (isAllowWindowOrderByLiterals(session)) {
                         warningCollector.add(
                                 new PrestoWarning(

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
@@ -144,7 +144,7 @@ public class RowExpressionCompiler
                     RowExpression function = getSqlFunctionRowExpression(
                             functionMetadata,
                             functionImplementation,
-                            metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                            metadata.getFunctionAndTypeManager(),
                             sqlFunctionProperties,
                             sessionFunctions,
                             call.getArguments());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -282,7 +282,7 @@ public class RowExpressionInterpreter
                 RowExpression function = getSqlFunctionRowExpression(
                         functionMetadata,
                         functionImplementation,
-                        metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                        metadata.getFunctionAndTypeManager(),
                         session.getSqlFunctionProperties(),
                         session.getSessionFunctions(),
                         node.getArguments());
@@ -582,10 +582,10 @@ public class RowExpressionInterpreter
 
                     if (hasUnresolvedValue) {
                         List<RowExpression> simplifiedExpressionValues = Stream.concat(
-                                Stream.concat(
-                                        Stream.of(toRowExpression(target, node.getArguments().get(0))),
-                                        unresolvedValues.stream().filter(determinismEvaluator::isDeterministic).distinct()),
-                                unresolvedValues.stream().filter((expression -> !determinismEvaluator.isDeterministic(expression))))
+                                        Stream.concat(
+                                                Stream.of(toRowExpression(target, node.getArguments().get(0))),
+                                                unresolvedValues.stream().filter(determinismEvaluator::isDeterministic).distinct()),
+                                        unresolvedValues.stream().filter((expression -> !determinismEvaluator.isDeterministic(expression))))
                                 .collect(toImmutableList());
                         return new SpecialFormExpression(IN, node.getType(), simplifiedExpressionValues);
                     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
@@ -74,7 +74,7 @@ public class TranslateExpressionsUtil
 
     public static RowExpression toRowExpression(Expression expression, Metadata metadata, Session session, Map<NodeRef<Expression>, Type> types, SqlToRowExpressionTranslator.Context context)
     {
-        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), session, context);
+        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager(), session, context);
     }
 
     public static Map<NodeRef<Expression>, Type> analyzeCallExpressionTypes(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineSqlFunctions.java
@@ -106,7 +106,7 @@ public class InlineSqlFunctions
                 return getSqlFunctionRowExpression(
                         functionMetadata,
                         (SqlInvokedScalarFunctionImplementation) metadata.getFunctionAndTypeManager().getScalarFunctionImplementation(functionHandle),
-                        metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                        metadata.getFunctionAndTypeManager(),
                         session.getSqlFunctionProperties(),
                         session.getSessionFunctions(),
                         rewrittenArguments);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -119,7 +119,7 @@ public class ExpressionEquivalence
                 WarningCollector.NOOP);
 
         // convert to row expression
-        return translate(expression, expressionTypes, variableInput, metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), session);
+        return translate(expression, expressionTypes, variableInput, metadata.getFunctionAndTypeManager(), session);
     }
 
     private static class CanonicalizationVisitor

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -108,6 +108,9 @@ public final class SqlFunctionUtils
                         Optional.empty(),
                         sqlFunctionProperties,
                         sessionFunctions,
+                        // TODO: use session to determine if this is a native query
+                        // https://github.com/prestodb/presto/issues/20008
+                        false,
                         new SqlToRowExpressionTranslator.Context()),
                 functionMetadata.getArgumentNames().get(),
                 arguments,

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -82,27 +83,27 @@ public final class SqlFunctionUtils
     public static RowExpression getSqlFunctionRowExpression(
             FunctionMetadata functionMetadata,
             SqlInvokedScalarFunctionImplementation implementation,
-            FunctionAndTypeResolver functionAndTypeResolver,
+            FunctionAndTypeManager functionAndTypeManager,
             SqlFunctionProperties sqlFunctionProperties,
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
             List<RowExpression> arguments)
     {
         VariableAllocator variableAllocator = new VariableAllocator();
-        Map<String, VariableReferenceExpression> argumentVariables = allocateFunctionArgumentVariables(functionMetadata, functionAndTypeResolver, variableAllocator);
-        Expression expression = getSqlFunctionImplementationExpression(functionMetadata, implementation, functionAndTypeResolver, variableAllocator, sqlFunctionProperties, argumentVariables);
+        Map<String, VariableReferenceExpression> argumentVariables = allocateFunctionArgumentVariables(functionMetadata, functionAndTypeManager.getFunctionAndTypeResolver(), variableAllocator);
+        Expression expression = getSqlFunctionImplementationExpression(functionMetadata, implementation, functionAndTypeManager.getFunctionAndTypeResolver(), variableAllocator, sqlFunctionProperties, argumentVariables);
 
         // Translate to row expression
         return SqlFunctionArgumentBinder.bindFunctionArguments(
                 SqlToRowExpressionTranslator.translate(
                         expression,
                         analyzeSqlFunctionExpression(
-                                functionAndTypeResolver,
+                                functionAndTypeManager.getFunctionAndTypeResolver(),
                                 sqlFunctionProperties,
                                 expression,
                                 argumentVariables.values().stream()
                                         .collect(toImmutableMap(VariableReferenceExpression::getName, VariableReferenceExpression::getType))).getExpressionTypes(),
                         ImmutableMap.of(),
-                        functionAndTypeResolver,
+                        functionAndTypeManager,
                         Optional.empty(),
                         Optional.empty(),
                         sqlFunctionProperties,

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/CustomFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/CustomFunctions.java
@@ -14,9 +14,13 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
 import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
 import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
 
@@ -44,5 +48,14 @@ public final class CustomFunctions
     public static boolean customIsNullBigint(@SqlNullable @SqlType(StandardTypes.BIGINT) Long value)
     {
         return value == null;
+    }
+
+    @SqlInvokedScalarFunction(value = "custom_square", deterministic = true, calledOnNullInput = false)
+    @Description("Custom SQL to test NULLIF in Functions")
+    @SqlParameters({@SqlParameter(name = "x", type = "integer"), @SqlParameter(name = "y", type = "integer")})
+    @SqlType("integer")
+    public static String customSquare()
+    {
+        return "RETURN IF(NULLIF(x, y) IS NOT NULL, x * x, y * y)";
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -1020,7 +1020,7 @@ public final class FunctionAssertions
 
     private RowExpression toRowExpression(Expression projection, Map<NodeRef<Expression>, Type> expressionTypes, Map<VariableReferenceExpression, Integer> layout)
     {
-        return translate(projection, expressionTypes, layout, metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), session);
+        return translate(projection, expressionTypes, layout, metadata.getFunctionAndTypeManager(), session);
     }
 
     private static Page getAtMostOnePage(Operator operator, Page sourcePage)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
@@ -13,8 +13,14 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.operator.scalar.annotations.SqlInvokedScalarFromAnnotationsParser;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -22,10 +28,21 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 public class TestCustomFunctions
         extends AbstractTestFunctions
 {
+    public TestCustomFunctions()
+    {
+    }
+
+    protected TestCustomFunctions(FeaturesConfig config)
+    {
+        super(config);
+    }
+
     @BeforeClass
     public void setupClass()
     {
         registerScalar(CustomFunctions.class);
+        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(CustomFunctions.class);
+        this.functionAssertions.addFunctions(functions);
     }
 
     @Test
@@ -46,5 +63,12 @@ public class TestCustomFunctions
     {
         assertFunction("custom_is_null(CAST(NULL AS BIGINT))", BOOLEAN, true);
         assertFunction("custom_is_null(0)", BOOLEAN, false);
+    }
+
+    @Test
+    public void testNullIf()
+    {
+        assertFunction("custom_square(2, 5)", IntegerType.INTEGER, 4);
+        assertFunction("custom_square(5, 5)", IntegerType.INTEGER, 25);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -268,7 +268,7 @@ public class TestRowExpressionSerde
 
     private RowExpression translate(Expression expression, boolean optimize)
     {
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), TEST_SESSION);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
         if (optimize) {
             RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
             return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
@@ -74,13 +74,13 @@ public class TestingRowExpressionTranslator
                 expression,
                 getExpressionTypes(expression, typeProvider),
                 ImmutableMap.of(),
-                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                metadata.getFunctionAndTypeManager(),
                 TEST_SESSION);
     }
 
     public RowExpression translateAndOptimize(Expression expression, Map<NodeRef<Expression>, Type> types)
     {
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), TEST_SESSION);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
         return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
@@ -184,7 +184,7 @@ public class CommonSubExpressionBenchmark
         Expression expression = createExpression(value, METADATA, TypeProvider.copyOf(symbolTypes));
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager().getFunctionAndTypeResolver(), TEST_SESSION);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
         return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
@@ -182,7 +182,7 @@ public class PageProcessorBenchmark
         Expression expression = createExpression(value, METADATA, TypeProvider.copyOf(symbolTypes));
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager().getFunctionAndTypeResolver(), TEST_SESSION);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
         return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewriter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewriter.java
@@ -147,7 +147,7 @@ public class TestCommonSubExpressionRewriter
                 expression,
                 expressionTypes,
                 ImmutableMap.of(),
-                METADATA.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                METADATA.getFunctionAndTypeManager(),
                 SESSION);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -167,7 +167,7 @@ public class TestExpressionCompiler
         else {
             executor = newDirectExecutorService();
         }
-        functionAssertions = new FunctionAssertions();
+        this.functionAssertions = setFunctionAssertions();
     }
 
     @AfterClass(alwaysRun = true)
@@ -193,6 +193,13 @@ public class TestExpressionCompiler
     {
         assertTrue(Futures.allAsList(futures).isDone(), "Expression test futures are not complete");
         log.info("FINISHED %s in %s verified %s expressions", method.getName(), Duration.nanosSince(start), futures.size());
+    }
+
+    // This is a setter and not a test method.
+    // TestNG considers this as a test method since we have annotated the class with @Test.
+    public FunctionAssertions setFunctionAssertions()
+    {
+        return new FunctionAssertions();
     }
 
     @Test
@@ -640,12 +647,12 @@ public class TestExpressionCompiler
         // combination of types in one filter
         assertFilter(
                 ImmutableList.of(
-                        "bound_row.nested_column_0 = 1234", "bound_row.nested_column_7 >= 1234",
-                        "bound_row.nested_column_1 = 34", "bound_row.nested_column_8 >= 33",
-                        "bound_row.nested_column_2 = 'hello'", "bound_row.nested_column_9 >= 'hello'",
-                        "bound_row.nested_column_3 = 12.34", "bound_row.nested_column_10 >= 12.34",
-                        "bound_row.nested_column_4 = true", "NOT (bound_row.nested_column_11 = false)",
-                        "bound_row.nested_column_6.nested_nested_column = 'innerFieldValue'", "bound_row.nested_column_13.nested_nested_column LIKE 'innerFieldValue'")
+                                "bound_row.nested_column_0 = 1234", "bound_row.nested_column_7 >= 1234",
+                                "bound_row.nested_column_1 = 34", "bound_row.nested_column_8 >= 33",
+                                "bound_row.nested_column_2 = 'hello'", "bound_row.nested_column_9 >= 'hello'",
+                                "bound_row.nested_column_3 = 12.34", "bound_row.nested_column_10 >= 12.34",
+                                "bound_row.nested_column_4 = true", "NOT (bound_row.nested_column_11 = false)",
+                                "bound_row.nested_column_6.nested_nested_column = 'innerFieldValue'", "bound_row.nested_column_13.nested_nested_column LIKE 'innerFieldValue'")
                         .stream().collect(joining(" AND ")),
                 true);
     }
@@ -1606,6 +1613,9 @@ public class TestExpressionCompiler
     public void testNullif()
             throws Exception
     {
+        assertExecute("nullif(BIGINT '2', INT '2')", BIGINT, null);
+        assertExecute("nullif(INT '2', BIGINT '2')", INTEGER, null);
+        assertExecute("nullif(INT '2', BIGINT '3')", INTEGER, 2);
         assertExecute("nullif(NULL, NULL)", UNKNOWN, null);
         assertExecute("nullif(NULL, 2)", UNKNOWN, null);
         assertExecute("nullif(2, NULL)", INTEGER, 2);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
@@ -183,7 +183,7 @@ public class TestInlineSqlFunctions
                 IntegerType.INTEGER);
     }
 
-    private void assertInlined(String inputExpressionStr, String expectedExpressionStr, String variable, Type type)
+    protected void assertInlined(String inputExpressionStr, String expectedExpressionStr, String variable, Type type)
     {
         RowExpression inputExpression = new TestingRowExpressionTranslator(tester.getMetadata()).translate(inputExpressionStr, ImmutableMap.of(variable, type));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -986,7 +986,7 @@ public class PlanBuilder
                 expression,
                 expressionTypes,
                 ImmutableMap.of(),
-                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                metadata.getFunctionAndTypeManager(),
                 session);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -609,7 +609,7 @@ public class BenchmarkDecimalOperators
             Expression expression = createExpression(value, metadata, TypeProvider.copyOf(symbolTypes));
 
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, metadata, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
-            RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(), TEST_SESSION);
+            RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, metadata.getFunctionAndTypeManager(), TEST_SESSION);
             RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
             return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
         }

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -40,6 +40,13 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
         </dependency>
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestExpressionCompiler.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestExpressionCompiler.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.operator.scalar.FunctionAssertions;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.TestExpressionCompiler;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Ignore;
+
+public abstract class AbstractTestExpressionCompiler
+        extends TestExpressionCompiler
+{
+    @Override
+    public FunctionAssertions setFunctionAssertions()
+    {
+        return new FunctionAssertions(getQueryRunner().getDefaultSession(), new FeaturesConfig().setNativeExecutionEnabled(true));
+    }
+
+    protected abstract QueryRunner getQueryRunner();
+
+    // TODO: The following test have trouble converting long to Decimal.
+    // https://github.com/prestodb/presto/issues/19999
+    @Override
+    @Ignore
+    public void testBinaryOperatorsDecimalBigint()
+            throws Exception
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testBinaryOperatorsDecimalInteger()
+            throws Exception
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testBinaryOperatorsDecimalDouble()
+            throws Exception
+    {
+    }
+
+    // Remove the override from the following tests on a need basis, not all expressions have custom handling for native query runner, hence they are ignored.
+    @Override
+    @Ignore
+    public void smokedTest()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void filterFunction()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testUnaryOperators()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testFilterEmptyInput()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testNestedColumnFilter()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsLongLong()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsLongDouble()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsDoubleDouble()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsString()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsLongDecimal()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTernaryOperatorsDecimalDouble()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testCast()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testTryCast()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testAnd()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testOr()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testNot()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testIf()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testSimpleCase()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testSearchCaseSingle()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testSearchCaseMultiple()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testIn()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testHugeIn()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testInComplexTypes()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testFunctionCall()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testFunctionCallRegexp()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testFunctionCallJson()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testFunctionWithSessionCall()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testExtract()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testLike()
+    {
+    }
+
+    @Override
+    @Ignore
+    public void testCoalesce()
+    {
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -262,6 +262,19 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testNullIf()
+    {
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
+        assertQuery("SELECT NULLIF(totalprice, 0.5) FROM (SELECT COUNT(1) AS totalprice FROM lineitem WHERE shipdate >= '9999-99-99')");
+    }
+
+    @Test
     public void testCast()
     {
         assertQuery("SELECT CAST(linenumber as TINYINT), CAST(linenumber AS SMALLINT), "

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkExpressionCompiler.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkExpressionCompiler.java
@@ -11,25 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.nativeworker;
+package com.facebook.presto.spark;
 
-import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.nativeworker.AbstractTestExpressionCompiler;
 import com.facebook.presto.testing.QueryRunner;
 
-public class TestPrestoNativeGeneralQueriesJSON
-        extends AbstractTestNativeGeneralQueries
+public class TestPrestoSparkExpressionCompiler
+        extends AbstractTestExpressionCompiler
 {
     @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
+    protected QueryRunner getQueryRunner()
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
-    }
-
-    @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner()
-            throws Exception
-    {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkSqlFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkSqlFunctions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.operator.scalar.TestCustomFunctions;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+
+public class TestPrestoSparkSqlFunctions
+        extends TestCustomFunctions
+{
+    public TestPrestoSparkSqlFunctions()
+    {
+        super(new FeaturesConfig().setNativeExecutionEnabled(true));
+    }
+}

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -235,7 +235,7 @@ public class TestPinotQueryBase
                 expression,
                 ImmutableMap.of(),
                 WarningCollector.NOOP);
-        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager.getFunctionAndTypeResolver(), session);
+        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager, session);
     }
 
     protected LimitNode limit(PlanBuilder pb, long count, PlanNode source)


### PR DESCRIPTION
The usage of type coercion in NULLIF in presto/java made it incompatible with 
presto native, this was made possible by specialForm. Handle NULLIF in presto 
native using the expanded form:

> if (equal(cast(first as <common type>), cast(second as <common type>)), cast(null as firstType), first)

Extend TestExpressionCompiler to native test suite with addition of nullIf in 
GeneralQueries test suite.


```
== NO RELEASE NOTE ==
```
