### PR TITLE
[native] Add ANALYZE STATS support

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -67,7 +67,18 @@ std::string mapScalarFunction(const std::string& name) {
 }
 
 std::string mapAggregateOrWindowFunction(const std::string& name) {
-  return boost::to_lower_copy(name);
+  static const std::unordered_map<std::string, std::string> kFunctionNames = {
+      {"presto.default.$internal$max_data_size_for_stats",
+       "presto.default.max_data_size_for_stats"},
+      {"presto.default.$internal$sum_data_size_for_stats",
+       "presto.default.sum_data_size_for_stats"},
+  };
+  std::string lowerCaseName = boost::to_lower_copy(name);
+  auto it = kFunctionNames.find(name);
+  if (it != kFunctionNames.end()) {
+    return it->second;
+  }
+  return lowerCaseName;
 }
 
 std::string getFunctionName(const protocol::Signature& signature) {

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -69,4 +69,9 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testInsertIntoSpecialPartitionName(){}
+
+    // @TODO Refer https://github.com/prestodb/presto/issues/20294
+    @Override
+    @Ignore
+    public void testAnalyzeStats() {}
 }


### PR DESCRIPTION
Analyze stats requires functions max_data_size_for_stats and sum_data_size_for_stats that were implemented in Velox. But these are internal functions in Presto mapped to presto.default.$internal$ namesapce. 

Translate the name mappings correctly during fragment translation to Velox to support "ANALYZE STATS"

Resolves: https://github.com/facebookincubator/velox/issues/5447 and https://github.com/facebookincubator/velox/issues/5484

