### PR TITLE
[native pos] Propagate taskInfo updates to Spark metrics

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -50,7 +50,6 @@ import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcessFactory;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleWriteInfo;
-import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spi.plan.OutputNode;
@@ -282,9 +281,6 @@ public class PrestoSparkNativeTaskExecutorFactory
         }
         SerializedTaskInfo serializedTaskInfo = new SerializedTaskInfo(serializeZstdCompressed(taskInfoCodec, taskInfoOptional.get()));
         taskInfoCollector.add(serializedTaskInfo);
-
-        // Update Spark Accumulators for spark internal metrics
-        PrestoSparkStatsCollectionUtils.collectMetrics(taskInfoOptional.get());
     }
 
     private static void processTaskInfoForErrorsOrCompletion(TaskInfo taskInfo)


### PR DESCRIPTION
Currently, we update the spark metrics accumulators only after the task is complete. This means that spark sees no progress or activity on the task until the task is complete. This also means that we can't effectively use the stalled tasks killer in spark scheduler as it relies on spark accumulators being updated regularly to measure if a task is making progress.

This commit fixes this by ensuring that everytime we receive TaskInfo from CPP process we immediately update Spark accumulators to let spark know that we are making progress

```
== NO RELEASE NOTE ==
```
