### PR TITLE
[native]Add bucket table check on write in Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1722,6 +1722,10 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     auto hiveOutputTableHandle =
         std::dynamic_pointer_cast<protocol::HiveOutputTableHandle>(
             createHandle->handle.connectorHandle);
+    VELOX_USER_CHECK_NULL(
+        hiveOutputTableHandle->bucketProperty,
+        "Bucket table write is not supported: {}",
+        toJsonString(*hiveOutputTableHandle->bucketProperty));
 
     for (const auto& columnHandle : hiveOutputTableHandle->inputColumns) {
       inputColumns.emplace_back(
@@ -1739,6 +1743,11 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     auto hiveInsertTableHandle =
         std::dynamic_pointer_cast<protocol::HiveInsertTableHandle>(
             insertHandle->handle.connectorHandle);
+
+    VELOX_USER_CHECK_NULL(
+        hiveInsertTableHandle->bucketProperty,
+        "Bucket table write is not supported: {}",
+        toJsonString(*hiveInsertTableHandle->bucketProperty));
 
     for (const auto& columnHandle : hiveInsertTableHandle->inputColumns) {
       inputColumns.emplace_back(

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -804,10 +804,7 @@ public abstract class AbstractTestNativeGeneralQueries
     @Test
     public void testCreateUnpartitionedTableAsSelect()
     {
-        Session session = Session.builder(getSession())
-                .setSystemProperty("table_writer_merge_operator_enabled", "false")
-                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
-                .build();
+        Session session = buildSessionForTableWrite();
         // Generate temporary table name.
         String tmpTableName = generateRandomTableName();
         // Clean up if temporary table already exists.
@@ -835,6 +832,33 @@ public abstract class AbstractTestNativeGeneralQueries
         finally {
             dropTableIfExists(tmpTableName);
         }
+    }
+
+    @Test
+    public void testCreateBucketTableAsSelect()
+    {
+        Session session = buildSessionForTableWrite();
+        // Generate temporary table name.
+        String tmpTableName = generateRandomTableName();
+        // Clean up if temporary table already exists.
+        dropTableIfExists(tmpTableName);
+
+        // TODO: update this test condition after bucket write is supported by native worker.
+        try {
+            this.assertQueryFails(session, String.format("CREATE TABLE %s WITH (bucketed_by=array['orderkey'], bucket_count=11) AS SELECT * FROM orders_bucketed", tmpTableName), ".*Bucket table write is not supported.*");
+        }
+        finally {
+            dropTableIfExists(tmpTableName);
+        }
+    }
+
+    private Session buildSessionForTableWrite()
+    {
+        // TODO: enable this after column stats collection is enabled.
+        return Session.builder(getSession())
+                .setSystemProperty("table_writer_merge_operator_enabled", "false")
+                .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
+                .build();
     }
 
     private void dropTableIfExists(String tableName)


### PR DESCRIPTION
Add bucket writer support check when convert a presto plan
to velox so as to ease debugging instead of failing at write finish
processing at the coordinator side. Add a presto native e2e test
to cover this.

```
== NO RELEASE NOTE ==
```
