### PR TITLE
Add a pereiodic yield signal to Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -83,7 +83,7 @@ class PrestoServer {
  protected:
   /// Hook for derived PrestoServer implementations to add additional periodic
   /// tasks.
-  virtual void addAdditionalPeriodicTasks();
+  virtual void addAdditionalPeriodicTasks(){};
 
   virtual void initializeCoordinatorDiscoverer();
 
@@ -138,6 +138,8 @@ class PrestoServer {
   void initializeVeloxMemory();
 
  protected:
+  void addServerPeriodicTasks();
+
   void reportMemoryInfo(proxygen::ResponseHandler* downstream);
 
   void reportServerInfo(proxygen::ResponseHandler* downstream);
@@ -145,6 +147,9 @@ class PrestoServer {
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
   void populateMemAndCPUInfo();
+
+  // Periodically yield tasks if there are tasks queued.
+  void yieldTasks();
 
   const std::string configDirectoryPath_;
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -119,6 +119,11 @@ class TaskManager {
     return &queryContextManager_;
   }
 
+  /// Make upto target task threads to yield. Task candidate must have been on
+  /// thread for at least sliceMicros to be yieldable. Return the number of
+  /// threads in tasks that were requested to yield.
+  int32_t yieldTasks(int32_t numTargetThreadsToYield, int32_t timeSliceMicros);
+
   const QueryContextManager* getQueryContextManager() const {
     return &queryContextManager_;
   }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -271,6 +271,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 35s
           STR_PROP(kExchangeMaxErrorDuration, "30s"),
           STR_PROP(kExchangeRequestTimeout, "10s"),
+          NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
       };
 }
 
@@ -499,6 +500,10 @@ std::chrono::duration<double> SystemConfig::exchangeMaxErrorDuration() const {
 
 std::chrono::duration<double> SystemConfig::exchangeRequestTimeout() const {
   return toDuration(optionalProperty(kExchangeRequestTimeout).value());
+}
+
+int32_t SystemConfig::taskRunTimeSliceMicros() const {
+  return optionalProperty<int32_t>(kTaskRunTimeSliceMicros).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -253,6 +253,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kRemoteFunctionServerThriftPort{
       "remote-function-server.thrift.port"};
 
+  /// Do not include runtime stats in the returned task info if the task is
+  /// in running state.
   static constexpr std::string_view kSkipRuntimeStatsInRunningTaskInfo{
       "skip-runtime-stats-in-running-task-info"};
 
@@ -270,6 +272,10 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kExchangeRequestTimeout{
       "exchange.http-client.request-timeout"};
+
+  /// The maximum timeslice for a task on thread if there are threads queued.
+  static constexpr std::string_view kTaskRunTimeSliceMicros{
+      "task-run-timeslice-micros"};
 
   SystemConfig();
 
@@ -395,6 +401,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> exchangeMaxErrorDuration() const;
 
   std::chrono::duration<double> exchangeRequestTimeout() const;
+
+  int32_t taskRunTimeSliceMicros() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
Adds a mechanism to periodically cause long running Tasks to go off
thread if there is work queued on the Driver executor. Corresponds to
Presto's YieldSignal logic. Controlled by flag
task_timeslice_micros. Tasks that have been continuously on thread for
longer than this time will get a request to yield if there is work
queued on the executor.

```
== NO RELEASE NOTE ==
```
