### PR TITLE
[native] Add ccache to speed up presto_cpp linux build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -59,12 +59,28 @@ jobs:
             cd presto-native-execution
             make velox-submodule
       - run:
+          name: "Calculate merge-base date for CCache"
+          command: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/master HEAD) | tee merge-base-date
+      - restore_cache:
+          name: "Restore CCache cache"
+          keys:
+            - native-exe-linux-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
+      - run:
           name: Build
           command: |
+            mkdir -p .ccache
+            export CCACHE_DIR=$(realpath .ccache)
+            ccache -sz -M 8Gi
             source /opt/rh/gcc-toolset-9/enable
             cd presto-native-execution
             cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DPRESTO_ENABLE_PARQUET=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             ninja -C _build/debug -j 8
+            ccache -s
+      - save_cache:
+          name: "Save CCache cache"
+          key: native-exe-linux-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
+          paths:
+            - .ccache/
       - run:
           name: 'Run Unit Tests'
           command: |


### PR DESCRIPTION
Add ccache to speed up presto_cpp linux build

Test plan - Make sure CircleCi tests pass.

```
== NO RELEASE NOTE ==
```
