### PR TITLE
[native] Fix spill config name.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -278,7 +278,7 @@ class SystemConfig : public ConfigBase {
       "task-run-timeslice-micros"};
 
   static constexpr std::string_view kIncludeNodeInSpillPath{
-      "include_node_in_spill_path"};
+      "include-node-in-spill-path"};
 
   SystemConfig();
 


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/20369 introcues `include_node_in_spill_path`. The config name should have `-` as separator. Fixing here. Thanks @zacw7 for pointing it out.
