### PR TITLE
[native pos][tests] Reduce taskInfoUpdateInterval to speed up tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -87,6 +87,7 @@ public class PrestoSparkNativeQueryRunnerUtils
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>()
                 // Do not use default Prestissimo config files. Presto-Spark will generate the configs on-the-fly.
                 .put("catalog.config-dir", "/")
+                .put("task.info-update-interval", "100ms")
                 .put("native-execution-enabled", "true")
                 .put("spark.initial-partition-count", "1")
                 .put("register-test-functions", "true")


### PR DESCRIPTION
Currently, the default value of `task.info-update-interval` is set to `3sec`. We we wait atleast 3 secs to receive an update on the CPP task. This slows down test execution. Most test tasks are completed within few milliseconds. 
Updating this to `100ms` for tests. 

```
== NO RELEASE NOTE ==
```
