### PR TITLE
Optimize CASE expressions using only literals

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStra
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy.ALWAYS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy.NEVER;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Boolean.TRUE;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -276,6 +277,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN = "rewrite_left_join_null_filter_to_semi_join";
     public static final String USE_BROADCAST_WHEN_BUILDSIZE_SMALL_PROBESIDE_UNKNOWN = "use_broadcast_when_buildsize_small_probeside_unknown";
     public static final String ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT = "add_partial_node_for_row_number_with_limit";
+    public static final String REWRITE_CASE_TO_MAP_ENABLED = "rewrite_case_to_map_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1603,6 +1605,11 @@ public final class SystemSessionProperties
                         ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT,
                         "Add partial row number node for row number node with limit",
                         featuresConfig.isAddPartialNodeForRowNumberWithLimitEnabled(),
+                        false),
+                booleanProperty(
+                        REWRITE_CASE_TO_MAP_ENABLED,
+                        "Rewrite case with constant WHEN/THEN/ELSE clauses to use map literals",
+                        TRUE,
                         false));
     }
 
@@ -2695,5 +2702,10 @@ public final class SystemSessionProperties
     public static boolean isAddPartialNodeForRowNumberWithLimit(Session session)
     {
         return session.getSystemProperty(ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT, Boolean.class);
+    }
+
+    public static boolean isRewriteCaseToMapEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_CASE_TO_MAP_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -110,6 +110,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveUnsupportedDynamicFi
 import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteAggregationIfToFilter;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseExpressionPredicate;
+import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseToMap;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.RuntimeReorderJoinSides;
@@ -300,6 +301,12 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 new RewriteCaseExpressionPredicate(metadata.getFunctionAndTypeManager()).rules());
 
+        IterativeOptimizer caseToMapRewriter = new IterativeOptimizer(
+                ruleStats,
+                statsCalculator,
+                estimatedExchangesCostCalculator,
+                new RewriteCaseToMap(metadata.getFunctionAndTypeManager()).rules());
+
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser));
         PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata, statsCalculator));
 
@@ -437,6 +444,7 @@ public class PlanOptimizers
                 new RewriteIfOverAggregation(metadata.getFunctionAndTypeManager()));
 
         builder.add(
+                caseToMapRewriter,
                 caseExpressionPredicateRewriter,
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteCaseToMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteCaseToMap.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.expressions.LogicalRowExpressions;
+import com.facebook.presto.expressions.RowExpressionRewriter;
+import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.REWRITE_CASE_TO_MAP_ENABLED;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.coalesce;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class RewriteCaseToMap
+        extends RowExpressionRewriteRuleSet
+{
+    public RewriteCaseToMap(FunctionAndTypeManager functionAndTypeManager)
+    {
+        super(new Rewriter(functionAndTypeManager));
+    }
+
+    private static class Rewriter
+            implements PlanRowExpressionRewriter
+    {
+        private final CaseToMapRewriter caseToMapRewriter;
+
+        public Rewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.caseToMapRewriter = new CaseToMapRewriter(functionAndTypeManager);
+        }
+
+        @Override
+        public RowExpression rewrite(RowExpression expression, Rule.Context context)
+        {
+            return RowExpressionTreeRewriter.rewriteWith(caseToMapRewriter, expression);
+        }
+    }
+
+    private static class CaseToMapRewriter
+            extends RowExpressionRewriter<Void>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final FunctionResolution functionResolution;
+        private final LogicalRowExpressions logicalRowExpressions;
+
+        private CaseToMapRewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionAndTypeManager = functionAndTypeManager;
+            this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+            this.logicalRowExpressions = new LogicalRowExpressions(
+                    new RowExpressionDeterminismEvaluator(functionAndTypeManager),
+                    functionResolution,
+                    functionAndTypeManager);
+        }
+
+        private boolean addKeyValue(RowExpression key, Set<RowExpression> keySet, List<RowExpression> keys, RowExpression value, List<RowExpression> values)
+        {
+            // matching types and non-null values only allowed
+            if (!(key instanceof ConstantExpression) ||
+                    ((ConstantExpression) key).getValue() == null ||
+                    (keys.size() > 0 && !keys.get(0).getType().equals(key.getType()))) {
+                return false;
+            }
+
+            if (keySet.add(key)) {
+                // We allow all same type only
+                if (values.size() > 0 && !values.get(0).getType().equals(value.getType())) {
+                    return false;
+                }
+
+                keys.add(key);
+                values.add(value);
+            }
+
+            return true;
+        }
+
+        @Override
+        public RowExpression rewriteSpecialForm(SpecialFormExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (node.getForm() != SWITCH) {
+                return rewriteRowExpression(node, context, treeRewriter);
+            }
+
+            // by construction we should have at least one WHEN and ELSE is always added if missing
+            int numArgs = node.getArguments().size();
+            RowExpression lastArg = node.getArguments().get(numArgs - 1);
+
+            checkState(numArgs >= 2);
+            checkState(!(lastArg instanceof SpecialFormExpression && ((SpecialFormExpression) lastArg).getForm().equals(WHEN)));
+
+            if (!(lastArg instanceof ConstantExpression)) {
+                return node;
+            }
+
+            RowExpression firstArg = node.getArguments().get(0);
+            Set<RowExpression> keySet = new HashSet<>();
+            List<RowExpression> whens = new ArrayList<RowExpression>(node.getArguments().size());
+            List<RowExpression> thens = new ArrayList<RowExpression>(node.getArguments().size());
+            RowExpression checkExpr;
+            int start;
+
+            if (!(firstArg instanceof SpecialFormExpression && ((SpecialFormExpression) firstArg).getForm().equals(WHEN))) {
+                if (firstArg.equals(constant(true, BOOLEAN))) {
+                    // We generate weird CASE (true) WHEN p1 THEN v1 etc. for non-searched case
+                    // So drop the true
+                    checkExpr = null;
+                }
+                else {
+                    checkExpr = firstArg;
+                }
+
+                start = 1;
+            }
+            else {
+                checkExpr = null;
+                start = 0;
+            }
+
+            for (int i = start; i < numArgs - 1; i++) {
+                RowExpression whenClause = node.getArguments().get(i);
+                RowExpression value = whenClause.getChildren().get(1);
+
+                if (!(value instanceof ConstantExpression)) {
+                    // THEN is not a constant
+                    return node;
+                }
+
+                RowExpression when = whenClause.getChildren().get(0);
+                RowExpression key;
+                RowExpression curCheck;
+
+                if (when instanceof ConstantExpression) {
+                    if (!addKeyValue(when, keySet, whens, value, thens)) {
+                        return node;
+                    }
+                }
+                else if (logicalRowExpressions.isEqualsExpression(when)) {
+                    RowExpression lhs = when.getChildren().get(0);
+                    RowExpression rhs = when.getChildren().get(1);
+
+                    if (!lhs.getType().equals(rhs.getType())) {
+                        // We keep it simple
+                        return node;
+                    }
+
+                    if (lhs instanceof ConstantExpression) {
+                        curCheck = rhs;
+                        key = lhs;
+                    }
+                    else if (rhs instanceof ConstantExpression) {
+                        curCheck = lhs;
+                        key = rhs;
+                    }
+                    else {
+                        return node;
+                    }
+
+                    if (checkExpr == null) {
+                        checkExpr = curCheck;
+                    }
+                    else if (!curCheck.equals(checkExpr)) {
+                        return node;
+                    }
+
+                    if (!addKeyValue(key, keySet, whens, value, thens)) {
+                        return node;
+                    }
+                }
+                else if (when instanceof SpecialFormExpression && ((SpecialFormExpression) when).getForm() == IN) {
+                    curCheck = ((SpecialFormExpression) when).getArguments().get(0);
+                    if (checkExpr == null) {
+                        checkExpr = curCheck;
+                    }
+                    else if (!curCheck.equals(checkExpr)) {
+                        return node;
+                    }
+
+                    // For IN also we try to gather the args
+                    for (int j = 1; j < ((SpecialFormExpression) when).getArguments().size(); j++) {
+                        key = ((SpecialFormExpression) when).getArguments().get(j);
+                        if (!addKeyValue(key, keySet, whens, value, thens)) {
+                            return node;
+                        }
+                    }
+                }
+                else {
+                    return node;
+                }
+            }
+
+            // Here we have all values!
+            RowExpression mapLookup = makeMapAndAccess(whens, thens, checkExpr);
+
+            // if there is a non-trivial else, we coalesce
+            if (lastArg != null && !lastArg.equals(constantNull(thens.get(0).getType()))) {
+                // Null could be a legit value so we coalesce to the else part only if there was no key match
+                RowExpression keyArray = call("ARRAY", functionResolution.arrayConstructor(whens.stream().map(x -> x.getType()).collect(Collectors.toList())), new ArrayType(whens.get(0).getType()), whens);
+                RowExpression contains = call(functionAndTypeManager, "contains", BOOLEAN, keyArray, checkExpr);
+                return coalesce(mapLookup, specialForm(IF, mapLookup.getType(), contains, constant(null, mapLookup.getType()), lastArg));
+            }
+
+            return mapLookup;
+        }
+
+        private RowExpression makeMapAndAccess(List<RowExpression> keys, List<RowExpression> values, RowExpression mapIndex)
+        {
+            RowExpression keyArray = call("ARRAY", functionResolution.arrayConstructor(keys.stream().map(x -> x.getType()).collect(Collectors.toList())), new ArrayType(keys.get(0).getType()), keys);
+            RowExpression valueArray = call("ARRAY", functionResolution.arrayConstructor(values.stream().map(x -> x.getType()).collect(Collectors.toList())), new ArrayType(values.get(0).getType()), values);
+            Type keyType = keys.get(0).getType();
+            Type valueType = values.get(0).getType();
+            MethodHandle keyEquals =
+                    functionAndTypeManager.getJavaScalarFunctionImplementation(
+                            functionAndTypeManager.resolveOperator(OperatorType.EQUAL, fromTypes(keyType, keyType))).getMethodHandle();
+            MethodHandle keyHashcode =
+                    functionAndTypeManager.getJavaScalarFunctionImplementation(
+                            functionAndTypeManager.resolveOperator(OperatorType.HASH_CODE, fromTypes(keyType))).getMethodHandle();
+            RowExpression map = call(functionAndTypeManager, "MAP", new MapType(keyType, valueType, keyEquals, keyHashcode), keyArray, valueArray);
+            return call(functionAndTypeManager, "element_at", valueType, map, mapIndex);
+        }
+    }
+
+    @Override
+    public boolean isRewriterEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_CASE_TO_MAP_ENABLED, Boolean.class);
+    }
+
+    @Override
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                projectRowExpressionRewriteRule(),
+                filterRowExpressionRewriteRule(),
+                joinRowExpressionRewriteRule());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Arrays.asList;
 
@@ -98,7 +99,13 @@ public final class Expressions
 
     public static SpecialFormExpression coalesceNullToFalse(RowExpression rowExpression)
     {
-        return new SpecialFormExpression(rowExpression.getSourceLocation(), COALESCE, BOOLEAN, rowExpression, constant(false, BOOLEAN));
+        return coalesce(rowExpression, constant(false, BOOLEAN));
+    }
+
+    public static SpecialFormExpression coalesce(RowExpression rowExpression, RowExpression coalesced)
+    {
+        checkState(rowExpression.getType().equals(coalesced.getType()));
+        return new SpecialFormExpression(rowExpression.getSourceLocation(), COALESCE, coalesced.getType(), rowExpression, coalesced);
     }
 
     public static CallExpression not(FunctionAndTypeManager functionAndTypeManager, RowExpression rowExpression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -73,7 +73,6 @@ import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
 import static com.facebook.presto.common.predicate.Domain.singleValue;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
-import static com.facebook.presto.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
@@ -712,14 +711,13 @@ public class TestLogicalPlanner
         assertDistributedPlan("SELECT name, (SELECT name FROM region WHERE regionkey = nation.regionkey) FROM nation",
                 noJoinReordering(),
                 anyTree(
-                        filter(format("CASE \"is_distinct\" WHEN true THEN true ELSE CAST(fail(%s, 'Scalar sub-query has returned multiple rows') AS boolean) END", SUBQUERY_MULTIPLE_ROWS.toErrorCode().getCode()),
-                                markDistinct("is_distinct", ImmutableList.of("unique"),
+                        markDistinct("is_distinct", ImmutableList.of("unique"),
                                         join(LEFT, ImmutableList.of(equiJoinClause("n_regionkey", "r_regionkey")),
                                                 assignUniqueId("unique",
                                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                                 anyTree(tableScan("nation", ImmutableMap.of("n_regionkey", "regionkey"))))),
                                                 anyTree(
-                                                        tableScan("region", ImmutableMap.of("r_regionkey", "regionkey"))))))));
+                                                        tableScan("region", ImmutableMap.of("r_regionkey", "regionkey")))))));
     }
 
     @Test


### PR DESCRIPTION
Some tool generated queries have long case statements that simply compare the value of a single expression to a set of literals and map them to a different literal. In such cases, it's a lot more efficient to use map. So we rewrite:

CASE x 
  WHEN lit1 THHEN val1
  WHEN lit2 THHEN val2
  WHEN lit2 THHEN val3
..
ELSE default_value
END 

to:

COALESCE(MAP(ARRAY[lit1,lit2,lit3,...], ARRAY[val1, val2, val3, ...])[x], IF(contains(key, key_arr), null, default_value))

We also apply this to simple equality and IN comparisons like:

CASE WHEN x=lit1..
CASE WHEN x IN (lit1, lit2, ...)

Note that we apply this optimization *only* when all lit, val and default_val are constants taking care of NULLs appropriately

Test plan - tests added

```
== NO RELEASE NOTE ==
```
