### PR TITLE
Rewrite expressions in query plans when variables are constant.

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
@@ -7,10 +7,10 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, PARTITIONED):
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, [c_customer_id])
-                                    final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                    final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag)
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year])
-                                                partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                            remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag])
+                                                partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag)
                                                     join (INNER, PARTITIONED):
                                                         remote exchange (REPARTITION, HASH, [ss_customer_sk])
                                                             join (INNER, REPLICATED):
@@ -23,10 +23,10 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_customer_id_247])
-                                        final aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293)
+                                        final aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256)
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293])
-                                                    partial aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293)
+                                                remote exchange (REPARTITION, HASH, [c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256])
+                                                    partial aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256)
                                                         join (INNER, PARTITIONED):
                                                             remote exchange (REPARTITION, HASH, [ss_customer_sk_267])
                                                                 join (INNER, REPLICATED):
@@ -39,10 +39,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan customer
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [c_customer_id_747])
-                                    final aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804)
+                                    final aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756)
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804])
-                                                partial aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804)
+                                            remote exchange (REPARTITION, HASH, [c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756])
+                                                partial aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756)
                                                     join (INNER, PARTITIONED):
                                                         remote exchange (REPARTITION, HASH, [cs_bill_customer_sk_767])
                                                             join (INNER, REPLICATED):
@@ -55,10 +55,10 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan customer
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [c_customer_id_1140])
-                                final aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197)
+                                final aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149)
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197])
-                                            partial aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197)
+                                        remote exchange (REPARTITION, HASH, [c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149])
+                                            partial aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149)
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, [cs_bill_customer_sk_1160])
                                                         join (INNER, REPLICATED):
@@ -71,10 +71,10 @@ local exchange (GATHER, SINGLE, [])
                                                             scan customer
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [c_customer_id_1661])
-                        final aggregation over (c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670, d_year_1718)
+                        final aggregation over (c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670, d_year_1718])
-                                    partial aggregation over (c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670, d_year_1718)
+                                remote exchange (REPARTITION, HASH, [c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670])
+                                    partial aggregation over (c_birth_country_1674, c_customer_id_1661, c_email_address_1676, c_first_name_1668, c_last_name_1669, c_login_1675, c_preferred_cust_flag_1670)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_1682])
                                                 join (INNER, REPLICATED):
@@ -87,10 +87,10 @@ local exchange (GATHER, SINGLE, [])
                                                     scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [c_customer_id_2054])
-                    final aggregation over (c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063, d_year_2111)
+                    final aggregation over (c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063, d_year_2111])
-                                partial aggregation over (c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063, d_year_2111)
+                            remote exchange (REPARTITION, HASH, [c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063])
+                                partial aggregation over (c_birth_country_2067, c_customer_id_2054, c_email_address_2069, c_first_name_2061, c_last_name_2062, c_login_2068, c_preferred_cust_flag_2063)
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_2075])
                                             join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q09.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q09.plan.txt
@@ -1,4 +1,4 @@
-remote exchange (GATHER, SINGLE, [])
+cross join:
     cross join:
         cross join:
             cross join:
@@ -13,110 +13,81 @@ remote exchange (GATHER, SINGLE, [])
                                                 cross join:
                                                     cross join:
                                                         cross join:
-                                                            cross join:
-                                                                scan reason
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        final aggregation over ()
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (GATHER, SINGLE, [])
-                                                                                    partial aggregation over ()
-                                                                                        scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    final aggregation over ()
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (GATHER, SINGLE, [])
-                                                                                partial aggregation over ()
-                                                                                    scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                final aggregation over ()
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (GATHER, SINGLE, [])
-                                                                            partial aggregation over ()
-                                                                                scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
                                                             final aggregation over ()
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (GATHER, SINGLE, [])
                                                                         partial aggregation over ()
                                                                             scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (GATHER, SINGLE, [])
+                                                                    scan reason
                                                         final aggregation over ()
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (GATHER, SINGLE, [])
                                                                     partial aggregation over ()
                                                                         scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
                                                     final aggregation over ()
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (GATHER, SINGLE, [])
                                                                 partial aggregation over ()
                                                                     scan store_sales
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
                                                                 scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
                                             final aggregation over ()
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (GATHER, SINGLE, [])
                                                         partial aggregation over ()
                                                             scan store_sales
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
                                                         scan store_sales
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+            final aggregation over ()
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (GATHER, SINGLE, [])
+                        partial aggregation over ()
+                            scan store_sales
+        final aggregation over ()
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (GATHER, SINGLE, [])
+                    partial aggregation over ()
+                        scan store_sales
+    final aggregation over ()
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (GATHER, SINGLE, [])
+                partial aggregation over ()
+                    scan store_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
@@ -4,10 +4,10 @@ local exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, [c_customer_id])
-                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                        final aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year])
-                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
+                                remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag])
+                                    partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ss_customer_sk])
                                                 join (INNER, REPLICATED):
@@ -20,10 +20,10 @@ local exchange (GATHER, SINGLE, [])
                                                     scan customer
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [c_customer_id_153])
-                            final aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199)
+                            final aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162)
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199])
-                                        partial aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199)
+                                    remote exchange (REPARTITION, HASH, [c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162])
+                                        partial aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162)
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, [ss_customer_sk_173])
                                                     join (INNER, REPLICATED):
@@ -36,10 +36,10 @@ local exchange (GATHER, SINGLE, [])
                                                         scan customer
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [c_customer_id_525])
-                        final aggregation over (c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534, d_year_582)
+                        final aggregation over (c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534, d_year_582])
-                                    partial aggregation over (c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534, d_year_582)
+                                remote exchange (REPARTITION, HASH, [c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534])
+                                    partial aggregation over (c_birth_country_538, c_customer_id_525, c_email_address_540, c_first_name_532, c_last_name_533, c_login_539, c_preferred_cust_flag_534)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_546])
                                                 join (INNER, REPLICATED):
@@ -52,10 +52,10 @@ local exchange (GATHER, SINGLE, [])
                                                     scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [c_customer_id_790])
-                    final aggregation over (c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799, d_year_847)
+                    final aggregation over (c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799, d_year_847])
-                                partial aggregation over (c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799, d_year_847)
+                            remote exchange (REPARTITION, HASH, [c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799])
+                                partial aggregation over (c_birth_country_803, c_customer_id_790, c_email_address_805, c_first_name_797, c_last_name_798, c_login_804, c_preferred_cust_flag_799)
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_811])
                                             join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_2.plan.txt
@@ -1,69 +1,132 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        join (INNER, PARTITIONED):
+        cross join:
             cross join:
-                final aggregation over (i_brand_id, i_category_id, i_class_id)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [i_brand_id, i_category_id, i_class_id])
-                            partial aggregation over (i_brand_id, i_category_id, i_class_id)
-                                join (INNER, REPLICATED):
-                                    semijoin (PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [ss_item_sk])
-                                            join (INNER, REPLICATED):
+                join (INNER, PARTITIONED):
+                    final aggregation over (i_brand_id, i_category_id, i_class_id)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [i_brand_id, i_category_id, i_class_id])
+                                partial aggregation over (i_brand_id, i_category_id, i_class_id)
+                                    join (INNER, REPLICATED):
+                                        semijoin (PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_item_sk])
                                                 join (INNER, REPLICATED):
-                                                    scan store_sales
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan item
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [i_item_sk_1])
-                                                join (INNER, PARTITIONED):
-                                                    final aggregation over (expr_216, expr_217, expr_218)
-                                                        local exchange (REPARTITION, HASH, [expr_216, expr_217, expr_218])
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_53, i_category_id_57, i_class_id_55])
-                                                                partial aggregation over (i_brand_id_53, i_category_id_57, i_class_id_55)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan store_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_108, i_category_id_112, i_class_id_110])
-                                                                partial aggregation over (i_brand_id_108, i_category_id_112, i_class_id_110)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan catalog_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_167, i_category_id_171, i_class_id_169])
-                                                                partial aggregation over (i_brand_id_167, i_category_id_171, i_class_id_169)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [i_brand_id_8, i_category_id_12, i_class_id_10])
                                                             scan item
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    scan date_dim
+                                                remote exchange (REPARTITION, HASH, [i_item_sk_1])
+                                                    join (INNER, PARTITIONED):
+                                                        final aggregation over (expr_216, expr_217, expr_218)
+                                                            local exchange (REPARTITION, HASH, [expr_216, expr_217, expr_218])
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_53, i_category_id_57, i_class_id_55])
+                                                                    partial aggregation over (i_brand_id_53, i_category_id_57, i_class_id_55)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_108, i_category_id_112, i_class_id_110])
+                                                                    partial aggregation over (i_brand_id_108, i_category_id_112, i_class_id_110)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan catalog_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_167, i_category_id_171, i_class_id_169])
+                                                                    partial aggregation over (i_brand_id_167, i_category_id_171, i_class_id_169)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan web_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [i_brand_id_8, i_category_id_12, i_class_id_10])
+                                                                scan item
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        scan date_dim
+                    final aggregation over (i_brand_id_534, i_category_id_538, i_class_id_536)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [i_brand_id_534, i_category_id_538, i_class_id_536])
+                                partial aggregation over (i_brand_id_534, i_category_id_538, i_class_id_536)
+                                    join (INNER, REPLICATED):
+                                        semijoin (PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_item_sk_506])
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, [i_item_sk_578])
+                                                    join (INNER, PARTITIONED):
+                                                        final aggregation over (expr_862, expr_863, expr_864)
+                                                            local exchange (REPARTITION, HASH, [expr_862, expr_863, expr_864])
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_630, i_category_id_634, i_class_id_632])
+                                                                    partial aggregation over (i_brand_id_630, i_category_id_634, i_class_id_632)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_720, i_category_id_724, i_class_id_722])
+                                                                    partial aggregation over (i_brand_id_720, i_category_id_724, i_class_id_722)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan catalog_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                                remote exchange (REPARTITION, HASH, [i_brand_id_813, i_category_id_817, i_class_id_815])
+                                                                    partial aggregation over (i_brand_id_813, i_category_id_817, i_class_id_815)
+                                                                        join (INNER, REPLICATED):
+                                                                            join (INNER, REPLICATED):
+                                                                                scan web_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan date_dim
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan item
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [i_brand_id_585, i_category_id_589, i_class_id_587])
+                                                                scan item
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
@@ -87,89 +150,26 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan date_dim
-            cross join:
-                final aggregation over (i_brand_id_534, i_category_id_538, i_class_id_536)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [i_brand_id_534, i_category_id_538, i_class_id_536])
-                            partial aggregation over (i_brand_id_534, i_category_id_538, i_class_id_536)
-                                join (INNER, REPLICATED):
-                                    semijoin (PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [ss_item_sk_506])
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan item
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
+                    final aggregation over ()
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (GATHER, SINGLE, [])
+                                partial aggregation over ()
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [i_item_sk_578])
-                                                join (INNER, PARTITIONED):
-                                                    final aggregation over (expr_862, expr_863, expr_864)
-                                                        local exchange (REPARTITION, HASH, [expr_862, expr_863, expr_864])
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_630, i_category_id_634, i_class_id_632])
-                                                                partial aggregation over (i_brand_id_630, i_category_id_634, i_class_id_632)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan store_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_720, i_category_id_724, i_class_id_722])
-                                                                partial aggregation over (i_brand_id_720, i_category_id_724, i_class_id_722)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan catalog_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                            remote exchange (REPARTITION, HASH, [i_brand_id_813, i_category_id_817, i_class_id_815])
-                                                                partial aggregation over (i_brand_id_813, i_category_id_817, i_class_id_815)
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            scan web_sales
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan date_dim
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan item
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [i_brand_id_585, i_category_id_589, i_class_id_587])
-                                                            scan item
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    scan date_dim
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
-                        final aggregation over ()
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (GATHER, SINGLE, [])
-                                    partial aggregation over ()
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    partial aggregation over ()
-                                        join (INNER, REPLICATED):
-                                            scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    partial aggregation over ()
-                                        join (INNER, REPLICATED):
-                                            scan web_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                partial aggregation over ()
+                                    join (INNER, REPLICATED):
+                                        scan catalog_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
+                                partial aggregation over ()
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
@@ -4,10 +4,10 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
                     join (INNER, PARTITIONED):
-                        final aggregation over (ca_county_81, d_qoy_56, d_year_52)
+                        final aggregation over (ca_county_81)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_county_81, d_qoy_56, d_year_52])
-                                    partial aggregation over (ca_county_81, d_qoy_56, d_year_52)
+                                remote exchange (REPARTITION, HASH, [ca_county_81])
+                                    partial aggregation over (ca_county_81)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ss_addr_sk_29])
                                                 join (INNER, REPLICATED):
@@ -18,27 +18,25 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [ca_address_sk_74])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [2, 2000, ca_county_173])
-                                final aggregation over (ca_county_173, d_qoy_148, d_year_144)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [ca_county_173, d_qoy_148, d_year_144])
-                                            partial aggregation over (ca_county_173, d_qoy_148, d_year_144)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, [ss_addr_sk_121])
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [ca_address_sk_166])
-                                                            scan customer_address
-                    join (INNER, PARTITIONED):
-                        final aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                        final aggregation over (ca_county_173)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_county_345, d_qoy_320, d_year_316])
-                                    partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                                remote exchange (REPARTITION, HASH, [ca_county_173])
+                                    partial aggregation over (ca_county_173)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_addr_sk_121])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, [ca_address_sk_166])
+                                                    scan customer_address
+                    join (INNER, PARTITIONED):
+                        final aggregation over (ca_county_345)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [ca_county_345])
+                                    partial aggregation over (ca_county_345)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ws_bill_addr_sk_283])
                                                 join (INNER, REPLICATED):
@@ -49,50 +47,46 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [ca_address_sk_338])
                                                     scan customer_address
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [2, 2000, ca_county_448])
-                                final aggregation over (ca_county_448, d_qoy_423, d_year_419)
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [ca_county_448, d_qoy_423, d_year_419])
-                                            partial aggregation over (ca_county_448, d_qoy_423, d_year_419)
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, [ws_bill_addr_sk_386])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                        final aggregation over (ca_county_448)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [ca_county_448])
+                                    partial aggregation over (ca_county_448)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ws_bill_addr_sk_386])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [ca_address_sk_441])
-                                                            scan customer_address
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, [2, 2000, ca_county])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (ca_county, d_qoy, d_year)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [ca_county, d_qoy, d_year])
-                                        partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, [ss_addr_sk])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, [ca_address_sk_441])
+                                                    scan customer_address
+                join (INNER, PARTITIONED):
+                    final aggregation over (ca_county)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ca_county])
+                                partial aggregation over (ca_county)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ss_addr_sk])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, [ca_address_sk])
-                                                        scan customer_address
-                            final aggregation over (ca_county_242, d_qoy_217, d_year_213)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [ca_county_242, d_qoy_217, d_year_213])
-                                        partial aggregation over (ca_county_242, d_qoy_217, d_year_213)
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, [ws_bill_addr_sk])
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                scan customer_address
+                    final aggregation over (ca_county_242)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ca_county_242])
+                                partial aggregation over (ca_county_242)
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ws_bill_addr_sk])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, [ca_address_sk_235])
-                                                        scan customer_address
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [ca_address_sk_235])
+                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_1.plan.txt
@@ -3,10 +3,10 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, [i_item_sk, w_warehouse_sk])
-                    final aggregation over (d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk)
+                    final aggregation over (i_item_sk, w_warehouse_name, w_warehouse_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk])
-                                partial aggregation over (d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk)
+                            remote exchange (REPARTITION, HASH, [i_item_sk, w_warehouse_name, w_warehouse_sk])
+                                partial aggregation over (i_item_sk, w_warehouse_name, w_warehouse_sk)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
@@ -22,10 +22,10 @@ remote exchange (GATHER, SINGLE, [])
                                                 scan warehouse
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [i_item_sk_66, w_warehouse_sk_88])
-                        final aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
+                        final aggregation over (i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88])
-                                    partial aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
+                                remote exchange (REPARTITION, HASH, [i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88])
+                                    partial aggregation over (i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_2.plan.txt
@@ -3,10 +3,10 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, [i_item_sk, w_warehouse_sk])
-                    final aggregation over (d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk)
+                    final aggregation over (i_item_sk, w_warehouse_name, w_warehouse_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk])
-                                partial aggregation over (d_moy, i_item_sk, w_warehouse_name, w_warehouse_sk)
+                            remote exchange (REPARTITION, HASH, [i_item_sk, w_warehouse_name, w_warehouse_sk])
+                                partial aggregation over (i_item_sk, w_warehouse_name, w_warehouse_sk)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
@@ -22,10 +22,10 @@ remote exchange (GATHER, SINGLE, [])
                                                 scan warehouse
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [i_item_sk_66, w_warehouse_sk_88])
-                        final aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
+                        final aggregation over (i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88])
-                                    partial aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
+                                remote exchange (REPARTITION, HASH, [i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88])
+                                    partial aggregation over (i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
@@ -1,15 +1,15 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        final aggregation over (d_year, i_category, i_category_id)
+        final aggregation over (i_category, i_category_id)
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, [d_year, i_category, i_category_id])
-                    partial aggregation over (d_year, i_category, i_category_id)
+                remote exchange (REPARTITION, HASH, [i_category, i_category_id])
+                    partial aggregation over (i_category, i_category_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan item
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan date_dim
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
@@ -1,9 +1,9 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        final aggregation over (d_year, i_brand, i_brand_id)
+        final aggregation over (i_brand, i_brand_id)
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, [d_year, i_brand, i_brand_id])
-                    partial aggregation over (d_year, i_brand, i_brand_id)
+                remote exchange (REPARTITION, HASH, [i_brand, i_brand_id])
+                    partial aggregation over (i_brand, i_brand_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 scan store_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
@@ -3,10 +3,10 @@ remote exchange (GATHER, SINGLE, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
                 remote exchange (REPARTITION, HASH, [i_item_sk, s_store_name, s_zip])
-                    final aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
+                    final aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip])
-                                partial aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
+                            remote exchange (REPARTITION, HASH, [ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip])
+                                partial aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
@@ -90,10 +90,10 @@ remote exchange (GATHER, SINGLE, [])
                                                 scan item
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [i_item_sk_573, s_store_name_452, s_zip_472])
-                        final aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
+                        final aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472])
-                                    partial aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
+                                remote exchange (REPARTITION, HASH, [ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472])
+                                    partial aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q66.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q66.plan.txt
@@ -1,12 +1,12 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        final aggregation over (concat_306, d_year_307, w_city_302, w_country_305, w_county_303, w_state_304, w_warehouse_name_300, w_warehouse_sq_ft_301)
-            local exchange (REPARTITION, HASH, [concat_306, d_year_307, w_city_302, w_country_305, w_county_303, w_state_304, w_warehouse_name_300, w_warehouse_sq_ft_301])
-                partial aggregation over (concat, d_year, w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
-                    final aggregation over (d_year, w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
+        final aggregation over (w_city_302, w_country_305, w_county_303, w_state_304, w_warehouse_name_300, w_warehouse_sq_ft_301)
+            local exchange (REPARTITION, HASH, [w_city_302, w_country_305, w_county_303, w_state_304, w_warehouse_name_300, w_warehouse_sq_ft_301])
+                partial aggregation over (w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
+                    final aggregation over (w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_year, w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft])
-                                partial aggregation over (d_year, w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
+                            remote exchange (REPARTITION, HASH, [w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft])
+                                partial aggregation over (w_city, w_country, w_county, w_state, w_warehouse_name, w_warehouse_sq_ft)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
@@ -24,11 +24,11 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan warehouse
-                partial aggregation over (concat_242, d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
-                    final aggregation over (d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
+                partial aggregation over (w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
+                    final aggregation over (w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119])
-                                partial aggregation over (d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
+                            remote exchange (REPARTITION, HASH, [w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119])
+                                partial aggregation over (w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
@@ -4,10 +4,10 @@ local exchange (GATHER, SINGLE, [])
             join (INNER, PARTITIONED):
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, [c_customer_id])
-                        final aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                        final aggregation over (c_customer_id, c_first_name, c_last_name)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_customer_id, c_first_name, c_last_name, d_year])
-                                    partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
+                                remote exchange (REPARTITION, HASH, [c_customer_id, c_first_name, c_last_name])
+                                    partial aggregation over (c_customer_id, c_first_name, c_last_name)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ss_customer_sk])
                                                 join (INNER, REPLICATED):
@@ -20,10 +20,10 @@ local exchange (GATHER, SINGLE, [])
                                                     scan customer
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [c_customer_id_109])
-                            final aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155)
+                            final aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117)
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155])
-                                        partial aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155)
+                                    remote exchange (REPARTITION, HASH, [c_customer_id_109, c_first_name_116, c_last_name_117])
+                                        partial aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117)
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, [ss_customer_sk_129])
                                                     join (INNER, REPLICATED):
@@ -36,10 +36,10 @@ local exchange (GATHER, SINGLE, [])
                                                         scan customer
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [c_customer_id_417])
-                        final aggregation over (c_customer_id_417, c_first_name_424, c_last_name_425, d_year_474)
+                        final aggregation over (c_customer_id_417, c_first_name_424, c_last_name_425)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_customer_id_417, c_first_name_424, c_last_name_425, d_year_474])
-                                    partial aggregation over (c_customer_id_417, c_first_name_424, c_last_name_425, d_year_474)
+                                remote exchange (REPARTITION, HASH, [c_customer_id_417, c_first_name_424, c_last_name_425])
+                                    partial aggregation over (c_customer_id_417, c_first_name_424, c_last_name_425)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_438])
                                                 join (INNER, REPLICATED):
@@ -52,10 +52,10 @@ local exchange (GATHER, SINGLE, [])
                                                     scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [c_customer_id_634])
-                    final aggregation over (c_customer_id_634, c_first_name_641, c_last_name_642, d_year_691)
+                    final aggregation over (c_customer_id_634, c_first_name_641, c_last_name_642)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [c_customer_id_634, c_first_name_641, c_last_name_642, d_year_691])
-                                partial aggregation over (c_customer_id_634, c_first_name_641, c_last_name_642, d_year_691)
+                            remote exchange (REPARTITION, HASH, [c_customer_id_634, c_first_name_641, c_last_name_642])
+                                partial aggregation over (c_customer_id_634, c_first_name_641, c_last_name_642)
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, [ws_bill_customer_sk_655])
                                             join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q75.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q75.plan.txt
@@ -1,11 +1,11 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            single aggregation over (d_year_172, i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176)
-                final aggregation over (d_year_172, expr_177, expr_178, i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176)
-                    local exchange (REPARTITION, HASH, [d_year_172, i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176])
+            single aggregation over (i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176)
+                final aggregation over (expr_177, expr_178, i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176)
+                    local exchange (REPARTITION, HASH, [i_brand_id_173, i_category_id_175, i_class_id_174, i_manufact_id_176])
                         remote exchange (REPARTITION, HASH, [i_brand_id, i_category_id, i_class_id, i_manufact_id])
-                            partial aggregation over (d_year, expr, expr_13, i_brand_id, i_category_id, i_class_id, i_manufact_id)
+                            partial aggregation over (expr, expr_13, i_brand_id, i_category_id, i_class_id, i_manufact_id)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [cr_item_sk, cr_order_number])
                                         scan catalog_returns
@@ -21,7 +21,7 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
                         remote exchange (REPARTITION, HASH, [i_brand_id_28, i_category_id_32, i_class_id_30, i_manufact_id_34])
-                            partial aggregation over (d_year_51, expr_84, expr_85, i_brand_id_28, i_category_id_32, i_class_id_30, i_manufact_id_34)
+                            partial aggregation over (expr_84, expr_85, i_brand_id_28, i_category_id_32, i_class_id_30, i_manufact_id_34)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
                                         scan store_returns
@@ -37,7 +37,7 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
                         remote exchange (REPARTITION, HASH, [i_brand_id_107, i_category_id_111, i_class_id_109, i_manufact_id_113])
-                            partial aggregation over (d_year_130, expr_163, expr_164, i_brand_id_107, i_category_id_111, i_class_id_109, i_manufact_id_113)
+                            partial aggregation over (expr_163, expr_164, i_brand_id_107, i_category_id_111, i_class_id_109, i_manufact_id_113)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
                                         scan web_returns
@@ -52,11 +52,11 @@ local exchange (GATHER, SINGLE, [])
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
-            single aggregation over (d_year_619, i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
-                final aggregation over (d_year_619, expr_624, expr_625, i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
+            single aggregation over (i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
+                final aggregation over (expr_624, expr_625, i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [i_brand_id_275, i_category_id_279, i_class_id_277, i_manufact_id_281])
-                            partial aggregation over (d_year_298, expr_358, expr_359, i_brand_id_275, i_category_id_279, i_class_id_277, i_manufact_id_281)
+                            partial aggregation over (expr_358, expr_359, i_brand_id_275, i_category_id_279, i_class_id_277, i_manufact_id_281)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [cr_item_sk_324, cr_order_number_338])
                                         scan catalog_returns
@@ -72,7 +72,7 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
                         remote exchange (REPARTITION, HASH, [i_brand_id_397, i_category_id_401, i_class_id_399, i_manufact_id_403])
-                            partial aggregation over (d_year_420, expr_473, expr_474, i_brand_id_397, i_category_id_401, i_class_id_399, i_manufact_id_403)
+                            partial aggregation over (expr_473, expr_474, i_brand_id_397, i_category_id_401, i_class_id_399, i_manufact_id_403)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [sr_item_sk_446, sr_ticket_number_453])
                                         scan store_returns
@@ -88,7 +88,7 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan date_dim
                         remote exchange (REPARTITION, HASH, [i_brand_id_530, i_category_id_534, i_class_id_532, i_manufact_id_536])
-                            partial aggregation over (d_year_553, expr_610, expr_611, i_brand_id_530, i_category_id_534, i_class_id_532, i_manufact_id_536)
+                            partial aggregation over (expr_610, expr_611, i_brand_id_530, i_category_id_534, i_class_id_532, i_manufact_id_536)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, [wr_item_sk_579, wr_order_number_590])
                                         scan web_returns

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
@@ -3,10 +3,10 @@ local exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
             remote exchange (REPARTITION, HASH, [ss_customer_sk])
                 join (INNER, PARTITIONED):
-                    final aggregation over (d_year, ss_customer_sk, ss_item_sk)
+                    final aggregation over (ss_customer_sk, ss_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_year, ss_customer_sk, ss_item_sk])
-                                partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
+                            remote exchange (REPARTITION, HASH, [ss_customer_sk, ss_item_sk])
+                                partial aggregation over (ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ss_item_sk, ss_ticket_number])
@@ -17,10 +17,10 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan date_dim
-                    final aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
+                    final aggregation over (ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [d_year_53, ws_bill_customer_sk, ws_item_sk])
-                                partial aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
+                            remote exchange (REPARTITION, HASH, [ws_bill_customer_sk, ws_item_sk])
+                                partial aggregation over (ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
@@ -33,10 +33,10 @@ local exchange (GATHER, SINGLE, [])
                                                 scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [cs_bill_customer_sk])
-                    final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
+                    final aggregation over (cs_bill_customer_sk, cs_item_sk)
                         local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [cs_bill_customer_sk, cs_item_sk, d_year_130])
-                                partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
+                            remote exchange (REPARTITION, HASH, [cs_bill_customer_sk, cs_item_sk])
+                                partial aggregation over (cs_bill_customer_sk, cs_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, [cs_item_sk, cs_order_number])

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -786,6 +786,15 @@ Optimizer Properties
     outputs of the join. This optimization eliminates the cross join, may convert the outer join into an inner
     join and thereby produces more optimal plans.
 
+``optimizer.rewrite-expression-with-constant-variable``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    Extract expressions which have constant value from filter and assignment expressions, and replace the expressions with
+    constant value.
+
 
 Planner Properties
 --------------------------------------

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCanonicalPlanGenerator.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION;
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.REMOVE_SAFE_CONSTANTS;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
@@ -148,7 +149,7 @@ public class TestHiveCanonicalPlanGenerator
                     "SELECT * FROM test_column_predicates WHERE ds IN ('2020-09-01', '2020-09-02')",
                     "SELECT * FROM test_column_predicates");
             assertSameCanonicalLeafSubPlan(
-                    pushdownFilterEnabled(),
+                    pushdownFilterEnabledConstantPullUpDisabled(),
                     "SELECT * FROM test_column_predicates WHERE ds = '2020-09-01'",
                     "SELECT * FROM test_column_predicates WHERE ds = '2020-09-02'");
             assertSameCanonicalLeafSubPlan(
@@ -203,6 +204,14 @@ public class TestHiveCanonicalPlanGenerator
     {
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
+    }
+
+    private Session pushdownFilterEnabledConstantPullUpDisabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .setSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, "false")
                 .build();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedJoinQueriesWithDynamicFiltering.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedJoinQueriesWithDynamicFiltering.java
@@ -162,6 +162,9 @@ public class TestHiveDistributedJoinQueriesWithDynamicFiltering
                         return false;
                     }
                     ProjectNode projectNode = (ProjectNode) node;
+                    if (!(projectNode.getSource() instanceof FilterNode)) {
+                        return false;
+                    }
                     FilterNode filterNode = (FilterNode) projectNode.getSource();
                     TableScanNode tableScanNode = (TableScanNode) filterNode.getSource();
                     return tableName.equals(((HiveTableHandle) (tableScanNode.getTable().getConnectorHandle())).getTableName());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
@@ -180,7 +180,8 @@ public class TestHiveDistributedQueriesWithExchangeMaterialization
                 // We need to disable optimize_constant_grouping_keys so Optimizer does NOT optimize
                 // [Aggregate() -> Project(add constant) -> TableScan()] ==> [Project(add constant) -> Aggregate() -> TableScan()]
                 // which will lead to type changes in materialized tables
-                .setSystemProperty("optimize_constant_grouping_keys", "false");
+                .setSystemProperty("optimize_constant_grouping_keys", "false")
+                .setSystemProperty("rewrite_expression_with_constant_expression", "false");
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -227,7 +227,8 @@ public class TestHiveLogicalPlanner
 
         assertPlan(pushdownFilterEnabled, "SELECT partkey, linenumber FROM lineitem WHERE partkey = 10",
                 output(exchange(
-                        strictTableScan("lineitem", identityMap("partkey", "linenumber")))),
+                        project(
+                                strictTableScan("lineitem", identityMap("linenumber"))))),
                 plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), singleValue(BIGINT, 10L))), TRUE_CONSTANT, ImmutableSet.of("partkey")));
 
         // Only remaining predicate
@@ -293,7 +294,9 @@ public class TestHiveLogicalPlanner
 
         assertPlan(pushdownFilterEnabled, "SELECT partkey, orderkey, linenumber FROM lineitem WHERE partkey = 10 AND mod(orderkey, 2) = 1",
                 output(exchange(
-                        strictTableScan("lineitem", identityMap("partkey", "orderkey", "linenumber")))),
+                        project(
+                                ImmutableMap.of("expr_8", expression("10")),
+                                strictTableScan("lineitem", identityMap("orderkey", "linenumber"))))),
                 plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), singleValue(BIGINT, 10L))), remainingPredicate, ImmutableSet.of("partkey", "orderkey")));
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -62,10 +62,12 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTre
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.constrainedTableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unnest;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
@@ -166,9 +168,11 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    filter("orderkey < BIGINT'100'", constrainedTableScan(table,
-                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                            ImmutableMap.of("orderkey", "orderkey"))),
+                    project(
+                            ImmutableMap.of("ds_61", expression("'2019-01-02'")),
+                            filter("orderkey < BIGINT'100'", constrainedTableScan(table,
+                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                    ImmutableMap.of("orderkey", "orderkey")))),
                     filter("orderkey_62 < BIGINT'100'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_62", "orderkey")))));
         }
         finally {
@@ -531,8 +535,10 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    constrainedTableScan(table2,
-                            ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2019-01-02")))),
+                    project(
+                            ImmutableMap.of("ds_27", expression("'2019-01-02'")),
+                            constrainedTableScan(table2,
+                                    ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2019-01-02"))))),
                     constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
@@ -1160,7 +1166,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                                                             ProjectNode.class, constrainedTableScan(
                                                                                     table,
                                                                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2021-07-12"))),
-                                                                                    ImmutableMap.of("orderkey", "orderkey", "ds", "ds"))))))),
+                                                                                    ImmutableMap.of("orderkey", "orderkey"))))))),
                                     anyTree(
                                             constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of())))));
 
@@ -1354,26 +1360,24 @@ public class TestHiveMaterializedViewLogicalPlanner
 
             PlanMatchPattern expectedPattern = anyTree(
                     aggregation(
-                            singleGroupingSet("ds"),
-                            ImmutableMap.of(Optional.empty(), functionCall("sum", ImmutableList.of("count"))),
-                            ImmutableList.of(),
-                            ImmutableMap.of(),
-                            Optional.empty(),
+                            ImmutableMap.of("sum", functionCall("sum", ImmutableList.of("count"))),
                             SINGLE,
                             node(
                                     ExchangeNode.class,
                                     anyTree(
-                                            aggregation(
-                                                    ImmutableMap.of("count", functionCall("count", false, ImmutableList.of())),
-                                                    SINGLE,
-                                                    node(
-                                                            ExchangeNode.class,
-                                                            anyTree(
-                                                                    node(
-                                                                            ProjectNode.class, constrainedTableScan(
-                                                                                    table,
-                                                                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2021-07-12"))),
-                                                                                    ImmutableMap.of("ds", "ds"))))))),
+                                            project(
+                                                    ImmutableMap.of("ds_43", expression("'2021-07-12'")),
+                                                    aggregation(
+                                                            ImmutableMap.of("count", functionCall("count", false, ImmutableList.of())),
+                                                            SINGLE,
+                                                            node(
+                                                                    ExchangeNode.class,
+                                                                    anyTree(
+                                                                            node(
+                                                                                    ProjectNode.class, constrainedTableScan(
+                                                                                            table,
+                                                                                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2021-07-12"))),
+                                                                                            ImmutableMap.of()))))))),
                                     anyTree(
                                             constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of())))));
 
@@ -1459,11 +1463,13 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    join(INNER, ImmutableList.of(equiJoinClause("orderkey", "orderkey_7")),
-                            anyTree(filter("orderkey < BIGINT'10000'", constrainedTableScan(table1,
-                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                                    ImmutableMap.of("orderkey", "orderkey")))),
-                            anyTree(constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of("orderkey_7", "orderkey")))),
+                    project(
+                            ImmutableMap.of("expr_33", expression("'2019-01-02'")),
+                            join(INNER, ImmutableList.of(equiJoinClause("orderkey_7", "orderkey")),
+                                    anyTree(constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of("orderkey_7", "orderkey"))),
+                                    anyTree(filter("orderkey < BIGINT'10000'", constrainedTableScan(table1,
+                                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                            ImmutableMap.of("orderkey", "orderkey")))))),
                     filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {
@@ -1604,23 +1610,23 @@ public class TestHiveMaterializedViewLogicalPlanner
             setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, supplierTable, ImmutableList.of(suppliersView));
 
             String baseQuery = format("WITH long_name_supp AS ( %n" +
-                    "SELECT suppkey, name %n" +
-                    "FROM %s %n" +
-                    "WHERE name != 'bob'), " +
-                    "supp_returns AS (%n" +
-                    "SELECT suppkey, sum(quantity) AS returned_qty %n " +
-                    "FROM %s %n" +
-                    "WHERE returnflag = 'R' " +
-                    "GROUP BY suppkey, ds), %n" +
-                    "supp_sum AS (%n" +
-                    "SELECT suppkey, SUM(quantity) AS qty %n " +
-                    "FROM %s %n " +
-                    "GROUP BY suppkey, ds) %n " +
-                    "SELECT n.suppkey, n.name, r.returned_qty, s.qty %n " +
-                    "FROM long_name_supp AS n %n " +
-                    "LEFT JOIN supp_returns AS r ON n.suppkey = r.suppkey %n " +
-                    "LEFT JOIN supp_sum AS s ON n.suppkey = s.suppkey %n " +
-                    "ORDER BY suppkey, name",
+                            "SELECT suppkey, name %n" +
+                            "FROM %s %n" +
+                            "WHERE name != 'bob'), " +
+                            "supp_returns AS (%n" +
+                            "SELECT suppkey, sum(quantity) AS returned_qty %n " +
+                            "FROM %s %n" +
+                            "WHERE returnflag = 'R' " +
+                            "GROUP BY suppkey, ds), %n" +
+                            "supp_sum AS (%n" +
+                            "SELECT suppkey, SUM(quantity) AS qty %n " +
+                            "FROM %s %n " +
+                            "GROUP BY suppkey, ds) %n " +
+                            "SELECT n.suppkey, n.name, r.returned_qty, s.qty %n " +
+                            "FROM long_name_supp AS n %n " +
+                            "LEFT JOIN supp_returns AS r ON n.suppkey = r.suppkey %n " +
+                            "LEFT JOIN supp_sum AS s ON n.suppkey = s.suppkey %n " +
+                            "ORDER BY suppkey, name",
                     supplierTable, lineItemTable, lineItemTable);
 
             MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
@@ -1649,7 +1655,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                                     anyTree(
                                                             constrainedTableScan(lineItemTable,
                                                                     ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2021-07-11"))),
-                                                                    ImmutableMap.of("ds_108", "ds", "suppkey_94", "suppkey", "quantity_96", "quantity"))),
+                                                                    ImmutableMap.of("suppkey_94", "suppkey", "quantity_96", "quantity"))),
                                                     anyTree(
                                                             constrainedTableScan(lineItemView1,
                                                                     ImmutableMap.of(),
@@ -1717,15 +1723,15 @@ public class TestHiveMaterializedViewLogicalPlanner
 
             String baseQuery = format(
                     "SELECT t1.name, t1.suppkey, low_cost.partkey %n" +
-                    "FROM %s t1 %n" +
-                    "LEFT JOIN (%n" +
-                    "SELECT t2.partkey, t2.suppkey FROM %s t2 %n" +
-                    "LEFT JOIN (SELECT MIN(extendedprice) AS min_price, partkey, ds FROM %s GROUP BY partkey, ds) mp %n" +
-                    "ON mp.partkey = t2.partkey " +
-                    "WHERE t2.extendedprice <= mp.min_price*1.05) " +
-                    "low_cost " +
-                    "ON low_cost.suppkey = t1.suppkey " +
-                    "ORDER BY t1.name, t1.suppkey, low_cost.partkey", supplierTable, lineItemTable, lineItemTable);
+                            "FROM %s t1 %n" +
+                            "LEFT JOIN (%n" +
+                            "SELECT t2.partkey, t2.suppkey FROM %s t2 %n" +
+                            "LEFT JOIN (SELECT MIN(extendedprice) AS min_price, partkey, ds FROM %s GROUP BY partkey, ds) mp %n" +
+                            "ON mp.partkey = t2.partkey " +
+                            "WHERE t2.extendedprice <= mp.min_price*1.05) " +
+                            "low_cost " +
+                            "ON low_cost.suppkey = t1.suppkey " +
+                            "ORDER BY t1.name, t1.suppkey, low_cost.partkey", supplierTable, lineItemTable, lineItemTable);
 
             MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
             MaterializedResult baseQueryResult = computeActual(baseQuery);
@@ -1744,15 +1750,15 @@ public class TestHiveMaterializedViewLogicalPlanner
                                                             ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2021-07-11", "2021-07-12"))),
                                                             ImmutableMap.of("suppkey_0", "suppkey", "extendedprice", "extendedprice"))),
                                             anyTree(
-                                                            exchange(
-                                                                    anyTree(
-                                                                            constrainedTableScan(lineItemTable,
-                                                                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2021-07-11"))),
-                                                                                    ImmutableMap.of("ds_22", "ds", "partkey_7", "partkey", "extendedprice_11", "extendedprice"))),
-                                                                    anyTree(
-                                                                            constrainedTableScan(lineItemView,
-                                                                                    ImmutableMap.of(),
-                                                                                    ImmutableMap.of("ds_103", "ds", "partkey_102", "partkey")))))))));
+                                                    exchange(
+                                                            anyTree(
+                                                                    constrainedTableScan(lineItemTable,
+                                                                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2021-07-11"))),
+                                                                            ImmutableMap.of("partkey_7", "partkey", "extendedprice_11", "extendedprice"))),
+                                                            anyTree(
+                                                                    constrainedTableScan(lineItemView,
+                                                                            ImmutableMap.of(),
+                                                                            ImmutableMap.of("ds_103", "ds", "partkey_102", "partkey")))))))));
 
             assertPlan(queryOptimizationWithMaterializedView, baseQuery, expectedPattern);
         }
@@ -1794,10 +1800,10 @@ public class TestHiveMaterializedViewLogicalPlanner
                     view, table1, table2, table3));
 
             assertQueryFails(format("CREATE MATERIALIZED VIEW should_fail WITH (partitioned_by = ARRAY['ds']) AS " +
-                                    "SELECT t1.orderkey AS view_orderkey, t2.totalprice AS view_totalprice, t3.orderstatus AS view_orderstatus, t1.ds " +
-                                    "FROM %s t1 INNER JOIN %s t2 ON (t1.ds=t2.ds AND t1.orderkey = t2.orderkey) INNER JOIN %s t3" +
-                                    " ON (t1.orderkey = t3.orderkey)",
-                            table1, table2, table3),
+                            "SELECT t1.orderkey AS view_orderkey, t2.totalprice AS view_totalprice, t3.orderstatus AS view_orderstatus, t1.ds " +
+                            "FROM %s t1 INNER JOIN %s t2 ON (t1.ds=t2.ds AND t1.orderkey = t2.orderkey) INNER JOIN %s t3" +
+                            " ON (t1.orderkey = t3.orderkey)",
+                    table1, table2, table3),
                     "Materialized view tpch.should_fail must have at least one partition column" +
                             " that exists in orders_status_partitioned_join as well");
 
@@ -1820,20 +1826,22 @@ public class TestHiveMaterializedViewLogicalPlanner
 
             assertPlan(getSession(), viewQuery,
                     anyTree(
-                            join(INNER, ImmutableList.of(equiJoinClause("orderkey", "orderkey_28")),
-                                    anyTree(
-                                            filter("orderkey < BIGINT'10000'",
-                                                    constrainedTableScan(table1,
-                                                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                                                            ImmutableMap.of("orderkey", "orderkey")))),
-                                    anyTree(
-                                            join(INNER, ImmutableList.of(equiJoinClause("orderkey_7", "orderkey_28")),
-                                                    anyTree(
-                                                            filter("orderkey_7 < BIGINT'10000'",
-                                                                    constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of("orderkey_7", "orderkey")))),
-                                                    anyTree(
-                                                            filter("orderkey_28 < BIGINT'10000'",
-                                                                    constrainedTableScan(table3, ImmutableMap.of(), ImmutableMap.of("orderkey_28", "orderkey"))))))),
+                            project(
+                                    ImmutableMap.of("expr_56", expression("'2019-01-02'")),
+                                    join(INNER, ImmutableList.of(equiJoinClause("orderkey_7", "orderkey")),
+                                            anyTree(
+                                                    filter("orderkey_7 < BIGINT'10000'",
+                                                            constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of("orderkey_7", "orderkey")))),
+                                            anyTree(
+                                                    join(INNER, ImmutableList.of(equiJoinClause("orderkey_28", "orderkey")),
+                                                            anyTree(
+                                                                    filter("orderkey_28 < BIGINT'10000'",
+                                                                            constrainedTableScan(table3, ImmutableMap.of(), ImmutableMap.of("orderkey_28", "orderkey")))),
+                                                            anyTree(
+                                                                    filter("orderkey < BIGINT'10000'",
+                                                                            constrainedTableScan(table1,
+                                                                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                                                                    ImmutableMap.of("orderkey", "orderkey")))))))),
                             filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {
@@ -1930,22 +1938,21 @@ public class TestHiveMaterializedViewLogicalPlanner
 
             assertPlan(queryOptimizationWithMaterializedView, baseQuery, anyTree(
                     node(JoinNode.class,
+                            anyTree(
+                                    exchange(
+                                            anyTree(
+                                                    constrainedTableScan(table2,
+                                                            ImmutableMap.of(),
+                                                            ImmutableMap.of("orderkey_13", "orderkey"))),
+                                            anyTree(
+                                                    constrainedTableScan(view2,
+                                                            ImmutableMap.of(),
+                                                            ImmutableMap.of("ds_42", "ds", "orderkey_41", "orderkey"))))),
                             exchange(
                                     anyTree(
                                             constrainedTableScan(table,
                                                     ImmutableMap.of(),
-                                                    ImmutableMap.of()))),
-                            exchange(
-                                    anyTree(
-                                            exchange(
-                                                    anyTree(
-                                                            constrainedTableScan(table2,
-                                                                    ImmutableMap.of(),
-                                                                    ImmutableMap.of("ds_14", "ds", "orderkey_13", "orderkey"))),
-                                                    anyTree(
-                                                            constrainedTableScan(view2,
-                                                                    ImmutableMap.of(),
-                                                                    ImmutableMap.of("ds_42", "ds", "orderkey_41", "orderkey")))))))));
+                                                    ImmutableMap.of()))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view2);
@@ -2344,12 +2351,20 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    join(LEFT, ImmutableList.of(equiJoinClause("ds", "ds_8"), equiJoinClause("orderkey", "orderkey_7")),
-                            anyTree(filter("orderkey < BIGINT'10000'", constrainedTableScan(table1,
-                                    ImmutableMap.of(
-                                            "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                                    ImmutableMap.of("orderkey", "orderkey", "ds", "ds")))),
-                            anyTree(constrainedTableScan(table2, ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))), ImmutableMap.of("orderkey_7", "orderkey", "ds_8", "ds")))),
+                    project(
+                            join(LEFT, ImmutableList.of(equiJoinClause("expr_6", "expr_23"), equiJoinClause("orderkey", "orderkey_7")),
+                                    anyTree(
+                                            project(
+                                                    ImmutableMap.of("expr_6", expression("'2019-01-02'")),
+                                                    filter("orderkey < BIGINT'10000'",
+                                                            constrainedTableScan(table1,
+                                                                    ImmutableMap.of(
+                                                                            "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                                                    ImmutableMap.of("orderkey", "orderkey"))))),
+                                    anyTree(
+                                            project(ImmutableMap.of("expr_23", expression("'2019-01-02'")),
+                                                    anyTree(
+                                                            constrainedTableScan(table2, ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))), ImmutableMap.of("totalprice", "totalprice", "orderkey_7", "orderkey"))))))),
                     filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {
@@ -2523,9 +2538,11 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertEquals(computeActual(viewQuery), computeActual(baseQuery));
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    unnest(filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
-                            ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                            ImmutableMap.of("orderkey", "orderkey")))),
+                    project(
+                            ImmutableMap.of("ds_17", expression("'2019-01-02'")),
+                            unnest(filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
+                                    ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                    ImmutableMap.of("orderkey", "orderkey"))))),
                     filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestReplaceConstantVariableReferencesWithConstantsPartitionKeys.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestReplaceConstantVariableReferencesWithConstantsPartitionKeys.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.NATION;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static io.airlift.tpch.TpchTable.SUPPLIER;
+
+public class TestReplaceConstantVariableReferencesWithConstantsPartitionKeys
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, LINE_ITEM, CUSTOMER, NATION, SUPPLIER),
+                ImmutableMap.of(),
+                Optional.empty());
+    }
+
+    private Session enableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, "true")
+                .build();
+    }
+
+    @Test
+    public void testAggregationWithFilterOnPartitionKey()
+    {
+        try {
+            getQueryRunner().execute("CREATE TABLE orders_key_partitioned WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, totalprice, '2020-01-01' as ds FROM orders WHERE orderkey < 1000");
+
+            assertPlan(
+                    enableOptimization(),
+                    "select avg(totalprice), orderkey, ds from orders_key_partitioned where ds = '2020-01-01' group by ds, orderkey",
+                    output(
+                            anyTree(
+                                    project(
+                                            ImmutableMap.of("ds", expression("'2020-01-01'")),
+                                            anyTree(
+                                                    aggregation(
+                                                            singleGroupingSet("orderkey"),
+                                                            ImmutableMap.of(Optional.of("average"), functionCall("avg", ImmutableList.of("totalprice"))),
+                                                            ImmutableMap.of(),
+                                                            Optional.empty(),
+                                                            AggregationNode.Step.PARTIAL,
+                                                            tableScan("orders_key_partitioned", ImmutableMap.of("totalprice", "totalprice", "orderkey", "orderkey"))))))));
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS orders_key_partitioned");
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -85,6 +85,7 @@ import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
@@ -219,7 +220,8 @@ public class TestIcebergLogicalPlanner
 
         assertPlan(sessionWithFilterPushdown, "SELECT partkey, linenumber FROM lineitem WHERE partkey = 10",
                 output(exchange(
-                        strictTableScan("lineitem", identityMap("partkey", "linenumber")))),
+                        project(ImmutableMap.of("partkey", expression("10")),
+                                strictTableScan("lineitem", identityMap("linenumber"))))),
                 plan -> assertTableLayout(
                         plan,
                         "lineitem",
@@ -361,7 +363,8 @@ public class TestIcebergLogicalPlanner
 
         assertPlan(sessionWithFilterPushdown, "SELECT partkey, orderkey, linenumber FROM lineitem WHERE partkey = 10 AND mod(orderkey, 2) = 1",
                 output(exchange(
-                        strictTableScan("lineitem", identityMap("partkey", "orderkey", "linenumber")))),
+                        project(ImmutableMap.of("partkey", expression("10")),
+                                strictTableScan("lineitem", identityMap("orderkey", "linenumber"))))),
                 plan -> assertTableLayout(
                         plan,
                         "lineitem",

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -306,6 +306,7 @@ public final class SystemSessionProperties
     public static final String HANDLE_COMPLEX_EQUI_JOINS = "handle_complex_equi_joins";
     public static final String SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT = "skip_hash_generation_for_join_with_table_scan_input";
     public static final String GENERATE_DOMAIN_FILTERS = "generate_domain_filters";
+    public static final String REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION = "rewrite_expression_with_constant_expression";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1853,6 +1854,11 @@ public final class SystemSessionProperties
                         GENERATE_DOMAIN_FILTERS,
                         "Infer predicates from column domains during predicate pushdown",
                         featuresConfig.getGenerateDomainFilters(),
+                                false),
+                booleanProperty(
+                        REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION,
+                        "Rewrite left join with is null check to semi join",
+                        featuresConfig.isRewriteExpressionWithConstantVariable(),
                         false));
     }
 
@@ -3081,5 +3087,10 @@ public final class SystemSessionProperties
     public static boolean shouldGenerateDomainFilters(Session session)
     {
         return session.getSystemProperty(GENERATE_DOMAIN_FILTERS, Boolean.class);
+    }
+
+    public static boolean isRewriteExpressionWithConstantEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -284,6 +284,7 @@ public class FeaturesConfig
     private boolean inferInequalityPredicates;
     private boolean pullUpExpressionFromLambda;
     private boolean rewriteConstantArrayContainsToIn;
+    private boolean rewriteExpressionWithConstantVariable = true;
 
     private boolean preProcessMetadataCalls;
     private boolean handleComplexEquiJoins;
@@ -2983,6 +2984,19 @@ public class FeaturesConfig
     public FeaturesConfig setGenerateDomainFilters(boolean generateDomainFilters)
     {
         this.generateDomainFilters = generateDomainFilters;
+        return this;
+    }
+
+    public boolean isRewriteExpressionWithConstantVariable()
+    {
+        return this.rewriteExpressionWithConstantVariable;
+    }
+
+    @Config("optimizer.rewrite-expression-with-constant-variable")
+    @ConfigDescription("Rewrite expression with constant variables")
+    public FeaturesConfig setRewriteExpressionWithConstantVariable(boolean rewriteExpressionWithConstantVariable)
+    {
+        this.rewriteExpressionWithConstantVariable = rewriteExpressionWithConstantVariable;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -125,6 +125,8 @@ import com.facebook.presto.sql.planner.iterative.rule.ScaledWriterRule;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyCardinalityMap;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyCountOverConstant;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyRowExpressions;
+import com.facebook.presto.sql.planner.iterative.rule.SimplifySortWithConstantInput;
+import com.facebook.presto.sql.planner.iterative.rule.SimplifyTopNWithConstantInput;
 import com.facebook.presto.sql.planner.iterative.rule.SingleDistinctAggregationToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedInPredicateToJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedLateralJoinToJoin;
@@ -162,6 +164,7 @@ import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
+import com.facebook.presto.sql.planner.optimizations.ReplaceConstantVariableReferencesWithConstants;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
@@ -424,6 +427,20 @@ public class PlanOptimizers
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new SetFlatteningOptimizer(),
                 new ImplementIntersectAndExceptAsUnion(metadata.getFunctionAndTypeManager()),
+                new ReplaceConstantVariableReferencesWithConstants(metadata.getFunctionAndTypeManager()),
+                simplifyRowExpressionOptimizer,
+                new ReplaceConstantVariableReferencesWithConstants(metadata.getFunctionAndTypeManager()),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(
+                                new SimplifySortWithConstantInput(),
+                                new SimplifyTopNWithConstantInput(),
+                                new PullConstantsAboveGroupBy())),
+                // Run inlineProjections and PruneUnreferencedOutputs to simplify the plan after ReplaceConstantVariableReferencesWithConstants optimization
+                inlineProjections,
                 new PruneUnreferencedOutputs(),
                 inlineProjections,
                 new LimitPushDown(), // Run the LimitPushDown after flattening set operators to make it easier to do the set flattening
@@ -478,14 +495,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new RemoveRedundantCastToVarcharInJoinClause(metadata.getFunctionAndTypeManager()))),
-                new IterativeOptimizer(
-                        metadata,
-                        ruleStats,
-                        statsCalculator,
-                        estimatedExchangesCostCalculator,
-                        ImmutableSet.of(
-                                new PullConstantsAboveGroupBy())));
+                        ImmutableSet.of(new RemoveRedundantCastToVarcharInJoinClause(metadata.getFunctionAndTypeManager()))));
 
         builder.add(new IterativeOptimizer(
                 metadata,
@@ -572,6 +582,21 @@ public class PlanOptimizers
                 projectionPushDown,
                 new PayloadJoinOptimizer(metadata),
                 new UnaliasSymbolReferences(metadata.getFunctionAndTypeManager()), // Run again because predicate pushdown and projection pushdown might add more projections
+                // At this time, we may have some new constant variables after the first run of this optimizer, hence rerun here
+                new ReplaceConstantVariableReferencesWithConstants(metadata.getFunctionAndTypeManager()),
+                simplifyRowExpressionOptimizer,
+                new ReplaceConstantVariableReferencesWithConstants(metadata.getFunctionAndTypeManager()),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(
+                                new SimplifySortWithConstantInput(),
+                                new SimplifyTopNWithConstantInput(),
+                                new PullConstantsAboveGroupBy())),
+                // Run inlineProjections and PruneUnreferencedOutputs to simplify the plan after ReplaceConstantVariableReferencesWithConstants optimization
+                inlineProjections,
                 new PruneUnreferencedOutputs(), // Make sure to run this before index join. Filtered projections may not have all the columns.
                 new IndexJoinOptimizer(metadata), // Run this after projections and filters have been fully simplified and pushed down
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantsAboveGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantsAboveGroupBy.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.SystemSessionProperties.isOptimizeConstantGroupingKeys;
+import static com.facebook.presto.SystemSessionProperties.isRewriteExpressionWithConstantEnabled;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.project;
@@ -62,7 +63,7 @@ public class PullConstantsAboveGroupBy
     @Override
     public boolean isEnabled(Session session)
     {
-        return isOptimizeConstantGroupingKeys(session);
+        return isOptimizeConstantGroupingKeys(session) || isRewriteExpressionWithConstantEnabled(session);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifySortWithConstantInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifySortWithConstantInput.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.SortNode;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteExpressionWithConstantEnabled;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.sql.planner.plan.Patterns.sort;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class SimplifySortWithConstantInput
+        implements Rule<SortNode>
+{
+    private static final Capture<ProjectNode> SOURCE = Capture.newCapture();
+
+    private static final Pattern<SortNode> PATTERN = sort().with(source().matching(
+            project().matching(project -> project.getAssignments().getMap().values().stream().anyMatch(x -> x instanceof ConstantExpression)).capturedAs(SOURCE)));
+
+    @Override
+    public Pattern<SortNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRewriteExpressionWithConstantEnabled(session);
+    }
+
+    @Override
+    public Result apply(SortNode node, Captures captures, Context context)
+    {
+        ProjectNode projectNode = captures.get(SOURCE);
+        Map<VariableReferenceExpression, ConstantExpression> constantExpressionMap = projectNode.getAssignments().entrySet().stream().filter(x -> x.getValue() instanceof ConstantExpression)
+                .collect(toImmutableMap(Map.Entry::getKey, x -> (ConstantExpression) x.getValue()));
+        if (node.getOrderingScheme().getOrderByVariables().stream().anyMatch(x -> constantExpressionMap.containsKey(x))) {
+            List<Ordering> newOrderBy = node.getOrderingScheme().getOrderBy().stream()
+                    .filter(x -> !constantExpressionMap.containsKey(x.getVariable())).collect(toImmutableList());
+            if (newOrderBy.isEmpty()) {
+                return Result.ofPlanNode(projectNode);
+            }
+            OrderingScheme orderExcludeConstantVariable = new OrderingScheme(newOrderBy);
+            return Result.ofPlanNode(new SortNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), projectNode, orderExcludeConstantVariable, node.isPartial()));
+        }
+        return Result.empty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyTopNWithConstantInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyTopNWithConstantInput.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteExpressionWithConstantEnabled;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.planner.plan.Patterns.topN;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class SimplifyTopNWithConstantInput
+        implements Rule<TopNNode>
+{
+    private static final Capture<ProjectNode> SOURCE = Capture.newCapture();
+
+    private static final Pattern<TopNNode> PATTERN = topN().with(source().matching(
+            project().matching(project -> project.getAssignments().getMap().values().stream().anyMatch(x -> x instanceof ConstantExpression)).capturedAs(SOURCE)));
+
+    @Override
+    public Pattern<TopNNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRewriteExpressionWithConstantEnabled(session);
+    }
+
+    @Override
+    public Result apply(TopNNode node, Captures captures, Context context)
+    {
+        ProjectNode projectNode = captures.get(SOURCE);
+        Map<VariableReferenceExpression, ConstantExpression> constantExpressionMap = projectNode.getAssignments().entrySet().stream().filter(x -> x.getValue() instanceof ConstantExpression)
+                .collect(toImmutableMap(Map.Entry::getKey, x -> (ConstantExpression) x.getValue()));
+        if (node.getOrderingScheme().getOrderByVariables().stream().anyMatch(x -> constantExpressionMap.containsKey(x))) {
+            List<Ordering> newOrderBy = node.getOrderingScheme().getOrderBy().stream()
+                    .filter(x -> !constantExpressionMap.containsKey(x.getVariable())).collect(toImmutableList());
+            // convert to limit node if order by is empty
+            if (newOrderBy.isEmpty()) {
+                LimitNode limitNode = new LimitNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), projectNode, node.getCount(),
+                        node.getStep().equals(TopNNode.Step.PARTIAL) ? LimitNode.Step.PARTIAL : LimitNode.Step.FINAL);
+                return Result.ofPlanNode(limitNode);
+            }
+            OrderingScheme orderExcludeConstantVariable = new OrderingScheme(newOrderBy);
+            return Result.ofPlanNode(new TopNNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), projectNode, node.getCount(), orderExcludeConstantVariable, node.getStep()));
+        }
+        return Result.empty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -104,7 +104,7 @@ import static java.util.Objects.requireNonNull;
 public class ReplaceConstantVariableReferencesWithConstants
         implements PlanOptimizer
 {
-    private static final List<Type> SUPPORTED_JOIN_KEY_TYPE = ImmutableList.of(BIGINT, INTEGER, VARCHAR, DATE);
+    private static final List<Type> SUPPORTED_TYPES = ImmutableList.of(BIGINT, INTEGER, VARCHAR, DATE);
     private final FunctionAndTypeManager functionAndTypeManager;
 
     public ReplaceConstantVariableReferencesWithConstants(FunctionAndTypeManager functionAndTypeManager)
@@ -114,7 +114,7 @@ public class ReplaceConstantVariableReferencesWithConstants
 
     private static boolean isSupportedType(RowExpression rowExpression)
     {
-        return SUPPORTED_JOIN_KEY_TYPE.contains(rowExpression.getType()) || rowExpression.getType() instanceof VarcharType;
+        return SUPPORTED_TYPES.contains(rowExpression.getType()) || rowExpression.getType() instanceof VarcharType;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.OffsetNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteExpressionWithConstantEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.sql.planner.PlannerUtils.addOverrideProjection;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Get constant from filter and project node. Rewrite expressions in parent nodes with the constant.
+ * For example, for query "select orderkey, orderpriority, avg(totalprice) from orders where orderpriority='3-MEDIUM' group by 1, 2", the query plan changes from
+ * <pre>
+ *     - OutputNode
+ *          orderkey, orderpriority, avg
+ *          - Aggregate
+ *              avg := avg(totalprice)
+ *              Grouping Keys := [orderkey, orderpriority]
+ *              - Filter
+ *                  orderpriority = '3-MEDIUM'
+ *                  - TableScan
+ *                      orderkey := orderkey
+ *                      orderpriority := orderpriority
+ *                      totalprice := totalprice
+ * </pre>
+ * to
+ * <pre>
+ *      - OutputNode
+ *          orderkey, expr_12, avg
+ *          - project
+ *              orderkey := orderkey
+ *              expr_12 := '3-MEDIUM'
+ *              avg := avg
+ *              - Aggregate
+ *                  avg := avg(totalprice)
+ *                  Grouping Keys := [orderkey]
+ *                  - Filter
+ *                      orderpriority = '3-MEDIUM'
+ *                      - TableScan
+ *                          orderkey := orderkey
+ *                          orderpriority := orderpriority
+ *                          totalprice := totalprice
+ * </pre>
+ */
+public class ReplaceConstantVariableReferencesWithConstants
+        implements PlanOptimizer
+{
+    private static final List<Type> SUPPORTED_JOIN_KEY_TYPE = ImmutableList.of(BIGINT, INTEGER, VARCHAR, DATE);
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public ReplaceConstantVariableReferencesWithConstants(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    private static boolean isSupportedType(RowExpression rowExpression)
+    {
+        return SUPPORTED_JOIN_KEY_TYPE.contains(rowExpression.getType()) || rowExpression.getType() instanceof VarcharType;
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isRewriteExpressionWithConstantEnabled(session)) {
+            Rewriter rewriter = new Rewriter(idAllocator, functionAndTypeManager);
+            PlanNode rewrittenPlan = plan.accept(rewriter, null).getPlanNode();
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
+        }
+        return PlanOptimizerResult.optimizerResult(plan, false);
+    }
+
+    private static class Rewriter
+            extends InternalPlanVisitor<PlanNodeWithConstant, Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+        private final FunctionResolution functionResolution;
+        private boolean planChanged;
+
+        public Rewriter(PlanNodeIdAllocator idAllocator, FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+
+        private PlanNodeWithConstant accept(PlanNode node)
+        {
+            return node.accept(this, null);
+        }
+
+        private PlanNodeWithConstant planAndReplace(PlanNode node, boolean keepConstantConstraint)
+        {
+            List<PlanNodeWithConstant> children = node.getSources().stream().map(this::accept).collect(toImmutableList());
+            ImmutableList.Builder<PlanNode> newSources = ImmutableList.builder();
+
+            for (PlanNodeWithConstant planNodeWithConstant : children) {
+                PlanNode child = planNodeWithConstant.getPlanNode();
+                Map<VariableReferenceExpression, ConstantExpression> constantExpressionMap = planNodeWithConstant.getConstantExpressionMap();
+                if (child.getOutputVariables().stream().noneMatch(x -> constantExpressionMap.containsKey(x))) {
+                    newSources.add(child);
+                    continue;
+                }
+                newSources.add(addOverrideProjection(child, idAllocator, constantExpressionMap));
+            }
+            PlanNode result = replaceChildren(node, newSources.build());
+            if (!keepConstantConstraint) {
+                return new PlanNodeWithConstant(result, ImmutableMap.of());
+            }
+            ImmutableMap.Builder<VariableReferenceExpression, ConstantExpression> properties = ImmutableMap.builder();
+            children.stream().map(PlanNodeWithConstant::getConstantExpressionMap).forEach(properties::putAll);
+            return new PlanNodeWithConstant(result, properties.build());
+        }
+
+        @Override
+        public PlanNodeWithConstant visitPlan(PlanNode node, Void context)
+        {
+            return planAndReplace(node, false);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitFilter(FilterNode node, Void context)
+        {
+            PlanNodeWithConstant rewrittenChild = accept(node.getSource());
+
+            RowExpression predicate = node.getPredicate();
+            Map<VariableReferenceExpression, ConstantExpression> newConstantMap = new HashMap<>();
+            newConstantMap.putAll(rewrittenChild.getConstantExpressionMap());
+            for (RowExpression conjunct : extractConjuncts(predicate)) {
+                if (conjunct instanceof CallExpression && functionResolution.isEqualsFunction(((CallExpression) conjunct).getFunctionHandle())) {
+                    RowExpression argument0 = ((CallExpression) conjunct).getArguments().get(0);
+                    RowExpression argument1 = ((CallExpression) conjunct).getArguments().get(1);
+                    if (isSupportedType(argument0) && isSupportedType(argument1)) {
+                        if ((argument0 instanceof VariableReferenceExpression && argument1 instanceof ConstantExpression)
+                                || (argument1 instanceof VariableReferenceExpression && argument0 instanceof ConstantExpression)) {
+                            VariableReferenceExpression variable = (VariableReferenceExpression) (argument0 instanceof VariableReferenceExpression ? argument0 : argument1);
+                            ConstantExpression constant = (ConstantExpression) (argument0 instanceof ConstantExpression ? argument0 : argument1);
+                            // Get conflicting filter expression
+                            if (newConstantMap.containsKey(variable) && !newConstantMap.get(variable).equals(constant)) {
+                                return new PlanNodeWithConstant(replaceChildren(node, ImmutableList.of(rewrittenChild.getPlanNode())), ImmutableMap.of());
+                            }
+                            if (!constant.isNull()) {
+                                planChanged = true;
+                                newConstantMap.put(variable, constant);
+                            }
+                        }
+                    }
+                }
+            }
+
+            FilterNode newFilterNode = node;
+            if (!rewrittenChild.getConstantExpressionMap().isEmpty()) {
+                predicate = predicate.accept(new ExpressionRewriter(rewrittenChild.getConstantExpressionMap()), null);
+                newFilterNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node.getSource(), predicate);
+            }
+
+            return new PlanNodeWithConstant(replaceChildren(newFilterNode, ImmutableList.of(rewrittenChild.getPlanNode())), newConstantMap);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitProject(ProjectNode node, Void context)
+        {
+            PlanNodeWithConstant rewrittenChild = accept(node.getSource());
+            ProjectNode newProjectNode = node;
+            if (!rewrittenChild.getConstantExpressionMap().isEmpty()) {
+                Map<VariableReferenceExpression, RowExpression> newAssignments = node.getAssignments().getMap().entrySet().stream()
+                        .collect(toImmutableMap(x -> x.getKey(), x -> x.getValue().accept(new ExpressionRewriter(rewrittenChild.getConstantExpressionMap()), null)));
+                newProjectNode = new ProjectNode(idAllocator.getNextId(), node.getSource(), Assignments.copyOf(newAssignments));
+            }
+
+            ImmutableMap.Builder<VariableReferenceExpression, ConstantExpression> newConstantMap = ImmutableMap.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : newProjectNode.getAssignments().getMap().entrySet()) {
+                if (entry.getValue() instanceof ConstantExpression && isSupportedType(entry.getKey()) && isSupportedType(entry.getValue())) {
+                    ConstantExpression constantExpression = (ConstantExpression) entry.getValue();
+                    if (!constantExpression.isNull()) {
+                        planChanged = true;
+                        newConstantMap.put(entry.getKey(), constantExpression);
+                    }
+                }
+            }
+
+            return new PlanNodeWithConstant(replaceChildren(newProjectNode, ImmutableList.of(rewrittenChild.getPlanNode())), newConstantMap.build());
+        }
+
+        @Override
+        public PlanNodeWithConstant visitJoin(JoinNode node, Void context)
+        {
+            PlanNodeWithConstant rewrittenLeft = accept(node.getLeft());
+            PlanNodeWithConstant rewrittenRight = accept(node.getRight());
+            ImmutableMap.Builder<VariableReferenceExpression, ConstantExpression> outputConstantMap = ImmutableMap.builder();
+
+            // Output from inner side of outer joins can be NULL when no match, hence will not keep the constant constraint
+            if (node.getType().equals(JoinNode.Type.LEFT) || node.getType().equals(JoinNode.Type.INNER)) {
+                outputConstantMap.putAll(rewrittenLeft.getConstantExpressionMap());
+            }
+
+            if (node.getType().equals(JoinNode.Type.RIGHT) || node.getType().equals(JoinNode.Type.INNER)) {
+                outputConstantMap.putAll(rewrittenRight.getConstantExpressionMap());
+            }
+
+            // Add a projection with constant assignment for input source nodes if exist
+            List<PlanNode> sourceWithConstantProjection = ImmutableList.of(addOverrideProjection(rewrittenLeft.getPlanNode(), idAllocator, rewrittenLeft.getConstantExpressionMap()),
+                    addOverrideProjection(rewrittenRight.getPlanNode(), idAllocator, rewrittenRight.getConstantExpressionMap()));
+
+            return new PlanNodeWithConstant(replaceChildren(node, sourceWithConstantProjection), outputConstantMap.build());
+        }
+
+        @Override
+        public PlanNodeWithConstant visitUnion(UnionNode node, Void context)
+        {
+            List<PlanNodeWithConstant> rewrittenSources = node.getSources().stream().map(this::accept).collect(toImmutableList());
+            ImmutableMap.Builder<VariableReferenceExpression, ConstantExpression> outputConstantMap = ImmutableMap.builder();
+            if (rewrittenSources.stream().allMatch(x -> !x.getConstantExpressionMap().isEmpty())) {
+                for (Map.Entry<VariableReferenceExpression, List<VariableReferenceExpression>> entry : node.getVariableMapping().entrySet()) {
+                    VariableReferenceExpression outputVariable = entry.getKey();
+                    List<VariableReferenceExpression> inputList = entry.getValue();
+                    // Output variable is constant only when all corresponding variables in input are the same constant
+                    if (IntStream.range(0, inputList.size()).boxed().allMatch(idx -> rewrittenSources.get(idx).getConstantExpressionMap().containsKey(inputList.get(idx)))
+                            && IntStream.range(0, inputList.size()).boxed().map(idx -> rewrittenSources.get(idx).getConstantExpressionMap().get(inputList.get(idx))).distinct().count() == 1) {
+                        outputConstantMap.put(outputVariable, rewrittenSources.get(0).getConstantExpressionMap().get(inputList.get(0)));
+                    }
+                }
+            }
+            List<PlanNode> sourceWithConstantProjection = rewrittenSources.stream().map(x -> addOverrideProjection(x.getPlanNode(), idAllocator, x.getConstantExpressionMap())).collect(toImmutableList());
+            return new PlanNodeWithConstant(replaceChildren(node, sourceWithConstantProjection), outputConstantMap.build());
+        }
+
+        @Override
+        public PlanNodeWithConstant visitAggregation(AggregationNode node, Void context)
+        {
+            PlanNodeWithConstant rewrittenChild = accept(node.getSource());
+            List<PlanNode> sourceWithConstantProjection = ImmutableList.of(addOverrideProjection(rewrittenChild.getPlanNode(), idAllocator, rewrittenChild.getConstantExpressionMap()));
+            if (node.getGroupingSetCount() != 1) {
+                return new PlanNodeWithConstant(replaceChildren(node, sourceWithConstantProjection), ImmutableMap.of());
+            }
+            Map<VariableReferenceExpression, ConstantExpression> constantGroupByKeys = rewrittenChild.getConstantExpressionMap().entrySet().stream()
+                    .filter(x -> node.getGroupingKeys().contains(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            return new PlanNodeWithConstant(replaceChildren(node, sourceWithConstantProjection), constantGroupByKeys);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitTopN(TopNNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitSort(SortNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitLimit(LimitNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitSample(SampleNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitSemiJoin(SemiJoinNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitOffset(OffsetNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitUnnest(UnnestNode node, Void context)
+        {
+            return planAndReplace(node, true);
+        }
+    }
+
+    private static class PlanNodeWithConstant
+    {
+        private final PlanNode planNode;
+        private final Map<VariableReferenceExpression, ConstantExpression> constantExpressionMap;
+
+        public PlanNodeWithConstant(PlanNode planNode, Map<VariableReferenceExpression, ConstantExpression> constantExpressionMap)
+        {
+            checkArgument(constantExpressionMap.entrySet().stream().allMatch(entry -> entry.getKey().getType().equals(entry.getValue().getType())),
+                    "key and value in constantExpressionMap not of the same type");
+            this.planNode = planNode;
+            this.constantExpressionMap = constantExpressionMap.entrySet().stream().filter(entry -> planNode.getOutputVariables().contains(entry.getKey()))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        public PlanNode getPlanNode()
+        {
+            return planNode;
+        }
+
+        public Map<VariableReferenceExpression, ConstantExpression> getConstantExpressionMap()
+        {
+            return constantExpressionMap;
+        }
+    }
+
+    private static class ExpressionRewriter
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final Map<VariableReferenceExpression, ConstantExpression> expressionMap;
+
+        public ExpressionRewriter(Map<VariableReferenceExpression, ConstantExpression> expressionMap)
+        {
+            this.expressionMap = ImmutableMap.copyOf(expressionMap);
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            return new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    call.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList()));
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Void context)
+        {
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return lambda;
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            if (expressionMap.containsKey(reference)) {
+                return expressionMap.get(reference);
+            }
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            return new SpecialFormExpression(
+                    specialForm.getForm(),
+                    specialForm.getType(),
+                    specialForm.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList()));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -260,7 +260,8 @@ public class TestFeaturesConfig
                 .setSkipHashGenerationForJoinWithTableScanInput(false)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.NONE)
                 .setKHyperLogLogAggregationGroupNumberLimit(0)
-                .setGenerateDomainFilters(false));
+                .setGenerateDomainFilters(false)
+                .setRewriteExpressionWithConstantVariable(true));
     }
 
     @Test
@@ -467,6 +468,7 @@ public class TestFeaturesConfig
                 .put("optimizer.skip-hash-generation-for-join-with-table-scan-input", "true")
                 .put("khyperloglog-agg-group-limit", "1000")
                 .put("optimizer.generate-domain-filters", "true")
+                .put("optimizer.rewrite-expression-with-constant-variable", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -670,7 +672,8 @@ public class TestFeaturesConfig
                 .setSkipHashGenerationForJoinWithTableScanInput(true)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.ALL)
                 .setKHyperLogLogAggregationGroupNumberLimit(1000)
-                .setGenerateDomainFilters(true);
+                .setGenerateDomainFilters(true)
+                .setRewriteExpressionWithConstantVariable(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
@@ -49,6 +51,10 @@ public class TestCanonicalize
                         "    SELECT EXTRACT(DAY FROM DATE '2017-01-01')\n" +
                         ") t\n" +
                         "CROSS JOIN (VALUES 1)",
+                // This optimization will optimize out the projection below, hence disable it
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, "false")
+                        .build(),
                 anyTree(
                         join(INNER, ImmutableList.of(), Optional.empty(),
                                 project(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -442,11 +442,13 @@ public class TestLogicalPlanner
                 anyTree(
                         markDistinct(
                                 "is_distinct",
-                                ImmutableList.of("orderstatus"),
+                                ImmutableList.of("orderstatus_35"),
                                 "hash",
                                 anyTree(
-                                        project(ImmutableMap.of("hash", expression("combine_hash(bigint '0', coalesce(\"$operator$hash_code\"(orderstatus), 0))")),
-                                                tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus")))))));
+                                        project(ImmutableMap.of("hash", expression("combine_hash(bigint '0', coalesce(\"$operator$hash_code\"(orderstatus_35), 0))")),
+                                                project(
+                                                        ImmutableMap.of("orderstatus_35", expression("'F'")),
+                                                tableScan("orders", ImmutableMap.of())))))));
     }
 
     @Test
@@ -585,8 +587,9 @@ public class TestLogicalPlanner
                 "SELECT * FROM orders WHERE orderkey = (SELECT 1)",
                 anyTree(
                         join(INNER, ImmutableList.of(),
-                                filter("orderkey = BIGINT '1'",
-                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey"))),
+                                project(
+                                        filter("orderkey = BIGINT '1'",
+                                                tableScan("orders", ImmutableMap.of("orderkey", "orderkey")))),
                                 anyTree(
                                         project(ImmutableMap.of("orderkey", expression("1")), any())))));
     }
@@ -702,9 +705,11 @@ public class TestLogicalPlanner
                 "SELECT orderkey FROM orders WHERE 3 = (SELECT orderkey)",
                 OPTIMIZED,
                 any(
-                        filter(
-                                "X = BIGINT '3'",
-                                tableScan("orders", ImmutableMap.of("X", "orderkey")))));
+                        project(
+                                ImmutableMap.of("X", expression("3")),
+                                filter(
+                                        "X = BIGINT '3'",
+                                        tableScan("orders", ImmutableMap.of("X", "orderkey"))))));
     }
 
     @Test
@@ -727,15 +732,16 @@ public class TestLogicalPlanner
         // rewrite Limit to decorrelated Limit
         assertPlan("SELECT regionkey, n.nationkey FROM region CROSS JOIN LATERAL (SELECT nationkey FROM nation WHERE region.regionkey = 3 LIMIT 2) n",
                 any(
-                        join(
-                                INNER,
-                                ImmutableList.of(),
-                                Optional.empty(),
-                                //Optional.of("region_regionkey = BIGINT '3'"),
-                                any(tableScan("region", ImmutableMap.of("region_regionkey", "regionkey"))),
-                                limit(
-                                        2,
-                                        any(tableScan("nation", ImmutableMap.of("nation_nationkey", "nationkey")))))));
+                        project(
+                                join(
+                                        INNER,
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        //Optional.of("region_regionkey = BIGINT '3'"),
+                                        any(any(tableScan("region", ImmutableMap.of("region_regionkey", "regionkey")))),
+                                        limit(
+                                                2,
+                                                any(tableScan("nation", ImmutableMap.of("nation_nationkey", "nationkey"))))))));
     }
 
     @Test
@@ -994,11 +1000,13 @@ public class TestLogicalPlanner
         assertPlan(
                 "SELECT orderkey FROM orders WHERE orderkey=5",
                 output(
+                        project(
+                                ImmutableMap.of("expr_2", expression("5")),
                         filter("orderkey = BIGINT '5'",
                                 constrainedTableScanWithTableLayout(
                                         "orders",
                                         ImmutableMap.of(),
-                                        ImmutableMap.of("orderkey", "orderkey")))));
+                                        ImmutableMap.of("orderkey", "orderkey"))))));
         assertPlan(
                 "SELECT orderkey FROM orders WHERE orderstatus='F'",
                 output(
@@ -1176,15 +1184,15 @@ public class TestLogicalPlanner
                         "AND l.comment = p.comment " +
                         "WHERE l.comment = '42'",
                 anyTree(
-                        join(INNER, ImmutableList.of(equiJoinClause("l_suppkey", "p_suppkey")),
-                                anyTree(
-                                        filter(
-                                                "l_comment = '42'",
-                                                tableScan("lineitem", ImmutableMap.of("l_suppkey", "suppkey", "l_comment", "comment")))),
+                        join(INNER, ImmutableList.of(equiJoinClause("p_suppkey", "l_suppkey")),
                                 anyTree(
                                         filter(
                                                 "p_comment = '42' ",
-                                                tableScan("partsupp", ImmutableMap.of("p_suppkey", "suppkey", "p_partkey", "partkey", "p_comment", "comment")))))));
+                                                tableScan("partsupp", ImmutableMap.of("p_suppkey", "suppkey", "p_partkey", "partkey", "p_comment", "comment")))),
+                                anyTree(
+                                        filter(
+                                                "l_comment = '42'",
+                                                tableScan("lineitem", ImmutableMap.of("l_suppkey", "suppkey", "l_comment", "comment")))))));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
@@ -76,7 +76,7 @@ public class TestPullConstantsAboveGroupBy
     @Test
     public void testRuleDisabledDoesNotFire()
     {
-        RuleTester tester = new RuleTester(ImmutableList.of(), ImmutableMap.of("optimize_constant_grouping_keys", "false"));
+        RuleTester tester = new RuleTester(ImmutableList.of(), ImmutableMap.of("optimize_constant_grouping_keys", "false", "rewrite_expression_with_constant_expression", "false"));
 
         tester.assertThat(new PullConstantsAboveGroupBy())
             .on(p -> p.aggregation(ab -> ab

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifySortWithConstantInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifySortWithConstantInput.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.tree.SortItem;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestSimplifySortWithConstantInput
+        extends BaseRuleTest
+{
+    @Test
+    public void testAllSortKeyConstant()
+    {
+        tester().assertThat(new SimplifySortWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.sort(
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("1"), key2, p.rowExpression("2")),
+                                    p.values(key3)));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("key1", expression("1"), "key2", expression("2")),
+                                values("key3")));
+    }
+
+    @Test
+    public void testSomeSortKeyConstant()
+    {
+        tester().assertThat(new SimplifySortWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.sort(
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("1"), key2, p.rowExpression("key3")),
+                                    p.values(key3)));
+                })
+                .matches(
+                        sort(
+                                ImmutableList.of(sort("key2", SortItem.Ordering.ASCENDING, SortItem.NullOrdering.FIRST)),
+                                project(
+                                        ImmutableMap.of("key1", expression("1"), "key2", expression("key3")),
+                                        values("key3"))));
+    }
+
+    @Test
+    public void testNoSortKeyConstant()
+    {
+        tester().assertThat(new SimplifySortWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.sort(
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("key3"), key2, p.rowExpression("key3")),
+                                    p.values(key3)));
+                }).doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyTopNWithConstantInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyTopNWithConstantInput.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.tree.SortItem;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.limit;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestSimplifyTopNWithConstantInput
+        extends BaseRuleTest
+{
+    @Test
+    public void testAllSortKeyConstant()
+    {
+        tester().assertThat(new SimplifyTopNWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.topN(
+                            10,
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("1"), key2, p.rowExpression("2")),
+                                    p.values(key3)));
+                })
+                .matches(
+                        limit(
+                                10,
+                                project(
+                                        ImmutableMap.of("key1", expression("1"), "key2", expression("2")),
+                                        values("key3"))));
+    }
+
+    @Test
+    public void testSomeSortKeyConstant()
+    {
+        tester().assertThat(new SimplifyTopNWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.topN(
+                            10,
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("1"), key2, p.rowExpression("key3")),
+                                    p.values(key3)));
+                })
+                .matches(
+                        topN(
+                                10,
+                                ImmutableList.of(sort("key2", SortItem.Ordering.ASCENDING, SortItem.NullOrdering.FIRST)),
+                                project(
+                                        ImmutableMap.of("key1", expression("1"), "key2", expression("key3")),
+                                        values("key3"))));
+    }
+
+    @Test
+    public void testNoSortKeyConstant()
+    {
+        tester().assertThat(new SimplifyTopNWithConstantInput())
+                .on(p -> {
+                    VariableReferenceExpression key1 = p.variable("key1");
+                    VariableReferenceExpression key2 = p.variable("key2");
+                    VariableReferenceExpression key3 = p.variable("key3");
+                    return p.topN(
+                            10,
+                            ImmutableList.of(key1, key2),
+                            p.project(assignment(key1, p.rowExpression("key3"), key2, p.rowExpression("key3")),
+                                    p.values(key3)));
+                }).doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReplaceConstantVariableReferencesWithConstants.java
@@ -1,0 +1,567 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.limit;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unnest;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+
+public class TestReplaceConstantVariableReferencesWithConstants
+        extends BasePlanTest
+{
+    private Session enableOptimization()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, "true")
+                .build();
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        assertPlan("select orderkey, orderpriority, avg(totalprice) from orders where orderpriority='3-MEDIUM' group by 1, 2",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey", "expr_12", "avg"),
+                        project(
+                                ImmutableMap.of("expr_12", expression("'3-MEDIUM'")),
+                                aggregation(
+                                        ImmutableMap.of("avg", functionCall("avg", ImmutableList.of("totalprice"))),
+                                        anyTree(
+                                                filter(
+                                                        "orderpriority = '3-MEDIUM'",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "orderpriority", "orderpriority", "totalprice", "totalprice"))))))));
+    }
+
+    @Test
+    public void testUnnest()
+    {
+        assertPlan("select orderkey, orderpriority, idx from orders cross join unnest(array[1, 2]) t(idx) where orderpriority='3-MEDIUM'",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey", "expr_9", "field"),
+                        project(
+                                ImmutableMap.of("expr_9", expression("'3-MEDIUM'")),
+                                unnest(
+                                        ImmutableMap.of("expr", ImmutableList.of("field")),
+                                        project(
+                                                ImmutableMap.of("expr", expression("array[1, 2]")),
+                                                filter(
+                                                        "orderpriority = '3-MEDIUM'",
+                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "orderpriority", "orderpriority"))))))));
+    }
+
+    @Test
+    public void testInnerJoin()
+    {
+        assertPlan("select o.orderkey, o.orderpriority, l.tax from lineitem l join orders o on o.orderkey = l.orderkey where o.orderpriority='3-MEDIUM'",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey_0", "expr_14", "tax"),
+                        project(
+                                ImmutableMap.of("expr_14", expression("'3-MEDIUM'")),
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("orderkey", "orderkey_0")),
+                                        anyTree(
+                                                tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "tax", "tax"))),
+                                        anyTree(
+                                                filter(
+                                                        "orderpriority = '3-MEDIUM'",
+                                                        tableScan("orders", ImmutableMap.of("orderkey_0", "orderkey", "orderpriority", "orderpriority"))))))));
+    }
+
+    @Test
+    public void testLeftJoinNotTrigger()
+    {
+        assertPlan("select o.orderkey, o.orderpriority, l.tax from lineitem l left join (select orderkey, orderpriority from orders where orderpriority='3-MEDIUM') o on o.orderkey = l.orderkey",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey_0", "expr_9", "tax"),
+                        join(
+                                JoinNode.Type.LEFT,
+                                ImmutableList.of(equiJoinClause("orderkey", "orderkey_0")),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "tax", "tax"))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("expr_9", expression("'3-MEDIUM'")),
+                                                filter(
+                                                        "orderpriority = '3-MEDIUM'",
+                                                        tableScan("orders", ImmutableMap.of("orderkey_0", "orderkey", "orderpriority", "orderpriority"))))))));
+    }
+
+    @Test
+    public void testLeftJoinTrigger()
+    {
+        assertPlan("select o.orderkey, l.linestatus, l.tax from (select tax, linestatus, orderkey from lineitem where linestatus ='O') l left join orders o on o.orderkey = l.orderkey",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey_0", "expr_26", "tax"),
+                        project(
+                                ImmutableMap.of("expr_26", expression("'O'")),
+                                join(
+                                        JoinNode.Type.LEFT,
+                                        ImmutableList.of(equiJoinClause("orderkey", "orderkey_0")),
+                                        anyTree(
+                                                filter(
+                                                        "linestatus = 'O'",
+                                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "tax", "tax", "linestatus", "linestatus")))),
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("orderkey_0", "orderkey")))))));
+    }
+
+    @Test
+    public void testSemiJoin()
+    {
+        assertPlan("select orderpriority, orderkey from orders where orderpriority='3-MEDIUM' and orderkey in (select orderkey from lineitem)",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("expr_15", "orderkey"),
+                        project(
+                                ImmutableMap.of("expr_15", expression("'3-MEDIUM'")),
+                                filter(
+                                        "expr_8",
+                                        project(
+                                                semiJoin(
+                                                        "orderkey",
+                                                        "orderkey_1",
+                                                        "expr_8",
+                                                        project(
+                                                                filter(
+                                                                        "orderpriority = '3-MEDIUM'",
+                                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "orderpriority", "orderpriority")))),
+                                                        anyTree(
+                                                                project(
+                                                                        tableScan("lineitem", ImmutableMap.of("orderkey_1", "orderkey"))))))))));
+    }
+
+    @Test
+    public void testSimpleFilter()
+    {
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM'",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey", "expr_6"),
+                        project(
+                                ImmutableMap.of("expr_6", expression("'3-MEDIUM'")),
+                                filter(
+                                        "orderpriority = '3-MEDIUM'",
+                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "orderpriority", "orderpriority"))))));
+    }
+
+    @Test
+    public void testFilterOnSameVariable()
+    {
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM' and orderpriority='5-HIGH'",
+                enableOptimization(),
+                output(
+                        values("orderkey", "orderpriority")));
+    }
+
+    @Test
+    public void testJoinWithFilter()
+    {
+        assertPlan("with t1 as (select orderkey, orderstatus from orders where orderkey = 10) select l.orderkey, partkey, orderstatus from t1 join lineitem l on t1.orderkey = l.orderkey where partkey in (select suppkey from lineitem)",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey_9", "partkey", "orderstatus"),
+                        project(
+                                ImmutableMap.of("orderkey_9", expression("10")),
+                                filter(
+                                        "expr_37",
+                                        project(
+                                                semiJoin("partkey", "suppkey_17", "expr_37",
+                                                        project(
+                                                                join(JoinNode.Type.INNER,
+                                                                        ImmutableList.of(),
+                                                                        anyTree(
+                                                                                filter("orderkey = 10",
+                                                                                        tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "orderkey", "orderkey")))),
+                                                                        anyTree(
+                                                                                filter(
+                                                                                        "orderkey_9 = 10",
+                                                                                        tableScan("lineitem", ImmutableMap.of("orderkey_9", "orderkey", "partkey", "partkey")))))),
+                                                        anyTree(
+                                                                tableScan("lineitem", ImmutableMap.of("suppkey_17", "suppkey")))))))));
+    }
+
+    @Test
+    public void testConstantRowExpression()
+    {
+        assertPlan("select orderkey+1 as nk from lineitem where orderkey=1",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("expr", expression("2")),
+                                filter(
+                                        "orderkey=1",
+                                        tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey"))))));
+    }
+
+    @Test
+    public void testSort()
+    {
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM' order by orderpriority",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey", expression("orderkey"), "orderpriority", expression("'3-MEDIUM'")),
+                                filter(
+                                        "orderpriority='3-MEDIUM'",
+                                        tableScan("orders", ImmutableMap.of("orderpriority", "orderpriority", "orderkey", "orderkey"))))));
+    }
+
+    @Test
+    public void testSortOnMultipleKey()
+    {
+        ImmutableList<PlanMatchPattern.Ordering> orderBy = ImmutableList.of(sort("orderkey", ASCENDING, LAST));
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM' order by orderpriority, orderkey",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey", expression("orderkey"), "orderpriority", expression("'3-MEDIUM'")),
+                                anyTree(
+                                        sort(orderBy,
+                                                anyTree(
+                                                        project(
+                                                                ImmutableMap.of("orderkey", expression("orderkey")),
+                                                                filter(
+                                                                        "orderpriority='3-MEDIUM'",
+                                                                        tableScan("orders", ImmutableMap.of("orderpriority", "orderpriority", "orderkey", "orderkey"))))))))));
+    }
+
+    @Test
+    public void testTopN()
+    {
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM' order by orderpriority limit 10",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey", expression("orderkey"), "orderpriority", expression("'3-MEDIUM'")),
+                                limit(
+                                        10,
+                                        anyTree(
+                                                filter(
+                                                        "orderpriority='3-MEDIUM'",
+                                                        tableScan("orders", ImmutableMap.of("orderpriority", "orderpriority", "orderkey", "orderkey"))))))));
+    }
+
+    @Test
+    public void testTopNSortOnMultipleKey()
+    {
+        ImmutableList<PlanMatchPattern.Ordering> orderBy = ImmutableList.of(sort("orderkey", ASCENDING, LAST));
+        assertPlan("select orderkey, orderpriority from orders where orderpriority='3-MEDIUM' order by orderpriority, orderkey limit 10",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey", expression("orderkey"), "orderpriority", expression("'3-MEDIUM'")),
+                                topN(10, orderBy,
+                                        anyTree(
+                                                topN(
+                                                        10,
+                                                        orderBy,
+                                                        project(
+                                                                ImmutableMap.of("orderkey", expression("orderkey")),
+                                                                filter(
+                                                                        "orderpriority='3-MEDIUM'",
+                                                                        tableScan("orders", ImmutableMap.of("orderpriority", "orderpriority", "orderkey", "orderkey"))))))))));
+    }
+
+    @Test
+    public void testUnionAllWithSameConstant()
+    {
+        assertPlan("select orderkey, price, count(*) from (select orderkey, extendedprice as price from lineitem where orderkey=5 union all select orderkey, totalprice as price from orders where orderkey=5) group by orderkey, price",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey_11", expression("5")),
+                                aggregation(
+                                        ImmutableMap.of("count", functionCall("count", ImmutableList.of("count_29"))),
+                                        exchange(
+                                                anyTree(
+                                                        aggregation(
+                                                                ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                project(
+                                                                        filter(
+                                                                                "orderkey = 5",
+                                                                                tableScan("lineitem", ImmutableMap.of("extendedprice", "extendedprice", "orderkey", "orderkey")))))),
+                                                anyTree(
+                                                        aggregation(
+                                                                ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                project(
+                                                                        filter(
+                                                                                "orderkey_4 = 5",
+                                                                                tableScan("orders", ImmutableMap.of("orderkey_4", "orderkey", "totalprice", "totalprice")))))))))));
+    }
+
+    @Test
+    public void testUnionAllWithDifferentConstant()
+    {
+        assertPlan("select orderkey, price, count(*) from (select orderkey, extendedprice as price from lineitem where orderkey=5 union all select orderkey, totalprice as price from orders where orderkey=2) group by orderkey, price",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey_11", expression("orderkey_11")),
+                                aggregation(
+                                        ImmutableMap.of("count", functionCall("count", ImmutableList.of("count_29"))),
+                                        exchange(
+                                                project(
+                                                        project(
+                                                                ImmutableMap.of("orderkey_11", expression("orderkey")),
+                                                                aggregation(
+                                                                        ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                        project(
+                                                                                project(
+                                                                                        ImmutableMap.of("orderkey", expression("5")),
+                                                                                        filter(
+                                                                                                "orderkey = 5",
+                                                                                                tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "extendedprice", "extendedprice")))))))),
+                                                project(
+                                                        project(
+                                                                ImmutableMap.of("orderkey_11", expression("orderkey_4")),
+                                                                aggregation(
+                                                                        ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                        project(
+                                                                                project(
+                                                                                        ImmutableMap.of("orderkey_4", expression("2")),
+                                                                                        filter(
+                                                                                                "orderkey_4 = 2",
+                                                                                                tableScan("orders", ImmutableMap.of("orderkey_4", "orderkey", "totalprice", "totalprice")))))))))))));
+    }
+
+    @Test
+    public void testUnionAllWithOneConstant()
+    {
+        assertPlan("select orderkey, price, count(*) from (select orderkey, extendedprice as price from lineitem where orderkey=5 union all select orderkey, totalprice as price from orders) group by orderkey, price",
+                enableOptimization(),
+                output(
+                        project(
+                                ImmutableMap.of("orderkey_11", expression("orderkey_11")),
+                                aggregation(
+                                        ImmutableMap.of("count", functionCall("count", ImmutableList.of("count_29"))),
+                                        exchange(
+                                                project(
+                                                        project(
+                                                                ImmutableMap.of("orderkey_11", expression("orderkey")),
+                                                                aggregation(
+                                                                        ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                        project(
+                                                                                project(
+                                                                                        ImmutableMap.of("orderkey", expression("5")),
+                                                                                        filter(
+                                                                                                "orderkey = 5",
+                                                                                                tableScan("lineitem", ImmutableMap.of("orderkey", "orderkey", "extendedprice", "extendedprice")))))))),
+                                                project(
+                                                        project(
+                                                                ImmutableMap.of("orderkey_11", expression("orderkey_4")),
+                                                                aggregation(
+                                                                        ImmutableMap.of("count_29", functionCall("count", ImmutableList.of())),
+                                                                        project(
+                                                                                tableScan("orders", ImmutableMap.of("orderkey_4", "orderkey", "totalprice", "totalprice")))))))))));
+    }
+
+    @Test
+    public void testExtractConstantFromFilter()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new ReplaceConstantVariableReferencesWithConstants(createTestFunctionAndTypeManager()))
+                .on(planBuilder ->
+                {
+                    VariableReferenceExpression key1 = planBuilder.variable("key1", INTEGER);
+                    VariableReferenceExpression key2 = planBuilder.variable("key2", INTEGER);
+                    VariableReferenceExpression count = planBuilder.variable("cnt");
+                    return planBuilder.aggregation(
+                            aggregationBuilder -> aggregationBuilder
+                                    .source(
+                                            planBuilder.filter(
+                                                    planBuilder.rowExpression("key1= 3"),
+                                                    planBuilder.values(key1, key2)))
+                                    .singleGroupingSet(key1, key2)
+                                    .addAggregation(count, planBuilder.rowExpression("count()")));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("cnt", functionCall("count", ImmutableList.of())),
+                                project(
+                                        ImmutableMap.of("key1", expression("3")),
+                                        filter(
+                                                "key1=3",
+                                                values("key1", "key2")))));
+    }
+
+    // Do not extract constant variable when having conflicting filters
+    @Test
+    public void testConflictFilter()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new ReplaceConstantVariableReferencesWithConstants(createTestFunctionAndTypeManager()))
+                .on(planBuilder ->
+                {
+                    VariableReferenceExpression key1 = planBuilder.variable("key1", INTEGER);
+                    VariableReferenceExpression key2 = planBuilder.variable("key2", INTEGER);
+                    VariableReferenceExpression count = planBuilder.variable("cnt");
+                    return planBuilder.aggregation(
+                            aggregationBuilder -> aggregationBuilder
+                                    .source(
+                                            planBuilder.filter(
+                                                    planBuilder.rowExpression("key1=2"),
+                                                    planBuilder.filter(
+                                                            planBuilder.rowExpression("key1= 3"),
+                                                            planBuilder.values(key1, key2))))
+                                    .singleGroupingSet(key1, key2)
+                                    .addAggregation(count, planBuilder.rowExpression("count()")));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("cnt", functionCall("count", ImmutableList.of())),
+                                filter(
+                                        "key1=2",
+                                        filter(
+                                                "key1=3",
+                                                values("key1", "key2")))));
+    }
+
+    @Test
+    public void testConflictFilterAndProject()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new ReplaceConstantVariableReferencesWithConstants(createTestFunctionAndTypeManager()))
+                .on(planBuilder ->
+                {
+                    VariableReferenceExpression key1 = planBuilder.variable("key1", INTEGER);
+                    VariableReferenceExpression key2 = planBuilder.variable("key2", INTEGER);
+                    VariableReferenceExpression count = planBuilder.variable("cnt");
+                    return planBuilder.aggregation(
+                            aggregationBuilder -> aggregationBuilder
+                                    .source(
+                                            planBuilder.filter(
+                                                    planBuilder.rowExpression("key1= 3"),
+                                                    planBuilder.project(
+                                                            assignment(key1, planBuilder.rowExpression("2"), key2, planBuilder.rowExpression("key2")),
+                                                            planBuilder.values(key1, key2))))
+                                    .singleGroupingSet(key1, key2)
+                                    .addAggregation(count, planBuilder.rowExpression("count()")));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("cnt", functionCall("count", ImmutableList.of())),
+                                filter(
+                                        "key1=3",
+                                        project(
+                                                ImmutableMap.of("key1", expression("2")),
+                                                values("key1", "key2")))));
+    }
+
+    @Test
+    public void testExtractConstantFromProject()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new ReplaceConstantVariableReferencesWithConstants(createTestFunctionAndTypeManager()))
+                .on(planBuilder ->
+                {
+                    VariableReferenceExpression key1 = planBuilder.variable("key1", INTEGER);
+                    VariableReferenceExpression key2 = planBuilder.variable("key2", INTEGER);
+                    VariableReferenceExpression count = planBuilder.variable("cnt");
+                    return planBuilder.aggregation(
+                            aggregationBuilder -> aggregationBuilder
+                                    .source(
+                                            planBuilder.filter(
+                                                    planBuilder.rowExpression("key2 <> 3"),
+                                                    planBuilder.project(
+                                                            assignment(key1, planBuilder.rowExpression("3"), key2, planBuilder.rowExpression("key2")),
+                                                            planBuilder.values(key1, key2))))
+                                    .singleGroupingSet(key1, key2)
+                                    .addAggregation(count, planBuilder.rowExpression("count()")));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("cnt", functionCall("count", ImmutableList.of())),
+                                project(
+                                        ImmutableMap.of("key1", expression("3")),
+                                        filter(
+                                                "key2 <> 3",
+                                                project(
+                                                        ImmutableMap.of("key1", expression("3"), "key2", expression("key2")),
+                                                        values("key1", "key2"))))));
+    }
+
+    // If project get conflict constant, use the latest one
+    @Test
+    public void testConflictConstantFromProject()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new ReplaceConstantVariableReferencesWithConstants(createTestFunctionAndTypeManager()))
+                .on(planBuilder ->
+                {
+                    VariableReferenceExpression key1 = planBuilder.variable("key1", INTEGER);
+                    VariableReferenceExpression key2 = planBuilder.variable("key2", INTEGER);
+                    VariableReferenceExpression count = planBuilder.variable("cnt");
+                    return planBuilder.aggregation(
+                            aggregationBuilder -> aggregationBuilder
+                                    .source(
+                                            planBuilder.filter(
+                                                    planBuilder.rowExpression("key2 <> 3"),
+                                                    planBuilder.project(
+                                                            assignment(key1, planBuilder.rowExpression("5"), key2, planBuilder.rowExpression("key2")),
+                                                            planBuilder.project(
+                                                                    assignment(key1, planBuilder.rowExpression("3"), key2, planBuilder.rowExpression("key2")),
+                                                                    planBuilder.values(key1, key2)))))
+                                    .singleGroupingSet(key1, key2)
+                                    .addAggregation(count, planBuilder.rowExpression("count()")));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("cnt", functionCall("count", ImmutableList.of())),
+                                project(
+                                        ImmutableMap.of("key1", expression("5")),
+                                        filter(
+                                                "key2 <> 3",
+                                                project(
+                                                        ImmutableMap.of("key1", expression("5"), "key2", expression("key2")),
+                                                        project(
+                                                                ImmutableMap.of("key1", expression("3"), "key2", expression("key2")),
+                                                                values("key1", "key2")))))));
+    }
+}


### PR DESCRIPTION
Rewrite expressions in query plans if we know some variables are constant.

The benefit of this optimizer is in three aspects:

- add a projection to assign a variable with a constant when it's constant. The benefit is that, at runtime, constant projection assignments return RunLengthEncoded block, which consumes less memory, and we also have a handful of runtime optimizations for RunLengthEncoded block
- reduce the amount of data propagated during query execution. For example, if we have a filter on a column at the very bottom of the query and this column is not needed in some intermediate operators, we can avoid passing this column between these operators. A simplified example is `select orderkey, l.partkey, o.orderstatus from lineitem l join orders o using (orderkey) where orderstatus='F'`, with the optimization, orderstatus will not be in the join hashtable.
- Simplify some nodes, for example, Sort on constant variables, group by constant variables etc.


A variable reference expression in a query plan can be a constant 1) after a filter expression, for example, `select orderstatus, shippriority, count(*) from orders where orderstatus='F' group by orderstatus, shippriority`, orderstatus will be a constant after the filter expression. 2) after a project node which assigns constant to a variable reference.

After we know these constant variable references, we can avoid passing them along the query plans. Take the above query as an example, orderstatus is not passed along the plan.

Query: `select orderstatus, shippriority, count(*) from orders where orderstatus='F' group by orderstatus, shippriority`
Before:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                               >
     Output layout: [orderstatus, shippriority, count]                                                                                                                                                             >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Output[orderstatus, shippriority, _col2] => [orderstatus:varchar(1), shippriority:integer, count:bigint]                                                                                                    >
             _col2 := count (1:62)                                                                                                                                                                                 >
         - RemoteSource[1] => [orderstatus:varchar(1), shippriority:integer, count:bigint]                                                                                                                         >
                                                                                                                                                                                                                   >
 Fragment 1 [HASH]                                                                                                                                                                                                 >
     Output layout: [orderstatus, shippriority, count]                                                                                                                                                             >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Project[projectLocality = LOCAL] => [orderstatus:varchar(1), shippriority:integer, count:bigint]                                                                                                            >
         - Aggregate(FINAL)[orderstatus, shippriority][$hashvalue] => [orderstatus:varchar(1), shippriority:integer, $hashvalue:bigint, count:bigint]                                                              >
                 count := "presto.default.count"((count_13)) (1:62)                                                                                                                                                >
             - LocalExchange[HASH][$hashvalue] (orderstatus, shippriority) => [orderstatus:varchar(1), shippriority:integer, count_13:bigint, $hashvalue:bigint]                                                   >
                 - RemoteSource[2] => [orderstatus:varchar(1), shippriority:integer, count_13:bigint, $hashvalue_14:bigint]                                                                                        >
                                                                                                                                                                                                                   >
 Fragment 2 [SOURCE]                                                                                                                                                                                               >
     Output layout: [orderstatus, shippriority, count_13, $hashvalue_15]                                                                                                                                           >
     Output partitioning: HASH [orderstatus, shippriority][$hashvalue_15]                                                                                                                                          >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Aggregate(PARTIAL)[orderstatus, shippriority][$hashvalue_15] => [orderstatus:varchar(1), shippriority:integer, $hashvalue_15:bigint, count_13:bigint]                                                       >
             count_13 := "presto.default.count"(*) (1:62)                                                                                                                                                          >
         - ScanFilterProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.orders{dom>
                 Estimates: {source: CostBasedSourceInfo, rows: 15000 (424.80kB), cpu: 165000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 5000 (141.60kB), cpu: 330000.00, memory: 0.00, n>
                 $hashvalue_15 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderstatus), BIGINT'0')), COALESCE($operator$hash_code(shippriority), BIGINT'0')) (1:114)                     >
                 LAYOUT: tpch.orders{domains={orderstatus=[ [["F"]] ]}}                                                                                                                                            >
                 orderstatus := orderstatus:varchar(1):2:REGULAR (1:76)                                                                                                                                            >
                 shippriority := shippriority:int:7:REGULAR (1:76)   
```

After optimization:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                               >
     Output layout: [expr_10, shippriority, count]                                                                                                                                                                 >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Output[orderstatus, shippriority, _col2] => [expr_10:varchar(1), shippriority:integer, count:bigint]                                                                                                        >
             orderstatus := expr_10 (1:35)                                                                                                                                                                         >
             _col2 := count (1:62)                                                                                                                                                                                 >
         - RemoteSource[1] => [expr_10:varchar(1), shippriority:integer, count:bigint]                                                                                                                             >
                                                                                                                                                                                                                   >
 Fragment 1 [HASH]                                                                                                                                                                                                 >
     Output layout: [expr_10, shippriority, count]                                                                                                                                                                 >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Project[projectLocality = LOCAL] => [expr_10:varchar(1), shippriority:integer, count:bigint]                                                                                                                >
             expr_10 := VARCHAR'F'                                                                                                                                                                                 >
         - Aggregate(FINAL)[shippriority][$hashvalue] => [shippriority:integer, $hashvalue:bigint, count:bigint]                                                                                                   >
                 count := "presto.default.count"((count_13)) (1:62)                                                                                                                                                >
             - LocalExchange[HASH][$hashvalue] (shippriority) => [shippriority:integer, count_13:bigint, $hashvalue:bigint]                                                                                        >
                 - RemoteSource[2] => [shippriority:integer, count_13:bigint, $hashvalue_14:bigint]                                                                                                                >
                                                                                                                                                                                                                   >
 Fragment 2 [SOURCE]                                                                                                                                                                                               >
     Output layout: [shippriority, count_13, $hashvalue_15]                                                                                                                                                        >
     Output partitioning: HASH [shippriority][$hashvalue_15]                                                                                                                                                       >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Aggregate(PARTIAL)[shippriority][$hashvalue_15] => [shippriority:integer, $hashvalue_15:bigint, count_13:bigint]                                                                                            >
             count_13 := "presto.default.count"(*) (1:62)                                                                                                                                                          >
         - ScanFilterProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.orders{dom>
                 Estimates: {source: CostBasedSourceInfo, rows: 15000 (336.91kB), cpu: 165000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 5000 (112.30kB), cpu: 330000.00, memory: 0.00, n>
                 $hashvalue_15 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(shippriority), BIGINT'0')) (1:127)                                                                                          >
                 LAYOUT: tpch.orders{domains={orderstatus=[ [["F"]] ]}}                                                                                                                                            >
                 orderstatus := orderstatus:varchar(1):2:REGULAR (1:76)                                                                                                                                            >
                 shippriority := shippriority:int:7:REGULAR (1:76) 
```

### Test plan - (Please fill in how you tested your changes)

Add unit tests, and also run verifier runs
[verifier run](https://www.internalfb.com/intern/presto/verifier/results/?test_id=117096&build=&user=&limit=500&error_regex=&suite=), [run2](https://www.internalfb.com/intern/presto/verifier/results/?test_id=123257), [run3](https://www.internalfb.com/intern/presto/verifier/results/?test_id=123317), [run4](https://our.internmc.facebook.com/intern/presto/verifier/results/?test_id=143098), [run5](https://www.internalfb.com/intern/presto/verifier/results/?test_id=143206), [run6](https://our.internmc.facebook.com/intern/presto/verifier/results/?test_id=146772)

```
== RELEASE NOTES ==

General Changes
* Add an optimization to optimize queries which has equivalence check filter or constant assignments. Controlled by session property `rewrite_expression_with_constant_expression` and default to enabled.
```

