### PR TITLE
[native] Add support for distinct aggregations

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1624,25 +1624,27 @@ void VeloxQueryPlanConverterBase::toAggregations(
   for (const auto& entry : outputVariables) {
     aggregateNames.emplace_back(entry.name);
 
-    VELOX_USER_CHECK(
-        !aggregationMap.at(entry).distinct,
-        "Distinct aggregations are not supported yet.");
+    const auto& prestoAggregation = aggregationMap.at(entry);
 
     core::AggregationNode::Aggregate aggregate;
     aggregate.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
-        exprConverter_.toVeloxExpr(aggregationMap.at(entry).call));
-    if (aggregationMap.at(entry).mask != nullptr) {
-      aggregate.mask =
-          exprConverter_.toVeloxExpr(aggregationMap.at(entry).mask);
+        exprConverter_.toVeloxExpr(prestoAggregation.call));
+
+    aggregate.distinct = prestoAggregation.distinct;
+
+    if (prestoAggregation.mask != nullptr) {
+      aggregate.mask = exprConverter_.toVeloxExpr(prestoAggregation.mask);
     }
-    if (aggregationMap.at(entry).orderBy != nullptr) {
-      for (const auto& orderBy : aggregationMap.at(entry).orderBy->orderBy) {
+
+    if (prestoAggregation.orderBy != nullptr) {
+      for (const auto& orderBy : prestoAggregation.orderBy->orderBy) {
         aggregate.sortingKeys.emplace_back(
             exprConverter_.toVeloxExpr(orderBy.variable));
         aggregate.sortingOrders.emplace_back(
             toVeloxSortOrder(orderBy.sortOrder));
       }
     }
+
     aggregates.emplace_back(aggregate);
   }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -302,8 +302,10 @@ public abstract class AbstractTestNativeAggregations
         Session session = Session.builder(getSession())
                 .setSystemProperty("use_mark_distinct", "falze")
                 .build();
-        assertQueryFails(session, "SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem",
-                ".*Distinct aggregations are not supported yet.");
+        assertQuery(session, "SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem");
+        assertQuery(session, "SELECT count(distinct orderkey), sum(distinct linenumber), array_sort(array_agg(distinct linenumber)) FROM lineitem");
+        assertQueryFails(session, "SELECT count(distinct orderkey), array_agg(distinct linenumber ORDER BY linenumber) FROM lineitem",
+                ".*Aggregations over sorted unique values are not supported yet");
     }
 
     private void assertQueryResultCount(String sql, int expectedResultCount)


### PR DESCRIPTION
Enable queries like SELECT count(distinct x), sum(distict y) FROM t when use_mark_distinct is false.

```
== NO RELEASE NOTE ==
```
