### PR TITLE
Presto on Spark log functions invoked in query

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -371,9 +371,9 @@ public class PrestoSparkQueryExecutionFactory
                 ImmutableSet.of(),
                 planAndMore.map(PlanAndMore::getPlan).map(Plan::getStatsAndCosts).orElseGet(StatsAndCosts::empty),
                 ImmutableList.of(),
-                ImmutableSet.of(),
-                ImmutableSet.of(),
-                ImmutableSet.of(),
+                planAndMore.map(PlanAndMore::getInvokedScalarFunctions).orElseGet(ImmutableSet::of),
+                planAndMore.map(PlanAndMore::getInvokedAggregateFunctions).orElseGet(ImmutableSet::of),
+                planAndMore.map(PlanAndMore::getInvokedWindowFunctions).orElseGet(ImmutableSet::of),
                 planAndMore.map(PlanAndMore::getPlanCanonicalInfo).orElseGet(ImmutableList::of));
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spark.PrestoSparkPhysicalResourceCalculator;
 import com.facebook.presto.spark.PrestoSparkSourceStatsCollector;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -49,12 +50,18 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isLogInvokedFunctionNamesEnabled;
 import static com.facebook.presto.common.RuntimeMetricName.LOGICAL_PLANNER_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZER_TIME_NANOS;
+import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.facebook.presto.sql.analyzer.utils.StatementUtils.getQueryType;
@@ -144,6 +151,14 @@ public class PrestoSparkQueryPlanner
         List<String> columnNames = ((OutputNode) plan.getRoot()).getColumnNames();
         PhysicalResourceSettings physicalResourceSettings = new PrestoSparkPhysicalResourceCalculator()
                 .calculate(plan.getRoot(), new PrestoSparkSourceStatsCollector(metadata, session), session);
+        Map<FunctionKind, Set<String>> functionsInvoked = Collections.emptyMap();
+        if (isLogInvokedFunctionNamesEnabled(session)) {
+            functionsInvoked = analysis.getInvokedFunctions();
+        }
+        Set<String> invokedScalarFunctions = functionsInvoked.getOrDefault(SCALAR, Collections.emptySet());
+        Set<String> invokedAggregateFunctions = functionsInvoked.getOrDefault(AGGREGATE, Collections.emptySet());
+        Set<String> invokedWindowFunctions = functionsInvoked.getOrDefault(WINDOW, Collections.emptySet());
+
         return new PlanAndMore(
                 plan,
                 Optional.ofNullable(analysis.getUpdateType()),
@@ -152,7 +167,10 @@ public class PrestoSparkQueryPlanner
                 output,
                 queryType,
                 physicalResourceSettings,
-                getCanonicalInfo(session, plan.getRoot(), planCanonicalInfoProvider));
+                getCanonicalInfo(session, plan.getRoot(), planCanonicalInfoProvider),
+                invokedScalarFunctions,
+                invokedAggregateFunctions,
+                invokedWindowFunctions);
     }
 
     public static class PlanAndMore
@@ -165,6 +183,9 @@ public class PrestoSparkQueryPlanner
         private final Optional<QueryType> queryType;
         private final PhysicalResourceSettings physicalResourceSettings;
         private final List<CanonicalPlanWithInfo> planCanonicalInfo;
+        private final Set<String> invokedScalarFunctions;
+        private final Set<String> invokedAggregateFunctions;
+        private final Set<String> invokedWindowFunctions;
 
         public PlanAndMore(
                 Plan plan,
@@ -174,7 +195,10 @@ public class PrestoSparkQueryPlanner
                 Optional<Output> output,
                 Optional<QueryType> queryType,
                 PhysicalResourceSettings physicalResourceSettings,
-                List<CanonicalPlanWithInfo> planCanonicalInfo)
+                List<CanonicalPlanWithInfo> planCanonicalInfo,
+                Set<String> invokedScalarFunctions,
+                Set<String> invokedAggregateFunctions,
+                Set<String> invokedWindowFunctions)
         {
             this.plan = requireNonNull(plan, "plan is null");
             this.updateType = requireNonNull(updateType, "updateType is null");
@@ -184,6 +208,9 @@ public class PrestoSparkQueryPlanner
             this.queryType = requireNonNull(queryType, "queryType is null");
             this.physicalResourceSettings = requireNonNull(physicalResourceSettings, "physicalResourceSetting is null.");
             this.planCanonicalInfo = requireNonNull(planCanonicalInfo, "planCanonicalInfo is null");
+            this.invokedScalarFunctions = requireNonNull(invokedScalarFunctions, "invokedScalarFunctions is null");
+            this.invokedAggregateFunctions = requireNonNull(invokedAggregateFunctions, "invokedAggregateFunctions is null");
+            this.invokedWindowFunctions = requireNonNull(invokedWindowFunctions, "invokedWindowFunctions is null");
         }
 
         public Plan getPlan()
@@ -224,6 +251,21 @@ public class PrestoSparkQueryPlanner
         public List<CanonicalPlanWithInfo> getPlanCanonicalInfo()
         {
             return planCanonicalInfo;
+        }
+
+        public Set<String> getInvokedScalarFunctions()
+        {
+            return invokedScalarFunctions;
+        }
+
+        public Set<String> getInvokedAggregateFunctions()
+        {
+            return invokedAggregateFunctions;
+        }
+
+        public Set<String> getInvokedWindowFunctions()
+        {
+            return invokedWindowFunctions;
         }
     }
 }


### PR DESCRIPTION
## Change
QueryInfo.scalarFunctions, aggregateFunctions and windowsFunctions is empty for Presto on Spark jobs.
This PR grab the functions invoked from the initial query sql text analysis result and propagate it to QueryInfo object.

## Test plan
Existing unit tests. QueryInfo.scalarFunctions, aggregateFunctions and windowsFunctions are being populated properly.

```
== NO RELEASE NOTE ==
```
