### PR TITLE
[native pos] Add tests for json registration of functions with complex types

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -650,7 +650,7 @@ void PrestoServer::registerFunctions() {
       kPrestoDefaultPrefix);
   velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
   if (SystemConfig::instance()->registerTestFunctions()) {
-    velox::functions::prestosql::registerComparisonFunctions(
+    velox::functions::prestosql::registerAllScalarFunctions(
         "json.test_schema.");
     velox::aggregate::prestosql::registerAllAggregateFunctions(
         "json.test_schema.");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -118,5 +118,11 @@ public class TestPrestoSparkNativeSimpleQueries
     {
         assertQuery("SELECT json.test_schema.eq(1, linenumber) FROM lineitem", "SELECT 1 = linenumber FROM lineitem");
         assertQuery("SELECT json.test_schema.sum(linenumber) FROM lineitem", "SELECT sum(linenumber) FROM lineitem");
+
+        // Test functions with complex types (array, map, and row).
+        assertQuery("SELECT json.test_schema.array_constructor(linenumber) FROM lineitem", "SELECT array_constructor(linenumber) FROM lineitem");
+
+        assertQuery("SELECT json.test_schema.map(json.test_schema.array_constructor(linenumber), json.test_schema.array_constructor(linenumber)) FROM lineitem", "SELECT map(array_constructor(linenumber), array_constructor(linenumber)) FROM lineitem");
+        assertQuery("SELECT json.test_schema.map_entries(json.test_schema.map(json.test_schema.array_constructor(linenumber), json.test_schema.array_constructor(linenumber))) FROM lineitem", "SELECT map_entries(map(array_constructor(linenumber), array_constructor(linenumber))) FROM lineitem");
     }
 }

--- a/presto-native-execution/src/test/resources/external_functions.json
+++ b/presto-native-execution/src/test/resources/external_functions.json
@@ -17,6 +17,55 @@
         }
       }
     ],
+    "array_constructor":[
+      {
+        "docString":"function to construct an array from scalar parameters",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY(INTEGER)",
+        "paramTypes":[
+          "INTEGER"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "map":[
+      {
+        "docString":"function to construct a map from arrays of keys and values",
+        "functionKind": "SCALAR",
+        "outputType": "MAP(INTEGER, INTEGER)",
+        "paramTypes":[
+          "ARRAY(INTEGER)",
+          "ARRAY(INTEGER)"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "map_entries":[
+      {
+        "docString":"return an array of all entries in the given map.",
+        "functionKind": "SCALAR",
+        "outputType": "ARRAY(ROW(INTEGER, INTEGER))",
+        "paramTypes":[
+          "MAP(INTEGER, INTEGER)"
+        ],
+        "schema":"test_schema",
+        "routineCharacteristics": {
+          "language":"CPP",
+          "determinism":"DETERMINISTIC",
+          "nullCallClause":"CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
     "sum": [
       {
         "docString": "Returns sum of integers",


### PR DESCRIPTION
Summary:
Adding missing tests for json registration of functions with complex
types. In particular, this ensures that the Presto signature serialization
format which uses parenthesis (e.g. "array(integer)") is correctly applied for
json registration.

Differential Revision: D47425996

