### PR TITLE
Skip duplicate merge in hll.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/HyperLogLogFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/HyperLogLogFunctions.java
@@ -77,7 +77,7 @@ public final class HyperLogLogFunctions
         Slice initialSlice = block.getSlice(firstNonNullIndex, 0, block.getSliceLength(firstNonNullIndex));
         merged = HyperLogLog.newInstance(initialSlice);
 
-        for (int i = firstNonNullIndex; i < block.getPositionCount(); i++) {
+        for (int i = firstNonNullIndex + 1; i < block.getPositionCount(); i++) {
             Slice currentSlice = block.getSlice(i, 0, block.getSliceLength(i));
             if (!block.isNull(i)) {
                 merged.mergeWith(HyperLogLog.newInstance(currentSlice));


### PR DESCRIPTION
First non null index is already merged before the loop execution. Skipping the first index as it causes duplicate merge, although it does not change the results as merging hll with itself will always produce same hll.

Discussed here https://github.com/prestodb/presto/issues/20041

Existing tests are good enough.

```
== NO RELEASE NOTE ==
```
