### PR TITLE
Update Drift version to 1.36 (second attempt)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
-        <dep.drift.version>1.33</dep.drift.version>
+        <dep.drift.version>1.36</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
         <dep.joda.version>2.12.2</dep.joda.version>


### PR DESCRIPTION
The Drift update was reverted while we figured out some NoClassDefFoundErrors. Those have been resolved, so re-apply the change.

The Drift version includes a more recent version of Netty, which adds TLS 1.3 support by default (among other things). This will allow Drift clients and servers to establish and accept TLS 1.3 connections where they wouldn't before.

== RELEASE NOTES ==

General Changes

Add support for TLS 1.3 in Drift