### PR TITLE
[native pos] Fail the query if timed out fetching results from Velox

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
@@ -21,8 +21,6 @@ import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 
@@ -106,62 +104,58 @@ public class HttpNativeExecutionTaskInfoFetcher
     void doGetTaskInfo()
     {
         try {
-            ListenableFuture<BaseResponse<TaskInfo>> taskInfoFuture = workerClient.getTaskInfo();
-            Futures.addCallback(
-                    taskInfoFuture,
-                    new FutureCallback<BaseResponse<TaskInfo>>()
-                    {
-                        @Override
-                        public void onSuccess(BaseResponse<TaskInfo> result)
-                        {
-                            log.debug("TaskInfoCallback success %s", result.getValue().getTaskId());
-                            taskInfo.set(result.getValue());
-
-                            // Update Spark Accumulators for spark internal metrics
-                            // Note: Updating here also serves as a heartbeat to spark scheduler
-                            // that the task is making progress
-                            PrestoSparkStatsCollectionUtils.collectMetrics(taskInfo.get());
-
-                            if (result.getValue().getTaskStatus().getState().isDone()) {
-                                synchronized (taskFinished) {
-                                    taskFinished.notifyAll();
-                                }
-                            }
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t)
-                        {
-                            // record failure
-                            try {
-                                errorTracker.requestFailed(t);
-                            }
-                            catch (PrestoException e) {
-                                // Entering here means that we are unable
-                                // to get any task info from the CPP process
-                                // likely because process has crashed
-                                stop();
-                                lastException.set(e);
-                                synchronized (taskFinished) {
-                                    taskFinished.notifyAll();
-                                }
-                                return;
-                            }
-                            ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-                            try {
-                                // synchronously wait on throttling
-                                errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
-                            }
-                            catch (InterruptedException | ExecutionException | TimeoutException e) {
-                                // throttling error is not fatal, just log the error.
-                                log.debug(e.getMessage());
-                            }
-                        }
-                    },
-                    executor);
+            BaseResponse<TaskInfo> response = workerClient.getTaskInfo().get();
+            onSuccess(response);
         }
         catch (Throwable t) {
-            throw t;
+            onFailure(t);
+        }
+    }
+
+    private void onSuccess(BaseResponse<TaskInfo> result)
+    {
+        log.debug("TaskInfoCallback success %s", result.getValue().getTaskId());
+        taskInfo.set(result.getValue());
+
+        errorTracker.requestSucceeded();
+
+        // Update Spark Accumulators for spark internal metrics
+        // Note: Updating here also serves as a heartbeat to spark scheduler
+        // that the task is making progress
+        PrestoSparkStatsCollectionUtils.collectMetrics(taskInfo.get());
+
+        if (result.getValue().getTaskStatus().getState().isDone()) {
+            synchronized (taskFinished) {
+                taskFinished.notifyAll();
+            }
+        }
+    }
+
+    private void onFailure(Throwable t)
+    {
+        // record failure
+        try {
+            errorTracker.requestFailed(t);
+        }
+        catch (PrestoException e) {
+            // Entering here means that we are unable
+            // to get any task info from the CPP process
+            // likely because process has crashed
+            stop();
+            lastException.set(e);
+            synchronized (taskFinished) {
+                taskFinished.notifyAll();
+            }
+            return;
+        }
+        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        try {
+            // synchronously wait on throttling
+            errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException | ExecutionException | TimeoutException e) {
+            // throttling error is not fatal, just log the error.
+            log.debug(e.getMessage());
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -112,7 +112,10 @@ public class NativeExecutionTask
         if (!shuffleWriteInfo.isPresent()) {
             this.taskResultFetcher = Optional.of(new HttpNativeExecutionTaskResultFetcher(
                     updateScheduledExecutor,
+                    errorRetryScheduledExecutor,
                     this.workerClient,
+                    this.executor,
+                    queryManagerConfig.getRemoteTaskMaxErrorDuration(),
                     taskFinishedOrHasResult));
         }
         else {


### PR DESCRIPTION
Fix HttpNativeExecutionTaskResultFetcher::pollPage() and hasPage() method to
throw if failed to fetch results.

Use RequestErrorTracker to handle transitive failures.

Fix HttpNativeExecutionTaskInfoFetcher to reset RequestErrorTracker on success.

```
== NO RELEASE NOTE ==
```
