### PR TITLE
[native] Add backoff to Exchange requests

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -111,6 +111,32 @@ uint64_t toCapacity(const std::string& from, CapacityUnit to) {
        toBytesPerCapacityUnit(to));
 }
 
+std::chrono::duration<double> toDuration(const std::string& str) {
+  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*)");
+
+  double value;
+  std::string unit;
+  if (!RE2::FullMatch(str, kPattern, &value, &unit)) {
+    VELOX_USER_FAIL("Invalid duration '{}'", str);
+  }
+  if (unit == "ns") {
+    return std::chrono::duration<double, std::nano>(value);
+  } else if (unit == "us") {
+    return std::chrono::duration<double, std::micro>(value);
+  } else if (unit == "ms") {
+    return std::chrono::duration<double, std::milli>(value);
+  } else if (unit == "s") {
+    return std::chrono::duration<double>(value);
+  } else if (unit == "m") {
+    return std::chrono::duration<double, std::ratio<60>>(value);
+  } else if (unit == "h") {
+    return std::chrono::duration<double, std::ratio<60 * 60>>(value);
+  } else if (unit == "d") {
+    return std::chrono::duration<double, std::ratio<60 * 60 * 24>>(value);
+  }
+  VELOX_USER_FAIL("Invalid duration '{}'", str);
+}
+
 } // namespace
 
 ConfigBase::ConfigBase()
@@ -193,12 +219,6 @@ void ConfigBase::checkRegisteredProperties(
   }
 }
 
-static constexpr std::string_view kAnnouncementMinFrequencyMs{
-    "announcement-min-frequency-ms"};
-
-static constexpr std::string_view kAnnouncementMaxFrequencyMs{
-    "announcement-max-frequency-ms"};
-
 SystemConfig::SystemConfig() {
   registeredProps_ =
       std::unordered_map<std::string, folly::Optional<std::string>>{
@@ -250,6 +270,8 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLogNumZombieTasks, 20),
           NUM_PROP(kAnnouncementMinFrequencyMs, 25'000), // 25s
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 35s
+          STR_PROP(kExchangeMaxErrorDuration, "30s"),
+          STR_PROP(kExchangeRequestTimeout, "10s"),
       };
 }
 
@@ -470,6 +492,14 @@ uint64_t SystemConfig::announcementMinFrequencyMs() const {
 
 uint64_t SystemConfig::announcementMaxFrequencyMs() const {
   return optionalProperty<uint64_t>(kAnnouncementMaxFrequencyMs).value();
+}
+
+std::chrono::duration<double> SystemConfig::exchangeMaxErrorDuration() const {
+  return toDuration(optionalProperty(kExchangeMaxErrorDuration).value());
+}
+
+std::chrono::duration<double> SystemConfig::exchangeRequestTimeout() const {
+  return toDuration(optionalProperty(kExchangeRequestTimeout).value());
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -265,6 +265,12 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAnnouncementMaxFrequencyMs{
       "announcement-max-frequency-ms"};
 
+  static constexpr std::string_view kExchangeMaxErrorDuration{
+      "exchange.max-error-duration"};
+
+  static constexpr std::string_view kExchangeRequestTimeout{
+      "exchange.http-client.request-timeout"};
+
   SystemConfig();
 
   static SystemConfig* instance();
@@ -385,6 +391,10 @@ class SystemConfig : public ConfigBase {
   uint64_t announcementMinFrequencyMs() const;
 
   uint64_t announcementMaxFrequencyMs() const;
+
+  std::chrono::duration<double> exchangeMaxErrorDuration() const;
+
+  std::chrono::duration<double> exchangeRequestTimeout() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -115,7 +115,8 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
   // TODO Avoid copy by using IOBuf for body
   folly::SemiFuture<std::unique_ptr<HttpResponse>> sendRequest(
       const proxygen::HTTPMessage& request,
-      const std::string& body = "");
+      const std::string& body = "",
+      int64_t delayMs = 0);
 
   const std::shared_ptr<velox::memory::MemoryPool>& memoryPool() {
     return pool_;
@@ -166,12 +167,11 @@ class RequestBuilder {
     return *this;
   }
 
-  folly::SemiFuture<std::unique_ptr<HttpResponse>> send(
-      HttpClient* client,
-      const std::string& body = "") {
+  folly::SemiFuture<std::unique_ptr<HttpResponse>>
+  send(HttpClient* client, const std::string& body = "", int64_t delayMs = 0) {
     header(proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));
     headers_.ensureHostHeader();
-    return client->sendRequest(headers_, body);
+    return client->sendRequest(headers_, body, delayMs);
   }
 
  private:


### PR DESCRIPTION
This PR improves Exchange retry workflow in several ways:

* Add new config `exchange.max-error-duration`. Now PrestoExchangeSource will retry several times with a backoff till we hit this error duration. Only then the exchange will fail. Added a test.

* By the above change, we will also start displaying correct error messages. Instead of `Failed to fetch data...`, the backoff'd retry will cause delay and coordinator will show error from the worker that actually aborted the query. Java does the same. 

* Improved error message in case fetching from a worker fails after several tries. Added a test.

* Convert hardcoded exchange request timeout to config `exchange.http-client.request-timeout`. Config names are taken from Java. Added a test

```
== NO RELEASE NOTE ==
```
