### PR TITLE
Revert "[native] Randomize retry time with jitter after worker announcement failure.

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -31,8 +31,7 @@ class Announcer {
       const std::string& nodeId,
       const std::string& nodeLocation,
       const std::vector<std::string>& connectorIds,
-      const uint64_t minFrequencyMs,
-      const uint64_t maxFrequencyMs_,
+      uint64_t frequencyMs,
       const std::string& clientCertAndKeyPath = "",
       const std::string& ciphers = "");
 
@@ -45,26 +44,19 @@ class Announcer {
  private:
   void makeAnnouncement();
 
-  uint64_t getAnnouncementDelay() const;
-
   void scheduleNext();
 
   const std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
-  const uint64_t minFrequencyMs_;
-  const uint64_t maxFrequencyMs_;
+  const uint64_t frequencyMs_;
   const std::string announcementBody_;
   const proxygen::HTTPMessage announcementRequest_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
-  const std::string clientCertAndKeyPath_;
-  const std::string ciphers_;
-  /// jitter value for backoff delay time in case of announcment failure
-  const double backOffjitterParam_{0.1};
-
   folly::SocketAddress address_;
   std::shared_ptr<http::HttpClient> client_;
   std::atomic_bool stopped_{true};
   folly::EventBaseThread eventBaseThread_;
-  uint64_t failedAttempts_{0};
+  const std::string clientCertAndKeyPath_;
+  const std::string ciphers_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -228,8 +228,7 @@ void PrestoServer::run() {
         nodeId_,
         nodeLocation_,
         catalogNames,
-        systemConfig->announcementMinFrequencyMs(),
-        systemConfig->announcementMaxFrequencyMs(),
+        30'000 /*milliseconds*/,
         clientCertAndKeyPath,
         ciphers);
     announcer_->start();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -240,8 +240,6 @@ SystemConfig::SystemConfig() {
           STR_PROP(kEnableMemoryLeakCheck, "true"),
           NONE_PROP(kRemoteFunctionServerThriftPort),
           STR_PROP(kSkipRuntimeStatsInRunningTaskInfo, "true"),
-          NUM_PROP(kAnnouncementMinFrequencyMs, 100), // 100ms
-          NUM_PROP(kAnnouncementMaxFrequencyMs, 35'000), // 35s
       };
 }
 
@@ -424,14 +422,6 @@ bool SystemConfig::enableMemoryLeakCheck() const {
 
 bool SystemConfig::skipRuntimeStatsInRunningTaskInfo() const {
   return optionalProperty<bool>(kSkipRuntimeStatsInRunningTaskInfo).value();
-}
-
-uint64_t SystemConfig::announcementMinFrequencyMs() const {
-  return optionalProperty<uint64_t>(kAnnouncementMinFrequencyMs).value();
-}
-
-uint64_t SystemConfig::announcementMaxFrequencyMs() const {
-  return optionalProperty<uint64_t>(kAnnouncementMaxFrequencyMs).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -235,12 +235,6 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kSkipRuntimeStatsInRunningTaskInfo{
       "skip-runtime-stats-in-running-task-info"};
 
-  static constexpr std::string_view kAnnouncementMinFrequencyMs{
-      "announcement-min-frequency-ms"};
-
-  static constexpr std::string_view kAnnouncementMaxFrequencyMs{
-      "announcement-max-frequency-ms"};
-
   SystemConfig();
 
   static SystemConfig* instance();
@@ -345,10 +339,6 @@ class SystemConfig : public ConfigBase {
   bool enableMemoryLeakCheck() const;
 
   bool skipRuntimeStatsInRunningTaskInfo() const;
-
-  uint64_t announcementMinFrequencyMs() const;
-
-  uint64_t announcementMaxFrequencyMs() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -166,7 +166,6 @@ TEST_P(AnnouncerTestSuite, basic) {
       "test-node-location",
       {"hive", "tpch"},
       100 /*milliseconds*/,
-      500 /*milliseconds*/,
       keyPath,
       ciphers);
 


### PR DESCRIPTION
This reverts commit b0cde2e4a2ab9fe2c3576dd50acc330938cff6e3.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
