### PR TITLE
Preserve quotedness in QualifiedName

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -157,11 +157,6 @@ public final class MetadataUtil
         return new QualifiedObjectName(catalogName, schemaName, objectName);
     }
 
-    public static QualifiedName createQualifiedName(QualifiedObjectName name)
-    {
-        return QualifiedName.of(name.getCatalogName(), name.getSchemaName(), name.getObjectName());
-    }
-
     public static Optional<CatalogMetadata> getOptionalCatalogMetadata(Session session, TransactionManager transactionManager, String catalogName)
     {
         return transactionManager.getOptionalCatalogMetadata(session.getRequiredTransactionId(), catalogName);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2441,7 +2441,7 @@ class StatementAnalyzer
 
                     if (!field.isPresent()) {
                         if (name != null) {
-                            field = Optional.of(new Identifier(getLast(name.getOriginalParts())));
+                            field = Optional.of(getLast(name.getOriginalParts()));
                         }
                     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -108,7 +108,6 @@ import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectN
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataListing.listSchemas;
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
-import static com.facebook.presto.metadata.MetadataUtil.createQualifiedName;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.SessionFunctionHandle.SESSION_NAMESPACE;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
@@ -466,7 +465,7 @@ final class ShowQueriesRewrite
                 }
 
                 Query query = parseView(viewDefinition.get().getOriginalSql(), objectName, node);
-                String sql = formatSql(new CreateView(createQualifiedName(objectName), query, false, Optional.empty()), Optional.of(parameters)).trim();
+                String sql = formatSql(new CreateView(getQualifiedName(node, objectName), query, false, Optional.empty()), Optional.of(parameters)).trim();
                 return singleValueQuery("Create View", sql);
             }
 
@@ -492,7 +491,7 @@ final class ShowQueriesRewrite
 
                 CreateMaterializedView createMaterializedView = new CreateMaterializedView(
                         Optional.empty(),
-                        createQualifiedName(objectName),
+                        getQualifiedName(node, objectName),
                         query,
                         false,
                         propertyNodes,
@@ -598,6 +597,16 @@ final class ShowQueriesRewrite
                             .collect(toImmutableList())),
                     aliased(new Values(rows.build()), "functions", ImmutableList.copyOf(columns.keySet())),
                     ordering(ascending("argument_types")));
+        }
+
+        private QualifiedName getQualifiedName(ShowCreate node, QualifiedObjectName objectName)
+        {
+            List<Identifier> parts = node.getName().getOriginalParts();
+            Identifier tableName = (parts.size() > 2) ? parts.get(2) : ((parts.size() > 1) ? parts.get(1) : parts.get(0));
+            Identifier schemaName = (parts.size() > 2) ? parts.get(1) : ((parts.size() > 1) ? parts.get(0) : new Identifier(objectName.getSchemaName()));
+            Identifier catalogName = (parts.size() > 2) ? parts.get(0) : new Identifier(objectName.getCatalogName());
+
+            return QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName));
         }
 
         private List<Property> buildProperties(

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
+import static org.testng.Assert.assertEquals;
+
+public class TestSqlFormatter
+{
+    @Test
+    public void testSimpleExpression()
+    {
+        assetQuery("SELECT id\nFROM\n  public.orders\n");
+        assetQuery("SELECT id\nFROM\n  \"public\".\"order\"\n");
+        assetQuery("SELECT id\nFROM\n  \"public\".\"order\"\"2\"\n");
+    }
+
+    private void assetQuery(String query)
+    {
+        SqlParser parser = new SqlParser();
+        Statement statement = parser.createStatement(query, new ParsingOptions());
+        String formattedQuery = getFormattedSql(statement, parser, Optional.empty());
+        assertEquals(formattedQuery, query);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1101,12 +1101,10 @@ public final class SqlFormatter
             return characteristic.name().replace("_", " ");
         }
 
-        private static String formatName(String name)
+        private static String formatName(Identifier name)
         {
-            if (NAME_PATTERN.matcher(name).matches()) {
-                return name;
-            }
-            return "\"" + name.replace("\"", "\"\"") + "\"";
+            String delimiter = name.isDelimited() ? "\"" : "";
+            return delimiter + name.getValue().replace("\"", "\"\"") + delimiter;
         }
 
         private static String formatName(QualifiedName name)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2137,11 +2137,7 @@ class AstBuilder
 
     private QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
     {
-        List<String> parts = visit(context.identifier(), Identifier.class).stream()
-                .map(Identifier::getValue) // TODO: preserve quotedness
-                .collect(Collectors.toList());
-
-        return QualifiedName.of(parts);
+        return QualifiedName.of(visit(context.identifier(), Identifier.class));
     }
 
     private static boolean isDistinct(SqlBaseParser.SetQuantifierContext setQuantifier)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
@@ -15,9 +15,7 @@ package com.facebook.presto.sql.tree;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -76,7 +74,20 @@ public class DereferenceExpression
      */
     public static QualifiedName getQualifiedName(DereferenceExpression expression)
     {
-        List<String> parts = tryParseParts(expression.base, expression.field.getValue().toLowerCase(Locale.ENGLISH));
+        List<Identifier> parts = null;
+        if (expression.base instanceof Identifier) {
+            parts = ImmutableList.of((Identifier) expression.base, expression.field);
+        }
+        else if (expression.base instanceof DereferenceExpression) {
+            QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) expression.base);
+            if (baseQualifiedName != null) {
+                ImmutableList.Builder<Identifier> builder = ImmutableList.builder();
+                builder.addAll(baseQualifiedName.getOriginalParts());
+                builder.add(expression.field);
+                parts = builder.build();
+            }
+        }
+
         return parts == null ? null : QualifiedName.of(parts);
     }
 
@@ -94,22 +105,6 @@ public class DereferenceExpression
         }
 
         return result;
-    }
-
-    private static List<String> tryParseParts(Expression base, String fieldName)
-    {
-        if (base instanceof Identifier) {
-            return ImmutableList.of(((Identifier) base).getValue(), fieldName);
-        }
-        else if (base instanceof DereferenceExpression) {
-            QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) base);
-            if (baseQualifiedName != null) {
-                List<String> newList = new ArrayList<>(baseQualifiedName.getParts());
-                newList.add(fieldName);
-                return newList;
-            }
-        }
-        return null;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
@@ -20,43 +20,43 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.isEmpty;
-import static com.google.common.collect.Iterables.transform;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class QualifiedName
 {
     private final List<String> parts;
-    private final List<String> originalParts;
+    private final List<Identifier> originalParts;
 
     public static QualifiedName of(String first, String... rest)
     {
         requireNonNull(first, "first is null");
-        return of(ImmutableList.copyOf(Lists.asList(first, rest)));
+        return of(ImmutableList.copyOf(Lists.asList(first, rest).stream().map(Identifier::new).collect(Collectors.toList())));
     }
 
     public static QualifiedName of(String name)
     {
         requireNonNull(name, "name is null");
-        return of(ImmutableList.of(name));
+        return of(ImmutableList.of(new Identifier(name)));
     }
 
-    public static QualifiedName of(Iterable<String> originalParts)
+    public static QualifiedName of(Iterable<Identifier> originalParts)
     {
         requireNonNull(originalParts, "originalParts is null");
         checkArgument(!isEmpty(originalParts), "originalParts is empty");
-        List<String> parts = ImmutableList.copyOf(transform(originalParts, part -> part.toLowerCase(ENGLISH)));
 
-        return new QualifiedName(ImmutableList.copyOf(originalParts), parts);
+        return new QualifiedName(ImmutableList.copyOf(originalParts));
     }
 
-    private QualifiedName(List<String> originalParts, List<String> parts)
+    private QualifiedName(List<Identifier> originalParts)
     {
         this.originalParts = originalParts;
-        this.parts = parts;
+        this.parts = originalParts.stream().map(identifier -> identifier.getValue().toLowerCase(ENGLISH)).collect(toImmutableList());
     }
 
     public List<String> getParts()
@@ -64,7 +64,7 @@ public class QualifiedName
         return parts;
     }
 
-    public List<String> getOriginalParts()
+    public List<Identifier> getOriginalParts()
     {
         return originalParts;
     }
@@ -85,8 +85,8 @@ public class QualifiedName
             return Optional.empty();
         }
 
-        List<String> subList = parts.subList(0, parts.size() - 1);
-        return Optional.of(new QualifiedName(subList, subList));
+        List<Identifier> subList = originalParts.subList(0, originalParts.size() - 1);
+        return Optional.of(new QualifiedName(subList));
     }
 
     public boolean hasSuffix(QualifiedName suffix)

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -158,6 +158,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.query;
@@ -2314,7 +2315,7 @@ public class TestSqlParser
         final String[] tableNames = {"t", "s.t", "c.s.t"};
 
         for (String fullName : tableNames) {
-            QualifiedName qualifiedName = QualifiedName.of(Arrays.asList(fullName.split("\\.")));
+            QualifiedName qualifiedName = makeQualifiedName(fullName);
             assertStatement(format("SHOW STATS FOR %s", qualifiedName), new ShowStats(new Table(qualifiedName)));
         }
     }
@@ -2325,7 +2326,7 @@ public class TestSqlParser
         final String[] tableNames = {"t", "s.t", "c.s.t"};
 
         for (String fullName : tableNames) {
-            QualifiedName qualifiedName = QualifiedName.of(Arrays.asList(fullName.split("\\.")));
+            QualifiedName qualifiedName = makeQualifiedName(fullName);
             assertStatement(format("SHOW STATS FOR (SELECT * FROM %s)", qualifiedName),
                     createShowStats(qualifiedName, ImmutableList.of(new AllColumns()), Optional.empty()));
             assertStatement(format("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0)", qualifiedName),
@@ -2347,6 +2348,14 @@ public class TestSqlParser
                                                     new Identifier("field"),
                                                     new LongLiteral("0"))))));
         }
+    }
+
+    private QualifiedName makeQualifiedName(String tableName)
+    {
+        List<Identifier> parts = Arrays.stream(tableName.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList());
+        return QualifiedName.of(parts);
     }
 
     private ShowStats createShowStats(QualifiedName name, List<SelectItem> selects, Optional<Expression> where)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -814,6 +814,22 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testViewWithReservedKeywords()
+    {
+        skipTestUnless(supportsViews());
+
+        assertUpdate("CREATE TABLE \"group\" AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+
+        @Language("SQL") String query = "SELECT orderkey, orderstatus, totalprice / 2 half FROM orders";
+
+        assertUpdate("CREATE OR REPLACE VIEW test_view AS " + "SELECT orderkey, orderstatus, totalprice / 2 half FROM \"group\"");
+
+        assertQuery("SELECT * FROM test_view", query);
+
+        assertUpdate("DROP VIEW test_view");
+    }
+
+    @Test
     public void testViewCaseSensitivity()
     {
         skipTestUnless(supportsViews());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
@@ -16,18 +16,20 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.verifier.framework.DataMatchResult;
 import com.facebook.presto.verifier.framework.QueryBundle;
-import com.google.common.base.Splitter;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.COLUMN_MISMATCH;
@@ -87,7 +89,9 @@ public class IgnoredFunctionsMismatchResolver
 
     private static String normalizeFunctionName(String name)
     {
-        return normalizeFunctionName(QualifiedName.of(Splitter.on(".").splitToList(name)));
+        return normalizeFunctionName(QualifiedName.of(Arrays.stream(name.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList())));
     }
 
     private static String normalizeFunctionName(QualifiedName name)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
@@ -15,16 +15,18 @@ package com.facebook.presto.verifier.rewrite;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class QueryRewriteConfig
 {
@@ -43,7 +45,9 @@ public class QueryRewriteConfig
     {
         this.tablePrefix = tablePrefix == null ?
                 null :
-                QualifiedName.of(Splitter.on(".").splitToList(tablePrefix));
+                QualifiedName.of(Arrays.stream(tablePrefix.split("\\."))
+                        .map(Identifier::new)
+                        .collect(Collectors.toList()));
         return this;
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -228,14 +228,14 @@ public class QueryRewriter
 
     private QualifiedName generateTemporaryName(Optional<QualifiedName> originalName, QualifiedName prefix)
     {
-        List<String> parts = new ArrayList<>();
+        List<Identifier> parts = new ArrayList<>();
         int originalSize = originalName.map(QualifiedName::getOriginalParts).map(List::size).orElse(0);
         int prefixSize = prefix.getOriginalParts().size();
         if (originalName.isPresent() && originalSize > prefixSize) {
             parts.addAll(originalName.get().getOriginalParts().subList(0, originalSize - prefixSize));
         }
         parts.addAll(prefix.getOriginalParts());
-        parts.set(parts.size() - 1, prefix.getSuffix() + "_" + randomUUID().toString().replace("-", ""));
+        parts.set(parts.size() - 1, new Identifier(prefix.getSuffix() + "_" + randomUUID().toString().replace("-", "")));
         return QualifiedName.of(parts);
     }
 


### PR DESCRIPTION
Presto doesn't maintain the quotedness of an identifier when using SqlQueryFormatter so it results in throwing parsing error if quoted table name is a reserved word

Test plan 

Before this PR, presto throws an error when using a reserved keyword in a prepared statement or while creating a view.

```
presto:imjalpreet> create view group_view security invoker as select * from imjalpreet."group";

Query 20230530_141710_00001_fxwah failed: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{imjalpreet.group}], where=null, groupBy=Optional.empty, having=null, orderBy=Optional.empty, offset=null, limit=null}, orderBy=Optional.empty}

presto:imjalpreet> PREPARE stmt0 FROM select * from imjalpreet."group";

Query 20230530_142117_00003_fxwah failed: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{imjalpreet.group}], where=null, groupBy=Optional.empty, having=null, orderBy=Optional.empty, offset=null, limit=null}, orderBy=Optional.empty}
```

After this PR, queries runs successfully.

```
presto:imjalpreet> create view group_view security invoker as select * from imjalpreet."group";
CREATE VIEW

presto:imjalpreet> PREPARE stmt0 FROM select * from imjalpreet."group";
PREPARE
```

```
== RELEASE NOTES ==

General Changes
* Preserve table name quoting in the output of ``SHOW CREATE VIEW``.
* Fix failure when preparing statements or creating views that contain a quoted reserved word as a table name.
```
