### PR TITLE
Add join output order check in JoinNode constructor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.sanity.ValidateDependenciesChecker.checkLeftOutputVariablesBeforeRight;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
@@ -122,6 +123,8 @@ public class JoinNode
         this.rightHashVariable = rightHashVariable;
         this.distributionType = distributionType;
         this.dynamicFilters = ImmutableMap.copyOf(dynamicFilters);
+
+        checkLeftOutputVariablesBeforeRight(left.getOutputVariables(), outputVariables);
 
         Set<VariableReferenceExpression> inputVariables = ImmutableSet.<VariableReferenceExpression>builder()
                 .addAll(left.getOutputVariables())

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -101,6 +101,23 @@ public final class ValidateDependenciesChecker
         plan.accept(new Visitor(types), ImmutableSet.of());
     }
 
+    public static void checkLeftOutputVariablesBeforeRight(List<VariableReferenceExpression> leftVariables, List<VariableReferenceExpression> outputVariables)
+    {
+        int leftMaxPosition = -1;
+        Optional<Integer> rightMinPosition = Optional.empty();
+        Set<VariableReferenceExpression> leftVariablesSet = new HashSet<>(leftVariables);
+        for (int i = 0; i < outputVariables.size(); i++) {
+            VariableReferenceExpression variable = outputVariables.get(i);
+            if (leftVariablesSet.contains(variable)) {
+                leftMaxPosition = i;
+            }
+            else if (!rightMinPosition.isPresent()) {
+                rightMinPosition = Optional.of(i);
+            }
+        }
+        checkState(!rightMinPosition.isPresent() || rightMinPosition.get() > leftMaxPosition, "Not all left output variables are before right output variables");
+    }
+
     private static class Visitor
             extends InternalPlanVisitor<Void, Set<VariableReferenceExpression>>
     {
@@ -458,23 +475,6 @@ public final class ValidateDependenciesChecker
             }
 
             return null;
-        }
-
-        private void checkLeftOutputVariablesBeforeRight(List<VariableReferenceExpression> leftVariables, List<VariableReferenceExpression> outputVariables)
-        {
-            int leftMaxPosition = -1;
-            Optional<Integer> rightMinPosition = Optional.empty();
-            Set<VariableReferenceExpression> leftVariablesSet = new HashSet<>(leftVariables);
-            for (int i = 0; i < outputVariables.size(); i++) {
-                VariableReferenceExpression variable = outputVariables.get(i);
-                if (leftVariablesSet.contains(variable)) {
-                    leftMaxPosition = i;
-                }
-                else if (!rightMinPosition.isPresent()) {
-                    rightMinPosition = Optional.of(i);
-                }
-            }
-            checkState(!rightMinPosition.isPresent() || rightMinPosition.get() > leftMaxPosition, "Not all left output variables are before right output variables");
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
@@ -1051,7 +1051,7 @@ public class TestLogicalPropertyPropagation
                             TupleDomain.none(),
                             tester().getTableConstraints(ordersTableHandle));
 
-                    return p.join(JoinNode.Type.INNER, customerTableScan, ordersTableScan, emptyList(), ImmutableList.of(ordersOrderKeyVariable, customerCustKeyVariable, ordersCustKeyVariable), Optional.empty());
+                    return p.join(JoinNode.Type.INNER, customerTableScan, ordersTableScan, emptyList(), ImmutableList.of(customerCustKeyVariable, ordersOrderKeyVariable, ordersCustKeyVariable), Optional.empty());
                 })
                 .matches(expectedLogicalProperties);
 
@@ -1080,7 +1080,7 @@ public class TestLogicalPropertyPropagation
                             TupleDomain.none(),
                             tester().getTableConstraints(ordersTableHandle));
 
-                    return p.join(JoinNode.Type.INNER, p.limit(11, customerTableScan), p.limit(12, ordersTableScan), emptyList(), ImmutableList.of(ordersOrderKeyVariable, ordersCustKeyVariable, customerCustKeyVariable), Optional.empty());
+                    return p.join(JoinNode.Type.INNER, p.limit(11, customerTableScan), p.limit(12, ordersTableScan), emptyList(), ImmutableList.of(customerCustKeyVariable, ordersOrderKeyVariable, ordersCustKeyVariable), Optional.empty());
                 })
                 .matches(expectedLogicalProperties);
 
@@ -1120,8 +1120,7 @@ public class TestLogicalPropertyPropagation
                             orderTableConstraints);
 
                     return p.join(JoinNode.Type.INNER, customerTableScan, ordersTableScan, emptyList(),
-                            ImmutableList.of(ordersOrderKeyVariable, ordersCustKeyVariable, ordersCommentVariable,
-                                    customerCustKeyVariable, customerCommentVariable),
+                            ImmutableList.of(customerCustKeyVariable, customerCommentVariable, ordersOrderKeyVariable, ordersCustKeyVariable, ordersCommentVariable),
                             Optional.empty());
                 })
                 .matches(expectedLogicalProperties);
@@ -1215,7 +1214,7 @@ public class TestLogicalPropertyPropagation
 
                     return p.join(JoinNode.Type.FULL, p.limit(12, customerTableScan), p.limit(10, ordersTableScan),
                             ImmutableList.of(new JoinNode.EquiJoinClause(customerCustKeyVariable, ordersCustKeyVariable)),
-                            ImmutableList.of(ordersOrderKeyVariable, customerCustKeyVariable),
+                            ImmutableList.of(customerCustKeyVariable, ordersOrderKeyVariable),
                             Optional.empty());
                 })
                 .matches(expectedLogicalProperties);
@@ -1246,8 +1245,7 @@ public class TestLogicalPropertyPropagation
                             tester().getTableConstraints(ordersTableHandle));
 
                     return p.join(JoinNode.Type.INNER, p.limit(2, customerTableScan), ordersTableScan, emptyList(),
-                            ImmutableList.of(ordersOrderKeyVariable, ordersCustKeyVariable,
-                                    customerCustKeyVariable),
+                            ImmutableList.of(customerCustKeyVariable, ordersOrderKeyVariable, ordersCustKeyVariable),
                             Optional.empty());
                 })
                 .matches(expectedLogicalProperties);
@@ -1278,8 +1276,7 @@ public class TestLogicalPropertyPropagation
                             tester().getTableConstraints(ordersTableHandle));
 
                     return p.join(JoinNode.Type.INNER, ordersTableScan, p.limit(2, customerTableScan), emptyList(),
-                            ImmutableList.of(ordersOrderKeyVariable, ordersCustKeyVariable,
-                                    customerCustKeyVariable),
+                            ImmutableList.of(ordersOrderKeyVariable, ordersCustKeyVariable, customerCustKeyVariable),
                             Optional.empty());
                 })
                 .matches(expectedLogicalProperties);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -280,7 +280,7 @@ public class TestReorderJoins
                                 p.values(new PlanNodeId("valuesB"), ImmutableList.of(p.variable("B1")), TWO_ROWS),
                                 p.values(new PlanNodeId("valuesA"), p.variable("A1")), // matches isAtMostScalar
                                 ImmutableList.of(new EquiJoinClause(p.variable("A1"), p.variable("B1"))),
-                                ImmutableList.of(p.variable("A1"), p.variable("B1")),
+                                ImmutableList.of(p.variable("B1"), p.variable("A1")),
                                 Optional.empty()))
                 .overrideStats("valuesA", valuesA)
                 .overrideStats("valuesB", valuesB)


### PR DESCRIPTION
JoinNode has the requirement of left side input to be before right input in join output. However, this constraint is not enforced in JoinNode construction and only checked at the very end during plan validation phase.

Add the constraint check in JoinNode constructor, so that 1) it will prevent people from violating this constraint when adding new code 2) fail fast and help debug


### Test plan - (Please fill in how you tested your changes)

Easy change, and relied on existing unit tests

```
== NO RELEASE NOTE ==
```

