### PR TITLE
Remove useless code.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
@@ -48,7 +48,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -345,7 +344,6 @@ public class CursorProcessorCompiler
         Parameter cursor = arg("cursor", RecordCursor.class);
 
         ImmutableList.Builder<MethodDefinition> methods = ImmutableList.builder();
-        Map<VariableReferenceExpression, CommonSubExpressionFields> cseMap = new HashMap<>();
         int startLevel = commonSubExpressionsByLevel.keySet().stream().reduce(Math::min).get();
         int maxLevel = commonSubExpressionsByLevel.keySet().stream().reduce(Math::max).get();
         for (int i = startLevel; i <= maxLevel; i++) {
@@ -385,7 +383,6 @@ public class CursorProcessorCompiler
                             .retObject();
 
                     methods.add(method);
-                    cseMap.put(cseVariable, cseFields);
                 }
             }
         }


### PR DESCRIPTION
Some code seems useless after using the same RowExpressionCompiler to compile expressions.




```
== NO RELEASE NOTE ==
```
