### PR TITLE
Add partial row_number node for row_number with max count limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -275,6 +275,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN = "rewrite_cross_join_array_contains_to_inner_join";
     public static final String REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN = "rewrite_left_join_null_filter_to_semi_join";
     public static final String USE_BROADCAST_WHEN_BUILDSIZE_SMALL_PROBESIDE_UNKNOWN = "use_broadcast_when_buildsize_small_probeside_unknown";
+    public static final String ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT = "add_partial_node_for_row_number_with_limit";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1597,6 +1598,11 @@ public final class SystemSessionProperties
                         USE_BROADCAST_WHEN_BUILDSIZE_SMALL_PROBESIDE_UNKNOWN,
                         "Experimental: When probe side size is unknown but build size is within broadcast limit, choose broadcast join",
                         featuresConfig.isBroadcastJoinWithSmallBuildUnknownProbe(),
+                        false),
+                booleanProperty(
+                        ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT,
+                        "Add partial row number node for row number node with limit",
+                        featuresConfig.isAddPartialNodeForRowNumberWithLimitEnabled(),
                         false));
     }
 
@@ -2684,5 +2690,10 @@ public final class SystemSessionProperties
     public static boolean isUseBroadcastJoinWhenBuildSizeSmallProbeSizeUnknownEnabled(Session session)
     {
         return session.getSystemProperty(USE_BROADCAST_WHEN_BUILDSIZE_SMALL_PROBESIDE_UNKNOWN, Boolean.class);
+    }
+
+    public static boolean isAddPartialNodeForRowNumberWithLimit(Session session)
+    {
+        return session.getSystemProperty(ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -269,6 +269,7 @@ public class FeaturesConfig
     private JoinNotNullInferenceStrategy joinNotNullInferenceStrategy = NONE;
     private boolean leftJoinNullFilterToSemiJoin = true;
     private boolean broadcastJoinWithSmallBuildUnknownProbe;
+    private boolean addPartialNodeForRowNumberWithLimit = true;
 
     private boolean preProcessMetadataCalls;
 
@@ -2652,6 +2653,19 @@ public class FeaturesConfig
     public FeaturesConfig setBroadcastJoinWithSmallBuildUnknownProbe(boolean broadcastJoinWithSmallBuildUnknownProbe)
     {
         this.broadcastJoinWithSmallBuildUnknownProbe = broadcastJoinWithSmallBuildUnknownProbe;
+        return this;
+    }
+
+    public boolean isAddPartialNodeForRowNumberWithLimitEnabled()
+    {
+        return this.addPartialNodeForRowNumberWithLimit;
+    }
+
+    @Config("optimizer.add-partial-node-for-row-number-with-limit")
+    @ConfigDescription("Add partial row number node for row number node with limit")
+    public FeaturesConfig setAddPartialNodeForRowNumberWithLimitEnabled(boolean addPartialNodeForRowNumberWithLimit)
+    {
+        this.addPartialNodeForRowNumberWithLimit = addPartialNodeForRowNumberWithLimit;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -632,6 +632,7 @@ public class CanonicalPlanGenerator
                 partitionBy,
                 rowNumberVariable,
                 node.getMaxRowCountPerPartition(),
+                node.getPartial(),
                 Optional.empty());
         context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementOffset.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementOffset.java
@@ -91,6 +91,7 @@ public class ImplementOffset
                 ImmutableList.of(),
                 rowNumberSymbol,
                 Optional.empty(),
+                false,
                 Optional.empty());
 
         FilterNode filterNode = new FilterNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -281,6 +281,7 @@ public class HashGenerationOptimizer
                             node.getPartitionBy(),
                             node.getRowNumberVariable(),
                             node.getMaxRowCountPerPartition(),
+                            node.getPartial(),
                             Optional.of(hashVariable)),
                     child.getHashVariables());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -625,7 +625,7 @@ public class PruneUnreferencedOutputs
             }
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 
-            return new RowNumberNode(node.getSourceLocation(), node.getId(), source, node.getPartitionBy(), node.getRowNumberVariable(), node.getMaxRowCountPerPartition(), node.getHashVariable());
+            return new RowNumberNode(node.getSourceLocation(), node.getId(), source, node.getPartitionBy(), node.getRowNumberVariable(), node.getMaxRowCountPerPartition(), node.getPartial(), node.getHashVariable());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -429,7 +429,7 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Void> context)
         {
-            return new RowNumberNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalizeAndDistinct(node.getPartitionBy()), canonicalize(node.getRowNumberVariable()), node.getMaxRowCountPerPartition(), canonicalize(node.getHashVariable()));
+            return new RowNumberNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalizeAndDistinct(node.getPartitionBy()), canonicalize(node.getRowNumberVariable()), node.getMaxRowCountPerPartition(), node.getPartial(), canonicalize(node.getHashVariable()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -119,6 +119,7 @@ public class WindowFilterPushDown
                         node.getPartitionBy(),
                         getOnlyElement(node.getWindowFunctions().keySet()),
                         Optional.empty(),
+                        false,
                         Optional.empty());
             }
             return replaceChildren(node, ImmutableList.of(rewrittenSource));
@@ -256,7 +257,7 @@ public class WindowFilterPushDown
             if (node.getMaxRowCountPerPartition().isPresent()) {
                 newRowCountPerPartition = Math.min(node.getMaxRowCountPerPartition().get(), newRowCountPerPartition);
             }
-            return new RowNumberNode(node.getSourceLocation(), node.getId(), node.getSource(), node.getPartitionBy(), node.getRowNumberVariable(), Optional.of(newRowCountPerPartition), node.getHashVariable());
+            return new RowNumberNode(node.getSourceLocation(), node.getId(), node.getSource(), node.getPartitionBy(), node.getRowNumberVariable(), Optional.of(newRowCountPerPartition), false, node.getHashVariable());
         }
 
         private TopNRowNumberNode convertToTopNRowNumber(WindowNode windowNode, int limit)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
@@ -27,6 +27,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -37,6 +38,7 @@ public final class RowNumberNode
     private final List<VariableReferenceExpression> partitionBy;
     private final Optional<Integer> maxRowCountPerPartition;
     private final VariableReferenceExpression rowNumberVariable;
+    private final boolean partial;
     private final Optional<VariableReferenceExpression> hashVariable;
 
     @JsonCreator
@@ -47,9 +49,10 @@ public final class RowNumberNode
             @JsonProperty("partitionBy") List<VariableReferenceExpression> partitionBy,
             @JsonProperty("rowNumberVariable") VariableReferenceExpression rowNumberVariable,
             @JsonProperty("maxRowCountPerPartition") Optional<Integer> maxRowCountPerPartition,
+            @JsonProperty("partial") boolean partial,
             @JsonProperty("hashVariable") Optional<VariableReferenceExpression> hashVariable)
     {
-        this(sourceLocation, id, Optional.empty(), source, partitionBy, rowNumberVariable, maxRowCountPerPartition, hashVariable);
+        this(sourceLocation, id, Optional.empty(), source, partitionBy, rowNumberVariable, maxRowCountPerPartition, partial, hashVariable);
     }
 
     public RowNumberNode(
@@ -60,6 +63,7 @@ public final class RowNumberNode
             List<VariableReferenceExpression> partitionBy,
             VariableReferenceExpression rowNumberVariable,
             Optional<Integer> maxRowCountPerPartition,
+            boolean partial,
             Optional<VariableReferenceExpression> hashVariable)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
@@ -70,10 +74,13 @@ public final class RowNumberNode
         requireNonNull(maxRowCountPerPartition, "maxRowCountPerPartition is null");
         requireNonNull(hashVariable, "hashVariable is null");
 
+        checkState(!partial || maxRowCountPerPartition.isPresent(), "RowNumberNode cannot be partial when maxRowCountPerPartition is not present");
+
         this.source = source;
         this.partitionBy = ImmutableList.copyOf(partitionBy);
         this.rowNumberVariable = rowNumberVariable;
         this.maxRowCountPerPartition = maxRowCountPerPartition;
+        this.partial = partial;
         this.hashVariable = hashVariable;
     }
 
@@ -86,10 +93,12 @@ public final class RowNumberNode
     @Override
     public List<VariableReferenceExpression> getOutputVariables()
     {
-        return ImmutableList.<VariableReferenceExpression>builder()
-                .addAll(source.getOutputVariables())
-                .add(rowNumberVariable)
-                .build();
+        ImmutableList.Builder<VariableReferenceExpression> output = ImmutableList.builder();
+        output.addAll(source.getOutputVariables());
+        if (!partial) {
+            output.add(rowNumberVariable);
+        }
+        return output.build();
     }
 
     @JsonProperty
@@ -117,6 +126,12 @@ public final class RowNumberNode
     }
 
     @JsonProperty
+    public boolean getPartial()
+    {
+        return partial;
+    }
+
+    @JsonProperty
     public Optional<VariableReferenceExpression> getHashVariable()
     {
         return hashVariable;
@@ -131,12 +146,12 @@ public final class RowNumberNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new RowNumberNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), Iterables.getOnlyElement(newChildren), partitionBy, rowNumberVariable, maxRowCountPerPartition, hashVariable);
+        return new RowNumberNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), Iterables.getOnlyElement(newChildren), partitionBy, rowNumberVariable, maxRowCountPerPartition, partial, hashVariable);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new RowNumberNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, partitionBy, rowNumberVariable, maxRowCountPerPartition, hashVariable);
+        return new RowNumberNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, partitionBy, rowNumberVariable, maxRowCountPerPartition, partial, hashVariable);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -236,7 +236,8 @@ public class TestFeaturesConfig
                 .setRewriteCrossJoinWithOrFilterToInnerJoin(true)
                 .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(true)
                 .setLeftJoinNullFilterToSemiJoin(true)
-                .setBroadcastJoinWithSmallBuildUnknownProbe(false));
+                .setBroadcastJoinWithSmallBuildUnknownProbe(false)
+                .setAddPartialNodeForRowNumberWithLimitEnabled(true));
     }
 
     @Test
@@ -421,6 +422,7 @@ public class TestFeaturesConfig
                 .put("optimizer.default-join-selectivity-coefficient", "0.5")
                 .put("optimizer.rewrite-left-join-with-null-filter-to-semi-join", "false")
                 .put("experimental.optimizer.broadcast-join-with-small-build-unknown-probe", "true")
+                .put("optimizer.add-partial-node-for-row-number-with-limit", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -602,7 +604,8 @@ public class TestFeaturesConfig
                 .setRewriteCrossJoinWithOrFilterToInnerJoin(false)
                 .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(false)
                 .setLeftJoinNullFilterToSemiJoin(false)
-                .setBroadcastJoinWithSmallBuildUnknownProbe(true);
+                .setBroadcastJoinWithSmallBuildUnknownProbe(true)
+                .setAddPartialNodeForRowNumberWithLimitEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -936,6 +936,7 @@ public class PlanBuilder
                 partitionBy,
                 rowNumberVariable,
                 maxRowCountPerPartition,
+                false,
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.SystemSessionProperties.ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT;
 import static com.facebook.presto.SystemSessionProperties.AGGREGATION_PARTITIONING_MERGING_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.EXCHANGE_MATERIALIZATION_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
@@ -51,6 +52,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJo
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.rowNumber;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -297,6 +299,34 @@ public class TestAddExchangesPlans
     }
 
     @Test
+    public void testRowNumberWithPartialNode()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    *\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        a,\n" +
+                        "        ROW_NUMBER() OVER (\n" +
+                        "            PARTITION BY\n" +
+                        "                a\n" +
+                        "        ) <= 1 as keep\n" +
+                        "    FROM (\n" +
+                        "        VALUES\n" +
+                        "            (1)\n" +
+                        "    ) t (a)\n" +
+                        ") t where keep",
+                anyTree(
+                        rowNumber(
+                                pattern -> pattern.maxRowCountPerPartition(Optional.of(1)),
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                rowNumber(
+                                                        pattern -> pattern.maxRowCountPerPartition(Optional.of(1)),
+                                                        anyTree(values("a"))))))));
+    }
+
+    @Test
     public void testTopNRowNumberIsExactlyPartitioned()
     {
         assertExactDistributedPlan(
@@ -486,6 +516,7 @@ public class TestAddExchangesPlans
                         .setSystemProperty(JOIN_REORDERING_STRATEGY, ELIMINATE_CROSS_JOINS.toString())
                         .setSystemProperty(JOIN_DISTRIBUTION_TYPE, PARTITIONED.toString())
                         .setSystemProperty(PARTITIONING_PRECISION_STRATEGY, PREFER_EXACT_PARTITIONING.toString())
+                        .setSystemProperty(ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT, "true")
                         // Set for testSemiJoinExactlyPartitioned, which will be simplified if set to true
                         .setSystemProperty(SIMPLIFY_PLAN_WITH_EMPTY_INPUT, "false")
                         .build(),


### PR DESCRIPTION
When the row _number node has limit, it means that each partition will only emit a maximum number of rows. In this case, we can add a partial row_number node like we did for TopNRowNumber node. This PR includes two changes: 1) Add a partial field in RowNumberNode, when this field is set, the row number field will not be included in the output variables 2) Add option to add partial RowNumberNode before exchange

### Test plan - (Please fill in how you tested your changes)

Add unit tests, and [verifier tests](https://www.internalfb.com/intern/presto/verifier/results/?test_id=116229)

```
== RELEASE NOTES ==

General Changes
* Add option to add partial row number node for row number node with max count limit, enabled by session parameter `add_partial_node_for_row_number_node_with_limit`
```

