### PR TITLE
[native pos] allow drop table for native java test runner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -101,6 +101,15 @@ public class PrestoNativeQueryRunnerUtils
     public static QueryRunner createJavaQueryRunner(Optional<Path> baseDataDirectory, String security, String storageFormat)
             throws Exception
     {
+        ImmutableMap.Builder<String, String> hivePropertiesBuilder = new ImmutableMap.Builder<>();
+        hivePropertiesBuilder
+                .put("hive.storage-format", storageFormat)
+                .put("hive.pushdown-filter-enabled", "true");
+
+        if ("legacy".equals(security)) {
+            hivePropertiesBuilder.put("hive.allow-drop-table", "true");
+        }
+
         Optional<Path> dataDirectory = baseDataDirectory.map(path -> Paths.get(path.toString() + '/' + storageFormat));
         DistributedQueryRunner queryRunner =
                 HiveQueryRunner.createQueryRunner(
@@ -110,9 +119,7 @@ public class PrestoNativeQueryRunnerUtils
                                 "regex-library", "RE2J",
                                 "offset-clause-enabled", "true"),
                         security,
-                        ImmutableMap.of(
-                                "hive.storage-format", storageFormat,
-                                "hive.pushdown-filter-enabled", "true"),
+                        hivePropertiesBuilder.build(),
                         dataDirectory);
         return queryRunner;
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -78,8 +78,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testUnionAll() {}
-
-    @Override
-    @Ignore
-    public void testDecimalRangeFilters() {}
 }


### PR DESCRIPTION
Add hive.allow-drop-table permission to the test java runner to
avoid access denied error when dropping test tables in
TestPrestoSparkNativeGeneralQueries#testDecimalRangeFilters test suite.

Here is an example error we got for the error in the test:
```
Caused by: com.facebook.presto.spi.security.AccessDeniedException: Access Denied: Cannot drop table tpch.tmp_presto_9ca9bea345d14fbbb9f0ed061d577bca
	at com.facebook.presto.spi.security.AccessDeniedException.denyDropTable(AccessDeniedException.java:116)
	at com.facebook.presto.spi.security.AccessDeniedException.denyDropTable(AccessDeniedException.java:111)
	at com.facebook.presto.hive.security.LegacyAccessControl.checkCanDropTable(LegacyAccessControl.java:102)
	at com.facebook.presto.hive.security.SystemTableAwareAccessControl.checkCanDropTable(SystemTableAwareAccessControl.java:89)
	at com.facebook.presto.security.AccessControlManager.lambda$checkCanDropTable$20(AccessControlManager.java:319)
	at com.facebook.presto.security.AccessControlManager.authorizationCheck(AccessControlManager.java:773)
	at com.facebook.presto.security.AccessControlManager.checkCanDropTable(AccessControlManager.java:319)
	at com.facebook.presto.testing.TestingAccessControlManager.checkCanDropTable(TestingAccessControlManager.java:171)
	at com.facebook.presto.execution.DropTableTask.execute(DropTableTask.java:67)
	at com.facebook.presto.execution.DropTableTask.execute(DropTableTask.java:37)
	at com.facebook.presto.execution.DDLDefinitionExecution.executeTask(DDLDefinitionExecution.java:62)
	at com.facebook.presto.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:209)
```


```
== NO RELEASE NOTE ==
```
