### PR TITLE
Fix computation of QueuedQueries JMX metrics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -59,14 +59,12 @@ public class QueryManagerStats
     public void trackQueryStats(DispatchQuery managedQueryExecution)
     {
         submittedQueries.update(1);
-        queuedQueries.incrementAndGet();
         managedQueryExecution.addStateChangeListener(new StatisticsListener(managedQueryExecution));
     }
 
     public void trackQueryStats(QueryExecution managedQueryExecution)
     {
         submittedQueries.update(1);
-        queuedQueries.incrementAndGet();
         managedQueryExecution.addStateChangeListener(new StatisticsListener());
         managedQueryExecution.addFinalQueryInfoListener(finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -189,6 +189,7 @@ public class CoordinatorModule
 
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(DispatchManager.class).withGeneratedName();
         binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);
         binder.bind(DispatchExecutor.class).in(Scopes.SINGLETON);
         newExporter(binder).export(DispatchExecutor.class).withGeneratedName();


### PR DESCRIPTION
Fixes #19929

Test plan 

Validated that JMX metrics and Presto Console have the same values for Queued Query post this change.

The motivation behind the change: Due to the discrepancy between the count on UI and JMX metric, this PR tries to modify the way the JMX metric is being computed to make it consistent with the value displayed on Presto UI.  

```
== RELEASE NOTES ==

General Changes
* Fix Queued Query Count JMX Metrics (:issue:`19929`). Expose the QueryManagerStats metrics under the ``com.facebook.presto.dispatcher:name=DispatchManager`` namespace.

```
