### PR TITLE
Update PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,27 @@
-Test plan - (Please fill in how you tested your changes)
+## Description
+<!---Describe your changes in detail-->
 
-Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.
+## Motivation and Context
+<!---Why is this change required? What problem does it solve?-->
+<!---If it fixes an open issue, please link to the issue here.-->
 
-Fill in the release notes towards the bottom of the PR description.
-See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.
+## Impact
+<!---Describe any public API or user-facing feature change or any performance impact-->
+
+## Test Plan
+<!---Please fill in how you tested your change-->
+
+## Contributor checklist
+
+- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
+- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
+- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
+- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
+- [ ] Adequate tests were added if applicable.
+- [ ] CI passed.
+
+## Release Notes
+Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
 
 ```
 == RELEASE NOTES ==
@@ -22,3 +40,4 @@ If release note is NOT required, use:
 ```
 == NO RELEASE NOTE ==
 ```
+


### PR DESCRIPTION

Current PR template adds bunch of guideline urls but does not help organizing the PR description that can further help non-authors and reviewers to understand the PR in a better way. Hence proposing new PR template. 

