### PR TITLE
Support S3FileIO in Hadoop and Nessie backed Iceberg tables.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -98,6 +98,12 @@ Property Name                                        Description
 Configuration Properties
 ------------------------
 
+.. note::
+
+    The Iceberg connector supports configuration options for
+    `Amazon S3 <https://prestodb.io/docs/current/connector/hive.html##amazon-s3-configuration>`_
+    as Hive connector.
+
 The following configuration properties are available:
 
 ========================================= =====================================================


### PR DESCRIPTION
_See Also apache/iceberg#3546._

When an non-Hive catalog is used to back Iceberg, Presto does not set up the `s3`, `s3a`, or `s3n` file systems for Hadoop. This prevents non-Hive catalogs from accessing files in object storage without manually passing in a hive configuration.

As a small usability improvement, I've updated `IcebergResourceFactory` to apply `S3ConfigurationUpdater#updateConfiguration` when `iceberg.hadoop.config.resources` is not set. This has the effect of configuring the object storage file systems for Hadoop by default, with the same configuration properties as the Hive connector.

*Test plan*

I ran (via Docker Compose) a test query which created a new table using the `tpch.tiny.region` with Nessie/MinIO backed catalog. I then queried the table back out and compared it to the source `tpch.tiny.region` table.

<details>
<summary>Test Resources</summary>

Docker compose file:
```yaml
---
services:
  nessie:
    image: "ghcr.io/projectnessie/nessie"
    ports:
      - "19120:19120"
  minio:
    image: "quay.io/minio/minio"
    ports:
      - "9001:9001"
      - "9000:9000"
    command: |
      server /data --console-address ":9001"
```

Test Query:
```sql
create schema test;
create table test.region as (select * from tpch.tiny.region);
```

</details>


```
== RELEASE NOTES ==

General Changes
* Iceberg catalogues which use Hadoop or Nessie as catalogs now support reading from and writing to S3 with the same configuration options as the Hive catalog.
```
