### PR TITLE
Add cache for input table statistics in history optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.plan.PlanNodeWithHash;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanNodeCanonicalInfo;
 import com.google.common.annotations.VisibleForTesting;
@@ -39,6 +40,8 @@ public class HistoryBasedStatisticsCacheManager
 
     // Cache hashes of plan node.
     private final Map<QueryId, Map<CachingPlanCanonicalInfoProvider.CacheKey, PlanNodeCanonicalInfo>> canonicalInfoCache = new ConcurrentHashMap<>();
+
+    private final Map<QueryId, Map<CachingPlanCanonicalInfoProvider.InputTableCacheKey, PlanStatistics>> inputTableStatistics = new ConcurrentHashMap<>();
 
     public HistoryBasedStatisticsCacheManager() {}
 
@@ -71,10 +74,16 @@ public class HistoryBasedStatisticsCacheManager
         return canonicalInfoCache.computeIfAbsent(queryId, ignored -> new ConcurrentHashMap());
     }
 
+    public Map<CachingPlanCanonicalInfoProvider.InputTableCacheKey, PlanStatistics> getInputTableStatistics(QueryId queryId)
+    {
+        return inputTableStatistics.computeIfAbsent(queryId, ignored -> new ConcurrentHashMap());
+    }
+
     public void invalidate(QueryId queryId)
     {
         statisticsCache.remove(queryId);
         canonicalInfoCache.remove(queryId);
+        inputTableStatistics.remove(queryId);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Currently HBO has cache for PlanNodeCanonicalInfo for nodes in a query plan, i.e. we are to calculate the hash of a plan node once and cache the results.

However, the calculation of node hash involves getting the statistics of input tables from meta data. This stats are not cached, and can be accessed multiple times when calculating hashes for multiple plan nodes. Here I add a cache for the input table statistics.

### Test plan - (Please fill in how you tested your changes)

Run a [query](https://www.internalfb.com/intern/presto/query/?query_id=20230714_231424_00005_nfkxx#plan) to make sure HBO still works


```
== NO RELEASE NOTE ==
```
