### PR TITLE
Add support for NO_VALUES_MATCH UDF

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -174,6 +174,12 @@ Map Functions
 
         SELECT no_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'd'); -- true
 
+.. function:: no_values_match(x(K,V), function(V, boolean)) -> boolean
+
+    Returns whether no values of a map match the given predicate. Returns true if none of the values match the predicate (a special case is when the map is empty); false if one or more values match; NULL if the predicate function returns NULL for one or more values and false for all other values. ::
+
+        SELECT no_values_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'd'); -- true
+
 .. function:: transform_keys(map(K1,V), function(K1,V,K2)) -> map(K2,V)
 
     Returns a map that applies ``function`` to each entry of ``map`` and transforms the keys::

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
@@ -133,4 +133,15 @@ public class MapSqlFunctions
     {
         return "RETURN NONE_MATCH(MAP_KEYS(input), f)";
     }
+
+    @SqlInvokedScalarFunction(value = "no_values_match", deterministic = true, calledOnNullInput = true)
+    @Description("Returns whether no values of a map match the given predicate.")
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlParameters({@SqlParameter(name = "input", type = "map(K, V)"), @SqlParameter(name = "f", type = "function(V, boolean)")})
+    @SqlType("boolean")
+    public static String noValuesMatch()
+    {
+        return "RETURN NONE_MATCH(MAP_VALUES(input), f)";
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestNoValuesMatchFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestNoValuesMatchFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+
+public class TestNoValuesMatchFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), (x) -> x > 3)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[4, 5, 6], ARRAY[-1, -2, -3]), (x) -> x < -2)",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY['ab', 'bc', 'cd']), (x) -> x IS NULL)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY[123.0, 99.5, 1000.99]), (x) -> x > 1.0)",
+                BOOLEAN,
+                false);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> x > 0)", BOOLEAN, true);
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> x IS NULL)", BOOLEAN, true);
+        assertFunction("NO_VALUES_MATCH(MAP(), (x) -> FALSE)", BOOLEAN, true);
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("NO_VALUES_MATCH(NULL, (x) -> x LIKE '%ab%')", BOOLEAN, null);
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY['x', 'y']), (x) -> CAST(NULL AS BOOLEAN))", BOOLEAN, null);
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY['x', 'y']), (x) -> IF(x = 'x', false, CAST(NULL AS BOOLEAN)))", BOOLEAN, null);
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[1, 2, 3], ARRAY['x', 'y', 'z']), (x) -> IF(x IN ('x', 'y'), false, CAST(NULL AS BOOLEAN)))", BOOLEAN, null);
+        assertFunction("NO_VALUES_MATCH(MAP(ARRAY[1, 2, 3], ARRAY['x', 'y', 'z']), (x) -> IF(x = 'x', false, IF(x = 'y', true, CAST(NULL AS BOOLEAN))))", BOOLEAN, false);
+    }
+
+    @Test
+    public void testComplexValues()
+    {
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY[ROW('x', 1), ROW('y', 2)]), (x) -> x[1] = 'x')",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[2, 1], ARRAY[ROW('x', 1), ROW('x', -2)]), (x) -> x[2] >= 2)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[100, 200, 300], ARRAY[ROW('x', 1), ROW('x', -2), ROW('y', 1)]), (x) -> x[1] = 'ab')",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY[ROW('x', 1), ROW('y', 2)]), (x) -> x[2] LIKE '%ab%')",
+                SemanticErrorCode.TYPE_MISMATCH);
+        assertInvalidFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY[1, 2, 3], ARRAY[4, 5, 6]))",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "NO_VALUES_MATCH(MAP(ARRAY['a', 'b', 'c'], ARRAY[4, 5, 6]), 1)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Test plan

Added unit tests.
Build successfully using the following terminal command
- `./mvnw clean install -Dtest=TestNoValuesMatchFunction -fn -pl presto-main`

```
== RELEASE NOTES ==

General Changes
- Add function :func:`no_values_match`
```