### PR TITLE
Remove unneeded identity projects

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -45,6 +45,7 @@ import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.AssignmentUtils;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -95,6 +96,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.extractConju
 import static com.facebook.presto.spi.plan.ProjectNode.Locality;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.REMOTE;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.UNKNOWN;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
@@ -533,8 +535,8 @@ public class PredicatePushDown
             boolean equiJoinClausesUnmodified = ImmutableSet.copyOf(equiJoinClauses).equals(ImmutableSet.copyOf(node.getCriteria()));
 
             if (dynamicFilterEnabled && !equiJoinClausesUnmodified) {
-                leftSource = context.rewrite(new ProjectNode(idAllocator.getNextId(), node.getLeft(), leftProjections.build()), leftPredicate);
-                rightSource = context.rewrite(new ProjectNode(idAllocator.getNextId(), node.getRight(), rightProjections.build()), rightPredicate);
+                leftSource = context.rewrite(wrapInProjectIfNeeded(node.getLeft(), leftProjections.build()), leftPredicate);
+                rightSource = context.rewrite(wrapInProjectIfNeeded(node.getRight(), rightProjections.build()), rightPredicate);
             }
             else {
                 leftSource = context.rewrite(node.getLeft(), leftPredicate);
@@ -565,8 +567,14 @@ public class PredicatePushDown
                     !filtersEquivalent ||
                     (dynamicFilterEnabled && !dynamicFilters.equals(node.getDynamicFilters())) ||
                     !equiJoinClausesUnmodified) {
-                leftSource = new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), leftSource, leftProjections.build(), leftLocality);
-                rightSource = new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), rightSource, rightProjections.build(), rightLocality);
+                leftSource = wrapInProjectIfNeeded(leftSource, leftProjections.build(), leftLocality);
+                rightSource = wrapInProjectIfNeeded(rightSource, rightProjections.build(), rightLocality);
+
+                checkState(ImmutableSet.<VariableReferenceExpression>builder()
+                                .addAll(leftSource.getOutputVariables())
+                                .addAll(rightSource.getOutputVariables())
+                                .build().containsAll(node.getOutputVariables()),
+                        "JoinNode predicate pushdown incorrect : Left and right source are not producing original JoinNode output variables");
 
                 // if the distribution type is already set, make sure that changes from PredicatePushDown
                 // don't make the join node invalid.
@@ -580,6 +588,18 @@ public class PredicatePushDown
                     }
                 }
 
+                List<VariableReferenceExpression> newJoinOutputVariables = node.getOutputVariables();
+                // If, the new Join node is a cross-join OR
+                // we have a post join predicate that refers to variables that were not already referenced by the JoinNode
+                if ((node.getType() == INNER && equiJoinClauses.isEmpty() && !newJoinFilter.isPresent())
+                        || (!ImmutableSet.copyOf(newJoinOutputVariables).containsAll(VariablesExtractor.extractUnique(postJoinPredicate)))) {
+                    // Set the new output variables to be left + right output variables
+                    newJoinOutputVariables = ImmutableList.<VariableReferenceExpression>builder()
+                            .addAll(leftSource.getOutputVariables())
+                            .addAll(rightSource.getOutputVariables())
+                            .build();
+                }
+
                 output = new JoinNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -587,10 +607,7 @@ public class PredicatePushDown
                         leftSource,
                         rightSource,
                         equiJoinClauses,
-                        ImmutableList.<VariableReferenceExpression>builder()
-                                .addAll(leftSource.getOutputVariables())
-                                .addAll(rightSource.getOutputVariables())
-                                .build(),
+                        newJoinOutputVariables,
                         newJoinFilter,
                         node.getLeftHashVariable(),
                         node.getRightHashVariable(),
@@ -607,6 +624,25 @@ public class PredicatePushDown
             }
 
             return output;
+        }
+
+        private PlanNode wrapInProjectIfNeeded(PlanNode childNode, Assignments assignments)
+        {
+            return wrapInProjectIfNeeded(childNode, assignments, UNKNOWN);
+        }
+
+        private PlanNode wrapInProjectIfNeeded(PlanNode childNode, Assignments assignments, Locality locality)
+        {
+            if ((childNode instanceof ProjectNode || childNode instanceof JoinNode)
+                    && AssignmentUtils.isIdentity(assignments)) {
+                // By wrapping an identity Project over a child node of type :
+                // ProjectNode - we are adding no value
+                // JoinNode - we are preventing this JoinNode from participating in join re-ordering
+                // So we return the child node as is, without an identity project
+                return childNode;
+            }
+
+            return new ProjectNode(childNode.getSourceLocation(), idAllocator.getNextId(), childNode, assignments, locality);
         }
 
         private static DynamicFiltersResult createDynamicFilters(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignmentUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignmentUtils.java
@@ -41,6 +41,16 @@ public class AssignmentUtils
         return identityAssignments(asList(variables));
     }
 
+    public static boolean isIdentity(Assignments assignments)
+    {
+        for (Map.Entry<VariableReferenceExpression, RowExpression> assignment : assignments.entrySet()) {
+            if (!assignment.getKey().equals(assignment.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static boolean isIdentity(Assignments assignments, VariableReferenceExpression output)
     {
         RowExpression value = assignments.get(output);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ProjectNodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ProjectNodeUtils.java
@@ -14,10 +14,7 @@
 package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.spi.plan.ProjectNode;
-import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.spi.relation.VariableReferenceExpression;
-
-import java.util.Map;
+import com.facebook.presto.sql.planner.plan.AssignmentUtils;
 
 public class ProjectNodeUtils
 {
@@ -25,13 +22,6 @@ public class ProjectNodeUtils
 
     public static boolean isIdentity(ProjectNode projectNode)
     {
-        for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
-            RowExpression value = entry.getValue();
-            VariableReferenceExpression variable = entry.getKey();
-            if (!(value instanceof VariableReferenceExpression && ((VariableReferenceExpression) value).getName().equals(variable.getName()))) {
-                return false;
-            }
-        }
-        return true;
+        return AssignmentUtils.isIdentity(projectNode.getAssignments());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -482,12 +482,13 @@ public class TestLogicalPlanner
     {
         assertPlan("SELECT 1 FROM orders o LEFT JOIN lineitem l ON o.orderkey < l.orderkey WHERE l.orderkey IS NOT NULL",
                 anyTree(
-                        filter("O_ORDERKEY < L_ORDERKEY",
-                                join(INNER, ImmutableList.of(), Optional.empty(),
-                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")),
-                                        any(
-                                                filter("NOT (L_ORDERKEY IS NULL)",
-                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
+                        project(
+                                filter("O_ORDERKEY < L_ORDERKEY",
+                                        join(INNER, ImmutableList.of(), Optional.empty(),
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")),
+                                                any(
+                                                        filter("NOT (L_ORDERKEY IS NULL)",
+                                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))))));
     }
 
     @Test


### PR DESCRIPTION
ProjectNode's added during predicate pushdown can break join re-ordering. This change limits the addition of such projects to only essential cases

Fixes `Bug 2` from #19749

## Testing - 
- New unit tests added
- With dynamic filtering turned on, TPCDS queries have join-orders that match those with dynamic filtering turned off

### Results
Current code, showing major plan diffs when [Dynamic filtering ON vs OFF](https://aaneja.github.io/mypages/PR_19969_DynamicFilteringOn_FixVs281.html)
Fixed code, much fewer plan diffs [Dynamic filtering ON vs OFF](https://aaneja.github.io/mypages/PR_19969_TPCDS_DynamicFiltering_OnVsOff.html)

== RELEASE NOTES ==
```
General Changes
* Fix join re-ordering issues observed when dynamic filtering is turned on
```
