### PR TITLE
[native pos] Add logging to help root cause data loss

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -485,6 +485,7 @@ public abstract class AbstractPrestoSparkQueryExecution
                 PrestoSparkSerializedPage page = tuple._2;
                 currentFragmentOutputCompressedSizeInBytes += page.getSize();
                 currentFragmentOutputUncompressedSizeInBytes += page.getUncompressedSizeInBytes();
+                log.info("Received %s rows from taskId %s in fragment %s", page.getPositionCount(), tuple._1.getPartition(), inputFuture.getKey());
                 pages.add(page);
             }
             log.info(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -95,7 +95,7 @@ public class PrestoSparkHttpTaskClient
         this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
         this.planFragmentCodec = requireNonNull(planFragmentCodec, "planFragmentCodec is null");
         this.taskUpdateRequestCodec = requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
-        this.taskUri = getTaskUri(location, taskId);
+        this.taskUri = createTaskUri(location, taskId);
         this.infoRefreshMaxWait = requireNonNull(infoRefreshMaxWait, "infoRefreshMaxWait is null");
         this.tokenAuthenticator = requireNonNull(tokenAuthenticators, "tokenAuthenticator is null");
     }
@@ -225,7 +225,12 @@ public class PrestoSparkHttpTaskClient
         return location;
     }
 
-    private URI getTaskUri(URI baseUri, TaskId taskId)
+    public URI getTaskUri()
+    {
+        return taskUri;
+    }
+
+    private URI createTaskUri(URI baseUri, TaskId taskId)
     {
         return uriBuilderFrom(baseUri)
                 .appendPath(TASK_URI)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark.execution.nativeprocess;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.operator.PageBufferClient;
 import com.facebook.presto.operator.PageTransportErrorException;
-import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
@@ -24,8 +23,6 @@ import com.facebook.presto.spi.page.SerializedPage;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -109,10 +106,14 @@ public class HttpNativeExecutionTaskResultFetcher
                 });
     }
 
-    public void stop()
+    public void stop(boolean success)
     {
         if (schedulerFuture != null) {
             schedulerFuture.cancel(false);
+        }
+
+        if (success && !pageBuffer.isEmpty()) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("TaskResultFetcher is closed with {} pages left in the buffer", pageBuffer.size()));
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -182,10 +182,10 @@ public class NativeExecutionTask
     /**
      * Releases all resources, and kills all schedulers. It is caller's responsibility to call this method when NativeExecutionTask is no longer needed.
      */
-    public void stop()
+    public void stop(boolean success)
     {
         taskInfoFetcher.stop();
-        taskResultFetcher.ifPresent(fetcher -> fetcher.stop());
+        taskResultFetcher.ifPresent(fetcher -> fetcher.stop(success));
         workerClient.abortResults();
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -268,10 +268,10 @@ public class PrestoSparkNativeTaskExecutorFactory
         }
     }
 
-    private static void completeTask(CollectionAccumulator<SerializedTaskInfo> taskInfoCollector, NativeExecutionTask task, Codec<TaskInfo> taskInfoCodec)
+    private static void completeTask(boolean success, CollectionAccumulator<SerializedTaskInfo> taskInfoCollector, NativeExecutionTask task, Codec<TaskInfo> taskInfoCodec)
     {
         // stop the task
-        task.stop();
+        task.stop(success);
 
         // collect statistics (if available)
         Optional<TaskInfo> taskInfoOptional = task.getTaskInfo();
@@ -486,7 +486,7 @@ public class PrestoSparkNativeTaskExecutorFactory
             }
             catch (RuntimeException ex) {
                 // For a failed task, if taskInfo is present we still want to log the metrics
-                completeTask(taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec);
+                completeTask(false, taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec);
                 throw executionExceptionFactory.toPrestoSparkExecutionException(ex);
             }
             catch (InterruptedException e) {
@@ -495,7 +495,7 @@ public class PrestoSparkNativeTaskExecutorFactory
             }
 
             // Reaching here marks the end of task processing
-            completeTask(taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec);
+            completeTask(true, taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec);
             return Optional.empty();
         }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -829,7 +829,7 @@ public class TestPrestoSparkHttpClient
             assertEquals(10, resultPages.size());
             assertTrue(task.getTaskInfo().isPresent());
 
-            task.stop();
+            task.stop(true);
         }
         catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
We are seeing many queries producing fewer rows then expected. In all these instances, the query computed the results correctly, TableWriter saved these to files and returned the file paths. However, some file paths get lost between TableWriter and TableCommit stages. TableWriter returns N files, but TableCommit receives N - n files, where n is often 1, but sometimes is as high as 5.

Add logging to identify where data gets lots: one the worker or driver.

```
== NO RELEASE NOTE ==
```
