### PR TITLE
Describe ScyllaDB support in connectors docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -35,6 +35,7 @@ from different data sources.
     connector/prometheus
     connector/redis
     connector/redshift
+    connector/scylladb
     connector/sqlserver
     connector/system
     connector/thrift

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -2,12 +2,12 @@
 Cassandra Connector
 ===================
 
-The Cassandra connector allows querying data stored in Cassandra.
+The Cassandra connector allows querying data stored in Cassandra or in ScyllaDB.
 
 Compatibility
 -------------
 
-Connector is compatible with all Cassandra versions starting from 2.1.5.
+Connector is compatible with all Cassandra versions starting from 2.1.5. Latest ScyllaDB tested is 5.1.11.
 
 Configuration
 -------------
@@ -25,11 +25,15 @@ nodes used to discovery the cluster topology:
 You will also need to set ``cassandra.native-protocol-port`` if your
 Cassandra nodes are not using the default port (9042).
 
-Multiple Cassandra Clusters
+For ScyllaDB you don't need to add any additional configuration.
+ScyllaDB uses the same port as Cassandra by default.
+Just point to ScyllaDB nodes in ``cassandra.contact-points`` config property.
+
+Multiple Cassandra or ScyllaDB Clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
-Cassandra clusters, simply add another properties file to ``etc/catalog``
+Cassandra(ScyllaDB) clusters, simply add another properties file to ``etc/catalog``
 with a different name (making sure it ends in ``.properties``). For
 example, if you name the property file ``sales.properties``, Presto
 will create a catalog named ``sales`` using the configured connector.
@@ -156,7 +160,7 @@ Property Name                                                 Description
 ``cassandra.tls.truststore-password``                         Password for the trust store.
 ============================================================= ======================================================================
 
-Querying Cassandra Tables
+Querying Cassandra or ScyllaDB Tables
 -------------------------
 
 The ``users`` table is an example Cassandra table from the Cassandra

--- a/presto-docs/src/main/sphinx/connector/scylladb.rst
+++ b/presto-docs/src/main/sphinx/connector/scylladb.rst
@@ -1,0 +1,17 @@
+===================
+ScyllaDB Connector
+===================
+
+The Cassandra Connector enables querying data stored in `ScyllaDB <https://www.scylladb.com>`_.
+
+Compatibility
+-------------
+
+The connector has been tested and verified with ScyllaDB version 5.1.11.
+
+Configuration
+-------------
+
+No specific ScyllaDB configuration is needed. Please consult the documentation for the
+`Cassandra connector <https://prestodb.io/docs/current/connector/cassandra.html>`_ for further details.
+`For further information <https://docs.scylladb.com/stable/using-scylla/integrations/integration-presto.html>`_.


### PR DESCRIPTION
As ScyllaDB is a drop-in replacement for Cassandra, i checked if Cassandra connector works for ScyllaDB too. All checks passed, i was able to connect to ScyllaDB cluster with Cassandra connector and select data from tables.

Test plan - I've used local scylladb cluster, presto server and jaeger tracer collector. I added presto catalog with type `cassandra` pointing to scylladb cluster. Then i setup jaeger tracer collector which stored its traces to scylladb cluster and push send traces to the jaeger server. Through presto-cli i was able to select all traces data from scylladb.

```
== NO RELEASE NOTE ==
```
