### PR TITLE
Calculate the cost of cross joins

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractCostBasedPlanTest
     @Test(dataProvider = "getQueriesDataProvider")
     public void test(String queryResourcePath)
     {
-        assertEquals(generateQueryPlan(read(queryResourcePath)), read(getQueryPlanResourcePath(queryResourcePath)));
+        assertEquals(generateQueryPlan(read(queryResourcePath)), read(getQueryPlanResourcePath(queryResourcePath)), getSql(read(queryResourcePath)));
     }
 
     private String getQueryPlanResourcePath(String queryResourcePath)
@@ -117,12 +117,16 @@ public abstract class AbstractCostBasedPlanTest
         }
     }
 
-    private String generateQueryPlan(String query)
-    {
-        String sql = query.replaceAll("\\s+;\\s+$", "")
+    String getSql(String query) {
+        return query.replaceAll("\\s+;\\s+$", "")
                 .replace("${database}.${schema}.", "")
                 .replace("\"${database}\".\"${schema}\".\"${prefix}", "\"");
-        Plan plan = plan(sql, OPTIMIZED_AND_VALIDATED, false);
+    }
+
+
+    private String generateQueryPlan(String query)
+    {
+        Plan plan = plan(getSql(query), OPTIMIZED_AND_VALIDATED, false);
 
         JoinOrderPrinter joinOrderPrinter = new JoinOrderPrinter();
         plan.getRoot().accept(joinOrderPrinter, 0);

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -274,6 +274,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN = "rewrite_cross_join_or_to_inner_join";
     public static final String REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN = "rewrite_cross_join_array_contains_to_inner_join";
     public static final String REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN = "rewrite_left_join_null_filter_to_semi_join";
+    public static final String CALCULATE_CROSS_JOIN_COST = "calculate_cross_join_cost";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1465,16 +1466,16 @@ public final class SystemSessionProperties
                 stringProperty(
                         NATIVE_EXECUTION_PROGRAM_ARGUMENTS,
                         "Program arguments for native engine execution. The main target use case for this " +
-                        "property is to control logging levels using glog flags. E,g, to enable verbose mode, add " +
-                        "'--v 1'. More advanced glog gflags usage can be found at " +
-                        "https://rpg.ifi.uzh.ch/docs/glog.html\n" +
-                        "e.g. --vmodule=mapreduce=2,file=1,gfs*=3 --v=0\n" +
-                        "will:\n" +
-                        "\n" +
-                        "a. Print VLOG(2) and lower messages from mapreduce.{h,cc}\n" +
-                        "b. Print VLOG(1) and lower messages from file.{h,cc}\n" +
-                        "c. Print VLOG(3) and lower messages from files prefixed with \"gfs\"\n" +
-                        "d. Print VLOG(0) and lower messages from elsewhere",
+                                "property is to control logging levels using glog flags. E,g, to enable verbose mode, add " +
+                                "'--v 1'. More advanced glog gflags usage can be found at " +
+                                "https://rpg.ifi.uzh.ch/docs/glog.html\n" +
+                                "e.g. --vmodule=mapreduce=2,file=1,gfs*=3 --v=0\n" +
+                                "will:\n" +
+                                "\n" +
+                                "a. Print VLOG(2) and lower messages from mapreduce.{h,cc}\n" +
+                                "b. Print VLOG(1) and lower messages from file.{h,cc}\n" +
+                                "c. Print VLOG(3) and lower messages from files prefixed with \"gfs\"\n" +
+                                "d. Print VLOG(0) and lower messages from elsewhere",
                         featuresConfig.getNativeExecutionProgramArguments(),
                         false),
                 booleanProperty(
@@ -1591,6 +1592,11 @@ public final class SystemSessionProperties
                         REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN,
                         "Rewrite left join with is null check to semi join",
                         featuresConfig.isLeftJoinNullFilterToSemiJoin(),
+                        false),
+                booleanProperty(
+                        CALCULATE_CROSS_JOIN_COST,
+                        "calculate the cost of cross joins when optimizing the query plan rather than assume infinite cost",
+                        false,
                         false));
     }
 
@@ -2192,6 +2198,7 @@ public final class SystemSessionProperties
         }
         return intValue;
     }
+
     private static Double validateDoubleValueWithinSelectivityRange(Object value, String property)
     {
         Double number = (Double) value;
@@ -2673,5 +2680,10 @@ public final class SystemSessionProperties
     public static boolean isRewriteLeftJoinNullFilterToSemiJoinEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN, Boolean.class);
+    }
+
+    public static boolean calculateCrossJoinCost(Session session)
+    {
+        return session.getSystemProperty(CALCULATE_CROSS_JOIN_COST, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1596,7 +1596,7 @@ public final class SystemSessionProperties
                 booleanProperty(
                         CALCULATE_CROSS_JOIN_COST,
                         "calculate the cost of cross joins when optimizing the query plan rather than assume infinite cost",
-                        false,
+                        true,
                         false));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -63,6 +63,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.facebook.presto.SystemSessionProperties.calculateCrossJoinCost;
 import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
 import static com.facebook.presto.SystemSessionProperties.getJoinReorderingStrategy;
 import static com.facebook.presto.SystemSessionProperties.getMaxReorderedJoins;
@@ -267,7 +268,7 @@ public class ReorderJoins
                     .filter(JoinEnumerator::isJoinEqualityCondition)
                     .map(predicate -> toEquiJoinClause((CallExpression) predicate, leftVariables, context.getVariableAllocator()))
                     .collect(toImmutableList());
-            if (joinConditions.isEmpty()) {
+            if (joinConditions.isEmpty() && !calculateCrossJoinCost(session)) {
                 return INFINITE_COST_RESULT;
             }
             List<RowExpression> joinFilters = joinPredicates.stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -424,10 +424,16 @@ public class ReorderJoins
                 case BROADCAST:
                     return getPossibleJoinNodes(joinNode, REPLICATED);
                 case AUTOMATIC:
-                    ImmutableList.Builder<JoinEnumerationResult> result = ImmutableList.builder();
-                    result.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
-                    result.addAll(getPossibleJoinNodes(joinNode, REPLICATED, node -> isBelowMaxBroadcastSize(node, context)));
-                    return result.build();
+                    ImmutableList.Builder<JoinEnumerationResult> builder = ImmutableList.builder();
+                    if (!joinNode.getCriteria().isEmpty()) {
+                        builder.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
+                    }
+                    builder.addAll(getPossibleJoinNodes(joinNode, REPLICATED, node -> isBelowMaxBroadcastSize(node, context)));
+                    ImmutableList<JoinEnumerationResult> result = builder.build();
+                    if (result.isEmpty()) {
+                        return getPossibleJoinNodes(joinNode, REPLICATED);
+                    }
+                    return result;
                 default:
                     throw new IllegalArgumentException("unexpected join distribution type: " + distributionType);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -131,7 +131,7 @@ public class JoinNode
                 .addAll(right.getOutputVariables())
                 .build();
         checkArgument(new HashSet<>(inputVariables).containsAll(outputVariables), "Left and right join inputs do not contain all output variables");
-        checkArgument(!isCrossJoin() || inputVariables.size() == outputVariables.size(), "Cross join does not support output variables pruning or reordering");
+//        checkArgument(!isCrossJoin() || inputVariables.size() == outputVariables.size(), "Cross join does not support output variables pruning or reordering");
 
         checkArgument(!(criteria.isEmpty() && leftHashVariable.isPresent()), "Left hash variable is only valid in an equijoin");
         checkArgument(!(criteria.isEmpty() && rightHashVariable.isPresent()), "Right hash variable is only valid in an equijoin");

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCostCrossJoinsOrdering.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCostCrossJoinsOrdering.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.CALCULATE_CROSS_JOIN_COST;
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestCostCrossJoinsOrdering
+        extends BasePlanTest
+{
+    public TestCostCrossJoinsOrdering()
+    {
+        super(ImmutableMap.of(
+                CALCULATE_CROSS_JOIN_COST, "true",
+                JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.AUTOMATIC.name(),
+                JOIN_REORDERING_STRATEGY, FeaturesConfig.JoinReorderingStrategy.AUTOMATIC.name()));
+    }
+
+    @Test
+    public void testCrossJoinIsUsedInJoinReordering()
+    {
+        String query = "select 1 FROM supplier s , lineitem l , orders o where l.orderkey = o.orderkey";
+        assertPlan(query,
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED),
+                                tableScan("supplier"),
+                                exchange(join(INNER,
+                                        ImmutableList.of(equiJoinClause("L_ORDERKEY", "O_ORDERKEY")),
+                                        anyTree(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))),
+                                        anyTree(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithPredicate()
+    {
+        assertPlan("SELECT 1 from orders, lineitem, partsupp, region where partsupp.partkey = lineitem.partkey and lineitem.quantity > 7.5",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED),
+                                tableScan("orders"),
+                                anyTree(
+                                        join(INNER,
+                                                ImmutableList.of(),
+                                                Optional.empty(),
+                                                Optional.of(REPLICATED),
+                                                join(INNER,
+                                                        ImmutableList.of(equiJoinClause("L_PARTKEY", "R_PARTKEY")),
+                                                        anyTree(tableScan("lineitem", ImmutableMap.of("L_PARTKEY", "partkey"))),
+                                                        anyTree(tableScan("partsupp", ImmutableMap.of("R_PARTKEY", "partkey")))),
+                                                anyTree(tableScan("region")))))));
+    }
+
+    @Test
+    public void testMultiInnerJoin()
+    {
+        assertPlan("SELECT 1 from orders, customer, supplier, nation where orders.custkey = customer.custkey and nation.nationkey = supplier.nationkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED),
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("L_CUSTKEY", "R_CUSTKEY")),
+                                        anyTree(tableScan("orders", ImmutableMap.of("L_CUSTKEY", "custkey"))),
+                                        anyTree(tableScan("customer", ImmutableMap.of("R_CUSTKEY", "custkey")))),
+                                anyTree(join(INNER,
+                                        ImmutableList.of(equiJoinClause("L_NATIONKEY", "R_NATIONKEY")),
+                                        anyTree(tableScan("supplier", ImmutableMap.of("L_NATIONKEY", "nationkey"))),
+                                        anyTree(tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))))));
+    }
+}


### PR DESCRIPTION
Added a config (calculate_cross_join_cost) parameter which allows the optimizer to calculate the actual cost of the cross joins instead of assigning an infinite value to the cost. Previously, cross joins were always assumed to be infinite cost which prevented some more optimal join orderings from being considered. For an example, see GitHub issue #19894.

Fixes #19894 

Test plan - (Please fill in how you tested your changes)

A few unit tests with queries that previously had higher cost plans generated before the new property was enabled, asserting the new, more optimal join plan.

```
== RELEASE NOTES ==

General Changes
* A new session parameter (calculate_cross_join_cost) which allows the optimizer to calculate the cost of cross joins when optimizing the query plan.
```

