### PR TITLE
[native pos] Use RowNumberNode from Velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -149,7 +149,7 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);
 
-  std::shared_ptr<const velox::core::WindowNode> toVeloxQueryPlan(
+  std::shared_ptr<const velox::core::RowNumberNode> toVeloxQueryPlan(
       const std::shared_ptr<const protocol::RowNumberNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);


### PR DESCRIPTION
Update plan conversion to use optimized RowNumberNode instead of generic WindowNode.

```
== NO RELEASE NOTE ==
```
