### PR TITLE
[native] Add first version of json function signature parser

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -87,6 +87,11 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer)
 
+add_library(presto_json_signature_parser JsonSignatureParser.cpp)
+
+target_link_libraries(presto_json_signature_parser velox_expression
+                      ${FOLLY_WITH_DEPENDENCIES})
+
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()

--- a/presto-native-execution/presto_cpp/main/JsonSignatureParser.cpp
+++ b/presto-native-execution/presto_cpp/main/JsonSignatureParser.cpp
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/JsonSignatureParser.h"
+#include <folly/json.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::presto {
+namespace {
+
+// Parse a single type signature.
+velox::exec::TypeSignature parseTypeSignature(const folly::dynamic& input) {
+  VELOX_USER_CHECK(
+      input.isString(),
+      "Function type name should be a string. Got: {}",
+      input.typeName());
+  return velox::exec::parseTypeSignature(input.asString());
+}
+
+// Parses a list of type signatures.
+std::vector<velox::exec::TypeSignature> parseTypeSignatures(
+    const folly::dynamic& input) {
+  VELOX_USER_CHECK(
+      input.isArray(),
+      "Function paramType should be an array. Got: {}",
+      input.typeName());
+  std::vector<velox::exec::TypeSignature> typeSignatures;
+  typeSignatures.reserve(input.size());
+
+  for (const auto& it : input) {
+    typeSignatures.emplace_back(parseTypeSignature(it));
+  }
+  return typeSignatures;
+}
+
+// Parses a single signature.
+velox::exec::FunctionSignaturePtr parseSignature(const folly::dynamic& input) {
+  VELOX_USER_CHECK(
+      input.isObject(),
+      "Function signature should be an object. Got: {}",
+      input.typeName());
+
+  auto* outputType = input.get_ptr("outputType");
+  auto* paramTypes = input.get_ptr("paramTypes");
+  VELOX_USER_CHECK(
+      (outputType != nullptr) && (paramTypes != nullptr),
+      "`outputType` and `paramTypes` are mandatory in a signature.");
+
+  auto paramTypeSignatures = parseTypeSignatures(*paramTypes);
+  std::vector<bool> constantArguments(paramTypeSignatures.size(), false);
+
+  return std::make_shared<velox::exec::FunctionSignature>(
+      std::unordered_map<std::string, velox::exec::SignatureVariable>{},
+      parseTypeSignature(*outputType),
+      std::move(paramTypeSignatures),
+      std::move(constantArguments),
+      /*variableArity=*/false);
+}
+
+// Parses a list of signatures for a function.
+std::vector<velox::exec::FunctionSignaturePtr> parseSignatures(
+    const folly::dynamic& input) {
+  VELOX_USER_CHECK(
+      input.isArray(),
+      "The value for a function item should be an array of signatures. Got: {}",
+      input.typeName());
+  std::vector<velox::exec::FunctionSignaturePtr> signatures;
+  signatures.reserve(input.size());
+
+  for (const auto& signature : input) {
+    signatures.emplace_back(parseSignature(signature));
+  }
+  return signatures;
+}
+
+} // namespace
+
+JsonSignatureParser::JsonSignatureParser(const std::string& input) {
+  folly::dynamic topLevelJson;
+  try {
+    topLevelJson = folly::parseJson(input);
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(
+        "Unable to parse function signature JSON file: {}", e.what());
+  }
+
+  VELOX_USER_CHECK(
+      topLevelJson.isObject(),
+      "Top level json item needs to be an object. Got: {}",
+      topLevelJson.typeName());
+
+  // Search for the top-level key.
+  if (auto* found = topLevelJson.get_ptr("udfSignatureMap")) {
+    parse(*found);
+  } else {
+    VELOX_USER_FAIL("Unable to find top level 'udfSignatureMap' key.");
+  }
+}
+
+void JsonSignatureParser::parse(const folly::dynamic& input) {
+  VELOX_USER_CHECK(
+      input.isObject(),
+      "Input signatures should be an object. Got: {}",
+      input.typeName());
+
+  // Iterate over each function.
+  for (auto it : input.items()) {
+    // Check function name.
+    const auto& key = it.first;
+    VELOX_USER_CHECK(
+        key.isString() && !key.getString().empty(),
+        "The key for a function item should be a non-empty string. Got: '{}'",
+        key.asString());
+
+    // Check and parse list of signatures.
+    signaturesMap_.emplace(key.getString(), parseSignatures(it.second));
+  }
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/JsonSignatureParser.h
+++ b/presto-native-execution/presto_cpp/main/JsonSignatureParser.h
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "velox/expression/VectorFunction.h"
+
+namespace folly {
+struct dynamic;
+}
+
+namespace facebook::presto {
+
+/// Class to parse json signature files. It only parses the json and creates
+/// the FunctionSignature objects. It does not do the actual registration.
+/// It assumes the input json has the following format:
+///
+///  {
+///    "udfSignatureMap": {
+///      "my_function": [
+///        {
+///          "outputType": "varchar",
+///          "paramTypes": [
+///            "varchar"
+///          ],
+///          "schema": "my_schema",
+///          "routineCharacteristics": {
+///					   ...
+///			     }
+///        },
+///      ]
+///    }
+///  }
+///
+/// TODO: This json definition only supports scalar signatures for now. It also
+/// does not support variadic arguments, type variables, or constant arguments
+/// yet.
+///
+/// This class can be conveniently used in a range for loop:
+///
+///   for (const auto& it : JsonSignatureParser(jsonString)) {
+///     // registration code
+///   }
+class JsonSignatureParser {
+ public:
+  using TContainer = std::unordered_map<
+      std::string,
+      std::vector<velox::exec::FunctionSignaturePtr>>;
+
+  explicit JsonSignatureParser(const std::string& input);
+
+  // Iterator helpers.
+  size_t size() const {
+    return signaturesMap_.size();
+  }
+
+  TContainer::const_iterator begin() const {
+    return signaturesMap_.begin();
+  }
+
+  TContainer::const_iterator end() const {
+    return signaturesMap_.end();
+  }
+
+ private:
+  /// Parses the top level json parsed.
+  void parse(const folly::dynamic& input);
+
+  TContainer signaturesMap_;
+};
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
   AnnouncerTest.cpp
   CoordinatorDiscovererTest.cpp
   HttpServerWrapper.cpp
+  JsonSignatureParserTest.cpp
   PrestoExchangeSourceTest.cpp
   PrestoTaskTest.cpp
   QueryContextCacheTest.cpp
@@ -28,6 +29,7 @@ add_test(
 target_link_libraries(
   presto_server_test
   presto_server_lib
+  presto_json_signature_parser
   $<TARGET_OBJECTS:presto_type_converter>
   $<TARGET_OBJECTS:presto_types>
   velox_exec_test_lib

--- a/presto-native-execution/presto_cpp/main/tests/JsonSignatureParserTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/JsonSignatureParserTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/JsonSignatureParser.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+
+namespace facebook::presto::test {
+namespace {
+
+class JsonSignatureParserTest : public testing::Test {};
+
+TEST_F(JsonSignatureParserTest, broken) {
+  // Needs to parse and provide a top level `udfSignatureMap` object.
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser(""), "Unable to parse function signature JSON file");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{}"),
+      "Unable to find top level 'udfSignatureMap' key.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"wrong_key\": 123}"),
+      "Unable to find top level 'udfSignatureMap' key.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"udfSignatureMap\": 123}"),
+      "Input signatures should be an object.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"udfSignatureMap\": []}"),
+      "Input signatures should be an object");
+
+  EXPECT_NO_THROW(JsonSignatureParser parser("{\"udfSignatureMap\": {}}"));
+
+  // Broken signatures.
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"udfSignatureMap\": {\"\": []}}"),
+      "The key for a function item should be a non-empty string.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"udfSignatureMap\": {\"func\": [123]}}"),
+      "Function signature should be an object.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser("{\"udfSignatureMap\": {\"func\": [{}, {}]}}"),
+      "`outputType` and `paramTypes` are mandatory in a signature");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser(
+          "{\"udfSignatureMap\": "
+          "{\"func\": [{\"outputType\": 123, \"paramTypes\": []}]}}"),
+      "Function type name should be a string.");
+  VELOX_ASSERT_THROW(
+      JsonSignatureParser(
+          "{\"udfSignatureMap\": {\"func\": "
+          "[{\"outputType\": \"varchar\", \"paramTypes\": [123]}]}}"),
+      "Function type name should be a string.");
+
+  EXPECT_NO_THROW(JsonSignatureParser parser(
+      "{\"udfSignatureMap\": {\"func\": "
+      "[{\"outputType\": \"varchar\", \"paramTypes\": [\"varchar\"]}]}}"));
+}
+
+TEST_F(JsonSignatureParserTest, simpleTypes) {
+  auto input = R"(
+  {
+    "udfSignatureMap": {
+      "my_func": [
+        {
+          "outputType": "varchar",
+          "paramTypes": [
+            "varchar",
+            "varbinary",
+            "boolean",
+            "tinyint",
+            "smallint",
+            "integer",
+            "bigint",
+            "real",
+            "double",
+            "timestamp",
+            "date"
+          ]
+        }
+      ]
+    }
+  })";
+
+  JsonSignatureParser parser(input);
+  EXPECT_EQ(1, parser.size());
+
+  const auto& it = parser.begin();
+  EXPECT_EQ(it->first, "my_func");
+  EXPECT_EQ(it->second.size(), 1);
+
+  // We can just verify the counts here. If the type doesn't not exist or can't
+  // be parsed, the parsing constructor will throw.
+  const auto& signature = it->second.front();
+  EXPECT_EQ(signature->argumentTypes().size(), 11);
+}
+
+TEST_F(JsonSignatureParserTest, complexTypes) {
+  auto input = R"V(
+  {
+    "udfSignatureMap": {
+      "my_func": [
+        {
+          "outputType": "varchar",
+          "paramTypes": [
+            "array(bigint)",
+            "map(varchar, double)",
+            "row(varbinary, double, tinyint)",
+            "array(array(bigint))",
+            "map(array(map(bigint, array(boolean))))"
+          ]
+        }
+      ]
+    }
+  })V";
+
+  JsonSignatureParser parser(input);
+  EXPECT_EQ(1, parser.size());
+
+  const auto& it = parser.begin();
+  EXPECT_EQ(it->first, "my_func");
+  EXPECT_EQ(it->second.size(), 1);
+
+  // We can just verify the counts here. If the type doesn't exist or can't
+  // be parsed, the parsing constructor will throw.
+  const auto& signature = it->second.front();
+  EXPECT_EQ(signature->argumentTypes().size(), 5);
+}
+
+TEST_F(JsonSignatureParserTest, multiple) {
+  // Real example:
+  auto input = R"(
+  {
+    "udfSignatureMap": {
+      "fb_lower": [
+        {
+          "docString": "example 1",
+          "outputType": "varchar",
+          "paramTypes": [
+            "varchar"
+          ],
+          "schema": "spark",
+          "routineCharacteristics": {
+          "language": "CPP",
+        "determinism": "DETERMINISTIC",
+        "nullCallClause": "CALLED_ON_NULL_INPUT"
+      }
+    },
+    {
+      "docString": "example 2",
+      "outputType": "varchar",
+      "paramTypes": [
+        "varchar",
+        "varchar"
+      ],
+      "schema": "spark",
+      "routineCharacteristics": {
+        "language": "CPP",
+        "determinism": "DETERMINISTIC",
+        "nullCallClause": "CALLED_ON_NULL_INPUT"
+      }
+    }
+  ]
+  }
+  })";
+
+  JsonSignatureParser parser(input);
+  EXPECT_EQ(1, parser.size());
+
+  const auto& it = parser.begin();
+  EXPECT_EQ(it->first, "fb_lower");
+  EXPECT_EQ(it->second.size(), 2);
+
+  EXPECT_EQ(it->second[0]->returnType().baseName(), "varchar");
+  EXPECT_EQ(it->second[0]->argumentTypes().size(), 1);
+  EXPECT_EQ(it->second[0]->argumentTypes()[0].baseName(), "varchar");
+
+  EXPECT_EQ(it->second[1]->returnType().baseName(), "varchar");
+  EXPECT_EQ(it->second[1]->argumentTypes().size(), 2);
+  EXPECT_EQ(it->second[1]->argumentTypes()[0].baseName(), "varchar");
+  EXPECT_EQ(it->second[1]->argumentTypes()[1].baseName(), "varchar");
+}
+
+} // namespace
+} // namespace facebook::presto::test


### PR DESCRIPTION
Summary:
Adding a first version of the code to parse json function signature
files. It will be used to read json registration files generated for remote
functions.

Differential Revision: D47201915

