### PR TITLE
Add support of parquet_writer_version, 1.0 and 2.0

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 
 import javax.inject.Inject;
 
@@ -84,6 +85,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
@@ -150,8 +152,7 @@ public final class HiveSessionProperties
     @Inject
     public HiveSessionProperties(HiveClientConfig hiveClientConfig, OrcFileWriterConfig orcFileWriterConfig, ParquetFileWriterConfig parquetFileWriterConfig, CacheConfig cacheConfig)
     {
-        sessionProperties = ImmutableList.of(
-                booleanProperty(
+        sessionProperties = ImmutableList.of(booleanProperty(
                         IGNORE_TABLE_BUCKETING,
                         "Ignore table bucketing to enable reading from unbucketed partitions",
                         hiveClientConfig.isIgnoreTableBucketing(),
@@ -349,6 +350,15 @@ public final class HiveSessionProperties
                         "Parquet: Maximum size of a block to read",
                         hiveClientConfig.getParquetMaxReadBlockSize(),
                         false),
+                new PropertyMetadata<>(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer format version",
+                        VARCHAR,
+                        WriterVersion.class,
+                        parquetFileWriterConfig.getFormatVersion(),
+                        false,
+                        value -> WriterVersion.valueOf((String) value),
+                        WriterVersion::toString),
                 dataSizeSessionProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
                         "Parquet: Writer block size",
@@ -897,6 +907,11 @@ public final class HiveSessionProperties
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, WriterVersion.class);
     }
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
@@ -15,16 +15,24 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.hadoop.ParquetWriter;
 
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 
 public class ParquetFileWriterConfig
 {
     private boolean parquetOptimizedWriterEnabled;
 
+    private WriterVersion formatVersion = PARQUET_2_0;
     private DataSize blockSize = new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE);
     private DataSize pageSize = new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE);
+
+    public WriterVersion getFormatVersion()
+    {
+        return formatVersion;
+    }
 
     public DataSize getBlockSize()
     {
@@ -41,6 +49,13 @@ public class ParquetFileWriterConfig
     public DataSize getPageSize()
     {
         return pageSize;
+    }
+
+    @Config("hive.parquet.writer.format-version")
+    public ParquetFileWriterConfig setFormatVersion(WriterVersion formatVersion)
+    {
+        this.formatVersion = formatVersion;
+        return this;
     }
 
     @Config("hive.parquet.writer.page-size")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.joda.time.DateTimeZone;
@@ -45,6 +46,7 @@ import java.util.concurrent.Callable;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterBlockSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterPageSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetOptimizedWriterEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static java.util.Objects.requireNonNull;
@@ -101,6 +103,7 @@ public class ParquetFileWriterFactory
         }
 
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
+                .setWriterVersion((ParquetProperties.WriterVersion) getParquetWriterVersion(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
                 .build();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxBuff
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterValidateMode;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcStreamBufferSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcOptimizedWriterValidate;
 import static com.facebook.presto.iceberg.TypeConverter.toOrcType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
@@ -140,6 +141,7 @@ public class IcebergFileWriterFactory
             };
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
+                    .setWriterVersion(getParquetWriterVersion(session))
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .build();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 
 import javax.inject.Inject;
 
@@ -50,6 +51,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";
     private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
@@ -119,6 +121,15 @@ public final class IcebergSessionProperties
                         "Parquet: Maximum size of a block to read",
                         hiveClientConfig.getParquetMaxReadBlockSize(),
                         false),
+                new PropertyMetadata<>(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer format version",
+                        VARCHAR,
+                        WriterVersion.class,
+                        parquetFileWriterConfig.getFormatVersion(),
+                        false,
+                        value -> WriterVersion.valueOf((String) value),
+                        WriterVersion::toString),
                 dataSizeSessionProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
                         "Parquet: Writer block size",
@@ -299,6 +310,11 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, WriterVersion.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -48,7 +48,6 @@ import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.BROTLI;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.LZ4;
@@ -100,9 +99,10 @@ public class ParquetWriter
         this.messageType = requireNonNull(messageType, "messageType is null");
 
         ParquetProperties parquetProperties = ParquetProperties.builder()
-                .withWriterVersion(PARQUET_2_0)
+                .withWriterVersion(writerOption.getWriterVersion())
                 .withPageSize(writerOption.getMaxPageSize())
                 .build();
+
         CompressionCodecName compressionCodecName = getCompressionCodecName(compressionCodecClass);
         this.columnWriters = ParquetWriters.getColumnWriters(messageType, primitiveTypes, parquetProperties, compressionCodecName);
 
@@ -253,6 +253,7 @@ public class ParquetWriter
         long totalRows = rowGroups.stream().mapToLong(RowGroup::getNum_rows).sum();
         fileMetaData.setNum_rows(totalRows);
         fileMetaData.setRow_groups(ImmutableList.copyOf(rowGroups));
+        fileMetaData.setCreated_by("Presto");
 
         DynamicSliceOutput dynamicSliceOutput = new DynamicSliceOutput(40);
         Util.writeFileMetaData(fileMetaData, dynamicSliceOutput);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.parquet.writer;
 
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetWriterOptions
 {
+    private static final WriterVersion DEFAULT_FORMAT_VERSION = WriterVersion.PARQUET_2_0;
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
 
@@ -28,13 +30,20 @@ public class ParquetWriterOptions
         return new ParquetWriterOptions.Builder();
     }
 
+    private final WriterVersion writerVersion;
     private final int maxRowGroupSize;
     private final int maxPageSize;
 
-    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize)
+    private ParquetWriterOptions(WriterVersion writerVersion, DataSize maxRowGroupSize, DataSize maxPageSize)
     {
+        this.writerVersion = writerVersion;
         this.maxRowGroupSize = toIntExact(requireNonNull(maxRowGroupSize, "maxRowGroupSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
+    }
+
+    public WriterVersion getWriterVersion()
+    {
+        return writerVersion;
     }
 
     public int getMaxRowGroupSize()
@@ -49,8 +58,15 @@ public class ParquetWriterOptions
 
     public static class Builder
     {
+        private WriterVersion writerVersion = DEFAULT_FORMAT_VERSION;
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
+
+        public Builder setWriterVersion(WriterVersion formatVersion)
+        {
+            this.writerVersion = formatVersion;
+            return this;
+        }
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -66,7 +82,7 @@ public class ParquetWriterOptions
 
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize);
+            return new ParquetWriterOptions(writerVersion, maxBlockSize, maxPageSize);
         }
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV1.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV1.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterable;
+import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
+import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterable;
+import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables;
+import com.facebook.presto.parquet.writer.valuewriter.PrimitiveValueWriter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.parquet.writer.ParquetCompressor.getCompressor;
+import static com.facebook.presto.parquet.writer.ParquetDataOutput.createDataOutput;
+import static com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables.getIterator;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.bytes.BytesInput.copy;
+
+public class PrimitiveColumnWriterV1
+        implements ColumnWriter
+{
+    private final Type type;
+    private final ColumnDescriptor columnDescriptor;
+    private final CompressionCodecName compressionCodec;
+
+    private final PrimitiveValueWriter primitiveValueWriter;
+    private final RunLengthBitPackingHybridEncoder definitionLevelEncoder;
+    private final RunLengthBitPackingHybridEncoder repetitionLevelEncoder;
+
+    private final ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
+
+    private boolean closed;
+    private boolean getDataStreamsCalled;
+
+    // current page stats
+    private int currentPageRows;
+    private int currentPageNullCounts;
+    private int currentPageRowCount;
+
+    // column meta data stats
+    private final Set<Encoding> encodings;
+    private long totalCompressedSize;
+    private long totalUnCompressedSize;
+    private long totalRows;
+    private Statistics<?> columnStatistics;
+
+    private final int maxDefinitionLevel;
+
+    private final List<ParquetDataOutput> pageBuffer = new ArrayList<>();
+
+    @Nullable
+    private final ParquetCompressor compressor;
+
+    private final int pageSizeThreshold;
+
+    public PrimitiveColumnWriterV1(Type type, ColumnDescriptor columnDescriptor, PrimitiveValueWriter primitiveValueWriter, RunLengthBitPackingHybridEncoder definitionLevelEncoder, RunLengthBitPackingHybridEncoder repetitionLevelEncoder, CompressionCodecName compressionCodecName, int pageSizeThreshold)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.columnDescriptor = requireNonNull(columnDescriptor, "columnDescriptor is null");
+        this.maxDefinitionLevel = columnDescriptor.getMaxDefinitionLevel();
+
+        this.definitionLevelEncoder = requireNonNull(definitionLevelEncoder, "definitionLevelEncoder is null");
+        this.repetitionLevelEncoder = requireNonNull(repetitionLevelEncoder, "repetitionLevelEncoder is null");
+        this.primitiveValueWriter = requireNonNull(primitiveValueWriter, "primitiveValueWriter is null");
+        this.encodings = new HashSet<>();
+        this.compressionCodec = requireNonNull(compressionCodecName, "compressionCodecName is null");
+        this.compressor = getCompressor(compressionCodecName);
+        this.pageSizeThreshold = pageSizeThreshold;
+
+        this.columnStatistics = Statistics.createStats(columnDescriptor.getPrimitiveType());
+    }
+
+    @Override
+    public void writeBlock(ColumnChunk columnChunk)
+            throws IOException
+    {
+        checkState(!closed);
+
+        ColumnChunk current = new ColumnChunk(columnChunk.getBlock(),
+                ImmutableList.<DefinitionLevelIterable>builder()
+                        .addAll(columnChunk.getDefinitionLevelIterables())
+                        .add(DefinitionLevelIterables.of(columnChunk.getBlock(), maxDefinitionLevel))
+                        .build(),
+                ImmutableList.<RepetitionLevelIterable>builder()
+                        .addAll(columnChunk.getRepetitionLevelIterables())
+                        .add(RepetitionLevelIterables.of(columnChunk.getBlock()))
+                        .build());
+
+        // write values
+        primitiveValueWriter.write(columnChunk.getBlock());
+
+        // write definition levels
+        Iterator<Integer> defIterator = DefinitionLevelIterables.getIterator(current.getDefinitionLevelIterables());
+        while (defIterator.hasNext()) {
+            int next = defIterator.next();
+            definitionLevelEncoder.writeInt(next);
+            if (next != maxDefinitionLevel) {
+                currentPageNullCounts++;
+            }
+            currentPageRows++;
+        }
+
+        // write repetition levels
+        Iterator<Integer> repIterator = getIterator(current.getRepetitionLevelIterables());
+        while (repIterator.hasNext()) {
+            int next = repIterator.next();
+            repetitionLevelEncoder.writeInt(next);
+            if (next == 0) {
+                currentPageRowCount++;
+            }
+        }
+
+        if (getBufferedBytes() >= pageSizeThreshold) {
+            flushCurrentPageToBuffer();
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+    }
+
+    @Override
+    public List<BufferData> getBuffer()
+            throws IOException
+    {
+        checkState(closed);
+        return ImmutableList.of(new BufferData(getDataStreams(), getColumnMetaData()));
+    }
+
+    // Returns ColumnMetaData that offset is invalid
+    private ColumnMetaData getColumnMetaData()
+    {
+        checkState(getDataStreamsCalled);
+
+        ColumnMetaData columnMetaData = new ColumnMetaData(
+                ParquetTypeConverter.getType(columnDescriptor.getPrimitiveType().getPrimitiveTypeName()),
+                encodings.stream().map(parquetMetadataConverter::getEncoding).collect(toImmutableList()),
+                ImmutableList.copyOf(columnDescriptor.getPath()),
+                compressionCodec.getParquetCompressionCodec(),
+                totalRows,
+                totalUnCompressedSize,
+                totalCompressedSize,
+                -1);
+        columnMetaData.setStatistics(ParquetMetadataConverter.toParquetStatistics(columnStatistics));
+        return columnMetaData;
+    }
+
+    // page header
+    // repetition levels
+    // definition levels
+    // data
+    private void flushCurrentPageToBuffer()
+            throws IOException
+    {
+        ImmutableList.Builder<ParquetDataOutput> outputDataStreams = ImmutableList.builder();
+
+        BytesInput bytes = primitiveValueWriter.getBytes();
+        ParquetDataOutput repetitions = createDataOutput(copy(repetitionLevelEncoder.toBytes()));
+        ParquetDataOutput definitions = createDataOutput(copy(definitionLevelEncoder.toBytes()));
+
+        // Add encoding should be called after primitiveValueWriter.getBytes() and before primitiveValueWriter.reset()
+        encodings.add(primitiveValueWriter.getEncoding());
+
+        long uncompressedSize = bytes.size() + repetitions.size() + definitions.size();
+
+        ParquetDataOutput data;
+        long compressedSize;
+        if (compressor != null) {
+            data = compressor.compress(bytes);
+            compressedSize = data.size() + repetitions.size() + definitions.size();
+        }
+        else {
+            data = createDataOutput(copy(bytes));
+            compressedSize = uncompressedSize;
+        }
+
+        ByteArrayOutputStream pageHeaderOutputStream = new ByteArrayOutputStream();
+
+        Statistics<?> statistics = primitiveValueWriter.getStatistics();
+        statistics.incrementNumNulls(currentPageNullCounts);
+
+        columnStatistics.mergeStatistics(statistics);
+
+        parquetMetadataConverter.writeDataPageV2Header((int) uncompressedSize,
+                (int) compressedSize,
+                currentPageRows,
+                currentPageNullCounts,
+                currentPageRowCount,
+                statistics,
+                primitiveValueWriter.getEncoding(),
+                (int) repetitions.size(),
+                (int) definitions.size(),
+                pageHeaderOutputStream);
+
+        ParquetDataOutput pageHeader = createDataOutput(Slices.wrappedBuffer(pageHeaderOutputStream.toByteArray()));
+        outputDataStreams.add(pageHeader);
+        outputDataStreams.add(repetitions);
+        outputDataStreams.add(definitions);
+        outputDataStreams.add(data);
+
+        List<ParquetDataOutput> dataOutputs = outputDataStreams.build();
+
+        // update total stats
+        totalCompressedSize += pageHeader.size() + compressedSize;
+        totalUnCompressedSize += pageHeader.size() + uncompressedSize;
+        totalRows += currentPageRows;
+
+        pageBuffer.addAll(dataOutputs);
+
+        // reset page stats
+        currentPageRows = 0;
+        currentPageNullCounts = 0;
+        currentPageRowCount = 0;
+
+        definitionLevelEncoder.reset();
+        repetitionLevelEncoder.reset();
+        primitiveValueWriter.reset();
+    }
+
+    private List<ParquetDataOutput> getDataStreams()
+            throws IOException
+    {
+        List<ParquetDataOutput> dictPage = new ArrayList<>();
+        if (currentPageRows > 0) {
+            flushCurrentPageToBuffer();
+        }
+        // write dict page if possible
+        DictionaryPage dictionaryPage = primitiveValueWriter.toDictPageAndClose();
+        if (dictionaryPage != null) {
+            BytesInput pageBytes = copy(dictionaryPage.getBytes());
+            long uncompressedSize = dictionaryPage.getUncompressedSize();
+
+            ParquetDataOutput pageData = createDataOutput(pageBytes);
+            if (compressor != null) {
+                pageData = compressor.compress(pageBytes);
+            }
+            long compressedSize = pageData.size();
+
+            ByteArrayOutputStream dictStream = new ByteArrayOutputStream();
+            parquetMetadataConverter.writeDictionaryPageHeader(toIntExact(uncompressedSize),
+                    toIntExact(compressedSize),
+                    dictionaryPage.getDictionarySize(),
+                    dictionaryPage.getEncoding(),
+                    dictStream);
+            ParquetDataOutput pageHeader = createDataOutput(Slices.wrappedBuffer(dictStream.toByteArray()));
+            dictPage.add(pageHeader);
+            dictPage.add(pageData);
+            totalCompressedSize += pageHeader.size() + compressedSize;
+            totalUnCompressedSize += pageHeader.size() + uncompressedSize;
+
+            primitiveValueWriter.resetDictionary();
+        }
+        getDataStreamsCalled = true;
+
+        return ImmutableList.<ParquetDataOutput>builder()
+                .addAll(dictPage)
+                .addAll(pageBuffer)
+                .build();
+    }
+
+    @Override
+    public long getBufferedBytes()
+    {
+        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() +
+                definitionLevelEncoder.getBufferedSize() +
+                repetitionLevelEncoder.getBufferedSize() +
+                primitiveValueWriter.getBufferedSize();
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public void reset()
+    {
+        pageBuffer.clear();
+        closed = false;
+
+        totalCompressedSize = 0;
+        totalUnCompressedSize = 0;
+        totalRows = 0;
+        encodings.clear();
+        this.columnStatistics = Statistics.createStats(columnDescriptor.getPrimitiveType());
+
+        getDataStreamsCalled = false;
+    }
+}


### PR DESCRIPTION
Test plan - Add test cases for versions 1.0 and 2.0.

Enable Hive and Iceberg connectors to use either Parquet writer version 1.0 or 2.0 when writing Parquet data.

```
== RELEASE NOTES ==

Parquet Changes
* Update Hive and Iceberg connectors to use either Parquet writer version 1.0 or 2.0 when writing Parquet data.
```
