### PR TITLE
Make HttpClient owned by shared_ptr

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -130,7 +130,7 @@ void Announcer::makeAnnouncement() {
       LOG(INFO) << "Discovery service changed to " << newAddress.getAddressStr()
                 << ":" << newAddress.getPort();
       std::swap(address_, newAddress);
-      client_ = std::make_unique<http::HttpClient>(
+      client_ = std::make_shared<http::HttpClient>(
           eventBaseThread_.getEventBase(),
           address_,
           std::chrono::milliseconds(10'000),

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -52,7 +52,7 @@ class Announcer {
   const proxygen::HTTPMessage announcementRequest_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
   folly::SocketAddress address_;
-  std::unique_ptr<http::HttpClient> client_;
+  std::shared_ptr<http::HttpClient> client_;
   std::atomic_bool stopped_{true};
   folly::EventBaseThread eventBaseThread_;
   const std::string clientCertAndKeyPath_;

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -68,7 +68,7 @@ PrestoExchangeSource::PrestoExchangeSource(
       ciphers_(ciphers) {
   folly::SocketAddress address(folly::IPAddress(host_).str(), port_, true);
   auto* eventBase = folly::getUnsafeMutableGlobalEventBase();
-  httpClient_ = std::make_unique<http::HttpClient>(
+  httpClient_ = std::make_shared<http::HttpClient>(
       eventBase,
       address,
       std::chrono::milliseconds(10'000),

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -109,7 +109,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const std::string clientCertAndKeyPath_;
   const std::string ciphers_;
 
-  std::unique_ptr<http::HttpClient> httpClient_;
+  std::shared_ptr<http::HttpClient> httpClient_;
   int failedAttempts_;
   // The number of pages received from this presto exchange source.
   uint64_t numPages_{0};

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -99,7 +99,7 @@ class HttpResponse {
 // EventBase thread. Hence, the destructor of HttpClient must run on the
 // EventBase thread as well. Consider running HttpClient's destructor
 // via EventBase::runOnDestruction.
-class HttpClient {
+class HttpClient : public std::enable_shared_from_this<HttpClient> {
  public:
   HttpClient(
       folly::EventBase* FOLLY_NONNULL eventBase,

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -180,7 +180,7 @@ class HttpClientFactory {
     eventBaseThread_->join();
   }
 
-  std::unique_ptr<http::HttpClient> newClient(
+  std::shared_ptr<http::HttpClient> newClient(
       const folly::SocketAddress& address,
       const std::chrono::milliseconds& timeout,
       bool useHttps,
@@ -188,7 +188,7 @@ class HttpClientFactory {
     if (useHttps) {
       std::string clientCaPath = getCertsPath("client_ca.pem");
       std::string ciphers = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
-      return std::make_unique<http::HttpClient>(
+      return std::make_shared<http::HttpClient>(
           eventBase_.get(),
           address,
           timeout,
@@ -196,7 +196,7 @@ class HttpClientFactory {
           ciphers,
           std::move(reportOnBodyStatsFunc));
     } else {
-      return std::make_unique<http::HttpClient>(
+      return std::make_shared<http::HttpClient>(
           eventBase_.get(),
           address,
           timeout,


### PR DESCRIPTION
if HttpClient is owned by unique_ptr from PrestoExchangeSource, an error can cause the source to be deleted while there is activity on the client. The client runs activity in event base threads and registers callbacks. One crash occurs when Proxygen tries to set a timeout after 'timer_' from HttpClient has been deleted.

The ResponseHandler hereby takes a shared_ptr to the HttpClient so that its timer and other resources stay live for te duration of Proxygen callback chains.


```
== NO RELEASE NOTE ==
```
