### PR TITLE
Fix join output order for cross join or optimizer rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CrossJoinWithOrFilterToInnerJoin.java
@@ -264,7 +264,7 @@ public class CrossJoinWithOrFilterToInnerJoin
         RewrittenJoinInput rightJoinInput = rewriteJoinInput(variablesUsedInOrComparisionFromRight, joinNode.getRight(), joinKeyType, context.getVariableAllocator(), context.getIdAllocator());
 
         ImmutableList.Builder<VariableReferenceExpression> joinOutput = ImmutableList.builder();
-        joinOutput.addAll(joinNode.getOutputVariables()).add(leftJoinInput.getJoinKey()).add(leftJoinInput.getUnnestIndex());
+        joinOutput.add(leftJoinInput.getJoinKey()).add(leftJoinInput.getUnnestIndex()).addAll(joinNode.getOutputVariables());
         JoinNode newJoinNode = new JoinNode(joinNode.getSourceLocation(),
                 context.getIdAllocator().getNextId(),
                 joinNode.getType(),


### PR DESCRIPTION
As title. Left input should be before right side input in join output.

Has another PR https://github.com/prestodb/presto/pull/19886 which adds the check in JoinNode constructor, but still would like to ship this simple fix as the other PR may take some time to review.

### Test plan - (Please fill in how you tested your changes)
Existing unit tests

```
== RELEASE NOTES ==

General Changes
* Fix join output for CrossJoinWithOrFilterToInnerJoin optimizer rule.
```

