### PR TITLE
[native] Add node information in spill path.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -138,6 +138,8 @@ class TaskManager {
   /// Always returns non-empty string.
   static std::string buildTaskSpillDirectoryPath(
       const std::string& baseSpillPath,
+      const std::string& nodeIp,
+      const std::string& nodeId,
       const std::string& queryId,
       const protocol::TaskId& taskId);
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -520,6 +520,19 @@ class TaskManagerTest : public testing::Test {
         "{}={}\n", SystemConfig::kSpillerSpillPath, spillDirectory->path));
     sysConfigFile->close();
     SystemConfig::instance()->initialize(sysConfigFilePath);
+
+    auto nodeConfigFilePath =
+        fmt::format("{}/node.properties", spillDirectory->path);
+    auto nodeConfigFile = fileSystem->openFileForWrite(nodeConfigFilePath);
+    nodeConfigFile->append(fmt::format(
+        "{}={}\n{}={}",
+        NodeConfig::kNodeIp,
+        "192.16.7.66",
+        NodeConfig::kNodeId,
+        "12"));
+    nodeConfigFile->close();
+    NodeConfig::instance()->initialize(nodeConfigFilePath);
+
     return spillDirectory;
   }
 
@@ -924,12 +937,13 @@ TEST_F(TaskManagerTest, aggregationSpill) {
 
 TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
   EXPECT_EQ(
-      "fs::/base/2022-12-20/presto_native/20221220-Q/Task1/",
+      "fs::/base/192.168.10.2_19/2022-12-20/presto_native/20221220-Q/Task1/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fs::/base", "20221220-Q", "Task1"));
+          "fs::/base", "192.168.10.2", "19", "20221220-Q", "Task1"));
   EXPECT_EQ(
-      "fsx::/root/1970-01-01/presto_native/Q100/Task22/",
-      TaskManager::buildTaskSpillDirectoryPath("fsx::/root", "Q100", "Task22"));
+      "fsx::/root/192.16.10.2_sample_node_id/1970-01-01/presto_native/Q100/Task22/",
+      TaskManager::buildTaskSpillDirectoryPath(
+          "fsx::/root", "192.16.10.2", "sample_node_id", "Q100", "Task22"));
 }
 
 TEST_F(TaskManagerTest, getDataOnAbortedTask) {


### PR DESCRIPTION
Adding node ip and id in spilling path. This helps to have less spill directories, as previously it was created per query id. Updated tests.


```
== NO RELEASE NOTE ==
```
