### PR TITLE
[native] Split tests in E2E and run in parallel

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -50,6 +50,7 @@ executors:
 jobs:
   linux-build:
     executor: build
+    parallelism: 5
     steps:
       - checkout
       - run:
@@ -80,13 +81,35 @@ jobs:
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
             export TEMP_PATH="/tmp"
-            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C -Dtest=TestPrestoNative*
+            TESTFILES=$(circleci tests glob "presto-native-execution/src/test/**/Test*.java" | circleci tests split --split-by=timings)
+            # Convert file paths to comma separated class names
+            export TESTCLASSES=
+            export SPARKTESTS=
+            for test_file in $TESTFILES
+            do
+              tmp=${test_file##*/}
+              test_class=${tmp%%\.*}
+              if [[ $test_class == TestPrestoSpark* ]]; then
+                export SPARKTESTS="${SPARKTESTS},$test_class"
+              else
+                export TESTCLASSES="${TESTCLASSES},$test_class"
+              fi
+            done
+            export TESTCLASSES=${TESTCLASSES#,}
+            export SPARKTESTS=${SPARKTESTS#,}
+            if [ ! -z $TESTCLASSES ]; then
+              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+            fi
+            # set Spark tests as an environment variable
+            echo "export SPARKTESTS=$SPARKTESTS" >> "$BASH_ENV"
       - run:
           name: 'Run spark-native e2e tests'
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
             export TEMP_PATH="/tmp"
-            mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C -Dtest=TestPrestoSparkNative*
+            if [ ! -z $SPARKTESTS ]; then
+              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${SPARKTESTS}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C || true
+            fi
 
   linux-parquet-S3-build:
     executor: build


### PR DESCRIPTION
Split E2E tests and run them in parallel. Also, create a separate
run for Spark tests.

There are 5 jobs that are run in parallel with this change.
Please look at each job for test counts and failures.

```
== NO RELEASE NOTE ==
```