### PR TITLE
[hudi] Retry when inspect hudi commit status which has not been inser…

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiRecordCursors.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import io.airlift.compress.lzo.LzoCodec;
 import io.airlift.compress.lzo.LzopCodec;
+import io.airlift.units.Duration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
@@ -35,6 +36,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
 
 import java.io.IOException;
@@ -44,6 +46,7 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import static com.facebook.presto.hive.HudiRecordCursors.createRecordCursor;
+import static com.facebook.presto.hive.RetryDriver.retry;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hudi.HudiErrorCode.HUDI_FILESYSTEM_ERROR;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -51,6 +54,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_ALL_COLUMNS;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR;
@@ -58,6 +62,11 @@ import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_COLUMN_NA
 
 class HudiRecordCursors
 {
+    // cursors are in driver scope, so its could not block to long
+    private static final Duration BACKOFF_MIN_SLEEP = new Duration(1, SECONDS);
+    private static final Duration BACKOFF_MAX_SLEEP = new Duration(10, SECONDS);
+    private static final int MAX_RECURSIVE_LEVEL = 10;
+
     private HudiRecordCursors() {}
 
     public static RecordCursor createRealtimeRecordCursor(
@@ -115,21 +124,44 @@ class HudiRecordCursors
 
         // create record reader for split
         try {
-            HudiFile baseFile = getHudiBaseFile(split);
-            Path path = new Path(baseFile.getPath());
-            FileSplit fileSplit = new FileSplit(path, baseFile.getStart(), baseFile.getLength(), (String[]) null);
-            List<HoodieLogFile> logFiles = split.getLogFiles().stream().map(file -> new HoodieLogFile(file.getPath())).collect(toList());
-            String tablePath = split.getTable().getPath();
-            FileSplit hudiSplit = new HoodieRealtimeFileSplit(fileSplit, tablePath, logFiles, split.getInstantTime(), false, Option.empty());
-            return inputFormat.getRecordReader(hudiSplit, jobConf, Reporter.NULL);
-        }
-        catch (IOException e) {
+            return retry()
+                .exponentialBackoff(BACKOFF_MIN_SLEEP, BACKOFF_MAX_SLEEP, BACKOFF_MAX_SLEEP, 1.2)
+                .stopOnIllegalExceptions()
+                .stopOn(IOException.class, PrestoException.class)
+                .run("hudiGetRecordReaderCursor", () -> {
+                    try {
+                        HudiFile baseFile = getHudiBaseFile(split);
+                        Path path = new Path(baseFile.getPath());
+                        FileSplit fileSplit = new FileSplit(path, baseFile.getStart(), baseFile.getLength(), (String[]) null);
+                        List<HoodieLogFile> logFiles = split.getLogFiles().stream().map(file -> new HoodieLogFile(file.getPath())).collect(toList());
+                        String tablePath = split.getTable().getPath();
+                        FileSplit hudiSplit = new HoodieRealtimeFileSplit(fileSplit, tablePath, logFiles, split.getInstantTime(), false, Option.empty());
+                        return inputFormat.getRecordReader(hudiSplit, jobConf, Reporter.NULL);
+                    } catch (HoodieException e) {
+                        if (!isJsonParseException(e, MAX_RECURSIVE_LEVEL)) {
+                            throw new PrestoException(HUDI_CANNOT_OPEN_SPLIT, "current HoodieException is not JsonParseException, please check the cause exception", e);
+                        }
+                        throw e;
+                    }
+                });
+        } catch (Exception e) {
             String msg = format("Error opening Hive split %s using %s: %s",
-                    split,
-                    inputFormatName,
-                    firstNonNull(e.getMessage(), e.getClass().getName()));
+                split,
+                inputFormatName,
+                firstNonNull(e.getMessage(), e.getClass().getName()));
             throw new PrestoException(HUDI_CANNOT_OPEN_SPLIT, msg, e);
         }
+    }
+
+    private static boolean isJsonParseException(Throwable e, int level) {
+        if (level <= 0) {
+            return false;
+        }
+        // preorder traversal
+        if (e.getCause() instanceof com.fasterxml.jackson.core.JsonParseException) {
+            return true;
+        }
+        return isJsonParseException(e.getCause(), level - 1);
     }
 
     private static InputFormat<?, ?> createInputFormat(Configuration conf, String inputFormat)


### PR DESCRIPTION
# problems

## description

Presto read hudi meta information failed because deltacommit is incomplete.

## exception stack

```
2023-06-06T14:21:40.768+0800    ERROR   SplitRunner-10762-377052        com.facebook.presto.execution.executor.TaskExecutor     Error processing Split 20230606_062126_47120_es5w2.1.0.3-31 HudiSplit{baseFile=Optional[hdfs://xxx/user/hive/warehouse/hudi.db/xxx/ds=20230604/3113d1a2-a9af-4296-a733-066ad7ef177d-0_673-0-673_20230606141251.parquet:0+39026061], logFiles=[hdfs://xxx/user/hive/warehouse/hudi.db/xxx/ds=20230604/.3113d1a2-a9af-4296-a733-066ad7ef177d-0_20230606141251.log.1_2480-268-148321:0+2460238]} (start = 6.521797315719792E10, wall = 1187 ms, cpu = 0 ms, wait = 0 ms, calls = 1)
org.apache.hudi.exception.HoodieException: Could not create HoodieRealtimeRecordReader on path hdfs://xxx/user/hive/warehouse/hudi.db/xxx/ds=20230604/3113d1a2-a9af-4296-a733-066ad7ef177d-0_673-0-673_20230606141251.parquet
        at org.apache.hudi.hadoop.realtime.AbstractRealtimeRecordReader.<init>(AbstractRealtimeRecordReader.java:97)
        at org.apache.hudi.hadoop.realtime.RealtimeCompactedRecordReader.<init>(RealtimeCompactedRecordReader.java:70)
        at org.apache.hudi.hadoop.realtime.HoodieRealtimeRecordReader.constructRecordReader(HoodieRealtimeRecordReader.java:70)
        at org.apache.hudi.hadoop.realtime.HoodieRealtimeRecordReader.<init>(HoodieRealtimeRecordReader.java:47)
        at org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat.getRecordReader(HoodieParquetRealtimeInputFormat.java:81)
        at com.facebook.presto.hudi.HudiRecordCursors.createRecordReader(HudiRecordCursors.java:121)
        at com.facebook.presto.hudi.HudiRecordCursors.lambda$createRealtimeRecordCursor$0(HudiRecordCursors.java:89)
        at com.facebook.presto.hive.authentication.NoHdfsAuthentication.doAs(NoHdfsAuthentication.java:23)
        at com.facebook.presto.hive.HdfsEnvironment.doAs(HdfsEnvironment.java:81)
        at com.facebook.presto.hudi.HudiRecordCursors.createRealtimeRecordCursor(HudiRecordCursors.java:88)
        at com.facebook.presto.hudi.HudiPageSourceProvider.createPageSource(HudiPageSourceProvider.java:116)
        at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:63)
        at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:80)
        at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:231)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:417)
        at com.facebook.presto.operator.Driver.lambda$processFor$8(Driver.java:300)
        at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:721)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:293)
        at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1077)
        at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:162)
        at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:545)
        at com.facebook.presto.$gen.Presto_0_246_df11de5__0_246____20230522_105912_1.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.hudi.exception.HoodieIOException: Failed to fetch HoodieCommitMetadata for instant ([20230606141730__deltacommit__COMPLETED])
        at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.lambda$getCommitMetadataStream$2(HoodieActiveTimeline.java:352)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:356)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:464)
        at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.getLastCommitMetadataWithValidSchema(HoodieActiveTimeline.java:321)
        at org.apache.hudi.common.table.TableSchemaResolver.getLatestCommitMetadataWithValidSchema(TableSchemaResolver.java:455)
        at org.apache.hudi.common.table.TableSchemaResolver.getTableSchemaFromLatestCommitMetadata(TableSchemaResolver.java:223)
        at org.apache.hudi.common.table.TableSchemaResolver.getTableAvroSchemaInternal(TableSchemaResolver.java:197)
        at org.apache.hudi.common.table.TableSchemaResolver.getTableAvroSchema(TableSchemaResolver.java:137)
        at org.apache.hudi.common.table.TableSchemaResolver.getTableAvroSchema(TableSchemaResolver.java:126)
        at org.apache.hudi.hadoop.realtime.AbstractRealtimeRecordReader.init(AbstractRealtimeRecordReader.java:142)
        at org.apache.hudi.hadoop.realtime.AbstractRealtimeRecordReader.<init>(AbstractRealtimeRecordReader.java:94)
        ... 24 more
Caused by: java.io.IOException: unable to read commit metadata
        at org.apache.hudi.common.model.HoodieCommitMetadata.fromBytes(HoodieCommitMetadata.java:496)
        at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.lambda$getCommitMetadataStream$2(HoodieActiveTimeline.java:349)
        ... 40 more
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Unexpected end-of-input in field name
 at [Source: (StringReader); line: 58879, column: 31] (through reference chain: org.apache.hudi.common.model.HoodieCommitMetadata["partitionToWriteStats"]->java.util.LinkedHashMap["ds=20230605"]->java.util.ArrayList[524])
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:394)
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:365)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:302)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27)
				at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:527)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:364)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:29)
        at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4202)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3205)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3173)
        at org.apache.hudi.common.model.HoodieCommitMetadata.fromJsonString(HoodieCommitMetadata.java:240)
        at org.apache.hudi.common.model.HoodieCommitMetadata.fromBytes(HoodieCommitMetadata.java:494)
        ... 41 more
Caused by: com.fasterxml.jackson.core.io.JsonEOFException: Unexpected end-of-input in field name
 at [Source: (StringReader); line: 58880, column: 1417]
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportInvalidEOF(ParserMinimalBase.java:664)
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseName2(ReaderBasedJsonParser.java:1726)
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseName(ReaderBasedJsonParser.java:1710)
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextFieldName(ReaderBasedJsonParser.java:932)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:295)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:286)
        ... 54 more
```

## hoodie timeline file

<img width="1697" alt="image" src="https://github.com/prestodb/presto/assets/54064811/f72a2f55-e7dd-47a1-a5aa-6e71f572a918">

## solutions

Add retry for HudiCursor read Hudi FileSlices.

## Test plan

It run stably in our productions.

```
== RELEASE NOTES ==

Hudi Changes
- com.facebook.presto.hudi.HudiRecordCursors
```

