### PR TITLE
[native] Adding 'velox.properties' config file.

### DIFF
--- a/presto-native-execution/etc/velox.properties
+++ b/presto-native-execution/etc/velox.properties
@@ -1,0 +1,1 @@
+mutable-config=true

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -121,6 +121,7 @@ PrestoServer::~PrestoServer() {}
 void PrestoServer::run() {
   auto systemConfig = SystemConfig::instance();
   auto nodeConfig = NodeConfig::instance();
+  auto baseVeloxQueryConfig = BaseVeloxQueryConfig::instance();
   int httpPort{0};
   int httpExecThreads{0};
 
@@ -137,8 +138,8 @@ void PrestoServer::run() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
-    // Create velox query config after we initialized system config.
-    BaseVeloxQueryConfig::instance();
+    baseVeloxQueryConfig->initialize(
+        fmt::format("{}/velox.properties", configDirectoryPath_));
 
     httpPort = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -173,7 +173,7 @@ std::string PrestoServerOperations::veloxQueryConfigOperation(
           ServerOperation::actionString(op.action));
       return fmt::format(
           "{}\n",
-          BaseVeloxQueryConfig::instance()->getValue(name).value_or(
+          BaseVeloxQueryConfig::instance()->optionalProperty(name).value_or(
               "<default>"));
     }
     default:

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(presto_exception Exception.cpp)
 add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
 
 target_link_libraries(presto_exception velox_exception)
-target_link_libraries(presto_common velox_exception velox_config)
+target_link_libraries(presto_common velox_config velox_core velox_exception)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -18,6 +18,7 @@
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
+#include "velox/core/QueryConfig.h"
 
 #if __has_include("filesystem")
 #include <filesystem>
@@ -31,10 +32,17 @@ namespace facebook::presto {
 
 namespace {
 
+// folly::to<> does not generate 'true' and 'false', so we do it ourselves.
+std::string bool2String(bool value) {
+  return value ? "true" : "false";
+}
+
 #define STR_PROP(_key_, _val_) \
   { std::string(_key_), std::string(_val_) }
 #define NUM_PROP(_key_, _val_) \
   { std::string(_key_), folly::to<std::string>(_val_) }
+#define BOOL_PROP(_key_, _val_) \
+  { std::string(_key_), bool2String(_val_) }
 #define NONE_PROP(_key_) \
   { std::string(_key_), folly::none }
 
@@ -115,7 +123,7 @@ void ConfigBase::initialize(const std::string& filePath) {
   checkRegisteredProperties(values);
 
   bool mutableConfig{false};
-  auto it = values.find(std::string(SystemConfig::kMutableConfig));
+  auto it = values.find(std::string(kMutableConfig));
   if (it != values.end()) {
     mutableConfig = folly::to<bool>(it->second);
   }
@@ -161,7 +169,7 @@ folly::Optional<std::string> ConfigBase::setValue(
   }
   VELOX_USER_FAIL(
       "Config is not mutable. Consider setting '{}' to 'true'.",
-      SystemConfig::kMutableConfig);
+      kMutableConfig);
 }
 
 void ConfigBase::checkRegisteredProperties(
@@ -228,7 +236,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kHttpEnableStatsFilter, "false"),
           STR_PROP(kRegisterTestFunctions, "false"),
           NUM_PROP(kHttpMaxAllocateBytes, 65536),
-          NUM_PROP(kQueryMaxMemoryPerNode, "4GB"),
+          STR_PROP(kQueryMaxMemoryPerNode, "4GB"),
           STR_PROP(kEnableMemoryLeakCheck, "true"),
           NONE_PROP(kRemoteFunctionServerThriftPort),
           STR_PROP(kSkipRuntimeStatsInRunningTaskInfo, "true"),
@@ -478,44 +486,94 @@ uint64_t NodeConfig::nodeMemoryGb(
   return result;
 }
 
-BaseVeloxQueryConfig::BaseVeloxQueryConfig()
-    : mutable_{SystemConfig::instance()->mutableConfig()} {}
+BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
+  // Use empty instance to get default property values.
+  velox::core::QueryConfig c{{}};
+  using namespace velox::core;
+  registeredProps_ =
+      std::unordered_map<std::string, folly::Optional<std::string>>{
+          STR_PROP(kMutableConfig, "false"),
+          BOOL_PROP(QueryConfig::kCodegenEnabled, c.codegenEnabled()),
+          STR_PROP(
+              QueryConfig::kCodegenConfigurationFilePath,
+              c.codegenConfigurationFilePath()),
+          BOOL_PROP(QueryConfig::kCodegenLazyLoading, c.codegenLazyLoading()),
+          STR_PROP(QueryConfig::kSessionTimezone, c.sessionTimezone()),
+          BOOL_PROP(
+              QueryConfig::kAdjustTimestampToTimezone,
+              c.adjustTimestampToTimezone()),
+          BOOL_PROP(QueryConfig::kExprEvalSimplified, c.exprEvalSimplified()),
+          BOOL_PROP(QueryConfig::kExprTrackCpuUsage, c.exprTrackCpuUsage()),
+          BOOL_PROP(
+              QueryConfig::kOperatorTrackCpuUsage, c.operatorTrackCpuUsage()),
+          BOOL_PROP(
+              QueryConfig::kCastMatchStructByName, c.isMatchStructByName()),
+          BOOL_PROP(
+              QueryConfig::kCastToIntByTruncate, c.isCastToIntByTruncate()),
+          NUM_PROP(
+              QueryConfig::kMaxLocalExchangeBufferSize,
+              c.maxLocalExchangeBufferSize()),
+          NUM_PROP(
+              QueryConfig::kMaxPartialAggregationMemory,
+              c.maxPartialAggregationMemoryUsage()),
+          NUM_PROP(
+              QueryConfig::kMaxExtendedPartialAggregationMemory,
+              c.maxExtendedPartialAggregationMemoryUsage()),
+          NUM_PROP(
+              QueryConfig::kAbandonPartialAggregationMinRows,
+              c.abandonPartialAggregationMinRows()),
+          NUM_PROP(
+              QueryConfig::kAbandonPartialAggregationMinPct,
+              c.abandonPartialAggregationMinPct()),
+          NUM_PROP(
+              QueryConfig::kMaxPartitionedOutputBufferSize,
+              c.maxPartitionedOutputBufferSize()),
+          NUM_PROP(
+              QueryConfig::kPreferredOutputBatchBytes,
+              c.preferredOutputBatchBytes()),
+          NUM_PROP(
+              QueryConfig::kPreferredOutputBatchRows,
+              c.preferredOutputBatchRows()),
+          NUM_PROP(QueryConfig::kMaxOutputBatchRows, c.maxOutputBatchRows()),
+          BOOL_PROP(
+              QueryConfig::kHashAdaptivityEnabled, c.hashAdaptivityEnabled()),
+          BOOL_PROP(
+              QueryConfig::kAdaptiveFilterReorderingEnabled,
+              c.adaptiveFilterReorderingEnabled()),
+          BOOL_PROP(QueryConfig::kSpillEnabled, c.spillEnabled()),
+          BOOL_PROP(
+              QueryConfig::kAggregationSpillEnabled,
+              c.aggregationSpillEnabled()),
+          BOOL_PROP(QueryConfig::kJoinSpillEnabled, c.joinSpillEnabled()),
+          BOOL_PROP(QueryConfig::kOrderBySpillEnabled, c.orderBySpillEnabled()),
+          NUM_PROP(
+              QueryConfig::kAggregationSpillMemoryThreshold,
+              c.aggregationSpillMemoryThreshold()),
+          NUM_PROP(
+              QueryConfig::kJoinSpillMemoryThreshold,
+              c.joinSpillMemoryThreshold()),
+          NUM_PROP(
+              QueryConfig::kOrderBySpillMemoryThreshold,
+              c.orderBySpillMemoryThreshold()),
+          NUM_PROP(QueryConfig::kTestingSpillPct, c.testingSpillPct()),
+          NUM_PROP(QueryConfig::kMaxSpillLevel, c.maxSpillLevel()),
+          NUM_PROP(QueryConfig::kMaxSpillFileSize, c.maxSpillFileSize()),
+          NUM_PROP(QueryConfig::kMinSpillRunSize, c.minSpillRunSize()),
+          NUM_PROP(
+              QueryConfig::kSpillStartPartitionBit, c.spillStartPartitionBit()),
+          NUM_PROP(QueryConfig::kSpillPartitionBits, c.spillPartitionBits()),
+          NUM_PROP(
+              QueryConfig::kSpillableReservationGrowthPct,
+              c.spillableReservationGrowthPct()),
+          BOOL_PROP(
+              QueryConfig::kSparkLegacySizeOfNull, c.sparkLegacySizeOfNull()),
+      };
+}
 
 BaseVeloxQueryConfig* BaseVeloxQueryConfig::instance() {
   static std::unique_ptr<BaseVeloxQueryConfig> instance =
       std::make_unique<BaseVeloxQueryConfig>();
   return instance.get();
-}
-
-folly::Optional<std::string> BaseVeloxQueryConfig::setValue(
-    const std::string& propertyName,
-    const std::string& value) {
-  if (!mutable_) {
-    VELOX_USER_FAIL(
-        "Config is not mutable. "
-        "Consider setting System Config's '{}' to 'true'.",
-        SystemConfig::kMutableConfig);
-  }
-
-  folly::Optional<std::string> ret;
-  auto lockedValues = values_.wlock();
-  auto it = lockedValues->find(propertyName);
-  if (it != lockedValues->end()) {
-    ret = it->second;
-  }
-  (*lockedValues)[propertyName] = value;
-  return ret;
-}
-
-folly::Optional<std::string> BaseVeloxQueryConfig::getValue(
-    const std::string& propertyName) const {
-  folly::Optional<std::string> ret;
-  auto lockedValues = values_.rlock();
-  auto it = lockedValues->find(propertyName);
-  if (it != lockedValues->end()) {
-    ret = it->second;
-  }
-  return ret;
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/SystemConfigTest.cpp
@@ -42,7 +42,7 @@ class SystemConfigTest : public testing::Test {
         fmt::format("{}=11kB\n", SystemConfig::kQueryMaxMemoryPerNode));
     if (isMutable) {
       sysConfigFile->append(
-          fmt::format("{}={}\n", SystemConfig::kMutableConfig, "true"));
+          fmt::format("{}={}\n", ConfigBase::kMutableConfig, "true"));
     }
     sysConfigFile->close();
   }

--- a/presto-native-execution/presto_cpp/main/tests/CoordinatorDiscovererTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/CoordinatorDiscovererTest.cpp
@@ -38,7 +38,7 @@ class CoordinatorDiscovererTest : public testing::Test {
     auto fileSystem = filesystems::getFileSystem(configFilePath, nullptr);
     auto sysConfigFile = fileSystem->openFileForWrite(configFilePath);
     sysConfigFile->append(
-        fmt::format("{}={}\n", SystemConfig::kMutableConfig, "true"));
+        fmt::format("{}={}\n", ConfigBase::kMutableConfig, "true"));
     sysConfigFile->close();
   }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -538,8 +538,7 @@ class TaskManagerTest : public testing::Test {
     auto sysConfigFilePath = fmt::format("{}/config.properties", dir->path);
     auto fileSystem = filesystems::getFileSystem(sysConfigFilePath, nullptr);
     auto sysConfigFile = fileSystem->openFileForWrite(sysConfigFilePath);
-    sysConfigFile->append(
-        fmt::format("{}=true\n", SystemConfig::kMutableConfig));
+    sysConfigFile->append(fmt::format("{}=true\n", ConfigBase::kMutableConfig));
     sysConfigFile->append(
         fmt::format("{}=4GB\n", SystemConfig::kQueryMaxMemoryPerNode));
     sysConfigFile->close();

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -148,6 +148,7 @@ public class PrestoNativeQueryRunnerUtils
                         int port = 1234 + workerIndex;
 
                         // Write config files
+                        Files.write(tempDirectoryPath.resolve("velox.properties"), "".getBytes());
                         Files.write(tempDirectoryPath.resolve("config.properties"),
                                 format("discovery.uri=%s%n" +
                                         "presto.version=testversion%n" +

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -115,6 +115,7 @@ import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.NativeExecutionVeloxConfig;
 import com.facebook.presto.spark.node.PrestoSparkInternalNodeManager;
 import com.facebook.presto.spark.node.PrestoSparkNodePartitioningManager;
 import com.facebook.presto.spark.node.PrestoSparkQueryManager;
@@ -255,6 +256,7 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
         configBinder(binder).bindConfig(PrestoSparkConfig.class);
         configBinder(binder).bindConfig(TracingConfig.class);
+        configBinder(binder).bindConfig(NativeExecutionVeloxConfig.class);
         configBinder(binder).bindConfig(NativeExecutionSystemConfig.class);
         configBinder(binder).bindConfig(NativeExecutionNodeConfig.class);
         configBinder(binder).bindConfig(NativeExecutionConnectorConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcess.java
@@ -47,7 +47,7 @@ public class DetachedNativeExecutionProcess
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
             TaskManagerConfig taskManagerConfig,
-            WorkerProperty<?, ?, ?> workerProperty) throws IOException
+            WorkerProperty<?, ?, ?, ?> workerProperty) throws IOException
     {
         super(session,
                 uri,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/DetachedNativeExecutionProcessFactory.java
@@ -40,7 +40,7 @@ public class DetachedNativeExecutionProcessFactory
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final TaskManagerConfig taskManagerConfig;
-    private final WorkerProperty<?, ?, ?> workerProperty;
+    private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
     @Inject
     public DetachedNativeExecutionProcessFactory(
@@ -49,7 +49,7 @@ public class DetachedNativeExecutionProcessFactory
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             TaskManagerConfig taskManagerConfig,
-            WorkerProperty<?, ?, ?> workerProperty)
+            WorkerProperty<?, ?, ?, ?> workerProperty)
     {
         super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, taskManagerConfig, workerProperty);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spark.execution;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.NativeExecutionVeloxConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleInfoTranslator;
@@ -56,7 +57,7 @@ public class NativeExecutionModule
     public void configure(Binder binder)
     {
         binder.bind(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, new TypeLiteral<PrestoSparkShuffleInfoTranslator>() {}).setDefault().to(PrestoSparkLocalShuffleInfoTranslator.class).in(Scopes.SINGLETON);
         binder.bind(NativeExecutionTaskFactory.class).in(Scopes.SINGLETON);
         httpClientBinder(binder)
@@ -66,7 +67,7 @@ public class NativeExecutionModule
                     config.setMaxConnectionsPerServer(250);
                 });
         if (connectorConfig.isPresent()) {
-            binder.bind(PrestoSparkWorkerProperty.class).toInstance(new PrestoSparkWorkerProperty(new NativeExecutionSystemConfig(), connectorConfig.get(), new NativeExecutionNodeConfig()));
+            binder.bind(PrestoSparkWorkerProperty.class).toInstance(new PrestoSparkWorkerProperty(connectorConfig.get(), new NativeExecutionNodeConfig(), new NativeExecutionSystemConfig(), new NativeExecutionVeloxConfig()));
         }
         else {
             binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -66,6 +66,7 @@ public class NativeExecutionProcess
     private static final String NATIVE_EXECUTION_TASK_ERROR_MESSAGE = "Encountered too many errors talking to native process. The process may have crashed or be under too much load.";
     private static final String WORKER_CONFIG_FILE = "/config.properties";
     private static final String WORKER_NODE_CONFIG_FILE = "/node.properties";
+    private static final String WORKER_VELOX_CONFIG_FILE = "/velox.properties";
     private static final String WORKER_CONNECTOR_CONFIG_FILE = "/catalog/";
 
     private final Session session;
@@ -76,7 +77,7 @@ public class NativeExecutionProcess
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final RequestErrorTracker errorTracker;
     private final HttpClient httpClient;
-    private final WorkerProperty<?, ?, ?> workerProperty;
+    private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
     private Process process;
 
@@ -88,7 +89,7 @@ public class NativeExecutionProcess
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
             TaskManagerConfig taskManagerConfig,
-            WorkerProperty<?, ?, ?> workerProperty)
+            WorkerProperty<?, ?, ?, ?> workerProperty)
             throws IOException
     {
         this.port = getAvailableTcpPort();
@@ -212,6 +213,7 @@ public class NativeExecutionProcess
         // the native execution process eventually for process initialization.
         workerProperty.getSystemConfig().setHttpServerPort(port);
         workerProperty.populateAllProperties(
+                Paths.get(configBasePath, WORKER_VELOX_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_NODE_CONFIG_FILE),
                 Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE, getNativeExecutionCatalogName(session))));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcessFactory.java
@@ -47,7 +47,7 @@ public class NativeExecutionProcessFactory
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final TaskManagerConfig taskManagerConfig;
-    private final WorkerProperty<?, ?, ?> workerProperty;
+    private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
     private static NativeExecutionProcess process;
 
@@ -58,7 +58,7 @@ public class NativeExecutionProcessFactory
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             TaskManagerConfig taskManagerConfig,
-            WorkerProperty<?, ?, ?> workerProperty)
+            WorkerProperty<?, ?, ?, ?> workerProperty)
 
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * This config class corresponds to velox.properties for native execution process. Properties inside will be used in Configs::BaseVeloxQueryConfig in Configs.h/cpp
+ */
+public class NativeExecutionVeloxConfig
+{
+    private static final String CODEGEN_ENABLED = "codegen.enabled";
+
+    private boolean codegenEnabled;
+
+    public Map<String, String> getAllProperties()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        return builder.put(CODEGEN_ENABLED, String.valueOf(getCodegenEnabled())).build();
+    }
+
+    public boolean getCodegenEnabled()
+    {
+        return codegenEnabled;
+    }
+
+    @Config(CODEGEN_ENABLED)
+    public NativeExecutionVeloxConfig setCodegenEnabled(boolean codegenEnabled)
+    {
+        this.codegenEnabled = codegenEnabled;
+        return this;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
@@ -19,14 +19,15 @@ import com.google.inject.Inject;
  * A utility class that helps with properties and its materialization.
  */
 public class PrestoSparkWorkerProperty
-        extends WorkerProperty<NativeExecutionConnectorConfig, NativeExecutionNodeConfig, NativeExecutionSystemConfig>
+        extends WorkerProperty<NativeExecutionConnectorConfig, NativeExecutionNodeConfig, NativeExecutionSystemConfig, NativeExecutionVeloxConfig>
 {
     @Inject
     public PrestoSparkWorkerProperty(
-            NativeExecutionSystemConfig systemConfig,
             NativeExecutionConnectorConfig connectorConfig,
-            NativeExecutionNodeConfig nodeConfig)
+            NativeExecutionNodeConfig nodeConfig,
+            NativeExecutionSystemConfig systemConfig,
+            NativeExecutionVeloxConfig veloxConfig)
     {
-        super(connectorConfig, nodeConfig, systemConfig);
+        super(connectorConfig, nodeConfig, systemConfig, veloxConfig);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
@@ -52,28 +52,32 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * // New WorkerProperty with new InternalNativeExecutionNodeConfig
  * public class InternalWorkerProperty
- * extends WorkerProperty<NativeExecutionConnectorConfig, InternalNativeExecutionNodeConfig, NativeExecutionSystemConfig>
+ * extends WorkerProperty<NativeExecutionConnectorConfig, InternalNativeExecutionNodeConfig, NativeExecutionSystemConfig, NativeExecutionVeloxConfig>
  * {
  * @Inject public InternalWorkerProperty(
- * NativeExecutionSystemConfig systemConfig,
  * NativeExecutionConnectorConfig connectorConfig,
- * InternalNativeExecutionNodeConfig nodeConfig)
+ * InternalNativeExecutionNodeConfig nodeConfig,
+ * NativeExecutionSystemConfig systemConfig,
+ * NativeExecutionVeloxConfig veloxConfig)
  * {
  * super(connectorConfig, nodeConfig, systemConfig);
  * }
  * }
  */
-public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extends NativeExecutionNodeConfig, T3 extends NativeExecutionSystemConfig>
+public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extends NativeExecutionNodeConfig, T3 extends NativeExecutionSystemConfig, T4 extends NativeExecutionVeloxConfig>
 {
     private final T1 connectorConfig;
     private final T2 nodeConfig;
     private final T3 systemConfig;
+    private final T4 veloxConfig;
 
     public WorkerProperty(
             T1 connectorConfig,
             T2 nodeConfig,
-            T3 systemConfig)
+            T3 systemConfig,
+            T4 veloxConfig)
     {
+        this.veloxConfig = requireNonNull(veloxConfig, "veloxConfig is null");
         this.systemConfig = requireNonNull(systemConfig, "systemConfig is null");
         this.nodeConfig = requireNonNull(nodeConfig, "nodeConfig is null");
         this.connectorConfig = requireNonNull(connectorConfig, "connectorConfig is null");
@@ -94,9 +98,15 @@ public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extend
         return systemConfig;
     }
 
-    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path connectorConfigPath)
+    public T4 getVeloxConfig()
+    {
+        return veloxConfig;
+    }
+
+    public void populateAllProperties(Path veloxConfigPath, Path systemConfigPath, Path nodeConfigPath, Path connectorConfigPath)
             throws IOException
     {
+        populateProperty(veloxConfig.getAllProperties(), veloxConfigPath);
         populateProperty(systemConfig.getAllProperties(), systemConfigPath);
         populateProperty(nodeConfig.getAllProperties(), nodeConfigPath);
         populateProperty(connectorConfig.getAllProperties(), connectorConfigPath);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spark.execution.NativeExecutionTaskFactory;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
+import com.facebook.presto.spark.execution.property.NativeExecutionVeloxConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
@@ -765,9 +766,10 @@ public class TestPrestoSparkHttpClient
     {
         ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
-                new NativeExecutionSystemConfig(),
                 new NativeExecutionConnectorConfig(),
-                new NativeExecutionNodeConfig());
+                new NativeExecutionNodeConfig(),
+                new NativeExecutionSystemConfig(),
+                new NativeExecutionVeloxConfig());
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
                 new TestingHttpClient(responseManager),
                 newSingleThreadExecutor(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -34,6 +34,20 @@ import static org.testng.Assert.fail;
 public class TestNativeExecutionSystemConfig
 {
     @Test
+    public void testNativeExecutionVeloxConfig()
+    {
+        // Test defaults
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(NativeExecutionVeloxConfig.class)
+                .setCodegenEnabled(false));
+
+        // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
+        NativeExecutionVeloxConfig expected = new NativeExecutionVeloxConfig()
+                .setCodegenEnabled(true);
+        Map<String, String> properties = expected.getAllProperties();
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
     public void testNativeExecutionSystemConfig()
     {
         // Test defaults
@@ -133,7 +147,7 @@ public class TestNativeExecutionSystemConfig
     @Test
     public void testFilePropertiesPopulator()
     {
-        PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(new NativeExecutionSystemConfig(), new NativeExecutionConnectorConfig(), new NativeExecutionNodeConfig());
+        PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(new NativeExecutionConnectorConfig(), new NativeExecutionNodeConfig(), new NativeExecutionSystemConfig(), new NativeExecutionVeloxConfig());
         testPropertiesPopulate(workerProperty);
     }
 
@@ -142,10 +156,11 @@ public class TestNativeExecutionSystemConfig
         Path directory = null;
         try {
             directory = Files.createTempDirectory("presto");
+            Path veloxPropertiesPath = Paths.get(directory.toString(), "velox.properties");
             Path configPropertiesPath = Paths.get(directory.toString(), "config.properties");
             Path nodePropertiesPath = Paths.get(directory.toString(), "node.properties");
             Path connectorPropertiesPath = Paths.get(directory.toString(), "catalog/hive.properties");
-            workerProperty.populateAllProperties(configPropertiesPath, nodePropertiesPath, connectorPropertiesPath);
+            workerProperty.populateAllProperties(veloxPropertiesPath, configPropertiesPath, nodePropertiesPath, connectorPropertiesPath);
 
             verifyProperties(workerProperty.getSystemConfig().getAllProperties(), readPropertiesFromDisk(configPropertiesPath));
             verifyProperties(workerProperty.getNodeConfig().getAllProperties(), readPropertiesFromDisk(nodePropertiesPath));


### PR DESCRIPTION
This file is being loaded by BaseVeloxQueryConfig at startup.
BaseVeloxQueryConfig is being used as a base set of properties for QueryConfig.
Any session properties of the query override properties from BaseVeloxQueryConfig.

```
== NO RELEASE NOTE ==
```
