### PR TITLE
[native pos] Adjust ShuffleReader interface

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -170,18 +170,20 @@ bool LocalPersistentShuffleReader::hasNext() {
   return readPartitionFileIndex_ < readPartitionFiles_.size();
 }
 
-BufferPtr LocalPersistentShuffleReader::next(bool success) {
-  // On failure, reset the index of the files to be read.
-  if (!success) {
-    readPartitionFileIndex_ = 0;
-  }
-
+BufferPtr LocalPersistentShuffleReader::next() {
   auto filename = readPartitionFiles_[readPartitionFileIndex_];
   auto file = fileSystem_->openFileForRead(filename);
   auto buffer = AlignedBuffer::allocate<char>(file->size(), pool_, 0);
   file->pread(0, file->size(), buffer->asMutable<void>());
   ++readPartitionFileIndex_;
   return buffer;
+}
+
+void LocalPersistentShuffleReader::noMoreData(bool success) {
+  // On failure, reset the index of the files to be read.
+  if (!success) {
+    readPartitionFileIndex_ = 0;
+  }
 }
 
 std::vector<std::string> LocalPersistentShuffleReader::getReadPartitionFiles()

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -132,7 +132,9 @@ class LocalPersistentShuffleReader : public ShuffleReader {
 
   bool hasNext() override;
 
-  velox::BufferPtr next(bool success) override;
+  velox::BufferPtr next() override;
+
+  void noMoreData(bool success) override;
 
   folly::F14FastMap<std::string, int64_t> stats() const override {
     // Fake counter for testing only.

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -41,8 +41,13 @@ class ShuffleReader {
   virtual bool hasNext() = 0;
 
   /// Read the next block of data.
+  virtual velox::BufferPtr next() = 0;
+
+  /// Tell the shuffle system the reader is done. May be called with 'success'
+  /// true before reading all the data. This happens when a query has a LIMIT or
+  /// similar operator that finishes the query early.
   /// @param success set to false to indicate aborted client.
-  virtual velox::BufferPtr next(bool success) = 0;
+  virtual void noMoreData(bool success) = 0;
 
   /// Runtime statistics.
   virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -31,7 +31,7 @@ void UnsafeRowExchangeSource::request() {
       atEnd_ = true;
       queue_->enqueueLocked(nullptr, promises);
     } else {
-      auto buffer = shuffle_->next(true);
+      auto buffer = shuffle_->next();
       ++numBatches_;
 
       auto ioBuf = folly::IOBuf::wrapBuffer(buffer->as<char>(), buffer->size());

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -213,13 +213,16 @@ class TestShuffleReader : public ShuffleReader {
     return !(*readyPartitions_)[partition_].empty();
   }
 
-  BufferPtr next(bool success) override {
-    VELOX_CHECK(success, "Unexpected error")
+  BufferPtr next() override {
     VELOX_CHECK(!(*readyPartitions_)[partition_].empty());
 
     auto buffer = (*readyPartitions_)[partition_].back();
     (*readyPartitions_)[partition_].pop_back();
     return buffer;
+  }
+
+  void noMoreData(bool success) override {
+    VELOX_CHECK(success, "Unexpected error");
   }
 
   folly::F14FastMap<std::string, int64_t> stats() const override {


### PR DESCRIPTION
Remove 'success' parameter from ShuffleReader::next method. Add noMoreData (bool success) method. This makes ShuffleReader interface easier to reason about and consistent with the ShuffleWriter iterface.

```
== NO RELEASE NOTE ==
```
