### PR TITLE
[native] Fix presto_server_test build failure on MacOS

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -28,12 +28,12 @@ add_test(
 
 target_link_libraries(
   presto_server_test
-  presto_server_lib
   presto_json_signature_parser
+  velox_exec_test_lib
+  presto_server_lib
+  velox_dwio_common_test_utils
   $<TARGET_OBJECTS:presto_type_converter>
   $<TARGET_OBJECTS:presto_types>
-  velox_exec_test_lib
-  velox_dwio_common_test_utils
   velox_hive_connector
   velox_tpch_connector
   velox_presto_serializer


### PR DESCRIPTION
Fix presto_server_test build failure on MacOS when PRESTO_ENABLE_PARQUET=ON. 
Resolves https://github.com/prestodb/presto/issues/20340

```
== NO RELEASE NOTE ==
```
