### PR TITLE
Adding support for ANY_KEYS_MATCH udf in presto

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -18,6 +18,12 @@ Map Functions
 
         SELECT all_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> length(x) = 1); -- true
 
+.. function:: any_keys_match(x(K,V), function(K, boolean)) -> boolean
+
+    Returns whether any keys of a map match the given predicate. Returns true if one or more keys match the predicate; false if none of the keys match (a special case is when the map is empty); NULL if the predicate function returns NULL for one or more keys and false for all other keys. ::
+
+        SELECT any_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'a'); -- true
+
 .. function:: cardinality(x) -> bigint
     :noindex:
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
@@ -100,4 +100,15 @@ public class MapSqlFunctions
     {
         return "RETURN ALL_MATCH(MAP_KEYS(input), f)";
     }
+
+    @SqlInvokedScalarFunction(value = "any_keys_match", deterministic = true, calledOnNullInput = true)
+    @Description("Returns whether any key of a map matches the given predicate.")
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlParameters({@SqlParameter(name = "input", type = "map(K, V)"), @SqlParameter(name = "f", type = "function(K, boolean)")})
+    @SqlType("boolean")
+    public static String anyKeysMatch()
+    {
+        return "RETURN ANY_MATCH(MAP_KEYS(input), f)";
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAnyKeysMatchFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAnyKeysMatchFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+
+public class TestAnyKeysMatchFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[1, 2, 3], ARRAY[4, 5, 6]), (x) -> x > 2)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[-1, -2, -3], ARRAY[4, 5, 6]), (x) -> x < -3)",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY['ab', 'bc', 'cd'], ARRAY['x', 'y', 'z']), (x) -> x = 'ab')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[123.0, 99.5, 1000.99], ARRAY['x', 'y', 'z']), (x) -> x > 1.0)",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("ANY_KEYS_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> x > 0)", BOOLEAN, false);
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("ANY_KEYS_MATCH(NULL, (x) -> x LIKE '%ab%' )", BOOLEAN, null);
+        assertFunction("ANY_KEYS_MATCH(MAP(ARRAY['x', 'y'], ARRAY[1, 2]), (x) -> CAST(NULL AS BOOLEAN))", BOOLEAN, null);
+        assertFunction("ANY_KEYS_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY[1, 2, 3]), (x) -> IF(x = 'x', TRUE, CAST(NULL AS BOOLEAN)))", BOOLEAN, true);
+    }
+
+    @Test
+    public void testComplexKeys()
+    {
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[ROW('x', 1), ROW('y', 2)], ARRAY[1, 2]), (x) -> x[1] = 'x')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[ROW('x', 1), ROW('x', -2)], ARRAY[2, 1]), (x) -> x[2] >= 2)",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[ROW('x', 1), ROW('x', -2), ROW('y', 1)], ARRAY[100, 200, null]), (x) -> x[1] = 'ab')",
+                BOOLEAN,
+                false);
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[ROW('x', 1), ROW('y', 2)], ARRAY[1, 2]), (x) -> x[2] LIKE '%ab%')",
+                SemanticErrorCode.TYPE_MISMATCH);
+        assertInvalidFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY[1, 2, 3], ARRAY[4, 5, 6]))",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "ANY_KEYS_MATCH(MAP(ARRAY['a', 'b', 'c'], ARRAY[4, 5, 6]), 1)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Test plan

Added unit tests.
Build successfully using the following terminal command
- `./mvnw clean install -Dtest=TestAnyKeysMatchFunction -fn -pl presto-main`

```
== RELEASE NOTES ==

General Changes
* Add function :func:`any_keys_match`
```