### PR TITLE
Optimize LIKE for simple prefix matches

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7012,4 +7012,10 @@ public abstract class AbstractTestQueries
                 "sum(case when  orderstatus||'-'|| comment='F' THEN  totalprice END)" +
                 "FROM orders group by 1,2").getOnlyValue().toString().indexOf("element_at"), -1);
     }
+
+    @Test
+    public void testLikePrefix()
+    {
+        assertQuery("select x like 'abc%' from (values 'abc', 'def', 'bcd') T(x)");
+    }
 }


### PR DESCRIPTION
We optimize expressions of the form:

   x LIKE 'some string%'

to

   SUBSTR(x, 1, LENGTH('some string')) = 'some string'

As the trailing % is just wild card match and won't matter. For some of our heavy queries, we have seen upto 40% efficiency improvement with this.


Test plan - added test



```
== NO RELEASE NOTE ==
```
