### PR TITLE
[native] Disable circle ci presto-native job on macos

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -28,7 +28,6 @@ workflows:
       - format-check
       - header-check
       - linux-parquet-S3-build
-      - native-specific-macos
 
 executors:
   build:


### PR DESCRIPTION
Disable circle ci presto-native job on macos as the fix would take some time to implement. 
To fix the macos build, we need to fix the protobuf installation by pinning to version 21 from velox side first.

Test plan - (Please fill in how you tested your changes)
Make sure all circle ci runs are green

```
== NO RELEASE NOTE ==
```
