### PR TITLE
Add server operation to print task debug details

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -21,6 +21,7 @@
 #include <velox/expression/Expr.h>
 #include "presto_cpp/main/CPUMon.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
+#include "presto_cpp/main/PrestoServerOperations.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
 #if __has_include("filesystem")
@@ -177,6 +178,7 @@ class PrestoServer {
   std::atomic_bool shuttingDown_{false};
   std::chrono::steady_clock::time_point start_;
   std::unique_ptr<PeriodicTaskManager> periodicTaskManager_;
+  std::unique_ptr<PrestoServerOperations> prestoServerOperations_;
 
   // We update these members asynchronously and return in http requests w/o
   // delay.

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <string>
+#include "presto_cpp/main/TaskManager.h"
 
 namespace proxygen {
 class HTTPMessage;
@@ -27,21 +28,30 @@ struct ServerOperation;
 /// Static class implements Presto Server Operations.
 class PrestoServerOperations {
  public:
-  static void runOperation(
+  PrestoServerOperations(TaskManager* const taskManager)
+      : taskManager_(taskManager) {}
+
+  void runOperation(
       proxygen::HTTPMessage* message,
       proxygen::ResponseHandler* downstream);
 
-  static std::string connectorOperation(
+  std::string connectorOperation(
       const ServerOperation& op,
       proxygen::HTTPMessage* message);
 
-  static std::string systemConfigOperation(
+  std::string systemConfigOperation(
       const ServerOperation& op,
       proxygen::HTTPMessage* message);
 
-  static std::string veloxQueryConfigOperation(
+  std::string veloxQueryConfigOperation(
       const ServerOperation& op,
       proxygen::HTTPMessage* message);
+
+  std::string debugOperation(
+      const ServerOperation& op,
+      proxygen::HTTPMessage* message);
+
+  TaskManager* const taskManager_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -583,6 +583,21 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
   return str;
 }
 
+std::string PrestoTask::toJsonString() const {
+  std::lock_guard<std::mutex> l(mutex);
+  folly::dynamic obj = folly::dynamic::object;
+  obj["task"] = task ? task->toString() : "null";
+  obj["taskStarted"] = taskStarted;
+  obj["lastHeartbeatMs"] = lastHeartbeatMs;
+  obj["lastTaskStatsUpdateMs"] = lastTaskStatsUpdateMs;
+  obj["lastMemoryReservation"] = lastMemoryReservation;
+
+  json j;
+  to_json(j, info);
+  obj["taskInfo"] = to_string(j);
+  return folly::toPrettyJson(obj);
+}
+
 protocol::RuntimeMetric toRuntimeMetric(
     const std::string& name,
     const RuntimeMetric& metric) {

--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -123,6 +123,8 @@ struct PrestoTask {
 
   protocol::TaskStatus updateStatusLocked();
   protocol::TaskInfo updateInfoLocked();
+
+  std::string toJsonString() const;
 };
 
 using TaskMap =

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -22,6 +22,8 @@ const folly::F14FastMap<std::string, ServerOperation::Action>
         {"getCacheStats", ServerOperation::Action::kGetCacheStats},
         {"setProperty", ServerOperation::Action::kSetProperty},
         {"getProperty", ServerOperation::Action::kGetProperty},
+        {"task", ServerOperation::Action::kTask},
+        {"trace", ServerOperation::Action::kTrace},
     };
 
 const folly::F14FastMap<ServerOperation::Action, std::string>
@@ -30,6 +32,8 @@ const folly::F14FastMap<ServerOperation::Action, std::string>
         {ServerOperation::Action::kGetCacheStats, "getCacheStats"},
         {ServerOperation::Action::kSetProperty, "setProperty"},
         {ServerOperation::Action::kGetProperty, "getProperty"},
+        {ServerOperation::Action::kTask, "task"},
+        {ServerOperation::Action::kTrace, "trace"},
     };
 
 const folly::F14FastMap<std::string, ServerOperation::Target>
@@ -37,6 +41,7 @@ const folly::F14FastMap<std::string, ServerOperation::Target>
         {"connector", ServerOperation::Target::kConnector},
         {"systemConfig", ServerOperation::Target::kSystemConfig},
         {"veloxQueryConfig", ServerOperation::Target::kVeloxQueryConfig},
+        {"debug", ServerOperation::Target::kDebug},
     };
 
 const folly::F14FastMap<ServerOperation::Target, std::string>
@@ -44,6 +49,7 @@ const folly::F14FastMap<ServerOperation::Target, std::string>
         {ServerOperation::Target::kConnector, "connector"},
         {ServerOperation::Target::kSystemConfig, "systemConfig"},
         {ServerOperation::Target::kVeloxQueryConfig, "veloxQueryConfig"},
+        {ServerOperation::Target::kDebug, "debug"},
     };
 
 ServerOperation::Target ServerOperation::targetFromString(

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -25,10 +25,18 @@ struct ServerOperation {
     kConnector,
     kSystemConfig,
     kVeloxQueryConfig,
+    kDebug,
   };
 
   /// The action this operation is trying to take
-  enum class Action { kClearCache, kGetCacheStats, kSetProperty, kGetProperty };
+  enum class Action {
+    kClearCache,
+    kGetCacheStats,
+    kSetProperty,
+    kGetProperty,
+    kTask,
+    kTrace,
+  };
 
   static const folly::F14FastMap<std::string, Target> kTargetLookup;
   static const folly::F14FastMap<Target, std::string> kReverseTargetLookup;

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -109,6 +109,10 @@ TEST_F(ServerOperationTest, buildServerOp) {
   EXPECT_EQ(ServerOperation::Target::kSystemConfig, op.target);
   EXPECT_EQ(ServerOperation::Action::kSetProperty, op.action);
 
+  op = buildServerOpFromHttpMsgPath("/v1/operation/debug/task");
+  EXPECT_EQ(ServerOperation::Target::kDebug, op.target);
+  EXPECT_EQ(ServerOperation::Action::kTask, op.action);
+
   EXPECT_THROW(
       op = buildServerOpFromHttpMsgPath("/v1/operation/whatzit/setProperty"),
       velox::VeloxUserError);


### PR DESCRIPTION
Adding server operations to return task->toString(), to allow for easier debugging of zombie tasks and stuck queries

Test plan: Ran in a cluster, and sent operation command to print stuff
```
== NO RELEASE NOTE ==
```
