### PR TITLE
[native pos] Change thread pool initial size to 1 to reduce the CPU usage

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -384,7 +384,8 @@ public class PrestoSparkModule
         ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("presto-spark-executor-%s"));
         binder.bind(Executor.class).toInstance(executor);
         binder.bind(ExecutorService.class).toInstance(executor);
-        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(0, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
+        // Set the initial thread pool size to 1 (instead of 0) to avoid the thread pool hogging CPU due to JDK8 bug: https://bugs.openjdk.org/browse/JDK-8129861
+        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(1, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
 
         // task executor
         binder.bind(EmbedVersion.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
We used to set the inital thread pool size to 0 which triggers the JDK8 bug[1] causing high CPU usage during query execution. By setting the size to 1, we're seeing the same query running with 50% less of the CPU time during the end-to-end execution.

[1] High processor load for ScheduledThreadPoolExecutor with 0 core threads
 https://bugs.openjdk.org/browse/JDK-8129861

```
== NO RELEASE NOTE ==
```
