### PR TITLE
[native] Fix typo in task logging

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -431,7 +431,7 @@ bool SystemConfig::logZombieTaskInfo() const {
 }
 
 uint32_t SystemConfig::logNumZombieTasks() const {
-  return optionalProperty<uint32_t>(kLogZombieTaskInfo).value();
+  return optionalProperty<uint32_t>(kLogNumZombieTasks).value();
 }
 
 NodeConfig::NodeConfig() {


### PR DESCRIPTION
Fix typo, which was using the wrong config

```
== NO RELEASE NOTE ==
```
