### PR TITLE
[native] Ignore HiveTableLayoutHandle::pushdownFilterEnabled flag

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -704,9 +704,9 @@ std::shared_ptr<connector::ConnectorTableHandle> toConnectorTableHandle(
   if (auto hiveLayout =
           std::dynamic_pointer_cast<const protocol::HiveTableLayoutHandle>(
               tableHandle.connectorTableLayout)) {
-    VELOX_CHECK(
-        hiveLayout->pushdownFilterEnabled,
-        "Table scan with filter pushdown disabled is not supported");
+    // Ignore pushdownFilterEnabled flag. This flag is used to switch between
+    // legacy and new version of ORC reader in Java, but Velox has only one
+    // implementation.
 
     for (const auto& entry : hiveLayout->partitionColumns) {
       partitionColumns.emplace(entry.name, toColumnHandle(&entry));


### PR DESCRIPTION
This flag is used to switch between legacy and new version of ORC reader in Java, but Velox has only one implementation.

Fixes errors like "VeloxRuntimeError: hiveLayout->pushdownFilterEnabled Table scan with filter pushdown disabled is not supported".

```
== NO RELEASE NOTE ==
```
