### PR TITLE
[native] Link velox_dwio_parquet_reader/writer unconditionally

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -66,10 +66,8 @@ target_link_libraries(
   ${GFLAGS_LIBRARIES}
   pthread)
 
-if(PRESTO_ENABLE_PARQUET)
-  target_link_libraries(presto_server_lib velox_dwio_parquet_reader
-                        velox_dwio_parquet_writer)
-endif()
+target_link_libraries(presto_server_lib velox_dwio_parquet_reader
+                      velox_dwio_parquet_writer)
 
 # Enabling Parquet causes build errors with missing symbols on MacOS. This is
 # likely due to a conflict between Thrift and FBThrift libraries. The build


### PR DESCRIPTION
PrestoServer.cpp includes velox/dwio/parquet/RegisterParquetReader/Writer.h
unconditionally, hence, it needs to link with corresponding libraries
unconditionally as well.

```
== NO RELEASE NOTE ==
```
