### PR TITLE
Add -DFOLLY_HAVE_INT128_T=ON to setup scripts and update images

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -32,7 +32,7 @@ workflows:
 executors:
   build:
     docker:
-      - image: prestocpp/prestocpp-avx-centos:kpai-20221018
+      - image: prestocpp/prestocpp-avx-centos:mike-20230613
     resource_class: 2xlarge
     environment:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"

--- a/.github/workflows/test-native-specific.yml
+++ b/.github/workflows/test-native-specific.yml
@@ -103,7 +103,7 @@ jobs:
 
   native-specific-linux:
     runs-on: ubuntu-latest
-    container: prestocpp/prestocpp-avx-centos:kpai-20221018
+    container: prestocpp/prestocpp-avx-centos:mike-20230613
 
     env:
       CC: /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    container: prestocpp/prestocpp-avx-centos:kpai-20221018
+    container: prestocpp/prestocpp-avx-centos:mike-20230613
 
     env:
       CC: /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/presto-native-execution/scripts/centos-container.dockfile
+++ b/presto-native-execution/scripts/centos-container.dockfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 # Build the test and build container for presto_cpp
 #
-FROM prestocpp/velox-avx-circleci:mikesh-20220717
+FROM ghcr.io/facebookincubator/velox-dev:circleci-avx
 
 COPY setup-centos.sh /
 COPY setup-helper-functions.sh /

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -67,7 +67,7 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
   git clone https://github.com/facebook/folly &&
   cd folly &&
   git checkout $FB_OS_VERSION &&
-  cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
+  cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DFOLLY_HAVE_INT128_T=ON
 )
 
 (


### PR DESCRIPTION
Build folly with FOLLY_HAVE_INT128_T on like https://github.com/facebookincubator/velox/pull/5113. This is required for using the latest velox version.
Rebuild docker image as prestocpp/prestocpp-avx-centos:root-20230613 and update ci configs for both circleci and github action.

Test plan - (Please fill in how you tested your changes)

Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```
