### PR TITLE
[native]Add register file sink interface to presto server

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -98,6 +98,10 @@ class PrestoServer {
   virtual std::vector<std::string> registerConnectors(
       const fs::path& configDirectoryPath);
 
+  /// Invoked to register the required dwio data sinks which are used by
+  /// connectors.
+  virtual void registerFileSinks() {}
+
   /// Invoked by presto shutdown procedure to unregister connectors.
   virtual void unregisterConnectors();
 


### PR DESCRIPTION
We need have register file sinks interface to allow register meta
internal file sinks.

```
== NO RELEASE NOTE ==
```
