### PR TITLE
[native] Handle same type NULLIF argument

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -611,22 +611,6 @@ TypedExprPtr convertDereferenceExpr(
 
   return std::make_shared<FieldAccessTypedExpr>(returnType, input, childName);
 }
-
-TypedExprPtr convertNullIfExpr(
-    const velox::TypePtr& returnType,
-    const std::vector<TypedExprPtr>& args) {
-  VELOX_CHECK_EQ(args.size(), 2);
-
-  // Convert nullif(a, b) to if(a = b, null, a).
-
-  std::vector<TypedExprPtr> newArgs = {
-      std::make_shared<CallTypedExpr>(
-          velox::BOOLEAN(), args, "presto.default.eq"),
-      std::make_shared<ConstantTypedExpr>(
-          returnType, velox::variant::null(returnType->kind())),
-      args[0]};
-  return std::make_shared<CallTypedExpr>(returnType, newArgs, "if");
-}
 } // namespace
 
 TypedExprPtr VeloxExprConverter::toVeloxExpr(
@@ -657,7 +641,7 @@ TypedExprPtr VeloxExprConverter::toVeloxExpr(
   }
 
   if (pexpr->form == protocol::Form::NULL_IF) {
-    return convertNullIfExpr(returnType, args);
+    VELOX_UNREACHABLE("NULL_IF not supported in specialForm")
   }
 
   auto form = std::string(json(pexpr->form));

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -263,7 +263,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT linenumber, NULL FROM lineitem ORDER BY 1 LIMIT 23");
     }
 
-    @Test (enabled = false)
+    @Test
     public void testNullIf()
     {
         assertQuery("SELECT NULLIF(totalprice, 0) FROM (SELECT SUM(extendedprice) AS totalprice FROM lineitem WHERE shipdate >= '1995-09-01')");
@@ -963,7 +963,7 @@ public abstract class AbstractTestNativeGeneralQueries
 
             // For special character in partition name, without correct handling, it would throw errors like 'Invalid partition spec: nationkey=A/B'
             // In this test, verify those partition names can be successfully created
-            String[] specialCharacters = new String[]{"\"", "#", "%", "''", "*", "/", ":", "=", "?", "\\", "\\x7F", "{", "[", "]", "^"}; // escape single quote for sql
+            String[] specialCharacters = new String[] {"\"", "#", "%", "''", "*", "/", ":", "=", "?", "\\", "\\x7F", "{", "[", "]", "^"}; // escape single quote for sql
             for (String specialCharacter : specialCharacters) {
                 getQueryRunner().execute(writeSession, String.format("INSERT INTO %s VALUES ('name', 'A%sB')", tmpTableName, specialCharacter));
                 assertQuery(String.format("SELECT nationkey FROM %s", tmpTableName), String.format("VALUES('A%sB')", specialCharacter));

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -140,6 +140,7 @@ public class PrestoNativeQueryRunnerUtils
                 ImmutableMap.<String, String>builder()
                         .put("http-server.http.port", "8080")
                         .put("experimental.internal-communication.thrift-transport-enabled", String.valueOf(useThrift))
+                        .put("native-execution-enabled", "true")
                         .putAll(getNativeWorkerSystemProperties())
                         .build(),
                 ImmutableMap.of(),

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -84,13 +84,8 @@ public class TestPrestoSparkNativeSimpleQueries
     {
         assertQuery("SELECT * FROM orders");
         assertQuery("SELECT orderkey, custkey FROM orders WHERE orderkey <= 200");
-        assertQuery("SELECT orderkey, custkey FROM orders ORDER BY orderkey LIMIT 4");
-    }
-
-    @Test (enabled = false)
-    public void testNullIf()
-    {
         assertQuery("SELECT nullif(orderkey, custkey) FROM orders");
+        assertQuery("SELECT orderkey, custkey FROM orders ORDER BY orderkey LIMIT 4");
     }
 
     @Test


### PR DESCRIPTION
- Remove NULLIF implementation from cpp server.
- Add support for handling same type arguments in NULLIF coordinator code.
- Prestissimo cluster need to pass the config `native-execution-enabled` in the coordinator to trigger the correct branch in the code.

```
== NO RELEASE NOTE ==
```
