### PR TITLE
[native pos] Fix TaskInfo fetcher logic to avoid concurrent runs

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
@@ -21,8 +21,6 @@ import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 
@@ -30,7 +28,6 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -54,10 +51,8 @@ public class HttpNativeExecutionTaskInfoFetcher
     private final PrestoSparkHttpTaskClient workerClient;
     private final ScheduledExecutorService updateScheduledExecutor;
     private final AtomicReference<TaskInfo> taskInfo = new AtomicReference<>();
-    private final Executor executor;
     private final Duration infoFetchInterval;
     private final RequestErrorTracker errorTracker;
-    private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final AtomicReference<RuntimeException> lastException = new AtomicReference<>();
     private final Duration maxErrorDuration;
     private final Object taskFinished;
@@ -69,16 +64,13 @@ public class HttpNativeExecutionTaskInfoFetcher
             ScheduledExecutorService updateScheduledExecutor,
             ScheduledExecutorService errorRetryScheduledExecutor,
             PrestoSparkHttpTaskClient workerClient,
-            Executor executor,
             Duration infoFetchInterval,
             Duration maxErrorDuration,
             Object taskFinished)
     {
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.updateScheduledExecutor = requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
-        this.executor = requireNonNull(executor, "executor is null");
         this.infoFetchInterval = requireNonNull(infoFetchInterval, "infoFetchInterval is null");
-        this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         this.errorTracker = new RequestErrorTracker(
                 "NativeExecution",
@@ -104,69 +96,6 @@ public class HttpNativeExecutionTaskInfoFetcher
         }
     }
 
-    @VisibleForTesting
-    void doGetTaskInfo()
-    {
-        try {
-            ListenableFuture<BaseResponse<TaskInfo>> taskInfoFuture = workerClient.getTaskInfo();
-            Futures.addCallback(
-                    taskInfoFuture,
-                    new FutureCallback<BaseResponse<TaskInfo>>()
-                    {
-                        @Override
-                        public void onSuccess(BaseResponse<TaskInfo> result)
-                        {
-                            log.debug("TaskInfoCallback success %s", result.getValue().getTaskId());
-                            taskInfo.set(result.getValue());
-
-                            // Update Spark Accumulators for spark internal metrics
-                            // Note: Updating here also serves as a heartbeat to spark scheduler
-                            // that the task is making progress
-                            PrestoSparkStatsCollectionUtils.collectMetrics(taskInfo.get());
-
-                            if (result.getValue().getTaskStatus().getState().isDone()) {
-                                synchronized (taskFinished) {
-                                    taskFinished.notifyAll();
-                                }
-                            }
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t)
-                        {
-                            // record failure
-                            try {
-                                errorTracker.requestFailed(t);
-                            }
-                            catch (PrestoException e) {
-                                // Entering here means that we are unable
-                                // to get any task info from the CPP process
-                                // likely because process has crashed
-                                stop();
-                                lastException.set(e);
-                                synchronized (taskFinished) {
-                                    taskFinished.notifyAll();
-                                }
-                                return;
-                            }
-                            ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-                            try {
-                                // synchronously wait on throttling
-                                errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
-                            }
-                            catch (InterruptedException | ExecutionException | TimeoutException e) {
-                                // throttling error is not fatal, just log the error.
-                                log.debug(e.getMessage());
-                            }
-                        }
-                    },
-                    executor);
-        }
-        catch (Throwable t) {
-            throw t;
-        }
-    }
-
     public Optional<TaskInfo> getTaskInfo()
             throws RuntimeException
     {
@@ -180,5 +109,59 @@ public class HttpNativeExecutionTaskInfoFetcher
     public AtomicReference<RuntimeException> getLastException()
     {
         return lastException;
+    }
+
+    @VisibleForTesting
+    void doGetTaskInfo()
+    {
+        try {
+            BaseResponse<TaskInfo> responseTaskInfo = workerClient.getTaskInfo().get();
+            taskInfo.set(responseTaskInfo.getValue());
+
+            // Update Spark Accumulators for spark internal metrics
+            // Note: Updating here also serves as a heartbeat to spark scheduler
+            // that the task is making progress
+            PrestoSparkStatsCollectionUtils.collectMetrics(taskInfo.get());
+
+            if (taskInfo.get().getTaskStatus().getState().isDone()) {
+                synchronized (taskFinished) {
+                    taskFinished.notifyAll();
+                }
+            }
+        }
+        catch (Exception ex) {
+            // track failure
+            try {
+                errorTracker.requestFailed(ex);
+            }
+            catch (PrestoException e) {
+                // Entering here means that we are unable
+                // to get any task info from the CPP process
+                // likely because process has crashed
+                stop();
+                lastException.set(e);
+                synchronized (taskFinished) {
+                    taskFinished.notifyAll();
+                }
+                return;
+            }
+            catch (Throwable t) {
+                log.error("Throwing unhandled exception. Will stop fetching taskInfo: ", t);
+                throw t;
+            }
+            ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+            try {
+                // synchronously wait on throttling
+                errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
+            }
+            catch (InterruptedException | ExecutionException | TimeoutException e) {
+                // throttling error is not fatal, just log the error.
+                log.debug(e.getMessage());
+            }
+        }
+        catch (Throwable t) {
+            log.error("Throwing unhandled exception. Will stop fetching taskInfo: ", t);
+            throw t;
+        }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -103,7 +103,6 @@ public class NativeExecutionTask
                 updateScheduledExecutor,
                 errorRetryScheduledExecutor,
                 this.workerClient,
-                this.executor,
                 taskManagerConfig.getInfoUpdateInterval(),
                 queryManagerConfig.getRemoteTaskMaxErrorDuration(),
                 taskFinishedOrHasResult);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -892,7 +892,6 @@ public class TestPrestoSparkHttpClient
                 newScheduledThreadPool(1),
                 newScheduledThreadPool(1),
                 workerClient,
-                newSingleThreadExecutor(),
                 new Duration(1, TimeUnit.SECONDS),
                 maxErrorDuration,
                 lock);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -65,7 +64,6 @@ public class TestHttpNativeExecutionTaskInfoFetcher
                 updateScheduledExecutor,
                 errorScheduler,
                 workerClient,
-                directExecutor(),
                 new Duration(1, TimeUnit.SECONDS),
                 new Duration(1, TimeUnit.SECONDS),
                 taskFinishedOrLostSignal);


### PR DESCRIPTION
Currently, due to using async callback inside the already async scheduled thread
we are making the scheduleAtFixedDelay's delay mechanism ineffective because
we early exit from the `doServerGet` call. The end result is that we will have
multiple outstanding `GET/info` call at a given time.

Making this call sync on the thread allows us to guard against this by ensuring
that we do not start the next instance of the work (http call) before
the first one returns.

```
== NO RELEASE NOTE ==
```
