### PR TITLE
[native] Minor log fixes.

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -158,7 +158,8 @@ void Announcer::makeAnnouncement() {
           LOG(ERROR) << "Announcement failed: " << response->error();
         } else {
           failedAttempts_ = 0;
-          LOG(INFO) << "Announcement succeeded: " << message->getStatusCode();
+          LOG(INFO) << "Announcement succeeded: HTTP "
+                    << message->getStatusCode();
         }
       })
       .thenError(

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -395,8 +395,8 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
 
   for (const auto& source : sources) {
     // Add all splits from the source to the task.
-    LOG(INFO) << "Adding " << source.splits.size() << " splits to " << taskId
-              << " for node " << source.planNodeId;
+    VLOG(1) << "Adding " << source.splits.size() << " splits to " << taskId
+            << " for node " << source.planNodeId;
     // Keep track of the max sequence for this batch of splits.
     long maxSplitSequenceId{-1};
     for (const auto& protocolSplit : source.splits) {
@@ -625,7 +625,7 @@ size_t TaskManager::cleanOldTasks() {
       }
     }
     LOG(INFO) << "cleanOldTasks: Cleaned " << taskIdsToClean.size()
-              << " old task(s) in " << elapsedMs << "ms";
+              << " old task(s) in " << elapsedMs << " ms";
   } else if (elapsedMs > 1000) {
     // If we took more than 1 second to run this, something might be wrong.
     LOG(INFO) << "cleanOldTasks: Didn't clean any old task(s). Took "


### PR DESCRIPTION
Fixing minor logs.

_Adding N splits to query_id for node 0_.
This line is very noisy, constitutes ~70% of log lines. Making it Vlog. Some stats from live system:
[logs]$ grep -nir "Adding" stderr | grep "splits to" | wc -l
60697
[ogs]$ cat stderr | wc -l
88945

Other two changes are for readability.

```
== NO RELEASE NOTE ==
```
