### PR TITLE
Enable Presto-on-Spark to use multiple retry strategies after failure

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -101,6 +101,7 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -146,6 +147,7 @@ import static com.facebook.presto.spark.util.PrestoSparkRetryExecutionUtils.getR
 import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.getActionResultWithTimeout;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.util.AnalyzerUtil.createAnalyzerOptions;
 import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -540,7 +542,7 @@ public class PrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            Optional<RetryExecutionStrategy> retryExecutionStrategy,
+            List<RetryExecutionStrategy> retryExecutionStrategies,
             Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
     {
         PrestoSparkConfInitializer.checkInitialized(sparkContext);
@@ -603,18 +605,19 @@ public class PrestoSparkQueryExecutionFactory
         Session session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory, authorizedIdentity);
         session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.empty());
 
-        if (retryExecutionStrategy.isPresent()) {
-            PrestoSparkRetryExecutionSettings prestoSparkRetryExecutionSettings = getRetryExecutionSettings(retryExecutionStrategy.get(), session);
+        if (!retryExecutionStrategies.isEmpty()) {
+            log.info("Going to retry with following strategies: %s", retryExecutionStrategies);
+            PrestoSparkRetryExecutionSettings prestoSparkRetryExecutionSettings = getRetryExecutionSettings(retryExecutionStrategies, session);
 
-            // Update spark setting in SparkConf, if present
-            prestoSparkRetryExecutionSettings.getSparkSettings().forEach(sparkContext.conf()::set);
+            // Update Spark setting in SparkConf, if present
+            prestoSparkRetryExecutionSettings.getSparkConfigProperties().forEach(sparkContext.conf()::set);
 
-            // Update presto settings in Session, if present
+            // Update Presto settings in Session, if present
             Session.SessionBuilder sessionBuilder = Session.builder(session);
-            prestoSparkRetryExecutionSettings.getPrestoSettings().forEach(sessionBuilder::setSystemProperty);
+            transferSessionPropertiesToSession(sessionBuilder, prestoSparkRetryExecutionSettings.getPrestoSessionProperties());
 
             Set<String> clientTags = new HashSet<>(session.getClientTags());
-            clientTags.add(retryExecutionStrategy.get().name());
+            retryExecutionStrategies.forEach(s -> clientTags.add(s.name()));
             sessionBuilder.setClientTags(clientTags);
 
             session = sessionBuilder.build();
@@ -818,5 +821,27 @@ public class PrestoSparkQueryExecutionFactory
     private boolean isFatalException(Throwable t)
     {
         return t instanceof PrestoSparkFatalException;
+    }
+
+    @VisibleForTesting
+    static Session.SessionBuilder transferSessionPropertiesToSession(Session.SessionBuilder session, Map<String, String> sessionProperties)
+    {
+        sessionProperties.forEach((key, value) -> {
+            // Presto session properties may also contain catalog properties in format catalog.property_name=value
+            String[] parts = key.split("\\.");
+            if (parts.length == 1) {
+                // system property
+                session.setSystemProperty(parts[0], value);
+            }
+            else if (parts.length == 2) {
+                // catalog property
+                session.setCatalogSessionProperty(parts[0], parts[1], value);
+            }
+            else {
+                throw new PrestoException(INVALID_SESSION_PROPERTY, "Unable to parse session property: " + key);
+            }
+        });
+
+        return session;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkRetryExecutionSettings.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkRetryExecutionSettings.java
@@ -19,22 +19,24 @@ import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkRetryExecutionSettings
 {
-    private final Map<String, String> sparkSettings;
-    private final Map<String, String> prestoSettings;
+    private final Map<String, String> sparkConfigProperties;
+    private final Map<String, String> prestoSessionProperties;
 
-    public PrestoSparkRetryExecutionSettings(Map<String, String> sparkSettings, Map<String, String> prestoSettings)
+    public PrestoSparkRetryExecutionSettings(
+            Map<String, String> sparkConfigProperties,
+            Map<String, String> prestoSessionProperties)
     {
-        this.sparkSettings = requireNonNull(sparkSettings, "sparkSettings is null");
-        this.prestoSettings = requireNonNull(prestoSettings, "sparkSettings is null");
+        this.sparkConfigProperties = requireNonNull(sparkConfigProperties, "sparkConfigProperties is null");
+        this.prestoSessionProperties = requireNonNull(prestoSessionProperties, "prestoSessionProperties is null");
     }
 
-    public Map<String, String> getSparkSettings()
+    public Map<String, String> getSparkConfigProperties()
     {
-        return sparkSettings;
+        return sparkConfigProperties;
     }
 
-    public Map<String, String> getPrestoSettings()
+    public Map<String, String> getPrestoSessionProperties()
     {
-        return prestoSettings;
+        return prestoSessionProperties;
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
@@ -27,6 +27,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.QueryAssertions;
+import com.google.common.collect.ImmutableList;
 import org.apache.spark.Dependency;
 import org.apache.spark.MapOutputStatistics;
 import org.apache.spark.rdd.RDD;
@@ -63,7 +64,7 @@ public class TestPrestoSparkQueryExecution
 
     private IPrestoSparkQueryExecution getPrestoSparkQueryExecution(Session session, String sql)
     {
-        return prestoSparkQueryRunner.createPrestoSparkQueryExecution(session, sql, Optional.empty());
+        return prestoSparkQueryRunner.createPrestoSparkQueryExecution(session, sql, ImmutableList.of());
     }
 
     @Test

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecutionFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.testing.TestingSession;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.transferSessionPropertiesToSession;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrestoSparkQueryExecutionFactory
+{
+    @Test
+    public void testTransferSessionProperties()
+    {
+        Session.SessionBuilder sessionBuilder = TestingSession.testSessionBuilder();
+        Map<String, String> sessionProperties = ImmutableMap.of(
+                "property_name", "property_value",
+                "catalog.property_name", "value2");
+
+        Session result = transferSessionPropertiesToSession(sessionBuilder, sessionProperties).build();
+
+        assertEquals(result.getSystemProperties().get("property_name"), "property_value");
+        assertEquals(result.getUnprocessedCatalogProperties().get("catalog").get("property_name"), "value2");
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testTransferSessionPropertiesWithInvalidProperty()
+    {
+        Session.SessionBuilder sessionBuilder = TestingSession.testSessionBuilder();
+        Map<String, String> sessionProperties = ImmutableMap.of(
+                "invalid.property.name", "property_value");
+
+        transferSessionPropertiesToSession(sessionBuilder, sessionProperties).build();
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spark.classloader_interface;
 import org.apache.spark.SparkContext;
 import org.apache.spark.util.CollectionAccumulator;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,6 +33,6 @@ public interface IPrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            Optional<RetryExecutionStrategy> retryExecutionStrategy,
+            List<RetryExecutionStrategy> retryExecutionStrategies,
             Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector);
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-import java.util.Optional;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,14 +22,14 @@ public class PrestoSparkFailure
 {
     private final String type;
     private final String errorCode;
-    private final Optional<RetryExecutionStrategy> retryExecutionStrategy;
+    private final List<RetryExecutionStrategy> retryExecutionStrategies;
 
-    public PrestoSparkFailure(String message, Throwable cause, String type, String errorCode, Optional<RetryExecutionStrategy> retryExecutionStrategy)
+    public PrestoSparkFailure(String message, Throwable cause, String type, String errorCode, List<RetryExecutionStrategy> retryExecutionStrategies)
     {
         super(message, cause);
         this.type = requireNonNull(type, "type is null");
         this.errorCode = requireNonNull(errorCode, "errorCode is null");
-        this.retryExecutionStrategy = requireNonNull(retryExecutionStrategy, "retryExecutionStrategy is null");
+        this.retryExecutionStrategies = requireNonNull(retryExecutionStrategies, "retryExecutionStrategies is null");
     }
 
     public String getType()
@@ -42,9 +42,9 @@ public class PrestoSparkFailure
         return errorCode;
     }
 
-    public Optional<RetryExecutionStrategy> getRetryExecutionStrategy()
+    public List<RetryExecutionStrategy> getRetryExecutionStrategies()
     {
-        return retryExecutionStrategy;
+        return retryExecutionStrategies;
     }
 
     @Override

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkFailure;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.google.common.collect.ImmutableList;
 import org.apache.spark.TaskContext;
 import org.apache.spark.util.CollectionAccumulator;
 import scala.Option;
@@ -116,14 +117,14 @@ public class PrestoSparkRunner
                 sparkQueueName,
                 queryStatusInfoOutputLocation,
                 queryDataOutputLocation,
-                Optional.empty());
+                ImmutableList.of());
         try {
             execute(queryExecutionFactory, prestoSparkRunnerContext);
         }
         catch (PrestoSparkFailure failure) {
-            if (failure.getRetryExecutionStrategy().isPresent()) {
+            if (!failure.getRetryExecutionStrategies().isEmpty()) {
                 PrestoSparkRunnerContext retryRunnerContext = new PrestoSparkRunnerContext.Builder(prestoSparkRunnerContext)
-                        .setRetryExecutionStrategy(failure.getRetryExecutionStrategy())
+                        .setRetryExecutionStrategies(failure.getRetryExecutionStrategies())
                         .build();
                 execute(queryExecutionFactory, retryRunnerContext);
                 return;
@@ -162,7 +163,7 @@ public class PrestoSparkRunner
                 new DistributionBasedPrestoSparkTaskExecutorFactoryProvider(distribution, bootstrapMetricsCollector),
                 prestoSparkRunnerContext.getQueryStatusInfoOutputLocation(),
                 prestoSparkRunnerContext.getQueryDataOutputLocation(),
-                prestoSparkRunnerContext.getRetryExecutionStrategy(),
+                prestoSparkRunnerContext.getRetryExecutionStrategies(),
                 Optional.of(bootstrapMetricsCollector));
 
         List<List<Object>> results = queryExecution.execute();

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spark.launcher;
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class PrestoSparkRunnerContext
     private final Optional<String> sparkQueueName;
     private final Optional<String> queryStatusInfoOutputLocation;
     private final Optional<String> queryDataOutputLocation;
-    private final Optional<RetryExecutionStrategy> retryExecutionStrategy;
+    private final List<RetryExecutionStrategy> retryExecutionStrategies;
 
     public PrestoSparkRunnerContext(
             String user,
@@ -65,7 +66,7 @@ public class PrestoSparkRunnerContext
             Optional<String> sparkQueueName,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            Optional<RetryExecutionStrategy> retryExecutionStrategy)
+            List<RetryExecutionStrategy> retryExecutionStrategies)
     {
         this.user = user;
         this.principal = principal;
@@ -86,7 +87,7 @@ public class PrestoSparkRunnerContext
         this.sparkQueueName = sparkQueueName;
         this.queryStatusInfoOutputLocation = queryStatusInfoOutputLocation;
         this.queryDataOutputLocation = queryDataOutputLocation;
-        this.retryExecutionStrategy = retryExecutionStrategy;
+        this.retryExecutionStrategies = retryExecutionStrategies;
     }
 
     public String getUser()
@@ -184,9 +185,9 @@ public class PrestoSparkRunnerContext
         return queryDataOutputLocation;
     }
 
-    public Optional<RetryExecutionStrategy> getRetryExecutionStrategy()
+    public List<RetryExecutionStrategy> getRetryExecutionStrategies()
     {
-        return retryExecutionStrategy;
+        return retryExecutionStrategies;
     }
 
     public static class Builder
@@ -210,7 +211,7 @@ public class PrestoSparkRunnerContext
         private Optional<String> sparkQueueName;
         private Optional<String> queryStatusInfoOutputLocation;
         private Optional<String> queryDataOutputLocation;
-        private Optional<RetryExecutionStrategy> retryExecutionStrategy;
+        private List<RetryExecutionStrategy> retryExecutionStrategies;
 
         public Builder(PrestoSparkRunnerContext prestoSparkRunnerContext)
         {
@@ -233,12 +234,12 @@ public class PrestoSparkRunnerContext
             this.sparkQueueName = prestoSparkRunnerContext.getSparkQueueName();
             this.queryStatusInfoOutputLocation = prestoSparkRunnerContext.getQueryStatusInfoOutputLocation();
             this.queryDataOutputLocation = prestoSparkRunnerContext.getQueryDataOutputLocation();
-            this.retryExecutionStrategy = prestoSparkRunnerContext.getRetryExecutionStrategy();
+            this.retryExecutionStrategies = prestoSparkRunnerContext.getRetryExecutionStrategies();
         }
 
-        public Builder setRetryExecutionStrategy(Optional<RetryExecutionStrategy> retryExecutionStrategy)
+        public Builder setRetryExecutionStrategies(List<RetryExecutionStrategy> retryExecutionStrategies)
         {
-            this.retryExecutionStrategy = requireNonNull(retryExecutionStrategy, "retryExecutionStrategy is null");
+            this.retryExecutionStrategies = requireNonNull(retryExecutionStrategies, "retryExecutionStrategies is null");
             return this;
         }
 
@@ -264,7 +265,7 @@ public class PrestoSparkRunnerContext
                     sparkQueueName,
                     queryStatusInfoOutputLocation,
                     queryDataOutputLocation,
-                    retryExecutionStrategy);
+                    retryExecutionStrategies);
         }
     }
 }


### PR DESCRIPTION
# Change

The `PrestoSparkFailureUtils` class in Presto on Spark has been enhanced to support multiple retry strategies concurrently. Previously, only one retry strategy could be utilized at a time. This pull request introduces the ability to use multiple retry strategies simultaneously. For instance, after an OOM failure, both memory increase and hash partition count increase strategies can be employed.


Proposed retry configuration could look like the following example. It incorporates all strategies simultaneously and merges their configurations:

```yaml
# Enable retry for OOMs
spark.retry-on-out-of-memory-with-increased-memory-settings-enabled: true

# Increase hash partition count for OOMs when the root cause is LOW_PARTITION_COUNT
spark.retry-on-out-of-memory-higher-hash-partition-count-enabled: true

# Increase memory and disable table bucketing
spark.retry-presto-session-properties: query_max_memory_per_node=25GB,query_max_total_memory_per_node=25GB,hive.ignore_table_bucketing=true

```

```
== RELEASE NOTES ==

General Changes
* Enable Presto-on-Spark to use multiple retry strategies simultaneously after failure
* Add support for catalog session properties for config option spark.retry-presto-session-properties
```

# Test Plan

Executed a series of test jobs using the provided example configuration. The retry success rate has significantly improved as a result.