### PR TITLE
[native]Add to config memory arbitration in Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -397,6 +397,28 @@ bool SystemConfig::useMmapAllocator() const {
   return optionalProperty<bool>(kUseMmapAllocator).value();
 }
 
+bool SystemConfig::enableMemoryArbitration() const {
+  return optionalProperty<bool>(kEnableMemoryArbitration).value_or(false);
+}
+
+uint64_t SystemConfig::initMemoryPoolCapacity() const {
+  static constexpr uint64_t kInitMemoryPoolCapacityDefault = 128 << 20;
+  return optionalProperty<uint64_t>(kInitMemoryPoolCapacity)
+      .value_or(kInitMemoryPoolCapacityDefault);
+}
+
+uint64_t SystemConfig::minMemoryPoolTransferCapacity() const {
+  static constexpr uint64_t kMinMemoryPoolTransferCapacityDefault = 32 << 20;
+  return optionalProperty<uint64_t>(kMinMemoryPoolTransferCapacity)
+      .value_or(kMinMemoryPoolTransferCapacityDefault);
+}
+
+uint32_t SystemConfig::reservedMemoryPoolCapacityPct() const {
+  static constexpr uint64_t kReservedMemoryPoolCapacityPctDefault = 10;
+  return optionalProperty<uint32_t>(kReservedMemoryPoolCapacityPct)
+      .value_or(kReservedMemoryPoolCapacityPctDefault);
+}
+
 bool SystemConfig::enableHttpAccessLog() const {
   return optionalProperty<bool>(kHttpEnableAccessLog).value();
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -202,6 +202,27 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kMmapArenaCapacityRatio{
       "mmap-arena-capacity-ratio"};
   static constexpr std::string_view kUseMmapAllocator{"use-mmap-allocator"};
+
+  static constexpr std::string_view kEnableMemoryArbitration{
+      "enable-memory-arbitration"};
+  /// The initial memory pool capacity in bytes allocated on creation.
+  ///
+  /// NOTE: this config only applies if the memory arbitration has been enabled.
+  static constexpr std::string_view kInitMemoryPoolCapacity{
+      "init-memory-pool-capacity"};
+  /// The minimal memory capacity in bytes transferred between memory pools
+  /// during memory arbitration.
+  ///
+  /// NOTE: this config only applies if the memory arbitration has been enabled.
+  static constexpr std::string_view kMinMemoryPoolTransferCapacity{
+      "min-memory-pool-transfer-capacity"};
+  /// The percentage of memory pool capacity reserved for system usage such as
+  /// the disk spilling memory usage.
+  ///
+  /// NOTE: this config only applies if the memory arbitration has been enabled.
+  static constexpr std::string_view kReservedMemoryPoolCapacityPct{
+      "reserved-memory-pool-capacity-pct"};
+
   static constexpr std::string_view kEnableVeloxTaskLogging{
       "enable_velox_task_logging"};
   static constexpr std::string_view kEnableVeloxExprSetLogging{
@@ -328,6 +349,14 @@ class SystemConfig : public ConfigBase {
   int32_t mmapArenaCapacityRatio() const;
 
   bool useMmapAllocator() const;
+
+  bool enableMemoryArbitration() const;
+
+  uint64_t initMemoryPoolCapacity() const;
+
+  uint64_t minMemoryPoolTransferCapacity() const;
+
+  uint32_t reservedMemoryPoolCapacityPct() const;
 
   bool enableHttpAccessLog() const;
 


### PR DESCRIPTION
Add the following system configs in Prestissimo to setup memory arbitrator
"enable-memory-arbitration": turn on/off memory arbitration
"init-memory-pool-capacity": the initial capacity allocated to a memory on
creation.
"min-memory-pool-transfer-capacity": the min capacity transfer between
memory pools during the memory arbitration.
"reserved-memory-pool-capacity-pct": the percentage of memory pool
capacity reserved for system usage such as disk spilling which is not involved
in memory arbitration.

```
== NO RELEASE NOTE ==
```
