### PR TITLE
Update Drift dependency to use Header transport by default and provide "thrift" ALPN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
-        <dep.drift.version>1.36</dep.drift.version>
+        <dep.drift.version>1.37</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
         <dep.joda.version>2.12.2</dep.joda.version>


### PR DESCRIPTION
This commit updates Drift version to 1.37. Thrift client/servers will now provide/expect the "thrift" ALPN value, which is meant to identify and select Header, Framed, and Unframed transports. Additionally, Drift Thrift clients will now use Header transport by default.

== RELEASE NOTES ==

General Changes

- Change default Drift client transport to HEADER
- Use "thrift" ALPN value for all Drift TLS connections (client and server)