### PR TITLE
Pin re2 version for presto_native docker job.

### DIFF
--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -15,6 +15,7 @@ set -e
 set -x
 
 export FB_OS_VERSION=v2022.11.14.00
+export RE2_VERSION=2021-04-01
 export nproc=$(getconf _NPROCESSORS_ONLN)
 
 dnf install -y maven
@@ -93,6 +94,7 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
 (
   git clone https://github.com/google/re2 &&
   cd re2 &&
+  git checkout $RE2_VERSION &&    
   cmake_install -DBUILD_SHARED_LIBS=ON
 )
 


### PR DESCRIPTION
Test plan - Tested locally. 

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

== NO RELEASE NOTE ==

Velox nightly jobs which build presto-native container fail due to newly added abseil dependency: https://app.circleci.com/pipelines/gh/facebookincubator/velox/26152/workflows/bda4c0aa-ce44-413d-bdc7-99fe1205b62c/jobs/165383 
