### PR TITLE
[native pos] Do not lose task results

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -480,6 +480,15 @@ public class PrestoSparkNativeTaskExecutorFactory
                 Optional<TaskInfo> taskInfo = nativeExecutionTask.getTaskInfo();
 
                 processTaskInfoForErrorsOrCompletion(taskInfo.get());
+
+                // Fetch the remaining results, if any.
+                if (nativeExecutionTask.hasResult()) {
+                    pageOptional = nativeExecutionTask.pollResult();
+                    if (!pageOptional.isPresent()) {
+                        throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to fetch result from completed native task");
+                    }
+                    return pageOptional;
+                }
             }
             catch (RuntimeException ex) {
                 // For a failed task, if taskInfo is present we still want to log the metrics


### PR DESCRIPTION
We are seeing many queries producing fewer rows then expected. In all these instances, the query computed the results correctly, TableWriter saved these to files and returned the file paths. However, some file paths get lost between TableWriter and TableCommit stages. TableWriter returns N files, but TableCommit receives N - n files, where n is often 1, but sometimes is as high as 5.

We believe this happens because
com.facebook.presto.spark.execution.task.PrestoSparkNativeTaskExecutorFactory.PrestoSparkNativeTaskOutputIterator#computeNext fails to fetch results after seeing that the task has completed. The existing logic is:

1- wait for results with timeout; 2- if no results; wait for task to complete or results received; 3- if task is complete, exit.

It is possible that 1 return with no results after a timeout. Then task completes and produces results. 2 returns, but we fail to check for results. Thus loosing results.

The fix is to check for results after (2).

```
== NO RELEASE NOTE ==
```
