### PR TITLE
Fix ParquetWriter.getWrittenBytes()

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -111,7 +111,7 @@ public class ParquetWriter
 
     public long getWrittenBytes()
     {
-        return outputStream.size();
+        return outputStream.longSize();
     }
 
     public long getBufferedBytes()


### PR DESCRIPTION
When loading large tables using CTAS, we sometimes get the following error:
```
java.lang.IllegalArgumentException: Size is greater than maximum int value
	at io.airlift.slice.Preconditions.checkArgument(Preconditions.java:32)
	at io.airlift.slice.OutputStreamSliceOutput.checkedCast(OutputStreamSliceOutput.java:369)
	at io.airlift.slice.OutputStreamSliceOutput.size(OutputStreamSliceOutput.java:103)
	at com.facebook.presto.parquet.writer.ParquetWriter.getWrittenBytes(ParquetWriter.java:108)
	at com.facebook.presto.hive.parquet.ParquetFileWriter.getWrittenBytes(ParquetFileWriter.java:83)
	at com.facebook.presto.iceberg.IcebergPageSink.writePage(IcebergPageSink.java:260)
	at com.facebook.presto.iceberg.IcebergPageSink.doAppend(IcebergPageSink.java:211)
	at com.facebook.presto.iceberg.IcebergPageSink.lambda$appendPage$0(IcebergPageSink.java:149)
	at com.facebook.presto.hive.authentication.HdfsAuthentication.lambda$doAs$0(HdfsAuthentication.java:24)
	at com.facebook.presto.hive.authentication.NoHdfsAuthentication.doAs(NoHdfsAuthentication.java:23)
	at com.facebook.presto.hive.authentication.HdfsAuthentication.doAs(HdfsAuthentication.java:23)
	at com.facebook.presto.hive.HdfsEnvironment.doAs(HdfsEnvironment.java:86)
	at com.facebook.presto.iceberg.IcebergPageSink.appendPage(IcebergPageSink.java:149)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSink.appendPage(ClassLoaderSafeConnectorPageSink.java:66)
	at com.facebook.presto.operator.TableWriterOperator.addInput(TableWriterOperator.java:341)
```
This is because the stream's size is over 2GB and cannot be expressed as an int when ParquetWriter.getWrittenBytes() is calling OutputStreamSliceOutput.size(). This PR fixes this issue by changing the ParquetWriter.getWrittenBytes() to call OutputStreamSliceOutput.longSize() instead.
 
```
== RELEASE NOTES ==

Hive Changes
* Fix a bug where the ParquetWriter throws "Size is greater than maximum int value" error when the table is large.
```
