### PR TITLE
[native pos] Simplify replicate-nulls-and-any logic

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.h
@@ -23,10 +23,12 @@ class ShuffleWriteNode : public velox::core::PlanNode {
  public:
   ShuffleWriteNode(
       const velox::core::PlanNodeId& id,
+      uint32_t numPartitions,
       const std::string& shuffleName,
       const std::string& serializedShuffleWriteInfo,
       velox::core::PlanNodePtr source)
       : velox::core::PlanNode(id),
+        numPartitions_{numPartitions},
         shuffleName_{shuffleName},
         serializedShuffleWriteInfo_(serializedShuffleWriteInfo),
         sources_{std::move(source)} {}
@@ -45,6 +47,10 @@ class ShuffleWriteNode : public velox::core::PlanNode {
     return sources_;
   }
 
+  uint32_t numPartitions() const {
+    return numPartitions_;
+  }
+
   const std::string& shuffleName() const {
     return shuffleName_;
   }
@@ -58,8 +64,11 @@ class ShuffleWriteNode : public velox::core::PlanNode {
   }
 
  private:
-  void addDetails(std::stringstream& stream) const override {}
+  void addDetails(std::stringstream& stream) const override {
+    stream << numPartitions_ << ", " << shuffleName_;
+  }
 
+  const uint32_t numPartitions_;
   const std::string shuffleName_;
   const std::string serializedShuffleWriteInfo_;
   const std::vector<velox::core::PlanNodePtr> sources_;

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -66,19 +66,22 @@ std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleReadNode(
 }
 
 std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleWriteNode(
+    uint32_t numPartitions,
     const std::string& shuffleName,
     const std::string& serializedWriteInfo) {
-  return [&shuffleName, &serializedWriteInfo](
-             PlanNodeId nodeId, PlanNodePtr source) -> PlanNodePtr {
+  return [=](PlanNodeId nodeId, PlanNodePtr source) -> PlanNodePtr {
     return std::make_shared<ShuffleWriteNode>(
-        nodeId, shuffleName, serializedWriteInfo, std::move(source));
+        nodeId,
+        numPartitions,
+        shuffleName,
+        serializedWriteInfo,
+        std::move(source));
   };
 }
 
 std::function<PlanNodePtr(std::string, PlanNodePtr)> addBroadcastWriteNode(
     const std::string& basePath) {
-  return [&basePath](
-             core::PlanNodeId nodeId,
+  return [=](core::PlanNodeId nodeId,
              core::PlanNodePtr source) -> core::PlanNodePtr {
     return std::make_shared<BroadcastWriteNode>(
         nodeId, basePath, std::move(source));

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -34,6 +34,7 @@ addShuffleReadNode(const velox::RowTypePtr& outputType);
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
 addShuffleWriteNode(
+    uint32_t numPartitions,
     const std::string& shuffleName,
     const std::string& serializedWriteInfo);
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -94,12 +94,13 @@ TEST_F(PlanNodeSerdeTest, shuffleWriteNode) {
       "}}";
   const std::string shuffleInfo =
       fmt::format(kTestShuffleInfoFormat, numPartitions, 1 << 20);
-  auto plan = exec::test::PlanBuilder()
-                  .values(data_, true)
-                  .addNode(addPartitionAndSerializeNode(numPartitions, false))
-                  .localPartition({})
-                  .addNode(addShuffleWriteNode(shuffleName, shuffleInfo))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values(data_, true)
+          .addNode(addPartitionAndSerializeNode(numPartitions, false))
+          .localPartition({})
+          .addNode(addShuffleWriteNode(numPartitions, shuffleName, shuffleInfo))
+          .planNode();
   testSerde(plan);
 }
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2441,6 +2441,7 @@ velox::core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
 
   planFragment.planNode = std::make_shared<operators::ShuffleWriteNode>(
       "root",
+      partitionedOutputNode->numPartitions(),
       shuffleName_,
       std::move(*serializedShuffleWriteInfo_),
       core::LocalPartitionNode::gather(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleReadInfo.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkLocalShuffleReadInfo.java
@@ -31,7 +31,6 @@ import static java.util.Objects.requireNonNull;
 public class PrestoSparkLocalShuffleReadInfo
         implements PrestoSparkShuffleReadInfo
 {
-    private final int numPartitions;
     // Presto queryId which is unique to each query.
     private final String queryId;
     // Partition ids which are supposed to be read by given shuffle read.
@@ -40,21 +39,13 @@ public class PrestoSparkLocalShuffleReadInfo
 
     @JsonCreator
     public PrestoSparkLocalShuffleReadInfo(
-            @JsonProperty("numPartitions") int numPartitions,
             @JsonProperty("queryId") String queryId,
             @JsonProperty("partitionIds") List<String> partitionIds,
             @JsonProperty("rootPath") String rootPath)
     {
-        this.numPartitions = numPartitions;
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.partitionIds = requireNonNull(partitionIds, "partitionIds is null");
         this.rootPath = requireNonNull(rootPath, "rootPath is null");
-    }
-
-    @JsonProperty
-    public int getNumPartitions()
-    {
-        return numPartitions;
     }
 
     @JsonProperty
@@ -79,7 +70,6 @@ public class PrestoSparkLocalShuffleReadInfo
     public String toString()
     {
         return toStringHelper(this)
-                .add("numPartitions", numPartitions)
                 .add("queryId", queryId)
                 .add("partitionIds", String.join(", ", partitionIds))
                 .add("rootPath", rootPath)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/shuffle/PrestoSparkLocalShuffleInfoTranslator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/shuffle/PrestoSparkLocalShuffleInfoTranslator.java
@@ -61,7 +61,6 @@ public class PrestoSparkLocalShuffleInfoTranslator
     public PrestoSparkLocalShuffleReadInfo createShuffleReadInfo(Session session, PrestoSparkShuffleReadDescriptor readDescriptor)
     {
         return new PrestoSparkLocalShuffleReadInfo(
-                readDescriptor.getNumPartitions(),
                 session.getQueryId().getId(),
                 readDescriptor.getPartitionIds(),
                 localShuffleRootPath);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
@@ -72,7 +72,7 @@ public class TestBatchTaskUpdateRequest
         PrestoSparkLocalShuffleInfoTranslator shuffleInfoTranslator = new PrestoSparkLocalShuffleInfoTranslator(
                 PRESTO_SPARK_LOCAL_SHUFFLE_READ_INFO_JSON_CODEC,
                 PRESTO_SPARK_LOCAL_SHUFFLE_WRITE_INFO_JSON_CODEC);
-        PrestoSparkLocalShuffleReadInfo readInfo = new PrestoSparkLocalShuffleReadInfo(0, "test_query_id", ImmutableList.of("shuffle1"), "/dummy/read/path");
+        PrestoSparkLocalShuffleReadInfo readInfo = new PrestoSparkLocalShuffleReadInfo("test_query_id", ImmutableList.of("shuffle1"), "/dummy/read/path");
 
         String stringSerializedReadInfo = shuffleInfoTranslator.createSerializedReadInfo(readInfo);
         PlanNodeId planNodeId = new PlanNodeId("planNodeId");
@@ -121,14 +121,13 @@ public class TestBatchTaskUpdateRequest
         PrestoSparkLocalShuffleInfoTranslator shuffleTranslator = new PrestoSparkLocalShuffleInfoTranslator(
                 PRESTO_SPARK_LOCAL_SHUFFLE_READ_INFO_JSON_CODEC,
                 PRESTO_SPARK_LOCAL_SHUFFLE_WRITE_INFO_JSON_CODEC);
-        PrestoSparkLocalShuffleReadInfo readInfo = new PrestoSparkLocalShuffleReadInfo(0, "test_query_id", ImmutableList.of("shuffle1"), "/dummy/read/path");
+        PrestoSparkLocalShuffleReadInfo readInfo = new PrestoSparkLocalShuffleReadInfo("test_query_id", ImmutableList.of("shuffle1"), "/dummy/read/path");
         PrestoSparkLocalShuffleWriteInfo writeInfo = new PrestoSparkLocalShuffleWriteInfo(1, "test_query_id", 0, "/dummy/write/path");
         String stringSerializedReadInfo = shuffleTranslator.createSerializedReadInfo(readInfo);
         String stringSerializedWriteInfo = shuffleTranslator.createSerializedWriteInfo(writeInfo);
         assertEquals(
                 stringSerializedReadInfo,
                 "{\n" +
-                        "  \"numPartitions\" : 0,\n" +
                         "  \"queryId\" : \"test_query_id\",\n" +
                         "  \"partitionIds\" : [ \"shuffle1\" ],\n" +
                         "  \"rootPath\" : \"/dummy/read/path\"\n" +


### PR DESCRIPTION
When replicate-nulls-and-any is true, PartitionAndSerialize operator emits an
extract boolean column which tells ShuffleWrite operator whether to replicate a
row to all partitions.

```
== NO RELEASE NOTE ==
```
