### PR TITLE
[native] Add support for ValuesNode with expressions

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -15,6 +15,7 @@
 #include "presto_cpp/main/QueryContextManager.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "presto_cpp/main/common/Configs.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
 
@@ -47,6 +48,49 @@ folly::CPUThreadPoolExecutor* driverCPUExecutor() {
 
 folly::IOThreadPoolExecutor* spillExecutorPtr() {
   return spillExecutor().get();
+}
+
+namespace {
+std::unordered_map<std::string, std::string> toConfigs(
+    const protocol::SessionRepresentation& session) {
+  // Use base velox query config as the starting point and add Presto session
+  // properties on top of it.
+  auto configs = BaseVeloxQueryConfig::instance()->values();
+  for (const auto& it : session.systemProperties) {
+    configs[it.first] = it.second;
+  }
+
+  // If there's a timeZoneKey, convert to timezone name and add to the
+  // configs. Throws if timeZoneKey can't be resolved.
+  if (session.timeZoneKey != 0) {
+    configs.emplace(
+        velox::core::QueryConfig::kSessionTimezone,
+        velox::util::getTimeZoneName(session.timeZoneKey));
+  }
+  return configs;
+}
+
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+toConnectorConfigs(const protocol::SessionRepresentation& session) {
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      connectorConfigs;
+  for (const auto& entry : session.catalogProperties) {
+    connectorConfigs.insert(
+        {entry.first,
+         std::unordered_map<std::string, std::string>(
+             entry.second.begin(), entry.second.end())});
+  }
+
+  return connectorConfigs;
+}
+} // namespace
+
+std::shared_ptr<velox::core::QueryCtx>
+QueryContextManager::findOrCreateQueryCtx(
+    const protocol::TaskId& taskId,
+    const protocol::SessionRepresentation& session) {
+  return findOrCreateQueryCtx(
+      taskId, toConfigs(session), toConnectorConfigs(session));
 }
 
 std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -107,11 +107,7 @@ class QueryContextManager {
 
   std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(
       const protocol::TaskId& taskId,
-      std::unordered_map<std::string, std::string>&& configStrings,
-      std::unordered_map<
-          std::string,
-          std::unordered_map<std::string, std::string>>&&
-          connectorConfigStrings);
+      const protocol::SessionRepresentation& session);
 
   // Calls the given functor for every present query context.
   void visitAllContexts(std::function<void(
@@ -119,6 +115,14 @@ class QueryContextManager {
                             const velox::core::QueryCtx*)> visitor) const;
 
  private:
+  std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(
+      const protocol::TaskId& taskId,
+      std::unordered_map<std::string, std::string>&& configStrings,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::string>>&&
+          connectorConfigStrings);
+
   folly::Synchronized<QueryContextCache> queryContextCache_;
 };
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -25,7 +25,6 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
-#include "velox/type/tz/TimeZoneMap.h"
 
 DEFINE_int32(
     old_task_ms,
@@ -248,38 +247,6 @@ void TaskManager::getDataForResultRequests(
 }
 
 namespace {
-std::unordered_map<std::string, std::string> toConfigs(
-    const protocol::SessionRepresentation& session) {
-  // Use base velox query config as the starting point and add Presto session
-  // properties on top of it.
-  auto configs = BaseVeloxQueryConfig::instance()->values();
-  for (const auto& it : session.systemProperties) {
-    configs[it.first] = it.second;
-  }
-
-  // If there's a timeZoneKey, convert to timezone name and add to the
-  // configs. Throws if timeZoneKey can't be resolved.
-  if (session.timeZoneKey != 0) {
-    configs.emplace(
-        velox::core::QueryConfig::kSessionTimezone,
-        velox::util::getTimeZoneName(session.timeZoneKey));
-  }
-  return configs;
-}
-
-std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-toConnectorConfigs(const protocol::SessionRepresentation& session) {
-  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-      connectorConfigs;
-  for (const auto& entry : session.catalogProperties) {
-    connectorConfigs.insert(
-        {entry.first,
-         std::unordered_map<std::string, std::string>(
-             entry.second.begin(), entry.second.end())});
-  }
-
-  return connectorConfigs;
-}
 
 /// Presto-on-Spark is expected to specify all splits at once along with
 /// no-more-splits flag. Verify that all plan nodes that require splits
@@ -316,35 +283,31 @@ void checkSplitsForBatchTask(
 std::unique_ptr<protocol::TaskInfo> TaskManager::createOrUpdateTask(
     const protocol::TaskId& taskId,
     const protocol::TaskUpdateRequest& updateRequest,
-    const velox::core::PlanFragment& planFragment) {
-  const auto& session = updateRequest.session;
-
+    const velox::core::PlanFragment& planFragment,
+    std::shared_ptr<velox::core::QueryCtx> queryCtx) {
   return createOrUpdateTask(
       taskId,
       planFragment,
       updateRequest.sources,
       updateRequest.outputIds,
-      toConfigs(session),
-      toConnectorConfigs(session));
+      queryCtx);
 }
 
 std::unique_ptr<protocol::TaskInfo> TaskManager::createOrUpdateBatchTask(
     const protocol::TaskId& taskId,
     const protocol::BatchTaskUpdateRequest& batchUpdateRequest,
-    const velox::core::PlanFragment& planFragment) {
+    const velox::core::PlanFragment& planFragment,
+    std::shared_ptr<velox::core::QueryCtx> queryCtx) {
   auto updateRequest = batchUpdateRequest.taskUpdateRequest;
 
   checkSplitsForBatchTask(planFragment.planNode, updateRequest.sources);
-
-  const auto& session = updateRequest.session;
 
   return createOrUpdateTask(
       taskId,
       planFragment,
       updateRequest.sources,
       updateRequest.outputIds,
-      toConfigs(session),
-      toConnectorConfigs(session));
+      std::move(queryCtx));
 }
 
 std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
@@ -352,11 +315,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
     const velox::core::PlanFragment& planFragment,
     const std::vector<protocol::TaskSource>& sources,
     const protocol::OutputBuffers& outputBuffers,
-    std::unordered_map<std::string, std::string>&& configStrings,
-    std::unordered_map<
-        std::string,
-        std::unordered_map<std::string, std::string>>&&
-        connectorConfigStrings) {
+    std::shared_ptr<velox::core::QueryCtx> queryCtx) {
   std::shared_ptr<exec::Task> execTask;
   bool startTask = false;
   auto prestoTask = findOrCreateTask(taskId);
@@ -368,9 +327,6 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
       if (prestoTask->info.taskStatus.state == protocol::TaskState::ABORTED) {
         return std::make_unique<TaskInfo>(prestoTask->updateInfoLocked());
       }
-
-      auto queryCtx = queryContextManager_.findOrCreateQueryCtx(
-          taskId, std::move(configStrings), std::move(connectorConfigStrings));
 
       execTask = exec::Task::create(
           taskId, planFragment, prestoTask->id.id(), std::move(queryCtx));

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -58,12 +58,14 @@ class TaskManager {
   std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
       const protocol::TaskId& taskId,
       const protocol::TaskUpdateRequest& updateRequest,
-      const velox::core::PlanFragment& planFragment);
+      const velox::core::PlanFragment& planFragment,
+      std::shared_ptr<velox::core::QueryCtx> queryCtx);
 
   std::unique_ptr<protocol::TaskInfo> createOrUpdateBatchTask(
       const protocol::TaskId& taskId,
       const protocol::BatchTaskUpdateRequest& batchUpdateRequest,
-      const velox::core::PlanFragment& planFragment);
+      const velox::core::PlanFragment& planFragment,
+      std::shared_ptr<velox::core::QueryCtx> queryCtx);
 
   // Iterates through a map of resultRequests and fetches data from
   // buffer manager. This method uses the getData() global call to fetch
@@ -152,11 +154,7 @@ class TaskManager {
       const velox::core::PlanFragment& planFragment,
       const std::vector<protocol::TaskSource>& sources,
       const protocol::OutputBuffers& outputBuffers,
-      std::unordered_map<std::string, std::string>&& configStrings,
-      std::unordered_map<
-          std::string,
-          std::unordered_map<std::string, std::string>>&&
-          connectorConfigStrings);
+      std::shared_ptr<velox::core::QueryCtx> queryCtx);
 
   std::shared_ptr<PrestoTask> findOrCreateTask(const protocol::TaskId& taskId);
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1380,6 +1380,19 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 
+velox::VectorPtr VeloxQueryPlanConverterBase::evaluateConstantExpression(
+    const velox::core::TypedExprPtr& expression) {
+  auto emptyRowVector = BaseVector::create<RowVector>(ROW({}), 1, pool_);
+  core::ExecCtx execCtx{pool_, queryCtx_};
+  exec::ExprSet exprSet{{expression}, &execCtx};
+  exec::EvalCtx context(&execCtx, &exprSet, emptyRowVector.get());
+
+  SelectivityVector rows{1};
+  std::vector<VectorPtr> result(1);
+  exprSet.eval(rows, context, result);
+  return result[0];
+}
+
 std::shared_ptr<const core::ValuesNode>
 VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::ValuesNode>& node,
@@ -1408,11 +1421,15 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
         if (!constantExpr->hasValueVector()) {
           setCellFromVariant(rowVector, row, column, constantExpr->value());
         } else {
-          auto columnVector = rowVector->childAt(column);
+          auto& columnVector = rowVector->childAt(column);
           columnVector->copy(constantExpr->valueVector().get(), row, 0, 1);
         }
       } else {
-        VELOX_FAIL("Expected constant expression");
+        // Evaluate the expression.
+        auto value = evaluateConstantExpression(expr);
+
+        auto& columnVector = rowVector->childAt(column);
+        columnVector->copy(value.get(), row, 0, 1);
       }
     }
   }

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -64,7 +64,8 @@ std::shared_ptr<const core::PlanNode> assertToVeloxQueryPlan(
   protocol::PlanFragment prestoPlan = json::parse(fragment);
   auto pool = memory::addDefaultLeafMemoryPool();
 
-  VeloxInteractiveQueryPlanConverter converter(pool.get());
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
   return converter
       .toVeloxQueryPlan(
           prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3")
@@ -79,8 +80,12 @@ std::shared_ptr<const core::PlanNode> assertToBatchVeloxQueryPlan(
 
   protocol::PlanFragment prestoPlan = json::parse(fragment);
   auto pool = memory::addDefaultLeafMemoryPool();
+  auto queryCtx = std::make_shared<core::QueryCtx>();
   VeloxBatchQueryPlanConverter converter(
-      shuffleName, std::move(serializedShuffleWriteInfo), pool.get());
+      shuffleName,
+      std::move(serializedShuffleWriteInfo),
+      queryCtx.get(),
+      pool.get());
   return converter
       .toVeloxQueryPlan(
           prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3")

--- a/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
@@ -65,7 +65,8 @@ TEST_F(TestValues, valuesRowVector) {
   testJsonRoundtrip(j, p);
 
   auto pool = memory::addDefaultLeafMemoryPool();
-  VeloxInteractiveQueryPlanConverter converter(pool.get());
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
   auto values = std::dynamic_pointer_cast<const core::ValuesNode>(
       converter.toVeloxQueryPlan(
           std::dynamic_pointer_cast<protocol::PlanNode>(p),
@@ -104,7 +105,8 @@ TEST_F(TestValues, valuesPlan) {
   testJsonRoundtrip(j, p);
 
   auto pool = memory::addDefaultLeafMemoryPool();
-  VeloxInteractiveQueryPlanConverter converter(pool.get());
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
   auto values = converter.toVeloxQueryPlan(
       std::dynamic_pointer_cast<protocol::OutputNode>(p->root)->source,
       nullptr,

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -384,6 +384,9 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT * FROM (VALUES (map(array[1, 2, 3], array[10, 20, 30]))) as t(a)");
 
         assertQuery("SELECT BIGINT '12345', INTEGER '1234', SMALLINT '123', TINYINT '12', TRUE, FALSE, DOUBLE '1.234', REAL '1.23', 'ABC', 'Somewhat longish string', NULL, array[1, 2, 3]");
+
+        // Test ValuesNode with expressions.
+        assertQuery("SELECT * FROM UNNEST(sequence(1, 10000), sequence(5, 10000)) as t(x, y)");
     }
 
     @Test


### PR DESCRIPTION
Sometimes ValuesNode contains expressions and not constants. In these case, we need to evaluate the expressions during plan coversion.

Before this change, a query like

  SELECT * FROM UNNEST(sequence(1, 10000)) as t(x)

failed with VeloxRuntimeError:  Expected constant expression

See #13499 for additional context.

```
== NO RELEASE NOTE ==
```
