### PR TITLE
[native pos] Fix bug in concurrent native process creation

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/NativeExecutionProcess.java
@@ -121,11 +121,19 @@ public class NativeExecutionProcess
     public synchronized void start()
             throws ExecutionException, InterruptedException, IOException
     {
-        if (process != null && process.isAlive()) {
+        start(getLaunchCommand());
+    }
+
+    @VisibleForTesting
+    synchronized void start(List<String> args)
+        throws ExecutionException, InterruptedException, IOException
+    {
+
+            if (process != null && process.isAlive()) {
             return;
         }
 
-        ProcessBuilder processBuilder = new ProcessBuilder(getLaunchCommand());
+        ProcessBuilder processBuilder = new ProcessBuilder(args);
         processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
         processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
         try {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -1266,4 +1266,15 @@ public class TestPrestoSparkHttpClient
             return super.createTaskInfoResponse(httpStatus, taskId);
         }
     }
+
+    public static class SuccessServerInfoResponseManager
+            extends TestingResponseManager.TestingServerResponseManager
+    {
+        @Override
+        public Response createServerInfoResponse()
+                throws PrestoException
+        {
+            return super.createServerInfoResponse();
+        }
+    }
 }


### PR DESCRIPTION
PR https://github.com/prestodb/presto/pull/19797 introduced a bug where by if multiple tasks run on an executor, then each of them would trigger generation of new process.

This is because, even though the nativeExecutionProcessFactory.getNativeExecutionProcess is protected by synchronized block, the condition process.isAlive() will always return false for all the threads that enter this block until atleast one of the previously entered threads calls process.start to make the process alive

This PR fixes this bug by moving the start call inside the synchronized block


```
== NO RELEASE NOTE ==
```
