### PR TITLE
Fix use-after-free in HTTP callbacks

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -139,7 +139,7 @@ void Announcer::makeAnnouncement() {
     return;
   }
 
-  client_->sendRequest(announcementRequest_, pool_.get(), announcementBody_)
+  client_->sendRequest(announcementRequest_, pool_, announcementBody_)
       .via(eventBaseThread_.getEventBase())
       .thenValue([](auto response) {
         auto message = response->headers();

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -107,7 +107,7 @@ void PrestoExchangeSource::doRequest() {
       .method(proxygen::HTTPMethod::GET)
       .url(path)
       .header(protocol::PRESTO_MAX_SIZE_HTTP_HEADER, "32MB")
-      .send(httpClient_.get(), pool_.get())
+      .send(httpClient_.get(), pool_)
       .via(driverCPUExecutor())
       .thenValue([path, self](std::unique_ptr<http::HttpResponse> response) {
         velox::common::testutil::TestValue::adjust(
@@ -273,7 +273,7 @@ void PrestoExchangeSource::acknowledgeResults(int64_t ackSequence) {
   http::RequestBuilder()
       .method(proxygen::HTTPMethod::GET)
       .url(ackPath)
-      .send(httpClient_.get(), pool_.get())
+      .send(httpClient_.get(), pool_)
       .via(driverCPUExecutor())
       .thenValue([self](std::unique_ptr<http::HttpResponse> response) {
         VLOG(1) << "Ack " << response->headers()->getStatusCode();
@@ -292,7 +292,7 @@ void PrestoExchangeSource::abortResults() {
   http::RequestBuilder()
       .method(proxygen::HTTPMethod::DELETE)
       .url(basePath_)
-      .send(httpClient_.get(), pool_.get())
+      .send(httpClient_.get(), pool_)
       .via(driverCPUExecutor())
       .thenValue([queue, self](std::unique_ptr<http::HttpResponse> response) {
         auto statusCode = response->headers()->getStatusCode();

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -114,7 +114,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
   // TODO Avoid copy by using IOBuf for body
   folly::SemiFuture<std::unique_ptr<HttpResponse>> sendRequest(
       const proxygen::HTTPMessage& request,
-      velox::memory::MemoryPool* pool,
+      std::shared_ptr<velox::memory::MemoryPool> pool,
       const std::string& body = "");
 
  private:
@@ -163,7 +163,7 @@ class RequestBuilder {
 
   folly::SemiFuture<std::unique_ptr<HttpResponse>> send(
       HttpClient* client,
-      velox::memory::MemoryPool* pool,
+      std::shared_ptr<velox::memory::MemoryPool> pool,
       const std::string& body = "") {
     header(proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));
     headers_.ensureHostHeader();


### PR DESCRIPTION
Summary:
In the HTTPClient, callbacks are scheduled on an eventBase. HTTPClient is kept alive using a shared_ptr, but it contains a raw pointer to MemoryPool. This MemoryPool may be freed if Task is aborted earlier, but a callback is executed much later.
We see crashes related to this when the batch cluster is under heavy load.

So the fix here is to keep shared_ptr to MemoryPool isntead of a raw pointer

Differential Revision: D46672533

