### PR TITLE
[native] Add all parquet tests to a test group

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -245,7 +245,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "JOIN lineitem i TABLESAMPLE BERNOULLI (40) ON o.orderkey = i.orderkey");
     }
 
-    @Test
+    @Test(groups = {"parquet"})
     public void testDateFilter()
     {
         String tmpTableName = generateRandomTableName();
@@ -1206,7 +1206,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT row(name, null, cast(row(nationkey, regionkey) as row(a bigint, b bigint))) FROM nation");
     }
 
-    @Test
+    @Test(groups = {"parquet"})
     public void testDecimalRangeFilters()
     {
         // Actual session is for the native query runner.

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesParquetUsingThrift.java
@@ -15,7 +15,9 @@ package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Test;
 
+@Test(groups = {"parquet"})
 public class TestPrestoNativeTpcdsQueriesParquetUsingThrift
         extends AbstractTestNativeTpcdsQueries
 {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
@@ -15,7 +15,9 @@ package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Test;
 
+@Test(groups = {"parquet"})
 public class TestPrestoNativeTpchQueriesParquetUsingJSON
         extends AbstractTestNativeTpchQueries
 {


### PR DESCRIPTION
Summary:
Add all parquet tests to a test group so that those tests can excluded from test runs with:
-DexcludedGroups=parquet'
There should be no impact on existing runs on github since you have to exclude the group explicitly.

Resolves https://github.com/prestodb/presto/issues/20374


Test Plan:
Circle CI runs. 
```
== NO RELEASE NOTE ==
```
