### PR TITLE
Introduce AlternativeNullableLongStateSerializer for presto native

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -361,4 +361,17 @@ public interface Block
      * The original block won't be modified.
      */
     Block appendNull();
+
+    /**
+     * Returns the converted long value at {@code position} if the value ar {@code position} can be converted to long.
+     * @throws UnsupportedOperationException if value at {@code position} is not compatible to be converted to long.
+     *
+     * Difference between toLong() and getLong() is:
+     * getLong() would only return value when the block is LongArrayBlock, otherwise it would throw exception.
+     * toLong() would return value for compatible types: LongArrayBlock, IntArrayBlock, ByteArrayBlock and ShortArrayBlock.
+     */
+    default long toLong(int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
@@ -275,6 +275,13 @@ public class ByteArrayBlock
     }
 
     @Override
+    public long toLong(int position)
+    {
+        checkReadablePosition(position);
+        return getByteUnchecked(position + arrayOffset);
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -679,6 +679,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public long toLong(int position)
+    {
+        return dictionary.toLong(getId(position));
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlock.java
@@ -275,6 +275,13 @@ public class IntArrayBlock
     }
 
     @Override
+    public long toLong(int position)
+    {
+        checkReadablePosition(position);
+        return getIntUnchecked(position + arrayOffset);
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
@@ -313,6 +313,13 @@ public class LongArrayBlock
     }
 
     @Override
+    public long toLong(int position)
+    {
+        checkReadablePosition(position);
+        return getLongUnchecked(position + arrayOffset);
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
@@ -272,6 +272,13 @@ public class ShortArrayBlock
     }
 
     @Override
+    public long toLong(int position)
+    {
+        checkReadablePosition(position);
+        return getShortUnchecked(position + arrayOffset);
+    }
+
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -111,7 +111,7 @@ public abstract class AbstractMinMaxAggregationFunction
 
         if (type.getJavaType() == long.class) {
             stateInterface = NullableLongState.class;
-            stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+            stateSerializer = getStateSerializer(stateInterface, classLoader);
             inputFunction = LONG_INPUT_FUNCTION.bindTo(compareMethodHandle);
             combineFunction = LONG_COMBINE_FUNCTION.bindTo(compareMethodHandle);
             outputFunction = LONG_OUTPUT_FUNCTION.bindTo(type);
@@ -164,6 +164,11 @@ public abstract class AbstractMinMaxAggregationFunction
                 classLoader);
         return new BuiltInAggregationFunctionImplementation(getSignature().getNameSuffix(), inputTypes, ImmutableList.of(intermediateType),
                 type, true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    protected AccumulatorStateSerializer<?> getStateSerializer(Class<? extends AccumulatorState> stateInterface, DynamicClassLoader classLoader)
+    {
+        return StateCompiler.generateStateSerializer(stateInterface, classLoader);
     }
 
     protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMaxAggregationFunction.java
@@ -13,7 +13,12 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.state.AlternativeNullableLongState;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 
 public class AlternativeMaxAggregationFunction
         extends MaxAggregationFunction
@@ -23,6 +28,11 @@ public class AlternativeMaxAggregationFunction
     public AlternativeMaxAggregationFunction()
     {
         super();
+    }
+
+    protected AccumulatorStateSerializer<?> getStateSerializer(Class<? extends AccumulatorState> stateInterface, DynamicClassLoader classLoader)
+    {
+        return StateCompiler.generateStateSerializer(AlternativeNullableLongState.class, classLoader);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMinAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMinAggregationFunction.java
@@ -13,7 +13,12 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.state.AlternativeNullableLongState;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 
 public class AlternativeMinAggregationFunction
         extends MinAggregationFunction
@@ -23,6 +28,11 @@ public class AlternativeMinAggregationFunction
     public AlternativeMinAggregationFunction()
     {
         super();
+    }
+
+    protected AccumulatorStateSerializer<?> getStateSerializer(Class<? extends AccumulatorState> stateInterface, DynamicClassLoader classLoader)
+    {
+        return StateCompiler.generateStateSerializer(AlternativeNullableLongState.class, classLoader);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/AlternativeNullableLongState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/AlternativeNullableLongState.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+/**
+ * AlternativeNullableLongState is a dummy class to help create corresponding AlternativeNullableLongStateSerializer
+ * in AlternativeMaxAggregationFunction and AlternativeMinAggregationFunction.
+ */
+@AccumulatorStateMetadata(stateSerializerClass = AlternativeNullableLongStateSerializer.class)
+public interface AlternativeNullableLongState
+        extends NullableLongState
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/AlternativeNullableLongStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/AlternativeNullableLongStateSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+
+/**
+ * AlternativeNullableLongStateSerializer is only used for presto native worker.
+ *
+ * The only difference between AlternativeNullableLongStateSerializer and NullableLongStateSerializer
+ * is the deserialize() function:
+ * 1. NullableLongStateSerializer can only deserialize long type since presto java uses long as the unified
+ * intermediate type for all integer data (long, int, smallint, tinyint).
+ * 2. AlternativeNullableLongStateSerializer can deserialize any types that are compatible with long
+ * (long, int, smallint, tinyint) since presto native use data's original types as intermediate types.
+ */
+public class AlternativeNullableLongStateSerializer
+        implements AccumulatorStateSerializer<NullableLongState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return BIGINT;
+    }
+
+    @Override
+    public void serialize(NullableLongState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            BIGINT.writeLong(out, state.getLong());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, NullableLongState state)
+    {
+        state.setNull(false);
+        // by using toLong(), we're able to deserialize compatible integer types with:
+        // 1. no precision loss
+        // 2. no performance difference
+        state.setLong(block.toLong(index));
+    }
+}


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```


This is built on top of https://github.com/prestodb/presto/pull/17857 and it would only affect prestissimo, and it gives prestissimo coordinator ability to deserialize more data types and with: 
1. no precision loss
2. no performance difference
