### PR TITLE
[native] Add retry logic to Spark tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -35,6 +35,22 @@ workflows:
       - header-check
       - linux-parquet-S3-build
 
+commands:
+  maven_install:
+    description: "Maven Install"
+    parameters:
+      maven_install_opts:
+        type: string
+      maven_fast_install:
+        type: string
+    steps:
+      - run:
+          name: "Maven Install"
+          command: |
+            export MAVEN_OPTS=<< parameters.maven_install_opts>>
+            # Sometimes mvn build fails because of network failures. Add logic to rerun the build to avoid non PR-relelated CI failures.
+            for i in $(seq 1 3); do ./mvnw clean install << parameters.maven_fast_install>> -pl 'presto-native-execution' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
+
 executors:
   build:
     docker:
@@ -103,12 +119,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: presto-native-execution
-      - run:
-          name: 'Maven Install'
-          command: |
-            export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-            # Sometimes mvn build fails because of network failures. Add logic to rerun the build to avoid non PR-relelated CI failures.
-            for i in $(seq 1 3); do ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
+      - maven_install:
+          maven_install_opts: ${MAVEN_INSTALL_OPTS}
+          maven_fast_install: ${MAVEN_FAST_INSTALL}
+
       - run:
           name: 'Run presto-native e2e tests'
           command: |
@@ -135,11 +149,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: presto-native-execution
-      - run:
-          name: 'Maven Install'
-          command: |
-            export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-            ./mvnw clean install ${MAVEN_FAST_INSTALL} -pl 'presto-native-execution' -am
+      - maven_install:
+          maven_install_opts: ${MAVEN_INSTALL_OPTS}
+          maven_fast_install: ${MAVEN_FAST_INSTALL}
       - run:
           name: 'Run spark e2e tests'
           command: |


### PR DESCRIPTION
Maven install may fail while downloading packages. Add retry logic to avoid failures caused by network connection.

Test plan - Make sure CircleCi tests pass


```
== NO RELEASE NOTE ==
```
