### PR TITLE
[native] Fail fast on distinct aggregations

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1636,6 +1636,9 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   for (const auto& entry : node->aggregations) {
     aggregateNames.emplace_back(entry.first.name);
 
+    VELOX_USER_CHECK(
+        !entry.second.distinct, "Distinct aggregations are not supported yet.");
+
     core::AggregationNode::Aggregate aggregate;
     aggregate.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
         exprConverter_.toVeloxExpr(entry.second.call));

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
@@ -293,6 +294,16 @@ public abstract class AbstractTestNativeAggregations
     {
         assertQuery("SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem");
         assertQuery("SELECT orderkey, count(distinct comment), sum(distinct linenumber) FROM lineitem GROUP BY 1");
+    }
+
+    @Test
+    public void testDistinct()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty("use_mark_distinct", "falze")
+                .build();
+        assertQueryFails(session, "SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem",
+                ".*Distinct aggregations are not supported yet.");
     }
 
     private void assertQueryResultCount(String sql, int expectedResultCount)


### PR DESCRIPTION
Velox doesn't support computing distinct aggregations yet. Fail the query fast to avoid hard-to-debug correctness issues.

```
== NO RELEASE NOTE ==
```
