### PR TITLE
Do not repartition in local exchange for partial row number node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -632,7 +632,7 @@ public class CanonicalPlanGenerator
                 partitionBy,
                 rowNumberVariable,
                 node.getMaxRowCountPerPartition(),
-                node.getPartial(),
+                node.isPartial(),
                 Optional.empty());
         context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -390,7 +390,7 @@ public class AddExchanges
         @Override
         public PlanWithProperties visitRowNumber(RowNumberNode node, PreferredProperties preferredProperties)
         {
-            checkArgument(!node.getPartial(), "RowNumberNode should not be partial before adding exchange");
+            checkArgument(!node.isPartial(), "RowNumberNode should not be partial before adding exchange");
 
             if (node.getPartitionBy().isEmpty()) {
                 PlanWithProperties child = planChild(node, PreferredProperties.undistributed());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -508,8 +508,11 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitRowNumber(RowNumberNode node, StreamPreferredProperties parentPreferences)
         {
-            // row number requires that all data be partitioned
-            StreamPreferredProperties requiredProperties = parentPreferences.withDefaultParallelism(session).withPartitioning(node.getPartitionBy());
+            StreamPreferredProperties requiredProperties = parentPreferences.withDefaultParallelism(session);
+            // final row number requires that all data be partitioned
+            if (!node.isPartial()) {
+                requiredProperties = requiredProperties.withPartitioning(node.getPartitionBy());
+            }
             return planAndEnforceChildren(node, requiredProperties, requiredProperties);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -281,7 +281,7 @@ public class HashGenerationOptimizer
                             node.getPartitionBy(),
                             node.getRowNumberVariable(),
                             node.getMaxRowCountPerPartition(),
-                            node.getPartial(),
+                            node.isPartial(),
                             Optional.of(hashVariable)),
                     child.getHashVariables());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -625,7 +625,7 @@ public class PruneUnreferencedOutputs
             }
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 
-            return new RowNumberNode(node.getSourceLocation(), node.getId(), source, node.getPartitionBy(), node.getRowNumberVariable(), node.getMaxRowCountPerPartition(), node.getPartial(), node.getHashVariable());
+            return new RowNumberNode(node.getSourceLocation(), node.getId(), source, node.getPartitionBy(), node.getRowNumberVariable(), node.getMaxRowCountPerPartition(), node.isPartial(), node.getHashVariable());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -429,7 +429,7 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Void> context)
         {
-            return new RowNumberNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalizeAndDistinct(node.getPartitionBy()), canonicalize(node.getRowNumberVariable()), node.getMaxRowCountPerPartition(), node.getPartial(), canonicalize(node.getHashVariable()));
+            return new RowNumberNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalizeAndDistinct(node.getPartitionBy()), canonicalize(node.getRowNumberVariable()), node.getMaxRowCountPerPartition(), node.isPartial(), canonicalize(node.getHashVariable()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
@@ -126,7 +126,7 @@ public final class RowNumberNode
     }
 
     @JsonProperty
-    public boolean getPartial()
+    public boolean isPartial()
     {
         return partial;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -793,7 +793,7 @@ public class PlanPrinter
             }
 
             NodeRepresentation nodeOutput = addNode(node,
-                    "RowNumber",
+                    format("RowNumber%s", node.isPartial() ? "Partial" : ""),
                     format("[%s]%s", Joiner.on(", ").join(args), formatHash(node.getHashVariable())));
             nodeOutput.appendDetailsLine("%s := %s%s", node.getRowNumberVariable(), "row_number()", formatSourceLocation(node.getRowNumberVariable().getSourceLocation()));
 


### PR DESCRIPTION
For partial row number node, we do not need all data to be partitioned, hence follow the partial topn row number node for local exchange.



### Test plan - (Please fill in how you tested your changes)

Test end to end for query `explain (type distributed) select * from (select *, row_number() over (partition by orderkey) <= 1 as keep from lineitem) where keep;`
Without the change here, a hash local exchange is added.
```
Fragment 2 [SOURCE]                                                                                                                           >
     Output layout: [orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitda>
     Output partitioning: HASH [orderkey][$hashvalue_138]                                                                                      >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                             >
     - RowNumberPartial[partition by (orderkey), limit = 1][$hashvalue_138] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:int>
             Estimates: {rows: 15432 (2.38MB), cpu: 31174590.55, memory: 2497710.55, network: 0.00}                                            >
             row_number_136 := row_number()                                                                                                    >
         - LocalExchange[HASH][$hashvalue_138] (orderkey) => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:dou>
                 Estimates: {rows: 60175 (9.29MB), cpu: 28676880.00, memory: 0.00, network: 0.00}                                              >
             - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analy>
                     Estimates: {rows: 60175 (9.29MB), cpu: 9197910.00, memory: 0.00, network: 0.00}/{rows: 60175 (9.29MB), cpu: 18937395.00, m>
                     $hashvalue_139 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey), BIGINT'0')) (1:113)                     >
                     LAYOUT: tpch.lineitem{}                                                                                                   >
                     quantity := quantity:double:4:REGULAR (1:113)                                                                             >
                     receiptdate := receiptdate:date:12:REGULAR (1:113)                                                                        >
                     shipinstruct := shipinstruct:varchar(25):13:REGULAR (1:113)                                                               >
                     discount := discount:double:6:REGULAR (1:113)                                                                             >
                     orderkey := orderkey:bigint:0:REGULAR (1:113)                                                                             >
                     shipdate := shipdate:date:10:REGULAR (1:113)                                                                              >
                     returnflag := returnflag:varchar(1):8:REGULAR (1:113)                                                                     >
                     suppkey := suppkey:bigint:2:REGULAR (1:113)                                                                               >
                     shipmode := shipmode:varchar(10):14:REGULAR (1:113)                                                                       >
                     partkey := partkey:bigint:1:REGULAR (1:113)                                                                               >
                     linenumber := linenumber:int:3:REGULAR (1:113)                                                                            >
                     extendedprice := extendedprice:double:5:REGULAR (1:113)                                                                   >
                     tax := tax:double:7:REGULAR (1:113)                                                                                       >
                     comment := comment:varchar(44):15:REGULAR (1:113)                                                                         >
                     commitdate := commitdate:date:11:REGULAR (1:113)                                                                          >
                     linestatus := linestatus:varchar(1):9:REGULAR (1:113)  
```
With the change here, no local exchange added
```
Fragment 2 [SOURCE]                                                                                                                           >
     Output layout: [orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitda>
     Output partitioning: HASH [orderkey][$hashvalue_138]                                                                                      >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                             >
     - RowNumberPartial[partition by (orderkey), limit = 1][$hashvalue_138] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:int>
             Estimates: {rows: 15432 (2.38MB), cpu: 21435105.55, memory: 2497710.55, network: 0.00}                                            >
             row_number_136 := row_number()                                                                                                    >
         - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePa>
                 Estimates: {rows: 60175 (9.29MB), cpu: 9197910.00, memory: 0.00, network: 0.00}/{rows: 60175 (9.29MB), cpu: 18937395.00, memor>
                 $hashvalue_138 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey), BIGINT'0')) (1:85)                          >
                 LAYOUT: tpch.lineitem{}                                                                                                       >
                 suppkey := suppkey:bigint:2:REGULAR (1:113)                                                                                   >
                 quantity := quantity:double:4:REGULAR (1:113)                                                                                 >
                 shipinstruct := shipinstruct:varchar(25):13:REGULAR (1:113)                                                                   >
                 commitdate := commitdate:date:11:REGULAR (1:113)                                                                              >
                 linenumber := linenumber:int:3:REGULAR (1:113)                                                                                >
                 returnflag := returnflag:varchar(1):8:REGULAR (1:113)                                                                         >
                 discount := discount:double:6:REGULAR (1:113)                                                                                 >
                 partkey := partkey:bigint:1:REGULAR (1:113)                                                                                   >
                 tax := tax:double:7:REGULAR (1:113)                                                                                           >
                 shipmode := shipmode:varchar(10):14:REGULAR (1:113)                                                                           >
                 extendedprice := extendedprice:double:5:REGULAR (1:113)                                                                       >
                 comment := comment:varchar(44):15:REGULAR (1:113)                                                                             >
                 shipdate := shipdate:date:10:REGULAR (1:113)                                                                                  >
                 linestatus := linestatus:varchar(1):9:REGULAR (1:113)                                                                         >
                 orderkey := orderkey:bigint:0:REGULAR (1:113)                                                                                 >
                 receiptdate := receiptdate:date:12:REGULAR (1:113) 
```

```
== NO RELEASE NOTE ==
```
