### PR TITLE
Upgrade jansi to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1203,7 +1203,7 @@
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
-                <version>1.8</version>
+                <version>1.18</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Jansi was previously introduced in https://github.com/prestodb/presto/pull/18960 to support running `presto-cli` on mac M1 with ARM.  This PR upgrades jansi from `1.8` to `1.18`, which is the highest version in 1.x.

```
== NO RELEASE NOTE ==
```
