### PR TITLE
Disable tracking of dependency directories

### DIFF
--- a/presto-native-execution/.gitignore
+++ b/presto-native-execution/.gitignore
@@ -1,0 +1,20 @@
+
+#==============================================================================#
+# This file specifies intentionally untracked files that git should ignore.
+#==============================================================================#
+
+
+
+#==============================================================================#
+# Ignore dependencies which are built locally. 
+#==============================================================================#
+antlr4/
+double-conversion/
+fbthrift/
+fizz/
+fmt/
+folly/
+proxygen/
+range-v3/
+re2/
+wangle/


### PR DESCRIPTION
Disable tracking of directories produced via setup-macos.sh . 