### PR TITLE
[native] Turn on 128 big into compile option for folly

### DIFF
--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -28,9 +28,8 @@ export PATH=$(brew --prefix bison)/bin:$PATH
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
   OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF
+   cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
-
 
 function install_fizz {
   github_checkout facebookincubator/fizz "${FB_OS_VERSION}"


### PR DESCRIPTION
We recently turned on [128bit support in velox set up](https://github.com/facebookincubator/velox/blob/main/scripts/setup-macos.sh#L98), and not turning it on in presto will fail the velox advancement and building with latest velox.

CC: @majetideepak 
```
== NO RELEASE NOTE ==
```
