### PR TITLE
Add Shrinidhi as codeowner for presto-spark* modules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,4 @@
 /presto-parquet @shangxinli @prestodb/committers
 /presto-orc @sdruzkin @prestodb/committers
 /presto-hive/**/com/facebook/presto/hive/security/ranger @agrawalreetika
+/presto-spark* @shrinidhijoshi


### PR DESCRIPTION
I would like to nominate @shrinidhijoshi  to be a code owner for the presto-spark* packages. Shrinidhi has deep understanding of both Java presto-on-spark and presto on spark native.  In his contributions and reviews he pays attention to correctness and performance as well as the simplicity/clarity of the code and whether it is aligned with the rest of Presto.  Additionally, Shrinidhi thinks holistically about the system architecture, and considerably simplified the original native presto-on-spark implementation by moving the native process creation to the task level.

## Some example contributions 
full list here: https://github.com/prestodb/presto/pulls?q=is%3Apr+author%3Ashrinidhijoshi
 
Simplifying how we create the native process for presto-spark + native:
 https://github.com/prestodb/presto/pull/19799

Spill Support for TopNRowNumberOperator:
https://github.com/prestodb/presto/pull/18400

Support for spark local mode:
https://github.com/prestodb/presto/pull/19407
https://github.com/prestodb/presto/pull/19435
https://github.com/prestodb/presto/pull/19629

bug fixes:
https://github.com/prestodb/presto/pull/20265
https://github.com/prestodb/presto/pull/20295

## Some example reviews
full list here: https://github.com/prestodb/presto/pulls?q=is%3Apr+reviewed-by%3Ashrinidhijoshi+-author%3Ashrinidhijoshi+

https://github.com/prestodb/presto/pull/19917#pullrequestreview-1519544995
https://github.com/prestodb/presto/pull/19676
https://github.com/prestodb/presto/pull/19189
https://github.com/prestodb/presto/pull/19926

Test plan - CI


```
== NO RELEASE NOTE ==
```
