### PR TITLE
Configure issues templates for Presto repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,43 @@
+---
+name: Open a Bug
+about: Create a bug report
+title: '[BUG]'
+labels: bug
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- Look through existing open and closed issues to see if someone has reported the issue before -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Presto version used:
+* Storage (HDFS/S3/GCS..):
+* Data source and connector used:
+* Deployment (Cloud or On-prem):
+* [Pastebin](https://pastebin.com/) link to the complete debug logs:
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug or a workaround -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Screenshots (if appropriate)
+
+## Context
+<!--- How has this issue affected you? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+
+blank_issues_enabled: false
+contact_links:
+  - name: Slack Support
+    url: https://https://prestodb.io/slack
+    about: Join the Presto Slack Channel to engage in conversations and get faster support.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Create a feature request
+title: '[Feature Request]'
+labels: 'feature request'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the feature request or improvement in the Title above -->
+<!--- Look through existing open and closed feature proposals to see if someone has asked for the feature before -->
+
+## Expected Behavior or Use Case
+<!--- Tell us how it should work -->
+
+## Presto Component, Service, or Connector
+<!--- Tell us to which service or component this request is related to -->
+
+## Possible Implementation
+<!--- Not obligatory, suggest ideas of how to implement the addition or change -->
+
+## Example Screenshots (if appropriate):
+
+## Context
+<!--- Why do you need this feature or improvement? What is your use case? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->

--- a/.github/ISSUE_TEMPLATE/usage-question.md
+++ b/.github/ISSUE_TEMPLATE/usage-question.md
@@ -1,0 +1,46 @@
+---
+name: Usage Question
+about: Report an issue faced while using Presto
+title: '[USAGE]'
+labels: usage
+
+---
+<!--Tips before filing an issue -->
+<!-- Join the Presto Slack Channel to engage in conversations and get faster support at https://https://prestodb.io/slack. -->
+<!-- If you have triaged this as a bug, then file an [BUG](https://github.com/prestodb/presto/issues/new/choose) directly. -->
+
+## Describe the problem you faced
+
+* A clear and concise description of the problem.
+* Was this working before or is this a first try?
+* If this worked before, then what has changed that recently?  
+* Provide table DDLs and `` EXPLAIN ANALYZE `` for your Presto queries.
+
+## Environment Description
+
+* Presto version used:
+* Storage (HDFS/S3/GCS..):
+* Data source and connectors or catalogs used:
+* Deployment (Cloud or On-prem):
+* [Pastebin](https://pastebin.com/) link to the complete debug logs:
+
+## Steps To Reproduce
+
+Steps to reproduce the behavior:
+1.
+2.
+3.
+4.
+
+## Expected behavior
+
+<!--- A clear and concise description of what you expected to happen.-->
+
+
+## Additional context
+
+<!--- Add any other context about the problem here. What is your use case? What are you trying to accomplish? Providing context helps us come up with a solution that is most useful in the real world.-->
+
+## Stacktrace
+
+<!---Add the complete stacktrace of the error.-->


### PR DESCRIPTION
You can add the templates that are available for contributors to use when they open new issues in the Presto repository.

Issue templates are helpful when you want to provide guidance for opening issues while allowing contributors and Presto users to specify the content of their issues. If you want contributors to provide specific, structured information when they open issues, issue forms help ensure that you receive your desired information.

Refer - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates