### PR TITLE
Add operator estimated output to operator statistics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.Column;
@@ -59,6 +60,8 @@ import com.facebook.presto.spi.eventlistener.QueryStatistics;
 import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.ResourceDistribution;
 import com.facebook.presto.spi.eventlistener.StageStatistics;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 import com.google.common.collect.ImmutableList;
@@ -79,7 +82,9 @@ import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizDistributedPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.jsonDistributedPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textDistributedPlan;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Double.NaN;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 import static java.time.Duration.ofMillis;
@@ -290,6 +295,8 @@ public class QueryMonitor
 
     private List<OperatorStatistics> createOperatorStatistics(QueryInfo queryInfo)
     {
+        Map<PlanNodeId, PlanNodeStatsEstimate> estimateMap = queryInfo.getPlanStatsAndCosts().getStats();
+        Map<PlanNodeId, PlanNode> planNodeIdMap = queryInfo.getPlanIdNodeMap();
         return queryInfo.getQueryStats().getOperatorSummaries().stream()
                 .map(operatorSummary -> new OperatorStatistics(
                         operatorSummary.getStageId(),
@@ -328,8 +335,19 @@ public class QueryMonitor
                         operatorSummary.getPeakTotalMemoryReservation(),
                         operatorSummary.getSpilledDataSize(),
                         Optional.ofNullable(operatorSummary.getInfo()).map(operatorInfoCodec::toJson),
-                        operatorSummary.getRuntimeStats()))
+                        operatorSummary.getRuntimeStats(),
+                        getPlanNodeEstimateOutputSize(operatorSummary.getPlanNodeId(), estimateMap, planNodeIdMap),
+                        estimateMap.containsKey(operatorSummary.getPlanNodeId()) ? estimateMap.get(operatorSummary.getPlanNodeId()).getOutputRowCount() : NaN))
                 .collect(toImmutableList());
+    }
+
+    private double getPlanNodeEstimateOutputSize(PlanNodeId nodeId, Map<PlanNodeId, PlanNodeStatsEstimate> estimateMap, Map<PlanNodeId, PlanNode> planNodeIdMap)
+    {
+        if (!estimateMap.containsKey(nodeId)) {
+            return NaN;
+        }
+        checkArgument(planNodeIdMap.containsKey(nodeId), "plan node does not exist in planNodeIdMap");
+        return estimateMap.get(nodeId).getOutputSizeInBytes(planNodeIdMap.get(nodeId));
     }
 
     private QueryStatistics createQueryStatistics(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.facebook.presto.sql.planner.CanonicalPlanWithInfo;
@@ -97,6 +99,7 @@ public class QueryInfo
     private final Set<String> windowsFunctions;
     // Using a list rather than map, to avoid implementing map key deserializer
     private final List<CanonicalPlanWithInfo> planCanonicalInfo;
+    private Map<PlanNodeId, PlanNode> planIdNodeMap;
 
     @JsonCreator
     public QueryInfo(
@@ -139,7 +142,8 @@ public class QueryInfo
             @JsonProperty("scalarFunctions") Set<String> scalarFunctions,
             @JsonProperty("aggregateFunctions") Set<String> aggregateFunctions,
             @JsonProperty("windowsFunctions") Set<String> windowsFunctions,
-            List<CanonicalPlanWithInfo> planCanonicalInfo)
+            List<CanonicalPlanWithInfo> planCanonicalInfo,
+            Map<PlanNodeId, PlanNode> planIdNodeMap)
     {
         requireNonNull(queryId, "queryId is null");
         requireNonNull(session, "session is null");
@@ -218,6 +222,7 @@ public class QueryInfo
         this.aggregateFunctions = aggregateFunctions;
         this.windowsFunctions = windowsFunctions;
         this.planCanonicalInfo = planCanonicalInfo == null ? ImmutableList.of() : planCanonicalInfo;
+        this.planIdNodeMap = planIdNodeMap == null ? ImmutableMap.of() : ImmutableMap.copyOf(planIdNodeMap);
     }
 
     @JsonProperty
@@ -474,6 +479,11 @@ public class QueryInfo
     public List<CanonicalPlanWithInfo> getPlanCanonicalInfo()
     {
         return planCanonicalInfo;
+    }
+
+    public Map<PlanNodeId, PlanNode> getPlanIdNodeMap()
+    {
+        return planIdNodeMap;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -33,6 +33,8 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.SelectedRole;
@@ -41,6 +43,7 @@ import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
@@ -150,6 +153,7 @@ public class QueryStateMachine
     private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
 
     private final AtomicReference<StatsAndCosts> planStatsAndCosts = new AtomicReference<>();
+    private final AtomicReference<Map<PlanNodeId, PlanNode>> planIdNodeMap = new AtomicReference<>();
     private final AtomicReference<List<CanonicalPlanWithInfo>> planCanonicalInfo = new AtomicReference<>();
     private final AtomicReference<Set<Input>> inputs = new AtomicReference<>(ImmutableSet.of());
     private final AtomicReference<Optional<Output>> output = new AtomicReference<>(Optional.empty());
@@ -489,7 +493,8 @@ public class QueryStateMachine
                 scalarFunctions.get(),
                 aggregateFunctions.get(),
                 windowsFunctions.get(),
-                Optional.ofNullable(planCanonicalInfo.get()).orElseGet(ImmutableList::of));
+                Optional.ofNullable(planCanonicalInfo.get()).orElseGet(ImmutableList::of),
+                Optional.ofNullable(planIdNodeMap.get()).orElseGet(ImmutableMap::of));
     }
 
     private QueryStats getQueryStats(Optional<StageInfo> rootStage, List<StageInfo> allStages)
@@ -542,6 +547,12 @@ public class QueryStateMachine
     {
         requireNonNull(statsAndCosts, "statsAndCosts is null");
         this.planStatsAndCosts.set(statsAndCosts);
+    }
+
+    public void setPlanIdNodeMap(Map<PlanNodeId, PlanNode> planIdNodeMap)
+    {
+        requireNonNull(planIdNodeMap, "planIdNodeMap is null");
+        this.planIdNodeMap.set(ImmutableMap.copyOf(planIdNodeMap));
     }
 
     public void setPlanCanonicalInfo(List<CanonicalPlanWithInfo> planCanonicalInfo)
@@ -1090,7 +1101,8 @@ public class QueryStateMachine
                 queryInfo.getScalarFunctions(),
                 queryInfo.getAggregateFunctions(),
                 queryInfo.getWindowsFunctions(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ImmutableMap.of());
         finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -543,6 +543,7 @@ public class SqlQueryExecution
 
             queryPlan.set(plan);
             stateMachine.setPlanStatsAndCosts(plan.getStatsAndCosts());
+            stateMachine.setPlanIdNodeMap(plan.getPlanIdNodeMap());
             stateMachine.setPlanCanonicalInfo(getCanonicalInfo(getSession(), plan.getRoot(), planCanonicalInfoProvider));
 
             // extract inputs

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Plan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Plan.java
@@ -15,6 +15,11 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.graph.Traverser;
+
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -44,5 +49,16 @@ public class Plan
     public StatsAndCosts getStatsAndCosts()
     {
         return statsAndCosts;
+    }
+
+    public Map<PlanNodeId, PlanNode> getPlanIdNodeMap()
+    {
+        Iterable<PlanNode> planIterator = Traverser.forTree(PlanNode::getSources)
+                .depthFirstPreOrder(root);
+        ImmutableMap.Builder<PlanNodeId, PlanNode> planNodeMap = ImmutableMap.builder();
+        for (PlanNode node : planIterator) {
+            planNodeMap.put(node.getId(), node);
+        }
+        return planNodeMap.build();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -199,6 +199,7 @@ public class TestQueryInfo
                         new CanonicalPlan(
                                 new ValuesNode(Optional.empty(), new PlanNodeId("0"), ImmutableList.of(), ImmutableList.of(), Optional.empty()),
                                 PlanCanonicalizationStrategy.DEFAULT),
-                        new PlanNodeCanonicalInfo("a", ImmutableList.of()))));
+                        new PlanNodeCanonicalInfo("a", ImmutableList.of()))),
+                ImmutableMap.of());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -149,7 +149,8 @@ public class TestBasicQueryInfo
                         ImmutableSet.of(),
                         ImmutableSet.of(),
                         ImmutableSet.of(),
-                        ImmutableList.of()));
+                        ImmutableList.of(),
+                        ImmutableMap.of()));
 
         assertEquals(basicInfo.getQueryId().getId(), "0");
         assertEquals(basicInfo.getState(), RUNNING);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -304,6 +304,7 @@ public class TestQueryStateInfo
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ImmutableMap.of());
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -376,7 +376,8 @@ public class PrestoSparkQueryExecutionFactory
                 planAndMore.map(PlanAndMore::getInvokedScalarFunctions).orElseGet(ImmutableSet::of),
                 planAndMore.map(PlanAndMore::getInvokedAggregateFunctions).orElseGet(ImmutableSet::of),
                 planAndMore.map(PlanAndMore::getInvokedWindowFunctions).orElseGet(ImmutableSet::of),
-                planAndMore.map(PlanAndMore::getPlanCanonicalInfo).orElseGet(ImmutableList::of));
+                planAndMore.map(PlanAndMore::getPlanCanonicalInfo).orElseGet(ImmutableList::of),
+                planAndMore.map(PlanAndMore::getPlan).map(Plan::getPlanIdNodeMap).orElseGet(ImmutableMap::of));
     }
 
     public static StageInfo createStageInfo(QueryId queryId, SubPlan plan, List<TaskInfo> taskInfos)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
@@ -75,6 +75,9 @@ public class OperatorStatistics
 
     private final RuntimeStats runtimeStats;
 
+    private final double estimateOutputDataSize;
+    private final double estimateOutputPositions;
+
     public OperatorStatistics(
             int stageId,
             int stageExecutionId,
@@ -121,7 +124,9 @@ public class OperatorStatistics
             DataSize spilledDataSize,
 
             Optional<String> info,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            double estimateOutputDataSize,
+            double estimateOutputPositions)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -171,6 +176,9 @@ public class OperatorStatistics
 
         this.info = requireNonNull(info, "info is null");
         this.runtimeStats = runtimeStats;
+
+        this.estimateOutputDataSize = estimateOutputDataSize;
+        this.estimateOutputPositions = estimateOutputPositions;
     }
 
     public int getStageId()
@@ -356,5 +364,15 @@ public class OperatorStatistics
     public RuntimeStats getRuntimeStats()
     {
         return runtimeStats;
+    }
+
+    public double getEstimateOutputDataSize()
+    {
+        return estimateOutputDataSize;
+    }
+
+    public double getEstimateOutputPositions()
+    {
+        return estimateOutputPositions;
     }
 }


### PR DESCRIPTION
Add estimated output to operator statistics, so that we can log and compare them with the accurate statistics.

Depended by https://github.com/facebookexternal/presto-facebook/pull/2387

### Test plan 

Tested in https://github.com/facebookexternal/presto-facebook/pull/2387



```
== NO RELEASE NOTE ==
```
