### PR TITLE
[native] Remove inheritence relationship between AsyncDataCache and MemoryAllo…

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -165,16 +165,11 @@ class PrestoServer {
   // Executor for exchange data over http.
   std::shared_ptr<folly::IOThreadPoolExecutor> exchangeExecutor_;
 
+  // Instance of MemoryAllocator used for all query memory allocations.
+  std::shared_ptr<velox::memory::MemoryAllocator> allocator_;
+
   // If not null,  the instance of AsyncDataCache used for in-memory file cache.
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
-
-  // Instance of MemoryAllocator used for all query memory allocations.
-  //
-  // NOTE: AsyncDataCache implements MemoryAllocator interface and wraps on top
-  // of a real memory allocator for the actual memory allocation. So if 'cache_'
-  // has been set, 'allocator_' is also set to 'cache_'. It provides memory
-  // allocations for both file cache and query memory.
-  std::shared_ptr<velox::memory::MemoryAllocator> allocator_;
 
   std::unique_ptr<http::HttpServer> httpServer_;
   std::unique_ptr<SignalHandler> signalHandler_;

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -135,7 +135,7 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
       executor().get(),
       std::move(configStrings),
       connectorConfigs,
-      memory::MemoryAllocator::getInstance(),
+      cache::AsyncDataCache::getInstance(),
       std::move(pool),
       spillExecutor(),
       queryId);

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2574,9 +2574,9 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
             planFragment.planNode =
                 std::make_shared<core::PartitionedOutputNode>(
                     "root",
+                    core::PartitionedOutputNode::Kind::kPartitioned,
                     partitioningKeys,
                     numPartitions,
-                    core::PartitionedOutputNode::Kind::kPartitioned,
                     partitioningScheme.replicateNullsAndAny,
                     std::make_shared<RoundRobinPartitionFunctionSpec>(),
                     outputType,
@@ -2594,9 +2594,9 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
             planFragment.planNode =
                 std::make_shared<core::PartitionedOutputNode>(
                     "root",
+                    core::PartitionedOutputNode::Kind::kPartitioned,
                     partitioningKeys,
                     numPartitions,
-                    core::PartitionedOutputNode::Kind::kPartitioned,
                     partitioningScheme.replicateNullsAndAny,
                     std::make_shared<HashPartitionFunctionSpec>(
                         inputType, keyChannels, constValues),
@@ -2642,9 +2642,9 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
 
     planFragment.planNode = std::make_shared<core::PartitionedOutputNode>(
         "root",
+        core::PartitionedOutputNode::Kind::kPartitioned,
         partitioningKeys,
         numPartitions,
-        core::PartitionedOutputNode::Kind::kPartitioned,
         partitioningScheme.replicateNullsAndAny,
         std::make_shared<HivePartitionFunctionSpec>(
             hivePartitioningHandle->bucketCount,


### PR DESCRIPTION
Summary:
Removing the relationship of AsyncDataCache inheritance from MemoryAllocator. Now they are depending on each other with registration mechanism. Related tests are refactored to be consistent with the new change.

Advance Velox version

X-link: https://github.com/facebookincubator/velox/pull/5503

Reviewed By: xiaoxmeng

Differential Revision: D47536273

Pulled By: tanjialiang

