### PR TITLE
[Native] Optimize docker image building logic

### DIFF
--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -21,12 +21,14 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream8
 FROM ${BASE_IMAGE} AS build-stage
 
 ARG CPU_TARGET=avx
+ARG NUM_THREADS=16
 ARG PRESTODB_REPOSITORY=https://github.com/prestodb/presto
 ARG PRESTODB_CHECKOUT=origin/master
 
 USER root:root
 
 ENV CPU_TARGET=${CPU_TARGET}
+ENV NUM_THREADS=${NUM_THREADS}
 
 ENV CC=/opt/rh/gcc-toolset-9/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-9/root/bin/g++
@@ -97,6 +99,7 @@ RUN --mount=type=ssh \
         PRESTO_ENABLE_S3=${PRESTO_ENABLE_S3} \
         PRESTO_ENABLE_HDFS=${PRESTO_ENABLE_HDFS} \
         PRESTO_ENABLE_TESTING=${PRESTO_ENABLE_TESTING} \
+        NUM_THREADS=${NUM_THREADS} \
         TREAT_WARNINGS_AS_ERRORS=OFF
 
 #-----------------------------------------------------------

--- a/presto-native-execution/scripts/release-centos-dockerfile/README.md
+++ b/presto-native-execution/scripts/release-centos-dockerfile/README.md
@@ -89,7 +89,7 @@ to run container build with default tag execute:
 docker run "presto/prestissimo-avx-centos:latest" \
             --use-env-params \
             --discovery-uri=http://localhost:8080 \
-            --http-server-port=8080"
+            --http-server-port=8080
 ```
 
 to run container interactively, not executing entrypoint file:
@@ -109,6 +109,7 @@ export IMAGE_NAME='presto/prestissimo-${CPU_TARGET}-centos'
 export IMAGE_TAG='latest'
 export IMAGE_REGISTRY='some-registry.my-domain.com/'
 export IMAGE_PUSH='0'
+export NUM_THREADS="16"
 export PRESTODB_REPOSITORY=$(git config --get remote.origin.url)
 export PRESTODB_CHECKOUT=$(git show -s --format="%H" HEAD)
 ```
@@ -125,6 +126,7 @@ docker build \
     --build-arg https_proxy \
     --build-arg no_proxy    \
     --build-arg CPU_TARGET  \
+    --build-arg NUM_THREADS  \
     --build-arg PRESTODB_REPOSITORY \
     --build-arg PRESTODB_CHECKOUT \
     --tag "${IMAGE_REGISTRY}${IMAGE_NAME}:${IMAGE_TAG}" .

--- a/presto-native-execution/scripts/release-centos-dockerfile/etc/velox.properties.template
+++ b/presto-native-execution/scripts/release-centos-dockerfile/etc/velox.properties.template
@@ -1,0 +1,1 @@
+mutable-config=true

--- a/presto-native-execution/scripts/release-centos-dockerfile/opt/common.sh
+++ b/presto-native-execution/scripts/release-centos-dockerfile/opt/common.sh
@@ -152,6 +152,15 @@ function render_node_configuration_files()
     prompt "Using default node.properties.template. No user config found."
     cat "${PRESTO_HOME}/etc/node.properties.template" > "${PRESTO_HOME}/node.properties"
   fi
+
+  if [ -f "${PRESTO_HOME}/velox.properties.template" ]
+  then
+    prompt "Using user provided velox.properties.template"
+    cat "${PRESTO_HOME}/velox.properties.template" > "${PRESTO_HOME}/velox.properties"
+  else
+    prompt "Using default velox.properties.template. No user config found."
+    cat "${PRESTO_HOME}/etc/velox.properties.template" > "${PRESTO_HOME}/velox.properties"
+  fi
 }
 
 function memory_gb_preflight_check()

--- a/presto-native-execution/scripts/release-centos-dockerfile/opt/entrypoint.sh
+++ b/presto-native-execution/scripts/release-centos-dockerfile/opt/entrypoint.sh
@@ -26,6 +26,7 @@ if [[ "${DEBUG}" == "0" || "${DEBUG}" == "false" || "${DEBUG}" == "False" ]]; th
 
 HTTP_SERVER_PORT="${HTTP_SERVER_PORT:-"8080"}"
 DISCOVERY_URI="${HTTP_SERVER_PORT:-"http://127.0.0.1:${HTTP_SERVER_PORT}"}"
+NODE_ENVIRONMENT="${NODE_ENVIRONMENT:-"intel-poland"}"
 
 while getopts ':-:' optchar; do
   case "$optchar" in
@@ -34,6 +35,7 @@ while getopts ':-:' optchar; do
         discovery-uri=*) DISCOVERY_URI="${OPTARG#*=}" ;;
         http-server-port=*) HTTP_SERVER_PORT="${OPTARG#*=}" ;;
         node-memory-gb=*) NODE_MEMORY_GB="${OPTARG#*=}" ;;
+        node-environment=*) NODE_ENVIRONMENT="${OPTARG#*=}" ;;
         use-env-params) USE_ENV_PARAMS=1 ;;
         *)
           presto_args+=($optchar)
@@ -53,11 +55,14 @@ function node_command_line_config()
   printf "discovery.uri=${DISCOVERY_URI}\n"            >> "${PRESTO_HOME}/config.properties"
   printf "http-server.http.port=${HTTP_SERVER_PORT}\n" >> "${PRESTO_HOME}/config.properties"
 
-  printf "node.environment=intel-poland\n"    >  "${PRESTO_HOME}/node.properties"
-  printf "node.location=torun-cluster\n"      >> "${PRESTO_HOME}/node.properties"
-  printf "node.id=${NODE_UUID}\n"             >> "${PRESTO_HOME}/node.properties"
-  printf "node.ip=$(hostname -I)\n"           >> "${PRESTO_HOME}/node.properties"
-  printf "node.memory_gb=${NODE_MEMORY_GB}\n" >> "${PRESTO_HOME}/node.properties"
+  printf "node.environment=${NODE_ENVIRONMENT}\n"    >  "${PRESTO_HOME}/node.properties"
+  printf "node.location=torun-cluster\n"             >> "${PRESTO_HOME}/node.properties"
+  [ -z "$NODE_UUID" ] && NODE_UUID=$(uuid) || return -2
+  printf "node.id=${NODE_UUID}\n"                    >> "${PRESTO_HOME}/node.properties"
+  printf "node.ip=$(hostname -I)\n"                  >> "${PRESTO_HOME}/node.properties"
+  printf "node.memory_gb=${NODE_MEMORY_GB}\n"        >> "${PRESTO_HOME}/node.properties"
+
+  printf "mutable-config=true\n" >> "${PRESTO_HOME}/velox.properties"
 }
 
 function node_configuration()

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -95,7 +95,7 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
   git clone https://github.com/google/re2 &&
   cd re2 &&
   git checkout $RE2_VERSION &&    
-  cmake_install -DBUILD_SHARED_LIBS=ON
+  cmake_install -DBUILD_SHARED_LIBS=ON -DBUILD_DEPS=ON
 )
 
 (


### PR DESCRIPTION
1. The current code for building the docker image does not support specifying the number of compilation threads, which will cause compilation failure if the memory is relatively small, this PR introduces the `NUM_THREADS` argument to solve this problem
2. [#19810](https://github.com/prestodb/presto/pull/19810) introduced the velox.properties configuration file, which must exist when running velox, but the current script for building the docker image does not add this configuration file
3. other logic for optimizing image building.

```
== NO RELEASE NOTE ==
```
