### PR TITLE
[Native] Enable reorder warning

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -31,12 +31,15 @@ if("${TREAT_WARNINGS_AS_ERRORS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
 
-set(KNOWN_WARNINGS "-Wno-nullability-completeness")
+# Known warnings that are benign can be disabled.
+set(DISABLED_WARNINGS
+    "-Wno-nullability-completeness -Wno-deprecated-declarations")
 
-# known warnings
-set(KNOWN_WARNINGS "${KNOWN_WARNINGS} -Wno-deprecated-declarations")
+# Important warnings that must be explicitly enabled.
+set(ENABLE_WARNINGS "-Wreorder")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
+set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} ${DISABLED_WARNINGS} ${ENABLE_WARNINGS}")
 
 # Add all Presto options below
 option(PRESTO_ENABLE_S3 "Build S3 connector" OFF)

--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -96,9 +96,9 @@ Announcer::Announcer(
       announcementRequest_(
           announcementRequest(address, port, nodeId, announcementBody_)),
       pool_(velox::memory::addDefaultLeafMemoryPool("Announcer")),
+      eventBaseThread_(false /*autostart*/),
       clientCertAndKeyPath_(clientCertAndKeyPath),
-      ciphers_(ciphers),
-      eventBaseThread_(false /*autostart*/) {}
+      ciphers_(ciphers) {}
 
 void Announcer::start() {
   eventBaseThread_.start("Announcer");

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -53,12 +53,12 @@ LocalPersistentShuffleWriter::LocalPersistentShuffleWriter(
     uint64_t maxBytesPerPartition,
     velox::memory::MemoryPool* FOLLY_NONNULL pool)
     : maxBytesPerPartition_(maxBytesPerPartition),
-      threadId_(std::this_thread::get_id()),
       pool_(pool),
       numPartitions_(numPartitions),
       rootPath_(std::move(rootPath)),
+      queryId_(std::move(queryId)),
       shuffleId_(shuffleId),
-      queryId_(std::move(queryId)) {
+      threadId_(std::this_thread::get_id()) {
   // Use resize/assign instead of resize(size, val).
   inProgressPartitions_.resize(numPartitions_);
   inProgressPartitions_.assign(numPartitions_, nullptr);

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -41,15 +41,14 @@ class PartitionAndSerializeOperator : public Operator {
             planNode->id(),
             "PartitionAndSerialize"),
         numPartitions_(planNode->numPartitions()),
-        replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
+        serializedRowType_{planNode->serializedRowType()},
+        keyChannels_(
+            toChannels(planNode->sources()[0]->outputType(), planNode->keys())),
         partitionFunction_(
             numPartitions_ == 1 ? nullptr
                                 : planNode->partitionFunctionFactory()->create(
                                       planNode->numPartitions())),
-        serializedRowType_{planNode->serializedRowType()},
-        keyChannels_(toChannels(
-            planNode->sources()[0]->outputType(),
-            planNode->keys())) {
+        replicateNullsAndAny_(planNode->isReplicateNullsAndAny()) {
     const auto& inputType = planNode->sources()[0]->outputType()->asRow();
     const auto& serializedRowTypeNames = serializedRowType_->names();
     bool identityMapping = true;


### PR DESCRIPTION
Identifying incorrect constructor member initialization order is important as they might lead to
subtle bugs.

```
== NO RELEASE NOTE ==
```

Resolves https://github.com/prestodb/presto/issues/19940