### PR TITLE
Add optimization rule to remove identity projection under project node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -95,6 +95,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushTableWriteThroughUnion
 import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveIdentityProjectionsBelowProjection;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantAggregateDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
@@ -273,7 +274,8 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 ImmutableSet.of(
                         new InlineProjections(metadata.getFunctionAndTypeManager()),
-                        new RemoveRedundantIdentityProjections()));
+                        new RemoveRedundantIdentityProjections(),
+                        new RemoveIdentityProjectionsBelowProjection()));
 
         IterativeOptimizer projectionPushDown = new IterativeOptimizer(
                 ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveIdentityProjectionsBelowProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveIdentityProjectionsBelowProjection.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.ProjectNodeUtils;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+
+public class RemoveIdentityProjectionsBelowProjection
+        implements Rule<ProjectNode>
+{
+    private static final Capture<ProjectNode> CHILD = newCapture();
+    private static final Pattern<ProjectNode> PATTERN = project().with(source().matching(project().matching(ProjectNodeUtils::isIdentity).capturedAs(CHILD)));
+
+    @Override
+    public Pattern<ProjectNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ProjectNode node, Captures captures, Context context)
+    {
+        ProjectNode child = captures.get(CHILD);
+        return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(child.getSource())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveIdentityProjectionsBelowProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveIdentityProjectionsBelowProjection.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+
+public class TestRemoveIdentityProjectionsBelowProjection
+        extends BaseRuleTest
+{
+    @Test
+    public void testTopProjectUseAllOfIdentityProject()
+    {
+        tester().assertThat(new RemoveIdentityProjectionsBelowProjection())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a");
+                    VariableReferenceExpression b = p.variable("b");
+                    VariableReferenceExpression c = p.variable("c");
+                    return p.project(
+                            assignment(a, p.rowExpression("b+1")),
+                            p.project(
+                                    identityAssignments(b),
+                                    p.values(c, b)));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("b+1")),
+                                values("c", "b")));
+    }
+
+    @Test
+    public void testTopProjectUseSubSetOfIdentityProject()
+    {
+        tester().assertThat(new RemoveIdentityProjectionsBelowProjection())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a");
+                    VariableReferenceExpression b = p.variable("b");
+                    VariableReferenceExpression c = p.variable("c");
+                    VariableReferenceExpression d = p.variable("d");
+                    return p.project(
+                            assignment(a, p.rowExpression("b+1")),
+                            p.project(
+                                    identityAssignments(b, c),
+                                    p.values(c, b, d)));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("b+1")),
+                                values("c", "b", "d")));
+    }
+}


### PR DESCRIPTION
Currently we have a rule [RemoveRedundantIdentityProjections](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantIdentityProjections.java), which removes identity projections.

However, as identity projections are used in project out unused output, hence it only remove identity projection node unless the output of the identity project is the same as the output of the projection's source. For example, for a query plan:
```
    - project
       a := a
       b := b
        - scan
           a, b, c

```
The identity projection will not be removed, due to it's projecting out the output from its source. This makes sense for most nodes, for example cross join has the constraint of having all input variables in output, and we are using identity projection to project out some columns in input in hash generation optimizer for cross join.

However, there is one case where it's safe to always remove identity project node, i.e. when it's parent is also a project node. For example:
```
- project
    d := a+2
    b := b
    - project
        a := a
        b := b
        - scan
            a, b, c
```
can be safely rewritten to:
```
- project
    d := a+2
    b := b
    - scan
        a, b, c
```

Test plan - (Please fill in how you tested your changes)

Add a unit test.
Also relies on existing unit tests.

```
== RELEASE NOTES ==

General Changes
* Add a optimizer rule `RemoveIdentityProjectionsBelowProjection` to remove identity projections under project node.
```

