### PR TITLE
Add Createsample aggregation operator 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -91,6 +91,7 @@ import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunctio
 import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggregationFunction;
+import com.facebook.presto.operator.aggregation.reservoirsample.BackingSample;
 import com.facebook.presto.operator.scalar.ArrayAllMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayAnyMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
@@ -661,6 +662,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(IntervalDayToSecondAverageAggregation.class)
                 .aggregates(IntervalYearToMonthAverageAggregation.class)
                 .aggregates(DifferentialEntropyAggregation.class)
+                .aggregate(BackingSample.class)
                 .aggregates(EntropyAggregation.class)
                 .aggregates(GeometricMeanAggregations.class)
                 .aggregates(RealGeometricMeanAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
@@ -28,10 +28,6 @@ public class UnweightedReservoirSampleStateStrategy
 {
     private final UnweightedDoubleReservoirSample reservoir;
 
-    public UnweightedDoubleReservoirSample getReservoir() {
-        return reservoir;
-    }
-
     public UnweightedReservoirSampleStateStrategy(long maxSamples)
     {
         if (maxSamples <= 0) {
@@ -56,6 +52,10 @@ public class UnweightedReservoirSampleStateStrategy
     private UnweightedReservoirSampleStateStrategy(UnweightedDoubleReservoirSample reservoir)
     {
         this.reservoir = reservoir;
+    }
+
+    public UnweightedDoubleReservoirSample getReservoir() {
+        return reservoir;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
@@ -28,6 +28,10 @@ public class UnweightedReservoirSampleStateStrategy
 {
     private final UnweightedDoubleReservoirSample reservoir;
 
+    public UnweightedDoubleReservoirSample getReservoir() {
+        return reservoir;
+    }
+
     public UnweightedReservoirSampleStateStrategy(long maxSamples)
     {
         if (maxSamples <= 0) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/BackingSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/BackingSample.java
@@ -1,0 +1,68 @@
+package com.facebook.presto.operator.aggregation.reservoirsample;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.LongArrayBlock;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.PrecisionRecallAggregation;
+import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyState;
+import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyStateStrategy;
+import com.facebook.presto.operator.aggregation.differentialentropy.UnweightedReservoirSampleStateStrategy;
+import com.facebook.presto.operator.aggregation.state.NullableDoubleState;
+import com.facebook.presto.spi.function.*;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+
+@AggregationFunction("create_sample")
+public class BackingSample {
+    private BackingSample() {}
+
+
+    @InputFunction
+    public static void input(
+            @AggregationState DifferentialEntropyState state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample)
+    {
+        DifferentialEntropyStateStrategy strategy = DifferentialEntropyStateStrategy.getStrategy(
+                state.getStrategy(),
+                size,
+                sample);
+        state.setStrategy(strategy);
+        strategy.add(sample);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState DifferentialEntropyState state, @AggregationState DifferentialEntropyState otherState)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        DifferentialEntropyStateStrategy otherStrategy = otherState.getStrategy();
+        if (strategy == null && otherStrategy != null) {
+            state.setStrategy(otherStrategy);
+            return;
+        }
+        if (otherStrategy == null) {
+            return;
+        }
+        DifferentialEntropyStateStrategy.combine(strategy, otherStrategy);
+    }
+
+    @OutputFunction("array(row)")
+//    @OutputFunction("double")
+    public static void output(@AggregationState DifferentialEntropyState state, BlockBuilder out)
+    {
+        double[] samples = ((UnweightedReservoirSampleStateStrategy) state.getStrategy()).getReservoir().getSamples();
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        for (double x: samples) {
+            DoubleType.DOUBLE.writeDouble(
+                    entryBuilder, x);
+        }
+        out.closeEntry();
+        // todo: needs to create a new type to write the samples to the block
+//        DOUBLE.writeDouble(out, samples.length == 0 ? Double.NaN : samples[0]);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/UnweightedDoubleReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/UnweightedDoubleReservoirSample.java
@@ -34,7 +34,7 @@ public class UnweightedDoubleReservoirSample
 
     private int seenCount;
     private double[] samples;
-
+    
     public UnweightedDoubleReservoirSample(int maxSamples)
     {
         checkArgument(
@@ -113,6 +113,7 @@ public class UnweightedDoubleReservoirSample
         }
         seenCount += other.seenCount;
         samples = merged;
+        System.out.println("merge data");
     }
 
     public int getTotalPopulationCount()


### PR DESCRIPTION
Create create_sample aggregation operator to create reservior sample for a single column (double type). The operator will return an array of doubles.  

Example: select create_sample(<sample_size>, tax) from lineitem;

Issue:  tried to change the second parameter from @SqlType(StandardTypes.DOUBLE) double to @SqlType(StandardTypes.ROW) RowType, and implemented input function, combine function and output function for the RowType data type. However, the following query returns error:

select create_sample(<sample_size>, row(tax)) from lineitem;

![image](https://github.com/prestodb/presto/assets/32505316/730bf85b-827f-4c83-84bb-7486d826e9b3)

