### PR TITLE
Update q02.sql

### DIFF
--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/tpch/q02.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/tpch/q02.sql
@@ -41,4 +41,5 @@ ORDER BY
   n.name,
   s.name,
   p.partkey
+LIMIT 100
 ;


### PR DESCRIPTION
Based on https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf Page 30. Section 2.4.2 Minimum Cost Supplier Query (Q2) The Q02 should return the first 100 selected rows.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
