### PR TITLE
[pos] Remove BatchTaskUpdateRequest log line

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -207,7 +207,6 @@ public class PrestoSparkHttpTaskClient
         URI batchTaskUri = uriBuilderFrom(taskUri)
                 .appendPath("batch")
                 .build();
-        log.info(format("BatchTaskUpdate: \n %s", taskUpdateRequestCodec.toJson(batchTaskUpdateRequest)));
         return httpClient.executeAsync(
                 setContentTypeHeaders(false, preparePost())
                         .setUri(batchTaskUri)


### PR DESCRIPTION
Some of the `BatchTaskUpdateRequest` objects are quite large and overwhelm the server while logging them; this can cause timeout exceptions. Therefore, will remove the line which logs these objects to mitigate timeout exceptions.

Test plan - (Please fill in how you tested your changes)
Code complies. Safe change.

```
== NO RELEASE NOTE ==
```
