### PR TITLE
Add bucketed writer support in Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(
   velox_hive_partition_function
   velox_window
   velox_dwio_dwrf_reader
+  velox_type_fbhive
   ${RE2}
   ${FOLLY_WITH_DEPENDENCIES}
   ${ANTLR4_RUNTIME}

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -431,7 +431,7 @@ bool SystemConfig::logZombieTaskInfo() const {
 }
 
 uint32_t SystemConfig::logNumZombieTasks() const {
-  return optionalProperty<uint32_t>(kLogZombieTaskInfo).value();
+  return optionalProperty<uint32_t>(kLogNumZombieTasks).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   velox_dwio_common_exception
   presto_type_converter
   presto_types
+  velox_type_fbhive
   ${ANTLR4_RUNTIME}
   velox_hive_partition_function)
 


### PR DESCRIPTION
Add to support bucket table write in Prestissimo with e2e hive
native tests. Note we don't support bucketed sort write table but
only bucketed table write.

The followup is to complete the update mode coverage in e2e once
velox side is ready and the bucket sort support.

Fix a bug in zombie task log config.

```
== NO RELEASE NOTE ==
```
