### PR TITLE
Add number of NULL elements in hash table into operator stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -643,6 +643,8 @@ public class HashBuilderOperator
     {
         LookupSourceSupplier partition = index.createLookupSourceSupplier(operatorContext.getSession(), hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, Optional.of(outputChannels));
         hashCollisionsCounter.recordHashCollision(partition.getHashCollisions(), partition.getExpectedHashCollisions());
+        operatorContext.recordNullJoinBuildKeyCount(partition.getPositionIsNullCount());
+        operatorContext.recordJoinBuildKeyCount(partition.getPositionCount());
         checkState(lookupSourceSupplier == null, "lookupSourceSupplier is already set");
         this.lookupSourceSupplier = partition;
         return partition;

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
@@ -82,6 +82,18 @@ public class JoinHashSupplier
     }
 
     @Override
+    public long getPositionIsNullCount()
+    {
+        return pagesHash.getPositionIsNullCount();
+    }
+
+    @Override
+    public long getPositionCount()
+    {
+        return pagesHash.getPositionCount();
+    }
+
+    @Override
     public double getExpectedHashCollisions()
     {
         return pagesHash.getExpectedHashCollisions();

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
@@ -26,4 +26,8 @@ public interface LookupSourceSupplier
      * @return checksum of this entity for heuristic checking equivalence of two instances
      */
     long checksum();
+
+    long getPositionIsNullCount();
+
+    long getPositionCount();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -73,6 +73,11 @@ public class OperatorContext
     private final CounterStat outputDataSize = new CounterStat();
     private final CounterStat outputPositions = new CounterStat();
 
+    // Number of NULL elements in hash table for join operator
+    private final AtomicLong nullJoinBuildKeyCount = new AtomicLong();
+    // Number of elements in hash table for join operator
+    private final AtomicLong joinBuildKeyCount = new AtomicLong();
+
     private final AtomicLong additionalCpuNanos = new AtomicLong();
 
     private final AtomicLong physicalWrittenDataSize = new AtomicLong();
@@ -219,6 +224,16 @@ public class OperatorContext
     {
         outputDataSize.update(sizeInBytes);
         outputPositions.update(positions);
+    }
+
+    public void recordNullJoinBuildKeyCount(long positions)
+    {
+        nullJoinBuildKeyCount.getAndAdd(positions);
+    }
+
+    public void recordJoinBuildKeyCount(long positions)
+    {
+        joinBuildKeyCount.getAndAdd(positions);
     }
 
     public void recordPhysicalWrittenData(long sizeInBytes)
@@ -545,7 +560,9 @@ public class OperatorContext
 
                 memoryFuture.get().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                 info,
-                runtimeStats);
+                runtimeStats,
+                nullJoinBuildKeyCount.get(),
+                joinBuildKeyCount.get());
     }
 
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -95,6 +95,9 @@ public class OperatorStats
 
     private final RuntimeStats runtimeStats;
 
+    private final long nullJoinBuildKeyCount;
+    private final long joinBuildKeyCount;
+
     @JsonCreator
     public OperatorStats(
             @JsonProperty("stageId") int stageId,
@@ -146,7 +149,9 @@ public class OperatorStats
 
             @Nullable
             @JsonProperty("info") OperatorInfo info,
-            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
+            @JsonProperty("runtimeStats") RuntimeStats runtimeStats,
+            @JsonProperty("nullJoinBuildKeyCount") long nullJoinBuildKeyCount,
+            @JsonProperty("joinBuildKeyCount") long joinBuildKeyCount)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -204,6 +209,8 @@ public class OperatorStats
 
         this.info = info;
         this.infoUnion = null;
+        this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
+        this.joinBuildKeyCount = joinBuildKeyCount;
     }
 
     @ThriftConstructor
@@ -257,7 +264,9 @@ public class OperatorStats
 
             RuntimeStats runtimeStats,
             @Nullable
-            OperatorInfoUnion infoUnion)
+            OperatorInfoUnion infoUnion,
+            long nullJoinBuildKeyCount,
+            long joinBuildKeyCount)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -315,6 +324,8 @@ public class OperatorStats
 
         this.infoUnion = infoUnion;
         this.info = null;
+        this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
+        this.joinBuildKeyCount = joinBuildKeyCount;
     }
 
     @JsonProperty
@@ -598,6 +609,20 @@ public class OperatorStats
         return infoUnion;
     }
 
+    @JsonProperty
+    @ThriftField(40)
+    public long getNullJoinBuildKeyCount()
+    {
+        return nullJoinBuildKeyCount;
+    }
+
+    @JsonProperty
+    @ThriftField(41)
+    public long getJoinBuildKeyCount()
+    {
+        return joinBuildKeyCount;
+    }
+
     public OperatorStats add(OperatorStats operatorStats)
     {
         return add(ImmutableList.of(operatorStats));
@@ -646,6 +671,9 @@ public class OperatorStats
         Optional<BlockedReason> blockedReason = this.blockedReason;
 
         RuntimeStats runtimeStats = RuntimeStats.copyOf(this.runtimeStats);
+
+        long nullJoinBuildKeyCount = this.nullJoinBuildKeyCount;
+        long joinBuildKeyCount = this.joinBuildKeyCount;
 
         Mergeable<OperatorInfo> base = getMergeableInfoOrNull(info);
         for (OperatorStats operator : operators) {
@@ -700,6 +728,9 @@ public class OperatorStats
             }
 
             runtimeStats.mergeWith(operator.getRuntimeStats());
+
+            nullJoinBuildKeyCount += operator.getNullJoinBuildKeyCount();
+            joinBuildKeyCount += operator.getJoinBuildKeyCount();
         }
 
         return new OperatorStats(
@@ -751,7 +782,9 @@ public class OperatorStats
                 blockedReason,
 
                 (OperatorInfo) base,
-                runtimeStats);
+                runtimeStats,
+                nullJoinBuildKeyCount,
+                joinBuildKeyCount);
     }
 
     @SuppressWarnings("unchecked")
@@ -815,6 +848,8 @@ public class OperatorStats
                 spilledDataSize,
                 blockedReason,
                 info,
-                runtimeStats);
+                runtimeStats,
+                nullJoinBuildKeyCount,
+                joinBuildKeyCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHash.java
@@ -50,6 +50,7 @@ public final class PagesHash
     private final byte[] positionToHashes;
     private final long hashCollisions;
     private final double expectedHashCollisions;
+    private final long positionIsNullCount;
 
     public PagesHash(
             AdaptiveLongBigArray addresses,
@@ -75,6 +76,7 @@ public final class PagesHash
         int positionsInStep = Math.min(positionCount + 1, (int) CACHE_SIZE.toBytes() / Integer.SIZE);
         long[] positionToFullHashes = new long[positionsInStep];
         long hashCollisionsLocal = 0;
+        long positionIsNullCountLocal = 0;
 
         for (int step = 0; step * positionsInStep <= positionCount; step++) {
             int stepBeginPosition = step * positionsInStep;
@@ -95,6 +97,7 @@ public final class PagesHash
             for (int position = 0; position < stepSize; position++) {
                 int realPosition = position + stepBeginPosition;
                 if (isPositionNull(realPosition)) {
+                    ++positionIsNullCountLocal;
                     continue;
                 }
 
@@ -125,6 +128,7 @@ public final class PagesHash
                 sizeOf(key) + sizeOf(positionToHashes);
         hashCollisions = hashCollisionsLocal;
         expectedHashCollisions = estimateNumberOfHashCollisions(positionCount, hashSize);
+        positionIsNullCount = positionIsNullCountLocal;
     }
 
     public final int getChannelCount()
@@ -150,6 +154,11 @@ public final class PagesHash
     public double getExpectedHashCollisions()
     {
         return expectedHashCollisions;
+    }
+
+    public long getPositionIsNullCount()
+    {
+        return positionIsNullCount;
     }
 
     public int getAddressIndex(int position, Page hashChannelsPage)

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
@@ -248,7 +248,9 @@ public class TaskResourceUtils
                 operatorStats.getSpilledDataSize(),
                 operatorStats.getBlockedReason(),
                 operatorStats.getRuntimeStats(),
-                convertToOperatorInfoUnion(operatorStats.getInfo()));
+                convertToOperatorInfoUnion(operatorStats.getInfo()),
+                operatorStats.getNullJoinBuildKeyCount(),
+                operatorStats.getJoinBuildKeyCount());
     }
 
     private static MetadataUpdates convertToThriftMetadataUpdates(
@@ -478,7 +480,9 @@ public class TaskResourceUtils
                 thriftOperatorStats.getSpilledDataSize(),
                 thriftOperatorStats.getBlockedReason(),
                 convertToOperatorInfo(thriftOperatorStats.getInfoUnion()),
-                thriftOperatorStats.getRuntimeStats());
+                thriftOperatorStats.getRuntimeStats(),
+                thriftOperatorStats.getNullJoinBuildKeyCount(),
+                thriftOperatorStats.getJoinBuildKeyCount());
     }
 
     private static MetadataUpdates convertFromThriftMetadataUpdates(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -101,7 +102,7 @@ public class CachingPlanCanonicalInfoProvider
             return planStatistics;
         }
         TableStatistics tableStatistics = metadata.getTableStatistics(session, key.getTableHandle(), key.getColumnHandles(), key.getConstraint());
-        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1);
+        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, Estimate.unknown(), Estimate.unknown());
         cache.put(key, planStatistics);
         return planStatistics;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
@@ -41,9 +41,12 @@ public class HashCollisionPlanNodeStats
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
+            long planNodeNullJoinBuildKeyCount,
+            long planNodeJoinBuildKeyCount,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -99,6 +102,8 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
                 merged.operatorInputStats,
+                merged.getPlanNodeNullJoinBuildKeyCount(),
+                merged.getPlanNodeJoinBuildKeyCount(),
                 operatorHashCollisionsStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -45,6 +45,8 @@ public class PlanNodeStats
     private final DataSize planNodeOutputDataSize;
 
     protected final Map<String, OperatorInputStats> operatorInputStats;
+    private final long planNodeNullJoinBuildKeyCount;
+    private final long planNodeJoinBuildKeyCount;
 
     PlanNodeStats(
             PlanNodeId planNodeId,
@@ -56,7 +58,9 @@ public class PlanNodeStats
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
-            Map<String, OperatorInputStats> operatorInputStats)
+            Map<String, OperatorInputStats> operatorInputStats,
+            long planNodeNullJoinBuildKeyCount,
+            long planNodeJoinBuildKeyCount)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
@@ -70,6 +74,8 @@ public class PlanNodeStats
         this.planNodeOutputDataSize = planNodeOutputDataSize;
 
         this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
+        this.planNodeNullJoinBuildKeyCount = planNodeNullJoinBuildKeyCount;
+        this.planNodeJoinBuildKeyCount = planNodeJoinBuildKeyCount;
     }
 
     private static double computedStdDev(double sumSquared, double sum, long n)
@@ -149,6 +155,16 @@ public class PlanNodeStats
                                 entry.getValue().getTotalDrivers())));
     }
 
+    public long getPlanNodeNullJoinBuildKeyCount()
+    {
+        return planNodeNullJoinBuildKeyCount;
+    }
+
+    public long getPlanNodeJoinBuildKeyCount()
+    {
+        return planNodeJoinBuildKeyCount;
+    }
+
     @Override
     public PlanNodeStats mergeWith(PlanNodeStats other)
     {
@@ -162,6 +178,8 @@ public class PlanNodeStats
         DataSize planNodeOutputDataSize = succinctBytes(this.planNodeOutputDataSize.toBytes() + other.planNodeOutputDataSize.toBytes());
 
         Map<String, OperatorInputStats> operatorInputStats = mergeMaps(this.operatorInputStats, other.operatorInputStats, OperatorInputStats::merge);
+        long planNodeNullJoinBuildKeyCount = this.planNodeNullJoinBuildKeyCount + other.planNodeNullJoinBuildKeyCount;
+        long planNodeJoinBuildKeyCount = this.planNodeJoinBuildKeyCount + other.planNodeJoinBuildKeyCount;
 
         return new PlanNodeStats(
                 planNodeId,
@@ -170,6 +188,8 @@ public class PlanNodeStats
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeRawInputPositions, planNodeRawInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
-                operatorInputStats);
+                operatorInputStats,
+                planNodeNullJoinBuildKeyCount,
+                planNodeJoinBuildKeyCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -80,6 +80,8 @@ public class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeOutputBytes = new HashMap<>();
         Map<PlanNodeId, Long> planNodeScheduledMillis = new HashMap<>();
         Map<PlanNodeId, Long> planNodeCpuMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeNullJoinBuildKeyCount = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeJoinBuildKeyCount = new HashMap<>();
 
         Map<PlanNodeId, Map<String, OperatorInputStats>> operatorInputStats = new HashMap<>();
         Map<PlanNodeId, Map<String, OperatorHashCollisionsStats>> operatorHashCollisionsStats = new HashMap<>();
@@ -149,6 +151,9 @@ public class PlanNodeStatsSummarizer
                 planNodeRawInputPositions.merge(planNodeId, operatorStats.getRawInputPositions(), Long::sum);
                 planNodeRawInputBytes.merge(planNodeId, operatorStats.getRawInputDataSize().toBytes(), Long::sum);
 
+                planNodeNullJoinBuildKeyCount.merge(planNodeId, operatorStats.getNullJoinBuildKeyCount(), Long::sum);
+                planNodeJoinBuildKeyCount.merge(planNodeId, operatorStats.getJoinBuildKeyCount(), Long::sum);
+
                 processedNodes.add(planNodeId);
             }
 
@@ -205,6 +210,8 @@ public class PlanNodeStatsSummarizer
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
                         operatorInputStats.get(planNodeId),
+                        planNodeNullJoinBuildKeyCount.get(planNodeId),
+                        planNodeJoinBuildKeyCount.get(planNodeId),
                         operatorHashCollisionsStats.get(planNodeId));
             }
             else if (windowNodeStats.containsKey(planNodeId)) {
@@ -219,6 +226,8 @@ public class PlanNodeStatsSummarizer
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
                         operatorInputStats.get(planNodeId),
+                        planNodeNullJoinBuildKeyCount.get(planNodeId),
+                        planNodeJoinBuildKeyCount.get(planNodeId),
                         windowNodeStats.get(planNodeId));
             }
             else {
@@ -232,7 +241,9 @@ public class PlanNodeStatsSummarizer
                         succinctDataSize(planNodeRawInputBytes.get(planNodeId), BYTE),
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
-                        operatorInputStats.get(planNodeId));
+                        operatorInputStats.get(planNodeId),
+                        planNodeNullJoinBuildKeyCount.get(planNodeId),
+                        planNodeJoinBuildKeyCount.get(planNodeId));
             }
 
             stats.add(nodeStats);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -230,13 +230,20 @@ public class TextRenderer
         for (int i = 0; i < estimateCount; i++) {
             PlanNodeStatsEstimate stats = node.getEstimatedStats().get(i);
             PlanCostEstimate cost = node.getEstimatedCost().get(i);
-            output.append(format("{source: %s, rows: %s (%s), cpu: %s, memory: %s, network: %s}",
+            String formatStr = "{source: %s, rows: %s (%s), cpu: %s, memory: %s, network: %s%s%s}";
+            boolean hasHashtableStats = stats.getJoinBuildKeyCount() > 0 || stats.getNullJoinBuildKeyCount() > 0;
+            if (hasHashtableStats) {
+                formatStr = "{source: %s, rows: %s (%s), cpu: %s, memory: %s, network: %s, hashtable size: %s, hashtable null: %s}";
+            }
+            output.append(format(formatStr,
                     stats.getSourceInfo().getClass().getSimpleName(),
                     formatAsLong(stats.getOutputRowCount()),
                     formatEstimateAsDataSize(stats.getOutputSizeInBytes(plan.getPlanNodeRoot())),
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMaxMemory()),
-                    formatDouble(cost.getNetworkCost())));
+                    formatDouble(cost.getNetworkCost()),
+                    hasHashtableStats ? formatDouble(stats.getJoinBuildKeyCount()) : "",
+                    hasHashtableStats ? formatDouble(stats.getNullJoinBuildKeyCount()) : ""));
 
             if (i < estimateCount - 1) {
                 output.append("/");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
@@ -37,9 +37,12 @@ public class WindowPlanNodeStats
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
+            long planNodeNullJoinBuildKeyCount,
+            long planNodeJoinBuildKeyCount,
             WindowOperatorStats windowOperatorStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -65,6 +68,8 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
                 merged.operatorInputStats,
+                merged.getPlanNodeNullJoinBuildKeyCount(),
+                merged.getPlanNodeJoinBuildKeyCount(),
                 windowOperatorStats);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
@@ -82,7 +82,7 @@ public class TestHistoricalPlanStatistics
 
     private PlanStatistics stats(double rows, double size)
     {
-        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1);
+        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1, Estimate.unknown(), Estimate.unknown());
     }
 
     private static HistoricalPlanStatistics updatePlanStatistics(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
@@ -123,8 +123,8 @@ public class TestHistoryBasedStatsProvider
                             TableScanNode node = (TableScanNode) PlanNodeWithHash.getPlanNode();
                             if (node.getTable().toString().contains("orders")) {
                                 return new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1),
-                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1)))));
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
+                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, Estimate.unknown(), Estimate.unknown())))));
                             }
                         }
                         return HistoricalPlanStatistics.empty();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -85,7 +85,9 @@ public class TestQueryStats
                     succinctBytes(130L),
                     Optional.empty(),
                     null,
-                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1)))),
+                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))),
+                    0,
+                    0),
             new OperatorStats(
                     20,
                     201,
@@ -125,7 +127,9 @@ public class TestQueryStats
                     succinctBytes(230L),
                     Optional.empty(),
                     null,
-                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2)))),
+                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))),
+                    0,
+                    0),
             new OperatorStats(
                     30,
                     301,
@@ -165,7 +169,9 @@ public class TestQueryStats
                     succinctBytes(330L),
                     Optional.empty(),
                     null,
-                    new RuntimeStats()));
+                    new RuntimeStats(),
+                    0,
+                    0));
 
     static final QueryStats EXPECTED = new QueryStats(
             new DateTime(1),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -87,7 +87,9 @@ public class TestOperatorStats
 
             Optional.empty(),
             NON_MERGEABLE_INFO,
-            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))));
+            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))),
+            0,
+            0);
 
     public static final OperatorStats MERGEABLE = new OperatorStats(
             0,
@@ -135,7 +137,9 @@ public class TestOperatorStats
             new DataSize(25, BYTE),
             Optional.empty(),
             MERGEABLE_INFO,
-            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))));
+            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))),
+            0,
+            0);
 
     @Test
     public void testJson()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -756,6 +756,12 @@ public final class PlanMatchPattern
         return this;
     }
 
+    public PlanMatchPattern withJoinBuildKeyStatistics(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount)
+    {
+        matchers.add(new StatsJoinBuildKeyCountMatcher(expectedJoinBuildKeyCount, expectedNullJoinBuildKeyCount));
+        return this;
+    }
+
     public static RvalueMatcher columnReference(String tableName, String columnName)
     {
         return new ColumnReference(tableName, columnName);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinBuildKeyCountMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinBuildKeyCountMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+
+public class StatsJoinBuildKeyCountMatcher
+        implements Matcher
+{
+    private final double expectedJoinBuildKeyCount;
+    private final double expectedNullJoinBuildKeyCount;
+
+    StatsJoinBuildKeyCountMatcher(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount)
+    {
+        this.expectedJoinBuildKeyCount = expectedJoinBuildKeyCount;
+        this.expectedNullJoinBuildKeyCount = expectedNullJoinBuildKeyCount;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return true;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return new MatchResult(Double.compare(stats.getStats(node).getJoinBuildKeyCount(), expectedJoinBuildKeyCount) == 0
+                && Double.compare(stats.getStats(node).getNullJoinBuildKeyCount(), expectedNullJoinBuildKeyCount) == 0);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "expectedJoinBuildKeyCount(" + expectedJoinBuildKeyCount + ")" + " expectedNullJoinBuildKeyCount(" + expectedNullJoinBuildKeyCount + ")";
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
@@ -122,7 +122,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1)), statsEquivalentRemoteSource))
@@ -171,7 +171,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))
@@ -198,7 +198,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1),
+                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1, Estimate.unknown(), Estimate.unknown()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
@@ -59,6 +59,14 @@ public final class Estimate
         return new Estimate(value);
     }
 
+    public static Estimate estimateFromDouble(double value)
+    {
+        if (isNaN(value)) {
+            return unknown();
+        }
+        return of(value);
+    }
+
     @JsonCreator
     @ThriftConstructor
     public Estimate(@JsonProperty("value") double value)

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
@@ -33,8 +33,8 @@ public class TestHistoricalStatisticsSerde
     public void TestSimpleHistoricalStatisticsEncoderDecoder()
     {
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1),
-                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1)))));
+                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
+                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, Estimate.unknown(), Estimate.unknown())))));
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
 
         // Test PlanHash
@@ -51,8 +51,8 @@ public class TestHistoricalStatisticsSerde
     {
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1),
-                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0))));
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()),
+                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0, Estimate.unknown(), Estimate.unknown()))));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
@@ -78,11 +78,11 @@ public class TestHistoricalStatisticsSerde
     {
         List<PlanStatistics> planStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1));
+            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()));
         }
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1),
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()),
                     planStatisticsEntryList));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);


### PR DESCRIPTION
Add number of null elements in a hash table and size of a hash table into plan statistics.
It will be recorded in history base statistics, and used for mitigating nulls skew in outer joins.

### Test plan - (Please fill in how you tested your changes)

Tested in https://github.com/facebookexternal/presto-facebook/pull/2413


```
== NO RELEASE NOTE ==
```
