### PR TITLE
[native] Expose getLocalIp to support ip per task.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -124,6 +124,13 @@ class PrestoServer {
   /// In the implementation any extra config properties can be registered.
   virtual void registerExtraConfigProperties() {}
 
+  /// Invoked to get the ip address of the process. In certain deployment
+  /// setup, each process has different ip address. Deployment environment
+  /// may provide there own library to get process specific ip address.
+  /// In such cases, getLocalIp can be overriden to pass process specific
+  /// ip address.
+  virtual std::string getLocalIp() const;
+
   /// Invoked to get the list of filters passed to the http server.
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
   getHttpServerFilters();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -13,7 +13,6 @@
  */
 
 #include <re2/re2.h>
-#include <unordered_set>
 
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -68,7 +68,7 @@ public abstract class AbstractTestNativeAggregations
         assertQuery("SELECT array_agg(nationkey ORDER BY name) FROM nation");
         assertQuery("SELECT orderkey, array_agg(quantity ORDER BY linenumber DESC) FROM lineitem GROUP BY 1");
 
-        assertQuery("SELECT map_keys(map_union(quantity_by_linenumber)) FROM orders_ex");
+        assertQuery("SELECT array_sort(map_keys(map_union(quantity_by_linenumber))) FROM orders_ex");
 
         assertQuery("SELECT orderkey, count_if(linenumber % 2 > 0) FROM lineitem GROUP BY 1");
         assertQuery("SELECT orderkey, bool_and(linenumber % 2 = 1) FROM lineitem GROUP BY 1");


### PR DESCRIPTION
`getLocalIp` is a namespace function.  Making it an instance function for PrestoServer, so that we can override it. In certain deployment scenario, the ip address needs to be passed to server based on container's network interface setup. Exposing the function allows to set the ip address in such cases.

Also fix an e2e test with map_key by passing array_sort before to make the result deterministic.

```
== NO RELEASE NOTE ==
```
