### PR TITLE
[native pos] Add arbitration and disk spilling related configs

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -61,8 +61,16 @@ public class NativeExecutionSystemConfig
     private static final String NUM_IO_THREADS = "num-io-threads";
     private static final String PRESTO_VERSION = "presto.version";
     private static final String SHUTDOWN_ONSET_SEC = "shutdown-onset-sec";
+    // Memory related configurations.
     private static final String SYSTEM_MEMORY_GB = "system-memory-gb";
     private static final String QUERY_MEMORY_GB = "query.max-memory-per-node";
+    private static final String USE_MMAP_ALLOCATOR = "use-mmap-allocator";
+    private static final String ENABLE_MEMORY_ARBITRATION = "enable-memory-arbitration";
+    private static final String MEMORY_POOL_INIT_CAPACITY = "memory-pool-init-capacity";
+    private static final String MEMORY_POOL_TRANSFER_CAPACITY = "memory-pool-transfer-capacity";
+    private static final String RESERVED_MEMORY_POOL_CAPACITY_PCT = "reserved-memory-pool-capacity-pct";
+    // Spilling related configs.
+    private static final String SPILLER_SPILL_PATH = "experimental.spiller-spill-path";
     private static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
     // Name of exchange client to use
     private static final String SHUFFLE_NAME = "shuffle.name";
@@ -83,6 +91,12 @@ public class NativeExecutionSystemConfig
     private int shutdownOnsetSec = 10;
     private int systemMemoryGb = 10;
     private DataSize queryMemoryGb = new DataSize(systemMemoryGb, DataSize.Unit.GIGABYTE);
+    private boolean useMmapAllocator = true;
+    private boolean enableMemoryArbitration = true;
+    private long memoryPoolInitCapacity = 512 << 20;
+    private long memoryPoolTransferCapacity = 256 << 20;
+    private int reservedMemoryPoolCapacityPct = 10;
+    private String spillerSpillPath = "";
     private int concurrentLifespansPerTask = 5;
     private int maxDriversPerTask = 15;
     private String prestoVersion = "dummy.presto.version";
@@ -111,6 +125,12 @@ public class NativeExecutionSystemConfig
                 .put(SHUTDOWN_ONSET_SEC, String.valueOf(getShutdownOnsetSec()))
                 .put(SYSTEM_MEMORY_GB, String.valueOf(getSystemMemoryGb()))
                 .put(QUERY_MEMORY_GB, String.valueOf(getQueryMemoryGb()))
+                .put(USE_MMAP_ALLOCATOR, String.valueOf(getUseMmapAllocator()))
+                .put(ENABLE_MEMORY_ARBITRATION, String.valueOf(getEnableMemoryArbitration()))
+                .put(MEMORY_POOL_INIT_CAPACITY, String.valueOf(getMemoryPoolInitCapacity()))
+                .put(MEMORY_POOL_TRANSFER_CAPACITY, String.valueOf(getMemoryPoolTransferCapacity()))
+                .put(RESERVED_MEMORY_POOL_CAPACITY_PCT, String.valueOf(getReservedMemoryPoolCapacityPct()))
+                .put(SPILLER_SPILL_PATH, String.valueOf(getSpillerSpillPath()))
                 .put(TASK_MAX_DRIVERS_PER_TASK, String.valueOf(getMaxDriversPerTask()))
                 .put(SHUFFLE_NAME, getShuffleName())
                 .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
@@ -319,6 +339,78 @@ public class NativeExecutionSystemConfig
     public DataSize getQueryMemoryGb()
     {
         return queryMemoryGb;
+    }
+
+    @Config(USE_MMAP_ALLOCATOR)
+    public NativeExecutionSystemConfig setUseMmapAllocator(boolean useMmapAllocator)
+    {
+        this.useMmapAllocator = useMmapAllocator;
+        return this;
+    }
+
+    public boolean getUseMmapAllocator()
+    {
+        return useMmapAllocator;
+    }
+
+    @Config(ENABLE_MEMORY_ARBITRATION)
+    public NativeExecutionSystemConfig setEnableMemoryArbitration(boolean enableMemoryArbitration)
+    {
+        this.enableMemoryArbitration = enableMemoryArbitration;
+        return this;
+    }
+
+    public boolean getEnableMemoryArbitration()
+    {
+        return enableMemoryArbitration;
+    }
+
+    @Config(MEMORY_POOL_INIT_CAPACITY)
+    public NativeExecutionSystemConfig setMemoryPoolInitCapacity(long memoryPoolInitCapacity)
+    {
+        this.memoryPoolInitCapacity = memoryPoolInitCapacity;
+        return this;
+    }
+
+    public long getMemoryPoolInitCapacity()
+    {
+        return memoryPoolInitCapacity;
+    }
+
+    @Config(MEMORY_POOL_TRANSFER_CAPACITY)
+    public NativeExecutionSystemConfig setMemoryPoolTransferCapacity(long memoryPoolTransferCapacity)
+    {
+        this.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
+        return this;
+    }
+
+    public long getMemoryPoolTransferCapacity()
+    {
+        return memoryPoolTransferCapacity;
+    }
+
+    @Config(RESERVED_MEMORY_POOL_CAPACITY_PCT)
+    public NativeExecutionSystemConfig setReservedMemoryPoolCapacityPct(int reservedMemoryPoolCapacityPct)
+    {
+        this.reservedMemoryPoolCapacityPct = reservedMemoryPoolCapacityPct;
+        return this;
+    }
+
+    public long getReservedMemoryPoolCapacityPct()
+    {
+        return reservedMemoryPoolCapacityPct;
+    }
+
+    @Config(SPILLER_SPILL_PATH)
+    public NativeExecutionSystemConfig setSpillerSpillPath(String spillerSpillPath)
+    {
+        this.spillerSpillPath = spillerSpillPath;
+        return this;
+    }
+
+    public String getSpillerSpillPath()
+    {
+        return spillerSpillPath;
     }
 
     @Config(CONCURRENT_LIFESPANS_PER_TASK)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
@@ -24,13 +24,26 @@ import java.util.Map;
 public class NativeExecutionVeloxConfig
 {
     private static final String CODEGEN_ENABLED = "codegen.enabled";
+    // Spilling related configs.
+    private static final String SPILL_ENABLED = "spill_enabled";
+    private static final String AGGREGATION_SPILL_ENABLED = "aggregation_spill_enabled";
+    private static final String JOIN_SPILL_ENABLED = "join_spill_enabled";
+    private static final String ORDER_BY_SPILL_ENABLED = "order_by_spill_enabled";
 
     private boolean codegenEnabled;
+    private boolean spillEnabled = true;
+    private boolean aggregationSpillEnabled;
+    private boolean joinSpillEnabled;
+    private boolean orderBySpillEnabled;
 
     public Map<String, String> getAllProperties()
     {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        return builder.put(CODEGEN_ENABLED, String.valueOf(getCodegenEnabled())).build();
+        return builder.put(CODEGEN_ENABLED, String.valueOf(getCodegenEnabled()))
+                .put(SPILL_ENABLED, String.valueOf(getSpillEnabled()))
+                .put(AGGREGATION_SPILL_ENABLED, String.valueOf(getAggregationSpillEnabled()))
+                .put(JOIN_SPILL_ENABLED, String.valueOf(getJoinSpillEnabled()))
+                .put(ORDER_BY_SPILL_ENABLED, String.valueOf(getOrderBySpillEnabled())).build();
     }
 
     public boolean getCodegenEnabled()
@@ -42,6 +55,54 @@ public class NativeExecutionVeloxConfig
     public NativeExecutionVeloxConfig setCodegenEnabled(boolean codegenEnabled)
     {
         this.codegenEnabled = codegenEnabled;
+        return this;
+    }
+
+    public boolean getSpillEnabled()
+    {
+        return spillEnabled;
+    }
+
+    @Config(SPILL_ENABLED)
+    public NativeExecutionVeloxConfig setSpillEnabled(boolean spillEnabled)
+    {
+        this.spillEnabled = spillEnabled;
+        return this;
+    }
+
+    public boolean getAggregationSpillEnabled()
+    {
+        return aggregationSpillEnabled;
+    }
+
+    @Config(AGGREGATION_SPILL_ENABLED)
+    public NativeExecutionVeloxConfig setAggregationSpillEnabled(boolean aggregationSpillEnabled)
+    {
+        this.aggregationSpillEnabled = aggregationSpillEnabled;
+        return this;
+    }
+
+    public boolean getJoinSpillEnabled()
+    {
+        return joinSpillEnabled;
+    }
+
+    @Config(JOIN_SPILL_ENABLED)
+    public NativeExecutionVeloxConfig setJoinSpillEnabled(boolean joinSpillEnabled)
+    {
+        this.joinSpillEnabled = joinSpillEnabled;
+        return this;
+    }
+
+    public boolean getOrderBySpillEnabled()
+    {
+        return orderBySpillEnabled;
+    }
+
+    @Config(ORDER_BY_SPILL_ENABLED)
+    public NativeExecutionVeloxConfig setOrderBySpillEnabled(boolean orderBySpillEnabled)
+    {
+        this.orderBySpillEnabled = orderBySpillEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -38,11 +38,19 @@ public class TestNativeExecutionSystemConfig
     {
         // Test defaults
         assertRecordedDefaults(ConfigAssertions.recordDefaults(NativeExecutionVeloxConfig.class)
-                .setCodegenEnabled(false));
+                .setCodegenEnabled(false)
+                .setSpillEnabled(true)
+                .setAggregationSpillEnabled(false)
+                .setJoinSpillEnabled(false)
+                .setOrderBySpillEnabled(false));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionVeloxConfig expected = new NativeExecutionVeloxConfig()
-                .setCodegenEnabled(true);
+                .setCodegenEnabled(true)
+                .setSpillEnabled(false)
+                .setAggregationSpillEnabled(true)
+                .setJoinSpillEnabled(true)
+                .setOrderBySpillEnabled(true);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }
@@ -67,6 +75,12 @@ public class TestNativeExecutionSystemConfig
                 .setShutdownOnsetSec(10)
                 .setSystemMemoryGb(10)
                 .setQueryMemoryGb(new DataSize(10, DataSize.Unit.GIGABYTE))
+                .setUseMmapAllocator(true)
+                .setEnableMemoryArbitration(true)
+                .setMemoryPoolInitCapacity(512 << 20)
+                .setMemoryPoolTransferCapacity(256 << 20)
+                .setReservedMemoryPoolCapacityPct(10)
+                .setSpillerSpillPath("")
                 .setConcurrentLifespansPerTask(5)
                 .setMaxDriversPerTask(15)
                 .setPrestoVersion("dummy.presto.version")
@@ -93,6 +107,12 @@ public class TestNativeExecutionSystemConfig
                 .setShutdownOnsetSec(30)
                 .setSystemMemoryGb(40)
                 .setQueryMemoryGb(new DataSize(20, DataSize.Unit.GIGABYTE))
+                .setUseMmapAllocator(false)
+                .setEnableMemoryArbitration(false)
+                .setMemoryPoolInitCapacity(32 << 20)
+                .setMemoryPoolTransferCapacity(32 << 20)
+                .setReservedMemoryPoolCapacityPct(20)
+                .setSpillerSpillPath("dummy.spill.path")
                 .setMaxDriversPerTask(30)
                 .setShuffleName("custom")
                 .setRegisterTestFunctions(true)


### PR DESCRIPTION
Add memory and disk spilling related configs for Spark on Prestissimo.
Also fix Prestissimo to pass memory reclaimer on query root pool creation.

```
== NO RELEASE NOTE ==
```
