### PR TITLE
[native pos] Add serializedBytes runtime stats to PartitionAndSerialize

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -212,6 +212,11 @@ class PartitionAndSerializeOperator : public Operator {
       VELOX_DCHECK_EQ(size, rowSizes_[i]);
       offset += size;
     }
+
+    {
+      auto lockedStats = stats_.wlock();
+      lockedStats->addRuntimeStat("serializedBytes", RuntimeCounter(totalSize));
+    }
   }
 
   const uint32_t numPartitions_;


### PR DESCRIPTION
We are seeing Presto-on-Spark native producing a lot more shuffle data(in bytes)
then Presto-on-Spark Java. We believe this is because native uses UnsafeRow
serialization format which is less compact than row-wise serde used in
Presto-on-Spark Java.

We also noticed that there is no easy way to tell how many bytes we shuffle.

Add 'serializedBytes' runtime stat to PartitionAndSerialize to track total number 
of bytes we shuffle.

```
== NO RELEASE NOTE ==
```
