### PR TITLE
[native]Add multi write driver support

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -71,7 +71,7 @@ TEST_F(PlanNodeSerdeTest, partitionAndSerializeNode) {
                   .values(data_, true)
                   .addNode(addPartitionAndSerializeNode(
                       4, false, reverseColumns(asRowType(data_[0]->type()))))
-                  .localPartition({})
+                  .localPartition(std::vector<std::string>{})
                   .planNode();
   testSerde(plan);
 }
@@ -98,7 +98,7 @@ TEST_F(PlanNodeSerdeTest, shuffleWriteNode) {
       exec::test::PlanBuilder()
           .values(data_, true)
           .addNode(addPartitionAndSerializeNode(numPartitions, false))
-          .localPartition({})
+          .localPartition(std::vector<std::string>{})
           .addNode(addShuffleWriteNode(numPartitions, shuffleName, shuffleInfo))
           .planNode();
   testSerde(plan);

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -456,7 +456,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
             .values(data, true)
             .addNode(addPartitionAndSerializeNode(
                 numPartitions, replicateNullsAndAny))
-            .localPartition({})
+            .localPartition(std::vector<std::string>{})
             .addNode(addShuffleWriteNode(
                 numPartitions, shuffleName, serializedShuffleWriteInfo))
             .planNode();
@@ -656,7 +656,7 @@ TEST_F(UnsafeRowShuffleTest, operators) {
   auto plan = exec::test::PlanBuilder()
                   .values({data}, true)
                   .addNode(addPartitionAndSerializeNode(4, false))
-                  .localPartition({})
+                  .localPartition(std::vector<std::string>{})
                   .addNode(addShuffleWriteNode(
                       4, std::string(TestShuffleFactory::kShuffleName), info))
                   .planNode();
@@ -1015,7 +1015,7 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
   auto plan = exec::test::PlanBuilder()
                   .values({data}, true)
                   .addNode(addPartitionAndSerializeNode(4, false))
-                  .localPartition({})
+                  .localPartition(std::vector<std::string>{})
                   .addNode(addShuffleWriteNode(
                       4,
                       std::string(TestShuffleFactory::kShuffleName),

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
   TypeSignatureTypeConverter.cpp antlr/TypeSignatureLexer.cpp
   antlr/TypeSignatureParser.cpp)
 
+include_directories(/opt/homebrew/opt/protobuf/include/)
+
 target_link_libraries(presto_type_converter velox_type)
 
 add_library(presto_types OBJECT PrestoToVeloxQueryPlan.cpp

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -143,6 +143,11 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);
 
+  std::shared_ptr<const velox::core::TableWriteMergeNode> toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::TableWriterMergeNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
   std::shared_ptr<const velox::core::UnnestNode> toVeloxQueryPlan(
       const std::shared_ptr<const protocol::UnnestNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1031,7 +1031,9 @@ public abstract class AbstractTestNativeGeneralQueries
     {
         // TODO: enable this after column stats collection is enabled.
         return Session.builder(getSession())
-                .setSystemProperty("table_writer_merge_operator_enabled", "false")
+                .setSystemProperty("table_writer_merge_operator_enabled", "true")
+                .setSystemProperty("task_writer_count", "4")
+                .setSystemProperty("task_partitioned_writer_count", "2")
                 .setCatalogSessionProperty("hive", "collect_column_statistics_on_write", "false")
                 .setCatalogSessionProperty("hive", "optimized_partition_update_serialization_enabled", "false")
                 .build();


### PR DESCRIPTION
Add table write merge node and operator creation support in Presto to
Velox query plan conversion to support the query shape with table write
merge session option on;
Add hive bucket function support in local partition node in Presto to Velox
query plan conversion to support multiple table write drivers;
Turn on table write merge and other multi table write driver session
properties in native java e2e test.

Also advance velox version

```
== NO RELEASE NOTE ==
```
