### PR TITLE
Fix the performance problem of InternalResourceGroup.getActiveWorkCount

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import java.util.Objects;
 import java.util.Set;
@@ -28,6 +29,7 @@ public class AllNodes
     private final Set<InternalNode> activeCoordinators;
     private final Set<InternalNode> activeResourceManagers;
     private final Set<InternalNode> activeCatalogServers;
+    private final int activeWorkerCount;
 
     public AllNodes(
             Set<InternalNode> activeNodes,
@@ -43,11 +45,18 @@ public class AllNodes
         this.activeCoordinators = ImmutableSet.copyOf(requireNonNull(activeCoordinators, "activeCoordinators is null"));
         this.activeResourceManagers = ImmutableSet.copyOf(requireNonNull(activeResourceManagers, "activeResourceManagers is null"));
         this.activeCatalogServers = ImmutableSet.copyOf(requireNonNull(activeCatalogServers, "activeCatalogServers is null"));
+
+        this.activeWorkerCount = Sets.difference(Sets.difference(activeNodes, activeResourceManagers), activeCatalogServers).size();
     }
 
     public Set<InternalNode> getActiveNodes()
     {
         return activeNodes;
+    }
+
+    public int getActiveWorkerCount()
+    {
+        return activeWorkerCount;
     }
 
     public Set<InternalNode> getInactiveNodes()


### PR DESCRIPTION
During an investigation of "missing metrics" problem, we traced it back to a performance problem with `InternalResourceGroup.getActiveWorkCount`. 

The evidences:

1. We took a JFR recording and we can see all the fb303 threads are blocked. 
2. By checking the thread dump, the lock is often held by this call `InternalResourceGroup.getActiveWorkCount`
3. We did a small benchmark, and it shows a simple `Sets.diff(Sets.diff)` is 30 times slower than HashSet.size(), which should be O(1). 


## Change

To fix the problem, we calculate the value in `AllNodes`' contr once, and then read many times. Since all the node sets in `AllNodes` are immutable, this is safe to do.

## Problem

The benchmark result is here. avgt = average time. 

https://gist.github.com/dongshengbc/be7eee51a4d98b0dc3363b294266424b

| Benchmark | Mode | Samples | Score | Score error | Units |
| ---- | ----  | ----   | ----  | ---- | ---- | 
| o.s.ImmutableSetBenchmark.testImmutableDiffSize | avgt|5|8.605|0.241|ns/op|
|o.s.ImmutableSetBenchmark.testImmutableSize|avgt|5|0.865|0.012  |ns/op|
|o.s.ImmutableSetBenchmark.testTwoImmutableDiffSize|avgt|5|22.483|0.923  |ns/op|
