### PR TITLE
Reduce dns lookup overhead on NodeScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -349,17 +349,17 @@ public class NodeScheduler
                     .filter(node -> includeCoordinator || !coordinatorIds.contains(node.getNodeIdentifier()))
                     .forEach(chosen::add);
 
-            InetAddress address;
-            try {
-                address = host.toInetAddress();
-            }
-            catch (UnknownHostException e) {
-                // skip hosts that don't resolve
-                continue;
-            }
-
             // consider a split with a host without a port as being accessible by all nodes in that host
             if (!host.hasPort()) {
+                InetAddress address;
+                try {
+                    address = host.toInetAddress();
+                }
+                catch (UnknownHostException e) {
+                    // skip hosts that don't resolve
+                    continue;
+                }
+
                 nodeMap.getAllNodesByHost().get(address).stream()
                         .filter(node -> includeCoordinator || !coordinatorIds.contains(node.getNodeIdentifier()))
                         .forEach(chosen::add);
@@ -376,17 +376,17 @@ public class NodeScheduler
                 nodeMap.getAllNodesByHostAndPort().get(host).stream()
                         .forEach(chosen::add);
 
-                InetAddress address;
-                try {
-                    address = host.toInetAddress();
-                }
-                catch (UnknownHostException e) {
-                    // skip hosts that don't resolve
-                    continue;
-                }
-
                 // consider a split with a host without a port as being accessible by all nodes in that host
                 if (!host.hasPort()) {
+                    InetAddress address;
+                    try {
+                        address = host.toInetAddress();
+                    }
+                    catch (UnknownHostException e) {
+                        // skip hosts that don't resolve
+                        continue;
+                    }
+
                     nodeMap.getAllNodesByHost().get(address).stream()
                             .forEach(chosen::add);
                 }


### PR DESCRIPTION
It does not need to dns lookup for hostname if HostAddress has port, which incurred additional overhead when dns too slow on some host environment.

Test plan
- compile success
- run success
- HostAddress with port, node selected expected
- HostAddress without port, node selected expected

```
== RELEASE NOTES ==

General Changes
* Reduce dns lookup overhead on NodeScheduler.
   This can avoid unnecessary dns lookup for HostAddress has port, while previous would incurred additional overhead when dns too slow on some host environment.

```

