### PR TITLE
[native] Fail fast when dereferencing anonymous fields

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -609,6 +609,14 @@ TypedExprPtr convertDereferenceExpr(
   VELOX_USER_CHECK_LT(childIndex, inputType.size());
   auto childName = inputType.names()[childIndex];
 
+  VELOX_USER_CHECK_EQ(
+      childIndex,
+      inputType.getChildIdx(childName),
+      "Cannot map field index to name in dereference expression: {}. "
+      "Input struct may have duplicate or empty field names: {}.",
+      childIndex,
+      inputType.toString())
+
   return std::make_shared<FieldAccessTypedExpr>(returnType, input, childName);
 }
 } // namespace

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -104,6 +104,9 @@ public class TestPrestoSparkNativeSimpleQueries
     public void testFailures()
     {
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
+
+        assertQueryFails("SELECT transform(array[row(orderkey, comment)], x -> x[2]) FROM orders", ".*Cannot map field index to name in dereference expression: 1.*");
+        assertQueryFails("SELECT transform(array[row(orderkey, orderkey * 10)], x -> x[2]) FROM orders", ".*Cannot map field index to name in dereference expression: 1.*");
     }
 
     /**


### PR DESCRIPTION
Velox derefence expression (FieldAccessTypedExpr) takes field name. If field
name is not unique the query may fail or return incorrect results. Fail the
query during plan translation to avoid cryptic errors and hard-to-detect wrong
results.

See https://github.com/facebookincubator/velox/issues/5536

```
== NO RELEASE NOTE ==
```
