### PR TITLE
[native] Add support for JsonPath type

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -165,6 +165,7 @@ std::optional<TypedExprPtr> tryConvertCast(
   static const char* kTryCast = "presto.default.try_cast";
 
   static const char* kRe2JRegExp = "Re2JRegExp";
+  static const char* kJsonPath = "JsonPath";
 
   if (signature.kind != protocol::FunctionKind::SCALAR) {
     return std::nullopt;
@@ -180,6 +181,10 @@ std::optional<TypedExprPtr> tryConvertCast(
   }
 
   if (returnType == kRe2JRegExp) {
+    return args[0];
+  }
+
+  if (returnType == kJsonPath) {
     return args[0];
   }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -325,6 +325,13 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testJsonExtract()
+    {
+        assertQuery("SELECT json_extract_scalar(cast(x as json), '$[1]') " +
+                "FROM (SELECT '[' || array_join(array[nationkey, regionkey], ',') || ']' as x FROM nation)");
+    }
+
+    @Test
     public void testValues()
     {
         assertQuery("SELECT 1, 0.24, ceil(4.5), 'A not too short ASCII string'");


### PR DESCRIPTION
Similar to Re2JRegExp, treat JsonPath as Varchar.

Fixes errors like 'Failed to parse type [JsonPath]'.

```
== NO RELEASE NOTE ==
```
