### PR TITLE
[native pos] Use the timeout as configured in http client

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionModule.java
@@ -25,14 +25,12 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-import io.airlift.units.Duration;
 import org.jheaps.annotations.VisibleForTesting;
 
 import java.util.Optional;
 
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class NativeExecutionModule
         implements Module
@@ -63,7 +61,6 @@ public class NativeExecutionModule
         httpClientBinder(binder)
                 .bindHttpClient("nativeExecution", ForNativeExecutionTask.class)
                 .withConfigDefaults(config -> {
-                    config.setRequestTimeout(new Duration(10, SECONDS));
                     config.setMaxConnectionsPerServer(250);
                 });
         if (connectorConfig.isPresent()) {


### PR DESCRIPTION
Http client timeout was hardcoded to 10s, this causes batchUpdateRequest to 
timeout if the cpp server could not respond within reasonable time. Under 
certain conditions the cpp server may take longer to respond.

Configure the timeout using `nativeExecution.http-client.request-timeout`
```
== RELEASE NOTES ==

General Changes
* Add property ``nativeExecution.http-client.request-timeout`` to configure http client timeout for presto on spark. This property is used by http client in executor which interacts with presto-native cpp server.
```

