### PR TITLE
[native] Use different commit strategies in Velox query plan converters

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1877,7 +1877,7 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->columnNames,
       insertTableHandle,
       outputType,
-      connector::CommitStrategy::kNoCommit,
+      getCommitStrategy(),
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 
@@ -2402,6 +2402,11 @@ velox::core::PlanNodePtr VeloxInteractiveQueryPlanConverter::toVeloxQueryPlan(
   return std::make_shared<core::ExchangeNode>(node->id, rowType);
 }
 
+velox::connector::CommitStrategy
+VeloxInteractiveQueryPlanConverter::getCommitStrategy() const {
+  return velox::connector::CommitStrategy::kNoCommit;
+}
+
 velox::core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     const protocol::PlanFragment& fragment,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
@@ -2463,6 +2468,11 @@ velox::core::PlanNodePtr VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     const protocol::TaskId& taskId) {
   auto rowType = toRowType(node->outputVariables);
   return std::make_shared<operators::ShuffleReadNode>(node->id, rowType);
+}
+
+velox::connector::CommitStrategy
+VeloxBatchQueryPlanConverter::getCommitStrategy() const {
+  return velox::connector::CommitStrategy::kTaskCommit;
 }
 
 void registerPrestoPlanNodeSerDe() {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -56,6 +56,8 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId) = 0;
 
+  virtual velox::connector::CommitStrategy getCommitStrategy() const = 0;
+
   velox::core::PlanNodePtr toVeloxQueryPlan(
       const std::shared_ptr<const protocol::OutputNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
@@ -204,6 +206,8 @@ class VeloxInteractiveQueryPlanConverter : public VeloxQueryPlanConverterBase {
       const std::shared_ptr<const protocol::RemoteSourceNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId) override;
+
+  velox::connector::CommitStrategy getCommitStrategy() const override;
 };
 
 class VeloxBatchQueryPlanConverter : public VeloxQueryPlanConverterBase {
@@ -229,6 +233,8 @@ class VeloxBatchQueryPlanConverter : public VeloxQueryPlanConverterBase {
       const std::shared_ptr<const protocol::RemoteSourceNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId) override;
+
+  velox::connector::CommitStrategy getCommitStrategy() const override;
 
  private:
   const std::string shuffleName_;


### PR DESCRIPTION
Use CommitStrategy::kNoCommit for VeloxInteractiveQueryPlanConverter and use CommitStrategy::kTaskCommit for VeloxBatchQueryPlanConverter.

Commit strategy determines behaviors of TableWriter related to committing. For example, target file name is composed in different ways based on the commit strategy.

```
== NO RELEASE NOTE ==
```
