### PR TITLE
[native pos] Fail over spark executor if native process launch failed

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -18,23 +18,29 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException;
 import com.facebook.presto.spark.execution.http.TestPrestoSparkHttpClient;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionVeloxConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilder;
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_EXECUTABLE_PATH;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class TestNativeExecutionProcess
 {
@@ -71,6 +77,18 @@ public class TestNativeExecutionProcess
         assertNotSame(process2, process);
     }
 
+    @Test
+    public void testNativeProcessShutdown()
+    {
+        Session session = testSessionBuilder().setSystemProperty(NATIVE_EXECUTION_EXECUTABLE_PATH, "/bin/echo").build();
+        NativeExecutionProcessFactory factory = createNativeExecutionProcessFactory();
+        // Set the maxRetryDuration to 0 ms to allow the RequestErrorTracker failing immediately
+        NativeExecutionProcess process = factory.createNativeExecutionProcess(session, BASE_URI, new Duration(0, TimeUnit.MILLISECONDS));
+        Throwable exception = expectThrows(PrestoSparkFatalException.class, process::start);
+        assertTrue(exception.getMessage().contains("Native process launch failed with multiple retries"));
+        assertFalse(process.isAlive());
+    }
+
     private NativeExecutionProcessFactory createNativeExecutionProcessFactory()
     {
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
@@ -81,7 +99,8 @@ public class TestNativeExecutionProcess
                 new NativeExecutionSystemConfig(),
                 new NativeExecutionVeloxConfig());
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
-                new TestPrestoSparkHttpClient.TestingHttpClient(new TestPrestoSparkHttpClient.TestingResponseManager(taskId.toString())),
+                new TestPrestoSparkHttpClient.TestingHttpClient(
+                        new TestPrestoSparkHttpClient.TestingResponseManager(taskId.toString(), new TestPrestoSparkHttpClient.FailureRetryResponseManager(5))),
                 newSingleThreadExecutor(),
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -316,7 +316,7 @@ public class TestPrestoSparkHttpClient
 
         SettableFuture<ServerInfo> future = process.getServerInfoWithRetry();
         Exception exception = expectThrows(ExecutionException.class, future::get);
-        assertTrue(exception.getMessage().contains("Encountered too many errors talking to native process. The process may have crashed or be under too much load"));
+        assertTrue(exception.getMessage().contains("Native process launch failed with multiple retries"));
     }
 
     @Test
@@ -1221,7 +1221,7 @@ public class TestPrestoSparkHttpClient
                 0);
     }
 
-    private static class FailureRetryResponseManager
+    public static class FailureRetryResponseManager
             extends TestingResponseManager.TestingServerResponseManager
     {
         private final int maxRetryCount;

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFatalException.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFatalException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+/*
+ * Represent fatal exception during presto-on-spark execution which indicate Spark to fail over current executor
+ * Here is the definition of scala fatal error Spark is relying on: https://www.scala-lang.org/api/2.13.3/scala/util/control/NonFatal$.html
+ */
+public class PrestoSparkFatalException
+        extends VirtualMachineError
+{
+    public PrestoSparkFatalException(String errorMessage, Throwable cause)
+    {
+        super(errorMessage, cause);
+    }
+}


### PR DESCRIPTION
 If the native process launch failed, it usually indicates the current host
 machine is overloaded, we need to throw a fatal error to let Spark shutdown
 current executor and fail over to another one.

```
== NO RELEASE NOTE ==
```
