### PR TITLE
[native] Revert Split tests in E2E and run in parallel

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -51,7 +51,6 @@ executors:
 jobs:
   linux-build:
     executor: build
-    parallelism: 5
     steps:
       - checkout
       - run:
@@ -82,35 +81,13 @@ jobs:
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
             export TEMP_PATH="/tmp"
-            TESTFILES=$(circleci tests glob "presto-native-execution/src/test/**/Test*.java" | circleci tests split --split-by=timings)
-            # Convert file paths to comma separated class names
-            export TESTCLASSES=
-            export SPARKTESTS=
-            for test_file in $TESTFILES
-            do
-              tmp=${test_file##*/}
-              test_class=${tmp%%\.*}
-              if [[ $test_class == TestPrestoSpark* ]]; then
-                export SPARKTESTS="${SPARKTESTS},$test_class"
-              else
-                export TESTCLASSES="${TESTCLASSES},$test_class"
-              fi
-            done
-            export TESTCLASSES=${TESTCLASSES#,}
-            export SPARKTESTS=${SPARKTESTS#,}
-            if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
-            fi
-            # set Spark tests as an environment variable
-            echo "export SPARKTESTS=$SPARKTESTS" >> "$BASH_ENV"
+            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C -Dtest=TestPrestoNative*
       - run:
           name: 'Run spark-native e2e tests'
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
             export TEMP_PATH="/tmp"
-            if [ ! -z $SPARKTESTS ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${SPARKTESTS}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C || true
-            fi
+            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C -Dtest=TestPrestoSparkNative*
 
   linux-parquet-S3-build:
     executor: build


### PR DESCRIPTION
#19722 split the tests to run in parallel. After this change not all tests seem to be running.
CircleCI linux-build with this change shows
[INFO] Tests run: 26 for presto-native
[INFO] Tests run: 18 for spark-native
https://app.circleci.com/pipelines/github/prestodb/presto/3257/workflows/07c55503-4fa9-4f3f-843c-0d479d47af81/jobs/5000

The previous count was
[INFO] Tests run: 162 for presto-native
[INFO] Tests run: 101 for presto-spark
https://app.circleci.com/pipelines/github/prestodb/presto/3203/workflows/ce3eda3f-95ab-4035-b8b2-c52788a2c23c/jobs/4811

The timings also do not match.

This reverts commit 446bde543376de993b0a91b2db9b1dede28f2374.

Resolves https://github.com/prestodb/presto/issues/19816

```
== NO RELEASE NOTE ==
```
