### PR TITLE
[native] Fix translation for TopNRowNumberNode

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2069,12 +2069,16 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   auto [sortFields, sortOrders] = toSortFieldsAndOrders(
       node->specification.orderingScheme.get(), exprConverter_);
 
+  std::optional<std::string> rowNumberColumnName;
+  if (!node->partial) {
+    rowNumberColumnName = node->rowNumberVariable.name;
+  }
   return std::make_shared<core::TopNRowNumberNode>(
       node->id,
       partitionFields,
       sortFields,
       sortOrders,
-      node->rowNumberVariable.name,
+      rowNumberColumnName,
       node->maxRowCountPerPartition,
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }


### PR DESCRIPTION
When translating TopNRowNumberNode from Presto to Velox, consult 'partial' flag to determine whether to specify 'rowNumberColumnName' or not.

This code path is covered by TestPrestoSparkNativeWindowQueries#testRowNumberWithFilter, but incorrect translation is getting masked by round-robin LocalExchange that follows TopnNRowNumberNode. This wouldn't always be so, but I'm not able to force the query plan that doesn't have that.

```
== NO RELEASE NOTE ==
```
