### PR TITLE
Upgrade Delta Standalone to 3.0.0

### DIFF
--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone_2.12</artifactId>
-            <version>0.6.0</version>
+            <version>3.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
This PR upgrades Delta Standalone dependency to [3.0.0](https://github.com/delta-io/delta/releases/tag/v3.0.0) for Delta Lake Connector.

Test plan - Existing tests

```
== RELEASE NOTES ==

Delta Lake Changes
* Upgrade Delta Standalone to 3.0.0
```
