### PR TITLE
Make presto Partition class extend the oss HMS Partition class

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -28,22 +28,19 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil.makeStorageDescriptor;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class Partition
+        extends org.apache.hadoop.hive.metastore.api.Partition
 {
-    private final String databaseName;
-    private final String tableName;
-    private final List<String> values;
     private final Storage storage;
     private final List<Column> columns;
-    private final Map<String, String> parameters;
     private final Optional<Long> partitionVersion;
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
-    private final int createTime;
     private final long lastDataCommitTime;
 
     @JsonCreator
@@ -58,43 +55,40 @@ public class Partition
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
             @JsonProperty("createTime") int createTime,
-            @JsonProperty("lastDataCommitTime") long lastDataCommitTime)
+            @JsonProperty("lastDataCommitTime") long lastDataCommitTime,
+            @JsonProperty("lastAccessTime") int lastAccessTime)
     {
-        this.databaseName = requireNonNull(databaseName, "databaseName is null");
-        this.tableName = requireNonNull(tableName, "tableName is null");
-        this.values = ImmutableList.copyOf(requireNonNull(values, "values is null"));
+        super(values, databaseName, tableName, createTime, lastAccessTime, makeStorageDescriptor(tableName, columns, storage, new HiveColumnConverter()), parameters);
         this.storage = requireNonNull(storage, "storage is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.partitionVersion = requireNonNull(partitionVersion, "partitionVersion is null");
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
-        this.createTime = createTime;
         this.lastDataCommitTime = lastDataCommitTime;
     }
 
     @JsonProperty
     public String getDatabaseName()
     {
-        return databaseName;
+        return super.getDbName();
     }
 
     @JsonProperty
     public String getTableName()
     {
-        return tableName;
+        return super.getTableName();
     }
 
     @JsonIgnore
     public SchemaTableName getSchemaTableName()
     {
-        return new SchemaTableName(databaseName, tableName);
+        return new SchemaTableName(this.getDatabaseName(), this.getTableName());
     }
 
     @JsonProperty
     public List<String> getValues()
     {
-        return values;
+        return super.getValues();
     }
 
     @JsonProperty
@@ -112,7 +106,7 @@ public class Partition
     @JsonProperty
     public Map<String, String> getParameters()
     {
-        return parameters;
+        return super.getParameters();
     }
 
     @JsonProperty
@@ -136,7 +130,7 @@ public class Partition
     @JsonProperty
     public int getCreateTime()
     {
-        return createTime;
+        return super.getCreateTime();
     }
 
     @JsonProperty
@@ -145,13 +139,19 @@ public class Partition
         return lastDataCommitTime;
     }
 
+    @JsonProperty
+    public int getLastAccessTime()
+    {
+        return super.getLastAccessTime();
+    }
+
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("databaseName", databaseName)
-                .add("tableName", tableName)
-                .add("values", values)
+                .add("databaseName", this.getDatabaseName())
+                .add("tableName", this.getTableName())
+                .add("values", this.getValues())
                 .toString();
     }
 
@@ -166,23 +166,24 @@ public class Partition
         }
 
         Partition partition = (Partition) o;
-        return Objects.equals(databaseName, partition.databaseName) &&
-                Objects.equals(tableName, partition.tableName) &&
-                Objects.equals(values, partition.values) &&
+        return Objects.equals(this.getDbName(), partition.getDatabaseName()) &&
+                Objects.equals(this.getTableName(), partition.getTableName()) &&
+                Objects.equals(this.getValues(), partition.getValues()) &&
                 Objects.equals(storage, partition.storage) &&
                 Objects.equals(columns, partition.columns) &&
-                Objects.equals(parameters, partition.parameters) &&
+                Objects.equals(this.getParameters(), partition.getParameters()) &&
                 Objects.equals(partitionVersion, partition.partitionVersion) &&
-                Objects.equals(eligibleToIgnore, partition.eligibleToIgnore) &&
-                Objects.equals(sealedPartition, partition.sealedPartition) &&
-                Objects.equals(createTime, partition.getCreateTime()) &&
-                Objects.equals(lastDataCommitTime, partition.getLastDataCommitTime());
+                eligibleToIgnore == partition.eligibleToIgnore &&
+                sealedPartition == partition.sealedPartition &&
+                this.getCreateTime() == partition.getCreateTime() &&
+                lastDataCommitTime == partition.getLastDataCommitTime() &&
+                this.getLastAccessTime() == partition.getLastAccessTime();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime, lastDataCommitTime);
+        return Objects.hash(super.hashCode(), storage, columns, partitionVersion, eligibleToIgnore, sealedPartition, lastDataCommitTime);
     }
 
     public static Builder builder()
@@ -208,6 +209,7 @@ public class Partition
         private boolean isSealedPartition = true;
         private int createTime;
         private long lastDataCommitTime;
+        private int lastAccessTime;
 
         private Builder()
         {
@@ -226,6 +228,7 @@ public class Partition
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
             this.lastDataCommitTime = partition.getLastDataCommitTime();
+            this.lastAccessTime = partition.getLastAccessTime();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -299,9 +302,27 @@ public class Partition
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime, lastDataCommitTime);
+            return new Partition(
+                    databaseName,
+                    tableName,
+                    values,
+                    storageBuilder.build(),
+                    columns,
+                    parameters,
+                    partitionVersion,
+                    isEligibleToIgnore,
+                    isSealedPartition,
+                    createTime,
+                    lastDataCommitTime,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -232,6 +232,7 @@ public class PartitionMetadata
                 eligibleToIgnore,
                 sealedPartition,
                 0,
+                0,
                 0);
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -115,6 +115,7 @@ public class TestRecordingHiveMetastore
             false,
             true,
             0,
+            0,
             0);
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -109,8 +109,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +129,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +161,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, 0)));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -271,6 +271,7 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 true,
                 0,
+                0,
                 0);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -472,6 +472,7 @@ public class TestHiveSplitManager
                         false,
                         true,
                         0,
+                        0,
                         0),
                 PARTITION_NAME,
                 partitionStatistics);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
@@ -86,7 +86,8 @@ public class TestS3SelectPushdown
                 false,
                 false,
                 1234,
-                4567L);
+                4567L,
+                0);
 
         table = new Table(
                 "db",
@@ -168,7 +169,8 @@ public class TestS3SelectPushdown
                 false,
                 false,
                 1234,
-                4567L);
+                4567L,
+                0);
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.of(newPartition)));
     }
 
@@ -221,7 +223,8 @@ public class TestS3SelectPushdown
                 false,
                 false,
                 1234,
-                4567L);
+                4567L,
+                0);
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.of(newPartition)));
     }
 


### PR DESCRIPTION
If any other implementation of HiveMetastore is able to directly return the presto Partition object then we can avoid the oss HMS Partition -> presto Partition conversion in `ThriftMetastreUtil.fromMetastoreApiPartition() `and thereby be more efficient.

```
== NO RELEASE NOTE ==
```
