### PR TITLE
[native] Use custom executor for exchange

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <folly/Uri.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/futures/Retrying.h>
 
 #include "presto_cpp/main/common/Configs.h"
@@ -68,16 +69,18 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       int destination,
       std::shared_ptr<velox::exec::ExchangeQueue> queue,
       velox::memory::MemoryPool* pool,
+      const std::shared_ptr<folly::IOThreadPoolExecutor>& executor,
       const std::string& clientCertAndKeyPath_ = "",
       const std::string& ciphers_ = "");
 
   bool shouldRequestLocked() override;
 
-  static std::unique_ptr<ExchangeSource> createExchangeSource(
+  static std::unique_ptr<ExchangeSource> create(
       const std::string& url,
       int destination,
       std::shared_ptr<velox::exec::ExchangeQueue> queue,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<folly::IOThreadPoolExecutor> executor);
 
   void close() override;
 
@@ -148,6 +151,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const uint16_t port_;
   const std::string clientCertAndKeyPath_;
   const std::string ciphers_;
+  const std::shared_ptr<folly::IOThreadPoolExecutor> exchangeExecutor_;
 
   std::shared_ptr<http::HttpClient> httpClient_;
   RetryState retryState_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -178,11 +178,6 @@ void PrestoServer::run() {
   protocol::registerHiveConnectors();
   protocol::registerTpchConnector();
 
-  auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
-      systemConfig->numIoThreads(),
-      std::make_shared<folly::NamedThreadFactory>("PrestoWorkerNetwork"));
-  folly::setUnsafeMutableGlobalIOExecutor(executor);
-
   initializeVeloxMemory();
 
   auto catalogNames = registerConnectors(fs::path(configDirectoryPath_));
@@ -281,8 +276,23 @@ void PrestoServer::run() {
   registerVectorSerdes();
   registerPrestoPlanNodeSerDe();
 
+  exchangeExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(
+      systemConfig->numIoThreads(),
+      std::make_shared<folly::NamedThreadFactory>("PrestoWorkerNetwork"));
+
+  PRESTO_STARTUP_LOG(INFO) << "Exchange executor has "
+                           << exchangeExecutor_->numThreads() << " threads.";
+
   facebook::velox::exec::ExchangeSource::registerFactory(
-      PrestoExchangeSource::createExchangeSource);
+      [this](
+          const std::string& taskId,
+          int destination,
+          std::shared_ptr<velox::exec::ExchangeQueue> queue,
+          memory::MemoryPool* pool) {
+        return PrestoExchangeSource::create(
+            taskId, destination, queue, pool, exchangeExecutor_);
+      });
+
   facebook::velox::exec::ExchangeSource::registerFactory(
       operators::UnsafeRowExchangeSource::createExchangeSource);
 
@@ -391,7 +401,7 @@ void PrestoServer::run() {
 
   auto cpuExecutor = driverCPUExecutor();
   PRESTO_SHUTDOWN_LOG(INFO)
-      << "Joining Driver CPU Executor '" << cpuExecutor->getName()
+      << "Joining driver CPU Executor '" << cpuExecutor->getName()
       << "': threads: " << cpuExecutor->numActiveThreads() << "/"
       << cpuExecutor->numThreads()
       << ", task queue: " << cpuExecutor->getTaskQueueSize();
@@ -399,11 +409,17 @@ void PrestoServer::run() {
 
   if (connectorIoExecutor_) {
     PRESTO_SHUTDOWN_LOG(INFO)
-        << "Joining IO Executor '" << connectorIoExecutor_->getName()
+        << "Joining connector IO Executor '" << connectorIoExecutor_->getName()
         << "': threads: " << connectorIoExecutor_->numActiveThreads() << "/"
         << connectorIoExecutor_->numThreads();
     connectorIoExecutor_->join();
   }
+
+  PRESTO_SHUTDOWN_LOG(INFO)
+      << "Joining exchange Executor '" << exchangeExecutor_->getName()
+      << "': threads: " << exchangeExecutor_->numActiveThreads() << "/"
+      << exchangeExecutor_->numThreads();
+  exchangeExecutor_->join();
 
   PRESTO_SHUTDOWN_LOG(INFO) << "Done joining our executors.";
 
@@ -608,6 +624,10 @@ std::vector<std::string> PrestoServer::registerConnectors(
   if (numConnectorIoThreads) {
     connectorIoExecutor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(numConnectorIoThreads);
+
+    PRESTO_STARTUP_LOG(INFO)
+        << "Connector IO executor has " << connectorIoExecutor_->numThreads()
+        << " threads.";
   }
   std::vector<std::string> catalogNames;
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -162,6 +162,9 @@ class PrestoServer {
   // Executor for async IO for connectors.
   std::unique_ptr<folly::IOThreadPoolExecutor> connectorIoExecutor_;
 
+  // Executor for exchange data over http.
+  std::shared_ptr<folly::IOThreadPoolExecutor> exchangeExecutor_;
+
   // If not null,  the instance of AsyncDataCache used for in-memory file cache.
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -142,7 +142,14 @@ class TaskManagerTest : public testing::Test {
     aggregate::prestosql::registerAllAggregateFunctions();
     parse::registerTypeResolver();
     exec::ExchangeSource::registerFactory(
-        PrestoExchangeSource::createExchangeSource);
+        [executor = exchangeExecutor_](
+            const std::string& taskId,
+            int destination,
+            std::shared_ptr<exec::ExchangeQueue> queue,
+            memory::MemoryPool* pool) {
+          return PrestoExchangeSource::create(
+              taskId, destination, queue, pool, executor);
+        });
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();
     };
@@ -575,6 +582,8 @@ class TaskManagerTest : public testing::Test {
   std::unique_ptr<TaskManager> taskManager_;
   std::unique_ptr<TaskResource> taskResource_;
   std::unique_ptr<facebook::presto::test::HttpServerWrapper> httpServerWrapper_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> exchangeExecutor_ =
+      std::make_shared<folly::IOThreadPoolExecutor>(10);
   long splitSequenceId_{0};
 };
 


### PR DESCRIPTION
We should not use driver cpu executor for exchanges - drivers should have their own relatively small thread pool.

Also avoid using global event bases.

```
== NO RELEASE NOTE ==
```
