### PR TITLE
Add cache for jdbc metadata calls

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -105,6 +105,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
         <!-- for testing -->
 
         <dependency>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class JdbcMetadataCache
+{
+    private final JdbcClient jdbcClient;
+
+    private final LoadingCache<KeyAndSession<SchemaTableName>, Optional<JdbcTableHandle>> tableHandleCache;
+    private final LoadingCache<KeyAndSession<JdbcTableHandle>, List<JdbcColumnHandle>> columnHandlesCache;
+
+    @Inject
+    public JdbcMetadataCache(JdbcClient jdbcClient, JdbcMetadataConfig config, JdbcMetadataCacheStats stats)
+    {
+        this(
+                newCachedThreadPool(daemonThreadsNamed("jdbc-metadata-cache" + "-%s")),
+                jdbcClient,
+                stats,
+                OptionalLong.of(config.getMetadataCacheTtl().toMillis()),
+                config.getMetadataCacheRefreshInterval().toMillis() >= config.getMetadataCacheTtl().toMillis() ? OptionalLong.empty() : OptionalLong.of(config.getMetadataCacheRefreshInterval().toMillis()),
+                config.getMetadataCacheMaximumSize());
+    }
+
+    public JdbcMetadataCache(
+            ExecutorService executor,
+            JdbcClient jdbcClient,
+            JdbcMetadataCacheStats stats,
+            OptionalLong cacheTtl,
+            OptionalLong refreshInterval,
+            long cacheMaximumSize)
+    {
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+
+        this.tableHandleCache = newCacheBuilder(cacheTtl, refreshInterval, cacheMaximumSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTableHandle), executor));
+        stats.setTableHandleCache(tableHandleCache);
+
+        this.columnHandlesCache = newCacheBuilder(cacheTtl, refreshInterval, cacheMaximumSize)
+                .build(asyncReloading(CacheLoader.from(this::loadColumnHandles), executor));
+        stats.setColumnHandlesCache(columnHandlesCache);
+    }
+
+    public JdbcTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        return get(tableHandleCache, new KeyAndSession<>(session, tableName)).orElse(null);
+    }
+
+    public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle jdbcTableHandle)
+    {
+        return get(columnHandlesCache, new KeyAndSession<>(session, jdbcTableHandle));
+    }
+
+    private Optional<JdbcTableHandle> loadTableHandle(KeyAndSession<SchemaTableName> tableName)
+    {
+        // The returned tableHandle can be null if it does not contain the table
+        return Optional.ofNullable(jdbcClient.getTableHandle(tableName.getSession(), JdbcIdentity.from(tableName.getSession()), tableName.getKey()));
+    }
+
+    private List<JdbcColumnHandle> loadColumnHandles(KeyAndSession<JdbcTableHandle> tableHandle)
+    {
+        return jdbcClient.getColumns(tableHandle.getSession(), tableHandle.getKey());
+    }
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(OptionalLong expiresAfterWriteMillis, OptionalLong refreshMillis, long maximumSize)
+    {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteMillis.isPresent()) {
+            cacheBuilder = cacheBuilder.expireAfterWrite(expiresAfterWriteMillis.getAsLong(), MILLISECONDS);
+        }
+        if (refreshMillis.isPresent() && (!expiresAfterWriteMillis.isPresent() || expiresAfterWriteMillis.getAsLong() > refreshMillis.getAsLong())) {
+            cacheBuilder = cacheBuilder.refreshAfterWrite(refreshMillis.getAsLong(), MILLISECONDS);
+        }
+        return cacheBuilder.maximumSize(maximumSize).recordStats();
+    }
+
+    private static <K, V> V get(LoadingCache<K, V> cache, K key)
+    {
+        try {
+            return cache.getUnchecked(key);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+    }
+
+    private static class KeyAndSession<T>
+    {
+        private final ConnectorSession session;
+        private final T key;
+
+        public KeyAndSession(ConnectorSession session, T key)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.key = requireNonNull(key, "key is null");
+        }
+
+        public ConnectorSession getSession()
+        {
+            return session;
+        }
+
+        public T getKey()
+        {
+            return key;
+        }
+
+        // Session object changes for every query. For caching to be effective across multiple queries,
+        // we should NOT include session in equals() and hashCode() methods below.
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            KeyAndSession<?> other = (KeyAndSession<?>) o;
+            return Objects.equals(key, other.key);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(key);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("session", session)
+                    .add("key", key)
+                    .toString();
+        }
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCacheStats.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCacheStats.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.google.common.cache.LoadingCache;
+import org.weakref.jmx.Managed;
+
+public class JdbcMetadataCacheStats
+{
+    private LoadingCache<?, ?> tableHandleCache;
+    private LoadingCache<?, ?> columnHandlesCache;
+
+    public void setTableHandleCache(LoadingCache<?, ?> tableHandleCache)
+    {
+        this.tableHandleCache = tableHandleCache;
+    }
+
+    public void setColumnHandlesCache(LoadingCache<?, ?> columnHandlesCache)
+    {
+        this.columnHandlesCache = columnHandlesCache;
+    }
+
+    @Managed
+    public long getTableHandleCacheHit()
+    {
+        return tableHandleCache.stats().hitCount();
+    }
+
+    @Managed
+    public long getTableHandleCacheMiss()
+    {
+        return tableHandleCache.stats().missCount();
+    }
+
+    @Managed
+    public long getTableHandleCacheEviction()
+    {
+        return tableHandleCache.stats().evictionCount();
+    }
+
+    @Managed
+    public long getTableHandleCacheSize()
+    {
+        return tableHandleCache.size();
+    }
+
+    @Managed
+    public long getColumnHandlesCacheHit()
+    {
+        return columnHandlesCache.stats().hitCount();
+    }
+
+    @Managed
+    public long getColumnHandlesCacheMiss()
+    {
+        return columnHandlesCache.stats().missCount();
+    }
+
+    @Managed
+    public long getColumnHandlesCacheEviction()
+    {
+        return columnHandlesCache.stats().evictionCount();
+    }
+
+    @Managed
+    public long getColumnHandlesCacheSize()
+    {
+        return columnHandlesCache.size();
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataConfig.java
@@ -15,10 +15,20 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
 
 public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
+    private Duration metadataCacheTtl = new Duration(0, TimeUnit.SECONDS);
+    private Duration metadataCacheRefreshInterval = new Duration(0, TimeUnit.SECONDS);
+    private long metadataCacheMaximumSize = 10000;
 
     public boolean isAllowDropTable()
     {
@@ -30,6 +40,47 @@ public class JdbcMetadataConfig
     public JdbcMetadataConfig setAllowDropTable(boolean allowDropTable)
     {
         this.allowDropTable = allowDropTable;
+        return this;
+    }
+
+    @NotNull
+    public Duration getMetadataCacheTtl()
+    {
+        return metadataCacheTtl;
+    }
+
+    @MinDuration("0ms")
+    @Config("metadata-cache-ttl")
+    public JdbcMetadataConfig setMetadataCacheTtl(Duration metadataCacheTtl)
+    {
+        this.metadataCacheTtl = metadataCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    public Duration getMetadataCacheRefreshInterval()
+    {
+        return metadataCacheRefreshInterval;
+    }
+
+    @MinDuration("1ms")
+    @Config("metadata-cache-refresh-interval")
+    public JdbcMetadataConfig setMetadataCacheRefreshInterval(Duration metadataCacheRefreshInterval)
+    {
+        this.metadataCacheRefreshInterval = metadataCacheRefreshInterval;
+        return this;
+    }
+
+    public long getMetadataCacheMaximumSize()
+    {
+        return metadataCacheMaximumSize;
+    }
+
+    @Min(1)
+    @Config("metadata-cache-maximum-size")
+    public JdbcMetadataConfig setMetadataCacheMaximumSize(long metadataCacheMaximumSize)
+    {
+        this.metadataCacheMaximumSize = metadataCacheMaximumSize;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
@@ -19,12 +19,14 @@ import static java.util.Objects.requireNonNull;
 
 public class JdbcMetadataFactory
 {
+    private final JdbcMetadataCache jdbcMetadataCache;
     private final JdbcClient jdbcClient;
     private final boolean allowDropTable;
 
     @Inject
-    public JdbcMetadataFactory(JdbcClient jdbcClient, JdbcMetadataConfig config)
+    public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config)
     {
+        this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         requireNonNull(config, "config is null");
         this.allowDropTable = config.isAllowDropTable();
@@ -32,6 +34,6 @@ public class JdbcMetadataFactory
 
     public JdbcMetadata create()
     {
-        return new JdbcMetadata(jdbcClient, allowDropTable);
+        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcModule.java
@@ -23,6 +23,8 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class JdbcModule
         implements Module
@@ -40,6 +42,11 @@ public class JdbcModule
         newOptionalBinder(binder, ConnectorAccessControl.class);
         newSetBinder(binder, Procedure.class);
         binder.bind(JdbcConnectorId.class).toInstance(new JdbcConnectorId(connectorId));
+
+        binder.bind(JdbcMetadataCache.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcMetadataCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(JdbcMetadataCacheStats.class).as(generatedNameOf(JdbcMetadataCacheStats.class, connectorId));
+
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -21,6 +22,8 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestJdbcMetadataConfig
 {
@@ -28,7 +31,10 @@ public class TestJdbcMetadataConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
-                .setAllowDropTable(false));
+                .setAllowDropTable(false)
+                .setMetadataCacheTtl(new Duration(0, SECONDS))
+                .setMetadataCacheRefreshInterval(new Duration(0, SECONDS))
+                .setMetadataCacheMaximumSize(10000));
     }
 
     @Test
@@ -36,10 +42,16 @@ public class TestJdbcMetadataConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("allow-drop-table", "true")
+                .put("metadata-cache-ttl", "1h")
+                .put("metadata-cache-refresh-interval", "10s")
+                .put("metadata-cache-maximum-size", "100")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
-                .setAllowDropTable(true);
+                .setAllowDropTable(true)
+                .setMetadataCacheTtl(new Duration(1, HOURS))
+                .setMetadataCacheRefreshInterval(new Duration(10, SECONDS))
+                .setMetadataCacheMaximumSize(100);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Created custom build with changes and tested by shadowing prod queries. 

```
== RELEASE NOTES ==
Jdbc Changes
* Add cache support for jdbc metadata calls. This can be enabled by configuring parameter `metadata-cache-ttl`, `metadata-cache-refresh-interval` and `metadata-cache-size`.
```
