### PR TITLE
[native pos] Re-launch the native process if it's already crashed

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -170,6 +170,7 @@ public class NativeExecutionProcess
                 }
             }
         }
+        process = null;
     }
 
     public boolean isAlive()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
@@ -73,7 +73,7 @@ public class NativeExecutionProcessFactory
             Session session,
             URI location)
     {
-        if (!isNativeExecutionProcessReuseEnabled(session) || process == null) {
+        if (!isNativeExecutionProcessReuseEnabled(session) || process == null || !process.isAlive()) {
             process = createNativeExecutionProcess(session, location, MAX_ERROR_DURATION);
         }
         return process;

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
 
 public class TestNativeExecutionProcess
 {
@@ -53,6 +54,21 @@ public class TestNativeExecutionProcess
         // Simulate the process is closed (crashed)
         process.close();
         assertFalse(process.isAlive());
+    }
+
+    @Test
+    public void testNativeProcessRelaunch()
+    {
+        Session session = testSessionBuilder().build();
+        NativeExecutionProcessFactory factory = createNativeExecutionProcessFactory();
+        NativeExecutionProcess process = factory.getNativeExecutionProcess(session, BASE_URI);
+        // Simulate the process is closed (crashed)
+        process.close();
+        assertFalse(process.isAlive());
+        NativeExecutionProcess process2 = factory.getNativeExecutionProcess(session, BASE_URI);
+        // Expecting the factory re-created a new process object so that the process and process2
+        // should be two different objects
+        assertNotSame(process2, process);
     }
 
     private NativeExecutionProcessFactory createNativeExecutionProcessFactory()


### PR DESCRIPTION
We're reusing the native process within the JVM for different tasks, if the native process is crashed by previous task, the next coming task should re-launch it to prevent further failure.

```
== NO RELEASE NOTE ==
```
