### PR TITLE
Extend payload join optimization for cases without map columns; fix b…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.common.type.ArrayType;
-import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.expressions.LogicalRowExpressions;
@@ -64,6 +62,9 @@ import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
 import static com.facebook.presto.sql.planner.PlannerUtils.coalesce;
 import static com.facebook.presto.sql.planner.PlannerUtils.equalityPredicate;
 import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.restrictOutput;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -136,8 +137,7 @@ public class PayloadJoinOptimizer
     {
         FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
         if (isEnabled(session)) {
-            PlanNode result = SimplePlanRewriter.rewriteWith(new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator), plan, new JoinContext());
-            return result;
+            return SimplePlanRewriter.rewriteWith(new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator), plan, new JoinContext());
         }
         return plan;
     }
@@ -174,41 +174,45 @@ public class PayloadJoinOptimizer
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
         }
 
-        private Set<VariableReferenceExpression> extractPayloadColumns(ImmutableSet<VariableReferenceExpression> columns)
-        {
-            return columns.stream().filter(var -> var.getType() instanceof MapType || var.getType() instanceof ArrayType).collect(toImmutableSet());
-        }
-
         @Override
-        public PlanNode visitPlan(PlanNode node, RewriteContext<JoinContext> context)
+        public PlanNode visitPlan(PlanNode planNode, RewriteContext<JoinContext> context)
         {
-            return context.defaultRewrite(node, context.get());
+            // do a default rewrite with a new context for each child to avoid lateral propagation of context information
+            List<PlanNode> newChildren = planNode.getSources().stream().map(childNode -> context.rewrite(childNode, new JoinContext())).collect(Collectors.toList());
+            return replaceChildren(planNode, newChildren);
         }
 
         @Override
         public PlanNode visitJoin(JoinNode joinNode, RewriteContext<JoinContext> context)
         {
             final JoinContext joinContext = context.get();
-            int numJoinKeys = joinContext.getJoinKeys().size();
+            Set<VariableReferenceExpression> inputJoinKeys = joinContext.getJoinKeys();
             PlanNode leftNode = joinNode.getLeft();
             PlanNode rightNode = joinNode.getRight();
-            boolean isTopJoin = numJoinKeys == 0;
+
+            boolean isTopJoin = joinContext.getJoinKeys().size() == 0;
 
             ImmutableSet<VariableReferenceExpression> leftColumns = leftNode.getOutputVariables().stream().collect(toImmutableSet());
+
+            // abort rewrite if some of the collected join keys are in the RHS of the current join
+            ImmutableSet<VariableReferenceExpression> rightJoinKeys = inputJoinKeys.stream().filter(key -> rightNode.getOutputVariables().contains(key)).collect(toImmutableSet());
             Set<VariableReferenceExpression> joinKeys = extractJoinKeys(joinNode.getFilter(), joinNode.getCriteria());
 
             ImmutableSet<VariableReferenceExpression> leftJoinKeys = intersection(joinKeys, leftColumns).immutableCopy();
-            if (!needsRewrite(joinNode.getType(), leftColumns, leftJoinKeys)) {
-                return context.defaultRewrite(joinNode, joinContext);
+            if (!rightJoinKeys.isEmpty() || !needsRewrite(joinNode.getType(), leftColumns, leftJoinKeys)) {
+                List<PlanNode> newChildren = joinNode.getSources().stream()
+                        .map(child -> defaultRewriteJoinChild(child, context, joinNode.isCrossJoin()))
+                        .collect(toImmutableList());
+                return replaceChildren(joinNode, newChildren);
             }
 
             joinContext.addKeys(leftJoinKeys);
             joinContext.incrementNumJoins();
 
             PlanNode newLeftNode = context.rewrite(leftNode, joinContext);
-            if (leftNode == newLeftNode) {
+            if (leftNode.equals(newLeftNode)) {
                 newLeftNode = context.rewrite(leftNode, new JoinContext());
-                return joinNode.replaceChildren(ImmutableList.of(newLeftNode, rightNode));
+                return replaceChildren(joinNode, ImmutableList.of(newLeftNode, rightNode));
             }
 
             List<VariableReferenceExpression> leftCols = newLeftNode.getOutputVariables();
@@ -231,25 +235,32 @@ public class PayloadJoinOptimizer
 
             if (isTopJoin && context.get().needsPayloadRejoin()) {
                 PlanNode payloadJoin = transformJoin(newJoinNode, joinContext);
+                // reset payload node as it has been reattached to the plan node
+                context.get().setPayloadNode(null);
+
                 // do a final check that the rewrite didn't lose any columns (can happen if there are intermediate projections on non-join keys that get hidden because of the DISTINCT keys computation)
-                if (!payloadJoin.getOutputVariables().containsAll(joinNode.getOutputVariables())) {
+                List<VariableReferenceExpression> outputVariables = joinNode.getOutputVariables();
+                if (!payloadJoin.getOutputVariables().containsAll(outputVariables)) {
                     return joinNode;
                 }
-                return payloadJoin;
+                return restrictOutput(payloadJoin, planNodeIdAllocator, outputVariables);
             }
 
             return newJoinNode;
         }
 
+        private PlanNode defaultRewriteJoinChild(PlanNode child, RewriteContext<JoinContext> context, boolean isCrossJoin)
+        {
+            PlanNode newChild = context.rewrite(child, new JoinContext());
+            if (isCrossJoin && child.getOutputVariables() != newChild.getOutputVariables()) {
+                return restrictOutput(newChild, planNodeIdAllocator, child.getOutputVariables());
+            }
+            return newChild;
+        }
+
         private boolean needsRewrite(JoinNode.Type joinType, ImmutableSet<VariableReferenceExpression> leftColumns, Set<VariableReferenceExpression> joinKeys)
         {
-            if (joinType == JoinNode.Type.LEFT && supportedJoinKeyTypes(joinKeys)) {
-                Set<VariableReferenceExpression> leftPayloadColumns = extractPayloadColumns(leftColumns);
-
-                return !leftPayloadColumns.isEmpty() && !leftPayloadColumns.containsAll(joinKeys);
-            }
-
-            return false;
+            return joinType == LEFT && supportedJoinKeyTypes(joinKeys) && leftColumns.stream().anyMatch(var -> !joinKeys.contains(var));
         }
 
         @Override
@@ -261,24 +272,17 @@ public class PayloadJoinOptimizer
 
             PlanNode child = projectNode.getSource();
 
-            Set<VariableReferenceExpression> joinKeys = context.get().getJoinKeys();
-            Assignments newAssignments = projectNode.getAssignments();
-            if (!child.getOutputVariables().containsAll(joinKeys)) {
-                Assignments.Builder assignments = Assignments.builder();
+            Set<VariableReferenceExpression> inputJoinKeys = context.get().getJoinKeys();
+            if (!child.getOutputVariables().containsAll(inputJoinKeys)) {
                 Map<VariableReferenceExpression, RowExpression> pushableExpressions = new HashMap<>();
 
                 projectNode.getAssignments().forEach((var, expr) -> {
-                    if (joinKeys.contains(var) && !var.equals(expr)) {
+                    if (inputJoinKeys.contains(var) && !var.equals(expr)) {
                         // join key computed in this projection: need to push down
-                        assignments.put(var, var);
                         pushableExpressions.put(var, expr);
-                    }
-                    else {
-                        assignments.put(var, expr);
                     }
                 });
 
-                newAssignments = assignments.build();
                 context.get().addProjectionsToPush(pushableExpressions);
             }
 
@@ -286,6 +290,26 @@ public class PayloadJoinOptimizer
 
             if (child.equals(newChild)) {
                 return projectNode;
+            }
+
+            // remove assignments that were pushed down
+            Set<VariableReferenceExpression> joinKeys = context.get().getJoinKeys();
+
+            Assignments newAssignments = projectNode.getAssignments();
+            if (context.get().needsPayloadRejoin() && !child.getOutputVariables().containsAll(joinKeys)) {
+                Assignments.Builder assignments = Assignments.builder();
+
+                projectNode.getAssignments().forEach((var, expr) -> {
+                    if (joinKeys.contains(var) && !var.equals(expr)) {
+                        // join key computed in this projection: need to push down
+                        assignments.put(var, var);
+                    }
+                    else {
+                        assignments.put(var, expr);
+                    }
+                });
+
+                newAssignments = assignments.build();
             }
 
             Set<VariableReferenceExpression> newChildOutputVarSet = newChild.getOutputVariables().stream().collect(toImmutableSet());
@@ -300,18 +324,11 @@ public class PayloadJoinOptimizer
         @Override
         public PlanNode visitFilter(FilterNode filterNode, RewriteContext<JoinContext> context)
         {
-            Set<VariableReferenceExpression> joinKeys = context.get().getJoinKeys();
-            List<VariableReferenceExpression> predicateVars = VariablesExtractor.extractAll(filterNode.getPredicate());
-
             if (isScanFilterProject(filterNode)) {
                 return rewriteScanFilterProject(filterNode, context);
             }
 
-            if (joinKeys.isEmpty() || joinKeys.containsAll(predicateVars)) {
-                return context.defaultRewrite(filterNode, context.get());
-            }
-
-            return filterNode;
+            return context.defaultRewrite(filterNode, new JoinContext());
         }
 
         @Override
@@ -495,7 +512,7 @@ public class PayloadJoinOptimizer
 
     private static class JoinContext
     {
-        private final Set<VariableReferenceExpression> joinKeys = new HashSet<>();
+        private Set<VariableReferenceExpression> joinKeys = new HashSet<>();
         private Map<VariableReferenceExpression, VariableReferenceExpression> joinKeyMap;
         private Map<VariableReferenceExpression, RowExpression> projectionsToPush = new HashMap<>();
 
@@ -544,6 +561,14 @@ public class PayloadJoinOptimizer
             this.payloadNode = payloadNode;
         }
 
+        public void reset()
+        {
+            joinKeys = new HashSet<>();
+            projectionsToPush = new HashMap<>();
+            joinKeyMap = null;
+            numJoins = 0;
+            payloadNode = null;
+        }
         public int getNumJoins()
         {
             return numJoins;

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
@@ -195,7 +195,13 @@ public class TestSingleStoreDistributedQueries
     }
 
     @Override
-    public void testPayloadJoins()
+    public void testPayloadJoinApplicability()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+
+    @Override
+    public void testPayloadJoinCorrectness()
     {
         // no op -- test not supported due to lack of support for array types.
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -33,6 +33,8 @@ import io.airlift.units.Duration;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -64,6 +66,7 @@ import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.tests.QueryAssertions.assertContains;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.airlift.units.Duration.nanosSince;
@@ -1224,11 +1227,10 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
-    public void testPayloadJoins()
+    public void testPayloadJoinApplicability()
     {
         Session sessionNoOpt = Session.builder(getSession())
                 .setSystemProperty(OPTIMIZE_PAYLOAD_JOINS, "false")
-                // TODO: fix payload join optimizer so that it will not fail when REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN is set to true
                 .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "false")
                 .build();
 
@@ -1240,27 +1242,7 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("create table lineitem_map as select *, map(ARRAY[1,3], ARRAY[2,4]) as m1, map(ARRAY[1,3], ARRAY[2,4]) as m2 from lineitem", 60175);
         assertUpdate("create table part_map as select *, map(ARRAY[1,3], ARRAY[2,4]) as m3, map(ARRAY[1,3], ARRAY[2,4]) as m4 from part", 2000);
 
-        String[] queries = {
-                "SELECT l.* FROM lineitem_map l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)",
-                "SELECT l.* FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-                "SELECT l.*, p.m3 FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join (select *, map(array[1,2], array[11,22]) as m3 from part) p on (l.partkey=p.partkey)",
-                "SELECT l.*, p.m3 FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join (select *, map(array[partkey], array[size]) as m3 from part) p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select * from lineitem_map where linenumber < 9) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select * from lineitem_map where orderkey <= 60000) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-                "SELECT cast (l.orderkey as int) as orderkey, l.partkey, MAP_CONCAT(CAST(l.m1 as map<int, real> ), cast(l.m2 as map<int, real>)) as m2 FROM (select * from lineitem_map) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-
-                "SELECT l.orderkey, l.partkey, MAP_CONCAT(CAST(l.m1 as map<int, real> ), cast(l.m2 as map<int, real>)) as m2 FROM (select * from lineitem_map where linenumber < 9) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-
-                "SELECT l.*, p.m3, p.m4 FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
-                "SELECT l.*, p.m3, p.m4 FROM lineitem_map l left join orders o on (l.orderkey+1= o.orderkey+1) left join part_map p on (l.partkey=p.partkey)",
-                "SELECT l.*, p.m3, p.m4 FROM lineitem_map l left join orders o on (cast(l.orderkey as int) = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select orderkey+1 as ok1, * from lineitem_map) l left join orders o on (l.ok1 = o.orderkey+1) left join part p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem_map) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
-                "with lm as (select quantity + 1 as q1, * from lineitem_map) SELECT l.* FROM (select * from lm) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
-                // This is the query which fail when REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN set to true
-                "SELECT l.* FROM lineitem_map l left join orders o on (cast(l.orderkey as varchar) = cast(o.orderkey as varchar)) left join part p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem_map) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)"
-        };
+        final List<String> queries = getPayloadQueries("lineitem_map");
 
         for (String query : queries) {
             MaterializedResult resultExplainQuery = computeActual(session, "EXPLAIN " + query);
@@ -1273,13 +1255,23 @@ public abstract class AbstractTestDistributedQueries
             assertEquals(materializedRows.getRowCount(), 60175);
         }
 
-        // Queries that we don't handle because of projections or lack of payload columns
+        // Queries that we don't handle because of unsupported operators or because intermediate queries use columns that will be hidden by the rewrite
         String[] nonOptimizableQueries = {
+                "SELECT l.* FROM (select * from lineitem inner join part using (partkey) where orderkey <= 60000) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
                 "with lm as (select if (quantity > 1, quantity, 1) as q1, * from lineitem_map), lm2 as (select if (q1 > 2, q1, 1) as q2, quantity,partkey,suppkey,linenumber,m1,m2 from lm left join orders o on (lm.orderkey=o.orderkey)) SELECT l.* FROM (select q2+3 as q3,partkey,suppkey,linenumber,m1,m2 from lm2) l left join part p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select rand(100) as pk100 from (select orderkey+1 as ok1, * from lineitem_map) l left join orders o on (l.ok1 = o.orderkey+1)) l left join part p on (l.pk100=p.partkey)",
-                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from lineitem) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
-                "SELECT l.*, p.m3, p.m4 FROM (select * from lineitem_map where false) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
-                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)"
+                "SELECT l.* FROM (select rand(100) as pk100 from (select orderkey+1 as ok1, * from lineitem) l left join orders o on (l.ok1 = o.orderkey+1)) l left join part p on (l.pk100=p.partkey)",
+                "SELECT l.*, p.m3, p.m4 FROM (select * from lineitem where false) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select distinct orderkey, partkey, quantity from lineitem) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select orderkey, partkey, sum(tax) as ss from lineitem group by orderkey, partkey) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select orderkey, partkey, sum(1) as ss from lineitem group by orderkey, partkey, suppkey) l left join orders o on (l.orderkey = o.orderkey) left join part_map p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select distinct orderkey, partkey from lineitem) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select orderkey, partkey, sum(1) as ss from lineitem group by orderkey, partkey) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)",
+                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) inner join part p on (l.partkey+1=p.partkey+1)",
+                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l inner join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)",
+                "SELECT l.* FROM (select m1, orderkey,partkey from lineitem_map where false) l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1) union select m1, orderkey,partkey from lineitem_map",
+                "SELECT l.* FROM (SELECT partkey,orderkey FROM UNNEST(ARRAY[1, 2], ARRAY[3, 4]) t(orderkey, partkey)) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select orderkey, partkey, count(*) from (select l.* from lineitem_map l left join orders o on (l.orderkey = o.orderkey)) group by orderkey, partkey) l left join part p on (l.partkey=p.partkey)",
         };
 
         for (String query : nonOptimizableQueries) {
@@ -1292,6 +1284,62 @@ public abstract class AbstractTestDistributedQueries
 
         MaterializedResult countStarQuery = computeActual(session, "select count(t.m1) from (SELECT l.* FROM lineitem_map l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)) t");
         assertEquals((Long) countStarQuery.getOnlyValue(), Long.valueOf(60175L));
+    }
+
+    @Test
+    public void testPayloadJoinCorrectness()
+    {
+        Session sessionNoOpt = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_PAYLOAD_JOINS, "false")
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "false")
+                .build();
+
+        Session session = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_PAYLOAD_JOINS, "true")
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "false")
+                .build();
+
+        assertUpdate("create table lineitem_small as select *, map(ARRAY[1,3], ARRAY[2,4]) as m1, map(ARRAY[1,3], ARRAY[2,4]) as m2 from lineitem order by partkey, orderkey limit 1000", 1000);
+
+        final List<String> queries = getPayloadQueries("lineitem_small");
+
+        for (String query : queries) {
+            MaterializedResult resultExplainQuery = computeActual(session, "EXPLAIN " + query);
+            MaterializedResult resultExplainQueryNoOpt = computeActual(sessionNoOpt, "EXPLAIN " + query);
+            String explainNoOpt = sanitizePlan((String) getOnlyElement(resultExplainQueryNoOpt.getOnlyColumnAsSet()));
+            String explainWithOpt = sanitizePlan((String) getOnlyElement(resultExplainQuery.getOnlyColumnAsSet()));
+            assertNotEquals(explainWithOpt, explainNoOpt, "Couldn't optimize query: " + query);
+            assertQueryWithSameQueryRunner(session, query, sessionNoOpt);
+        }
+    }
+
+    private static List<String> getPayloadQueries(String tableName)
+    {
+        String[] queries = {
+                "SELECT l.* FROM LINEITEM_TABLE l left join orders o on (l.orderkey+1 = o.orderkey+1) left join part p on (l.partkey+1=p.partkey+1)",
+                "SELECT l.* FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.*, p.m3 FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join (select *, map(array[1,2], array[11,22]) as m3 from part) p on (l.partkey=p.partkey)",
+                "SELECT l.*, p.m3 FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join (select *, map(array[partkey], array[size]) as m3 from part) p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select * from LINEITEM_TABLE where linenumber < 9) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select * from LINEITEM_TABLE where orderkey <= 60000) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT cast (l.orderkey as int) as orderkey, l.partkey, MAP_CONCAT(CAST(l.m1 as map<int, real> ), cast(l.m2 as map<int, real>)) as m2 FROM (select * from LINEITEM_TABLE) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+
+                "SELECT l.orderkey, l.partkey, MAP_CONCAT(CAST(l.m1 as map<int, real> ), cast(l.m2 as map<int, real>)) as m2 FROM (select * from LINEITEM_TABLE where linenumber < 9) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+
+                "SELECT l.*, p.m3, p.m4 FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join (select *, map(ARRAY[1,3], ARRAY[2,4]) as m3, map(ARRAY[1,3], ARRAY[2,4]) as m4 from part) p on (l.partkey=p.partkey) union all SELECT l.*,map(ARRAY[1,3], ARRAY[2,4]),map(ARRAY[1,3], ARRAY[2,4]) FROM LINEITEM_TABLE l where false",
+                "SELECT l.*, p.brand, p.size FROM LINEITEM_TABLE l left join orders o on (l.orderkey+1= o.orderkey+1) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.*, p.brand, p.size FROM LINEITEM_TABLE l left join orders o on (cast(l.orderkey as int) = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select orderkey+1 as ok1, * from LINEITEM_TABLE) l left join orders o on (l.ok1 = o.orderkey+1) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from LINEITEM_TABLE) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
+                "with lm as (select quantity + 1 as q1, * from LINEITEM_TABLE) SELECT l.* FROM (select * from lm) l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from LINEITEM_TABLE) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
+                "SELECT l.* FROM LINEITEM_TABLE l left join orders o on (cast(l.orderkey as varchar) = cast(o.orderkey as varchar)) left join part p on (l.partkey=p.partkey)",
+                "SELECT l.* FROM (select *, cast(orderkey as int) as ok from LINEITEM_TABLE) l left join (select *, cast(orderkey as int) as ok from orders) o on (l.ok = o.ok) left join (select *, cast(partkey as int) as pk from part) p on (l.ok=p.pk)",
+                "SELECT l.* FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey) left join (select 1 as m) mm on p.partkey=mm.m",
+                "SELECT l.* FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey) left join (select 1 as m) mm on p.partkey+1=mm.m",
+                "select * from (SELECT l.* FROM LINEITEM_TABLE l left join orders o on (l.orderkey = o.orderkey) left join part p on (l.partkey=p.partkey)) t, (select * from nation where name='JAPAN')",
+        };
+        return Arrays.stream(queries).map(q -> q.replace("LINEITEM_TABLE", tableName)).collect(toImmutableList());
     }
 
     @Test
@@ -1452,6 +1500,11 @@ public abstract class AbstractTestDistributedQueries
 
     private String sanitizePlan(String explain)
     {
-        return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX").replaceAll("\\[PlanNodeId (\\d+(?:,\\d+)*)\\]", "").replaceAll("Values => .*\n", "\n");
+        return explain
+                .replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX")
+                .replaceAll("hashvalue_[0-9][0-9]", "hashvalueXXX")
+                .replaceAll("sum_[0-9][0-9]", "sumXXX")
+                .replaceAll("\\[PlanNodeId (\\d+(?:,\\d+)*)\\]", "")
+                .replaceAll("Values => .*\n", "\n");
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -169,6 +169,10 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuery(queryRunner, session, actual, queryRunner, expected, false, false);
     }
 
+    protected void assertQueryWithSameQueryRunner(Session actualSession, @Language("SQL") String query, Session expectedSession)
+    {
+        QueryAssertions.assertQuery(queryRunner, actualSession, query, queryRunner, expectedSession, query, false, false);
+    }
     protected void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, expectedQueryRunner, expected, false, false);
@@ -189,11 +193,6 @@ public abstract class AbstractTestQueryFramework
     {
         checkArgument(queryRunner instanceof DistributedQueryRunner, "pattern assertion is only supported for DistributedQueryRunner");
         QueryAssertions.assertQuery(queryRunner, session, actual, expectedQueryRunner, expected, false, false, planAssertion);
-    }
-
-    protected void assertQueryWithSameQueryRunner(Session actualSession, @Language("SQL") String query, Session expectedSession)
-    {
-        QueryAssertions.assertQuery(queryRunner, actualSession, query, queryRunner, expectedSession, query, false, false);
     }
 
     public void assertQueryOrdered(@Language("SQL") String sql)


### PR DESCRIPTION
A collection of bug fixes for the payload join optimization, including the following:
+ fixed cases where not all collected join keys belong to the left-most table
+ abort optimization if the rewrite hides required columns
+ abort rewrite for operators other than Select/Project/Scan/Join. This fixes wrong result bugs when the query contains aggregates and other operators that may change the cardinality of intermediate levels
+ remove restriction for the fact table to have map or array columns. In the future we'll incorporate HBO to make a cost-based decision when to apply this optimization