### PR TITLE
[native] Enable Q2, Q78 in tpc-ds

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
@@ -430,13 +430,11 @@ public abstract class AbstractTestNativeTpcdsQueries
         assertQuery(session, getTpcdsQuery("01"));
     }
 
-    // TODO(spershin): Enable test when fixed.
-    // GitHub issue: https://github.com/facebookincubator/velox/issues/5412
-    @Test (enabled = false)
+    @Test
     public void testTpcdsQ2()
             throws Exception
     {
-        assertQueryFails(session, getTpcdsQuery("02"), "[\\s\\S]*Scalar function presto\\.default\\.round not registered with arguments[\\s\\S]*");
+        assertQuery(session, getTpcdsQuery("02"));
     }
 
     @Test
@@ -1007,13 +1005,11 @@ public abstract class AbstractTestNativeTpcdsQueries
         assertQuery(session, getTpcdsQuery("77"));
     }
 
-    // TODO(spershin): Enable test when fixed.
-    // GitHub issue: https://github.com/facebookincubator/velox/issues/5412
-    @Test (enabled = false)
+    @Test
     public void testTpcdsQ78()
             throws Exception
     {
-        assertQueryFails(session, getTpcdsQuery("78"), "[\\s\\S]*Scalar function presto\\.default\\.round not registered with arguments[\\s\\S]*");
+        assertQuery(session, getTpcdsQuery("78"));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/5412

After advancing Velox in https://github.com/prestodb/presto/pull/19987, Q2 / Q78 succeed

```
== NO RELEASE NOTE ==
```
