### PR TITLE
Make flow control for exchange

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -107,8 +107,16 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   /// Used by test to clear the node-wise memory usage tracking.
   static void testingClearMemoryUsage();
 
+  void deleteResults() override {
+    abortResults();
+  }
+
+  void acknowledge(int64_t sequence) override {
+    acknowledgeResults(sequence);
+  }
+
  private:
-  void request() override;
+  void request(uint64_t maxBytes) override;
 
   void doRequest(int64_t delayMs);
 
@@ -158,5 +166,8 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   // A boolean indicating whether abortResults() call was issued and was
   // successfully processed by the remote server.
   std::atomic_bool abortResultsSucceeded_{false};
+
+  // Size of current request.
+  uint64_t requestBytes_{0};
 };
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
@@ -37,9 +37,13 @@ class BroadcastExchangeSource : public velox::exec::ExchangeSource {
     return !atEnd_;
   }
 
-  void request() override;
+  void request(uint64_t maxBytes) override;
 
   void close() override {}
+
+  void deleteResults() override {}
+
+  void acknowledge(int64_t /*sequence*/) override {}
 
   folly::F14FastMap<std::string, int64_t> stats() const override;
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -393,15 +393,20 @@ class PrestoExchangeSourceTestSuite : public ::testing::TestWithParam<bool> {
   void requestNextPage(
       const std::shared_ptr<exec::ExchangeQueue>& queue,
       const std::shared_ptr<exec::ExchangeSource>& exchangeSource) {
+    constexpr int32_t kDefaultSize = 32 << 20;
     {
       std::lock_guard<std::mutex> l(queue->mutex());
       ASSERT_TRUE(exchangeSource->shouldRequestLocked());
+      queue->recordRequestLocked(1, kDefaultSize);
     }
-    exchangeSource->request();
+    exchangeSource->request(kDefaultSize);
+    std::lock_guard<std::mutex> l(queue->mutex());
+    exchangeSource->clearPendingLocked();
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<memory::MemoryAllocator> allocator_;
+  std::shared_ptr<exec::ExchangeClient> emptyClient_;
 };
 
 TEST_P(PrestoExchangeSourceTestSuite, basic) {
@@ -420,7 +425,8 @@ TEST_P(PrestoExchangeSourceTestSuite, basic) {
   auto producerAddress = serverWrapper.start().get();
   auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
 
@@ -445,7 +451,7 @@ TEST_P(PrestoExchangeSourceTestSuite, basic) {
   size_t deltaPool = pool_->currentBytes() - beforePoolSize;
   size_t deltaQueue = queue->totalBytes() - beforeQueueSize;
   EXPECT_EQ(deltaPool, deltaQueue);
-
+  exchangeSource->deleteResults();
   producer->waitForDeleteResults();
   serverWrapper.stop();
   EXPECT_EQ(pool_->currentBytes(), 0);
@@ -498,7 +504,7 @@ TEST_P(PrestoExchangeSourceTestSuite, retries) {
   auto producerAddress = serverWrapper.start().get();
   auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
 
@@ -541,7 +547,8 @@ TEST_P(PrestoExchangeSourceTestSuite, earlyTerminatingConsumer) {
   auto producerAddress = serverWrapper.start().get();
   auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
 
@@ -576,7 +583,8 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
   auto exchangeSource = std::make_shared<PrestoExchangeSource>(
@@ -603,6 +611,7 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducer) {
   size_t deltaQueue = queue->totalBytes() - beforeQueueSize;
   EXPECT_EQ(deltaPool, deltaQueue);
 
+  exchangeSource->deleteResults();
   producer->waitForDeleteResults();
   serverWrapper.stop();
   EXPECT_EQ(pool_->currentBytes(), 0);
@@ -628,7 +637,8 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducerAndEarlyTerminatingConsumer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
   auto exchangeSource = std::make_shared<PrestoExchangeSource>(
@@ -682,7 +692,8 @@ TEST_P(PrestoExchangeSourceTestSuite, failedProducer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
   auto exchangeSource = std::make_shared<PrestoExchangeSource>(
@@ -717,7 +728,8 @@ TEST_P(PrestoExchangeSourceTestSuite, exceedingMemoryCapacityForHttpResponse) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+  auto queue =
+      std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
   queue->addSourceLocked();
   queue->noMoreSources();
   auto exchangeSource = std::make_shared<PrestoExchangeSource>(
@@ -759,7 +771,8 @@ TEST_P(PrestoExchangeSourceTestSuite, memoryAllocationAndUsageCheck) {
     test::HttpServerWrapper serverWrapper(std::move(producerServer));
     auto producerAddress = serverWrapper.start().get();
 
-    auto queue = std::make_shared<exec::ExchangeQueue>(1 << 20);
+    auto queue =
+        std::make_shared<exec::ExchangeQueue>(1 << 20, 1 << 20, emptyClient_);
     queue->addSourceLocked();
     queue->noMoreSources();
     auto exchangeSource = std::make_shared<PrestoExchangeSource>(


### PR DESCRIPTION
Summary:
Make flow control for exchange

Adds a request size parameter to ExchangeClient::request(). Adds
counters tracking the history and current state of ExchangeSources,
ExchangeQueue and ExchangeClient.

The flo control of Exchange seeks to work within a maximum queue size
given by, Presto-compatible config name 'exchangeBufferSize()
exchange.max_buffer_size'.

All operations that either consume or process or add sources for
exchange call ExchangeClient::requestIfDue(). This checks if there are
requestable sources and space in the buffer and issues a suitable
number of requests. If this is called from enqueueing a reply from an
exchange source, the source is passed as an argument. requestIfDue
will first request other sources in a round robin fashion. If, after
requesting ther sources, there is space to also request the source
that just arrived, we send a direct request for more. If there is no
space in the queue, we acknowledge the data that may have arrived in
the reply and leave the just arrived source as non-pending. This will
be requested eventually after other sources produce data or time out.

ExchangeQueue tracks the average size of exchange response
pages. Requests are sized to multiples of these. When a request is
started, ExchangeQueue::expectedBytes_ is updated to reflect the
expected data. When a response arrives, the expectedBytes is updated
pro rata, i.e. if there are 3 pending, one response removes at least
1/3 of expectedBytes_.

This mechanism relies on request always producing a possibly empty
response within a relatively short time. This is the case in
Presto/Prestissimo. This is simulated in the test by periodically
timing out all pending callbacks in PartitionedoutputBufferManager.

The test runs exchanges of different widths with different buffer
sizes and variation of data sizes. It checks that the queue peak size
stays within limits.

Requires corresponding changes in Prestissimo PrestoExchangeSource.*.

X-link: https://github.com/facebookincubator/velox/pull/5262

Differential Revision: D46712319

Pulled By: pranjalssh

