### PR TITLE
Fixed bigquery table not found error

### DIFF
--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryClient.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryClient.java
@@ -64,8 +64,7 @@ public class BigQueryClient
 
     public TableInfo getTable(TableId tableId)
     {
-        TableId bigQueryTableId = tableIds.get(tableId);
-        Table table = bigQuery.getTable(bigQueryTableId != null ? bigQueryTableId : tableId);
+        Table table = bigQuery.getTable(tableId);
         if (table != null) {
             tableIds.putIfAbsent(tableId, table.getTableId());
             datasetIds.putIfAbsent(toDatasetId(tableId), toDatasetId(table.getTableId()));


### PR DESCRIPTION
 Connecting to BigQuery worked fine before, but querying any tables for data would fail with a "Table not found" error. This fixes that and results can now be queried/joined/etc just fine as expected.

```
== RELEASE NOTES ==

General Changes
* Fixed BigQuery "Table not found" error on any tables
```

I saw that the changes mentioned [here](https://github.com/prestodb/presto/issues/18428) were never pull requested properly and it's been more than 6 months, so I did this myself and can confirm BQ works fine with this. Hope that's okay!

Also this has been mentioned in issues [17906](https://github.com/prestodb/presto/issues/17906) and [17257](https://github.com/prestodb/presto/issues/17257) as well.