### PR TITLE
Add support for array_minus udf in Presto

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -88,6 +88,10 @@ Array Functions
 
     Returns the minimum value of input array.
 
+.. function:: array_minus(x, y) -> array
+
+    Returns an array of the elements by removing elements from ``x`` that are present in ``y``.
+
 .. function:: array_max_by(array(T), function(T, U)) -> T
 
     Applies the provided function to each element, and returns the element that gives the maximum value.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -136,4 +136,14 @@ public class ArraySqlFunctions
     {
         return "RETURN IF(none_match(input, x -> x is null), input, filter(input, x -> x is not null))";
     }
+
+    @SqlInvokedScalarFunction(value = "array_minus", deterministic = true, calledOnNullInput = true)
+    @Description("Returns an array of the elements in the union of x and y, without duplicates.")
+    @TypeParameter("T")
+    @SqlParameters({@SqlParameter(name = "x", type = "array(T)"), @SqlParameter(name = "y", type = "array(T)")})
+    @SqlType("array<T>")
+    public static String arrayMinus()
+    {
+        return "RETURN FILTER(x, z -> NOT CONTAINS(y, z))";
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArrayMinusFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArrayMinusFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+
+public class TestArrayMinusFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[1, 2, 3], ARRAY[4, 5, 6])",
+                new ArrayType(INTEGER),
+                ImmutableList.of(1, 2, 3));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[-1, -2, -3], ARRAY[-1, -2])",
+                new ArrayType(INTEGER),
+                ImmutableList.of(-3));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY['ab', 'bc', 'cd'], ARRAY['x', 'y', 'cd'])",
+                new ArrayType(createVarcharType(2)),
+                ImmutableList.of("ab", "bc"));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[double'123.0', double'99.5', double'1000.99'], ARRAY[double'100.0'])",
+                new ArrayType(DOUBLE),
+                ImmutableList.of(123.0d, 99.5d, 1000.99d));
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("ARRAY_MINUS(ARRAY[], ARRAY[1, 2, 3])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("ARRAY_MINUS(ARRAY[], ARRAY['a', 'b', 'c'])", new ArrayType(createVarcharType(1)), ImmutableList.of());
+        assertFunction("ARRAY_MINUS(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("ARRAY_MINUS(NULL, ARRAY[1, 2, 4])", new ArrayType(INTEGER), null);
+        assertFunction("ARRAY_MINUS(ARRAY[1, 2, 4], NULL)", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("ARRAY_MINUS(NULL, NULL)", new ArrayType(UNKNOWN), null);
+    }
+
+    @Test
+    public void testComplexKeys()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(RowType.field(createVarcharType(1)), RowType.field(INTEGER)));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[ROW('x', 1), ROW('y', 2)], ARRAY[ROW('x', 1), ROW('y', 2)])",
+                new ArrayType(rowType),
+                ImmutableList.of());
+        rowType = RowType.from(ImmutableList.of(RowType.field(INTEGER), RowType.field(createVarcharType(3))));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[ROW(1, 'abc'), ROW(-2, 'xyz')], ARRAY[])",
+                new ArrayType(rowType),
+                ImmutableList.of(ImmutableList.of(1, "abc"), ImmutableList.of(-2, "xyz")));
+        rowType = RowType.from(ImmutableList.of(RowType.field(createVarcharType(1)), RowType.field(INTEGER)));
+        assertFunction(
+                "ARRAY_MINUS(ARRAY[ROW('x', 1), ROW('x', -2), ROW('y', 1)], ARRAY[ROW('y', 2), ROW('x', -2)])",
+                new ArrayType(rowType),
+                ImmutableList.of(ImmutableList.of("x", 1), ImmutableList.of("y", 1)));
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "ARRAY_MINUS()",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "ARRAY_MINUS(ARRAY[1, 2, 3], ARRAY['x', 'y', 'z'])",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "ARRAY_MINUS(1, 2)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
UDF to return the difference of two arrays

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
