### PR TITLE
[native] Harden ExecutionFailureInfo.toStackTraceElement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
@@ -201,7 +201,12 @@ public class ExecutionFailureInfo
                 number = -2;
             }
             else if (matcher.group(4) != null) {
-                number = Integer.parseInt(matcher.group(4));
+                try {
+                    number = Integer.parseInt(matcher.group(4));
+                }
+                catch (NumberFormatException e) {
+                    // Stack trace parsing is best effort.
+                }
             }
             return new StackTraceElement(declaringClass, methodName, fileName, number);
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestExecutionFailureInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestExecutionFailureInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestExecutionFailureInfo
+{
+    @Test
+    public void testToStackTraceElement()
+    {
+        // Line number is present.
+        StackTraceElement element = ExecutionFailureInfo.toStackTraceElement("at java.util.ArrayList.forEach(ArrayList.java:123)");
+        assertEquals(element.getLineNumber(), 123);
+
+        // Line number is missing.
+        element = ExecutionFailureInfo.toStackTraceElement("at java.util.ArrayList.forEach(ArrayList.java)");
+        assertEquals(element.getLineNumber(), -1);
+
+        // Line number is not a number.
+        element = ExecutionFailureInfo.toStackTraceElement("at java.util.ArrayList.forEach(ArrayList.java:blah)");
+        assertEquals(element.getLineNumber(), -1);
+    }
+}


### PR DESCRIPTION
This method is used to parse stack traces from Java and C++. C++ stack traces do not have a fixed pattern though and we see failures when parsing line numbers. Ignore such failures.

Fixes Presto-in-Spark Native failures like this:

```
E0607 19:40:25.964808 4033885 Exceptions.h:68] Line: fbcode/github/presto-trunk/presto-native-execution/presto_cpp/presto_protocol/Connectors.cpp:56, Function:getConnectorKey, Expression: it != connectors().end() Connector with name xdb not registered, Source: RUNTIME, ErrorCode: INVALID_STATE


java.lang.NumberFormatException: For input string: ":basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer> const&, std::vector<facebook::presto::protocol::ScheduledSplit, std::allocator<facebook::presto::protocol::ScheduledSplit> >&, nlohmann::detail::priority_tag<1u>"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at com.facebook.presto.execution.ExecutionFailureInfo.toStackTraceElement(ExecutionFailureInfo.java:204)
	at com.facebook.presto.execution.ExecutionFailureInfo.toException(ExecutionFailureInfo.java:184)
	at com.facebook.presto.execution.ExecutionFailureInfo.toException(ExecutionFailureInfo.java:165)
	at java.util.Optional.map(Optional.java:215)
	at com.facebook.presto.spark.execution.operator.NativeExecutionOperator.processTaskInfo(NativeExecutionOperator.java:209)
	at com.facebook.presto.spark.execution.operator.NativeExecutionOperator.getOutput(NativeExecutionOperator.java:175)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:428)

```

```
== NO RELEASE NOTE ==
```
