### PR TITLE
Force using HTTP1.1 on Java 11 or later to avoid thread hanging on driver

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
-import com.facebook.presto.client.SocketChannelSocketFactory;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.net.HostAndPort;
 import okhttp3.OkHttpClient;
@@ -29,6 +28,7 @@ import static com.facebook.presto.client.ClientSession.stripTransactionId;
 import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY;
 import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_OAUTH_SCOPES_KEY;
 import static com.facebook.presto.client.OkHttpUtil.basicAuth;
+import static com.facebook.presto.client.OkHttpUtil.forceHttp11OnJava11OrLater;
 import static com.facebook.presto.client.OkHttpUtil.setupCookieJar;
 import static com.facebook.presto.client.OkHttpUtil.setupGCSOauth;
 import static com.facebook.presto.client.OkHttpUtil.setupHttpProxy;
@@ -76,7 +76,8 @@ public class QueryRunner
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
-        builder.socketFactory(new SocketChannelSocketFactory());
+        // Avoids threads hanging using http2 on java 11 or later
+        forceHttp11OnJava11OrLater(builder);
 
         setupTimeouts(builder, 30, SECONDS);
         setupCookieJar(builder);

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -15,6 +15,7 @@ package com.facebook.presto.client;
 
 import com.facebook.airlift.security.pem.PemReader;
 import com.google.common.base.CharMatcher;
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.net.HostAndPort;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -22,6 +23,7 @@ import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Response;
 
 import javax.net.ssl.KeyManager;
@@ -46,6 +48,7 @@ import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -276,5 +279,26 @@ public final class OkHttpUtil
     {
         GCSOAuthInterceptor handler = new GCSOAuthInterceptor(credentialPath, gcsOAuthScopesString);
         clientBuilder.addInterceptor(handler);
+    }
+
+    public static void forceHttp11OnJava11OrLater(OkHttpClient.Builder builder)
+    {
+        if (isJava11OrLater()) {
+            builder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
+        }
+    }
+
+    private static boolean isJava11OrLater()
+    {
+        try {
+            String javaVersion = StandardSystemProperty.JAVA_VERSION.value();
+            if (javaVersion == null) {
+                return false;
+            }
+            return Integer.parseInt(javaVersion.split("\\.")[0]) >= 11;
+        }
+        catch (NumberFormatException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
We have experienced deadlocks on the presto jdbc driver when executing presto with java 11 (by default in java 11, HTTP2 is used). We found that forcing to use HTTP 1.1 solves the problem. A similar issue was also reported on Trino: https://github.com/trinodb/trino/issues/1169
Solution to this problem was added by forcing to use HTTP1.1 if the driver is running on java 11. The same change was made to the cli tool too.
```
Access(23521)-3817-04.00-testdb.presto_ds" Id=57104 in BLOCKED CpuTime=75496124 on lock=java.lang.Object@492135c1 
     owned by OkHttp localhost Id=57127 
    at java.base@11.0.8/java.nio.channels.Channels.writeFully(Channels.java:91) 
    at java.base@11.0.8/java.nio.channels.Channels$1.write(Channels.java:172) 
    at java.base@11.0.8/sun.security.ssl.SSLSocketOutputRecord.deliver(SSLSocketOutputRecord.java:319) 
    at java.base@11.0.8/sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:1197) 
    at com.facebook.presto.jdbc.internal.okio.Okio$1.write(Okio.java:79) 
    at com.facebook.presto.jdbc.internal.okio.AsyncTimeout$1.write(AsyncTimeout.java:180) 
    at com.facebook.presto.jdbc.internal.okio.RealBufferedSink.flush(RealBufferedSink.java:216) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http2.Http2Writer.flush(Http2Writer.java:121) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:239) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:205) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http2.Http2Codec.writeRequestHeaders(Http2Codec.java:111) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:50) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:45) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:125) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121) 
    at com.facebook.presto.jdbc.internal.client.OkHttpUtil.lambda$basicAuth$1(OkHttpUtil.java:91) 
    at com.facebook.presto.jdbc.internal.client.OkHttpUtil$$Lambda$450/0x0000000800efec40.intercept(Unknown Source) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121) 
    at com.facebook.presto.jdbc.internal.client.OkHttpUtil.lambda$userAgent$0(OkHttpUtil.java:77) 
    at com.facebook.presto.jdbc.internal.client.OkHttpUtil$$Lambda$424/0x0000000800ecd840.intercept(Unknown Source) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147) 
    at com.facebook.presto.jdbc.internal.okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121) 
    at com.facebook.presto.jdbc.internal.okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:200) 
    at com.facebook.presto.jdbc.internal.okhttp3.RealCall.execute(RealCall.java:77) 
    at com.facebook.presto.jdbc.internal.client.JsonResponse.execute(JsonResponse.java:131) 
    at com.facebook.presto.jdbc.internal.client.StatementClientV1.advance(StatementClientV1.java:389) 
    at com.facebook.presto.jdbc.PrestoResultSet$ResultsPageIterator.computeNext(PrestoResultSet.java:1803) 
    at com.facebook.presto.jdbc.PrestoResultSet$ResultsPageIterator.computeNext(PrestoResultSet.java:1759) 
    at com.facebook.presto.jdbc.internal.guava.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141) 
    at com.facebook.presto.jdbc.internal.guava.collect.AbstractIterator.hasNext(AbstractIterator.java:136) 
    at com.facebook.presto.jdbc.internal.guava.collect.TransformedIterator.hasNext(TransformedIterator.java:42) 
    at com.facebook.presto.jdbc.internal.guava.collect.Iterators$ConcatenatedIterator.getTopMetaIterator(Iterators.java:1319) 
    at com.facebook.presto.jdbc.internal.guava.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1335) 
    at com.facebook.presto.jdbc.PrestoResultSet.next(PrestoResultSet.java:144) 
    at org.apache.commons.dbcp2.DelegatingResultSet.next(DelegatingResultSet.java:1160) 
```
Test plan - unit tests in the modified modules

== RELEASE NOTES ==

General Changes
* Forced to use HTTP 1.1 on presto-jdbc socketFactory when the java runtime version is greater than Java 11
* Forced to use HTTP 1.1 on presto-cli socketFactory when the java runtime version is greater than Java 11

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
