### PR TITLE
[Native] Fix use-after-free in HTTP callbacks (#19863)

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -130,6 +130,7 @@ void Announcer::makeAnnouncement() {
           eventBaseThread_.getEventBase(),
           address_,
           std::chrono::milliseconds(10'000),
+          pool_,
           clientCertAndKeyPath_,
           ciphers_);
     }
@@ -139,7 +140,7 @@ void Announcer::makeAnnouncement() {
     return;
   }
 
-  client_->sendRequest(announcementRequest_, pool_.get(), announcementBody_)
+  client_->sendRequest(announcementRequest_, announcementBody_)
       .via(eventBaseThread_.getEventBase())
       .thenValue([](auto response) {
         auto message = response->headers();


### PR DESCRIPTION
Summary:

In the HTTPClient, callbacks are scheduled on an eventBase. HTTPClient is kept alive using a shared_ptr, but it contains a raw pointer to MemoryPool. This MemoryPool may be freed if Task is aborted earlier, but a callback is executed much later.
We see crashes related to this when the batch cluster is under heavy load.

So the fix here is to keep shared_ptr to MemoryPool isntead of a raw pointer

Differential Revision: D46674355

```
== NO RELEASE NOTE ==
```

