### PR TITLE
Rewrite IN predicate for constant list

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -80,8 +80,25 @@ public class TestSimplifyRowExpressions
     public void testNestedExpressions()
     {
         assertSimplifies(
-                "(true and coalesce(X, true) IN (true, false)) IN (true, false)",
-                "(coalesce(X, true) IN (true, false)) IN (true, false)");
+                "(true and coalesce(X, true) IN (true, false, Y)) IN (true, false, Y)",
+                "(coalesce(X, true) IN (true, false, Y)) IN (true, false, Y)");
+    }
+
+    @Test
+    public void testInExpressions()
+    {
+        assertSimplifies(
+                "X IN (TRUE, FALSE)",
+                "X IS NOT NULL");
+        assertSimplifies(
+                "NULL IN (TRUE, FALSE)",
+                "FALSE");
+        assertSimplifies(
+                "X IN (TRUE, FALSE, Y)",
+                "X IN (TRUE, FALSE, Y)");
+        assertSimplifies(
+                "X IN (TRUE, FALSE, NULL)",
+                "X IN (TRUE, FALSE, NULL)");
     }
 
     @Test


### PR DESCRIPTION
When both constants `TRUE` and `FALSE` are present in the list of predicate `IN`, the expression can be converted into `IS NOT NULL`.

```
== NO RELEASE NOTE ==
```
