### PR TITLE
Adding support for ALL_VALUES_MATCH

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -11,6 +11,29 @@ The ``[]`` operator is used to retrieve the value corresponding to a given key f
 
 Map Functions
 -------------
+.. function:: all_keys_match(x(K,V), function(K, boolean)) -> boolean
+
+    Returns whether all keys of a map match the given predicate. Returns true if all the keys match the predicate (a special case is when the map is empty); false if one or more keys don’t match; NULL if the predicate function returns NULL for one or more keys and true for all other keys. ::
+
+        SELECT all_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> length(x) = 1); -- true
+
+.. function:: all_values_match(x(K,V), function(K, boolean)) -> boolean
+
+    Returns whether all values of a map match the given predicate. Returns true if all the values match the predicate (a special case is when the map is empty); false if one or more values don’t match; NULL if the predicate function returns NULL for one or more values and true for all other values. ::
+
+        SELECT all_values_match(map(array['a', 'b', 'c'], array['d', 'e', 'f']), x -> length(x) = 1); -- true
+
+.. function:: any_keys_match(x(K,V), function(K, boolean)) -> boolean
+
+    Returns whether any keys of a map match the given predicate. Returns true if one or more keys match the predicate; false if none of the keys match (a special case is when the map is empty); NULL if the predicate function returns NULL for one or more keys and false for all other keys. ::
+
+        SELECT any_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'a'); -- true
+
+.. function:: any_values_match(x(K,V), function(V, boolean)) -> boolean
+
+    Returns whether any values of a map matches the given predicate. Returns true if one or more values match the predicate; false if none of the values match (a special case is when the map is empty); NULL if the predicate function returns NULL for one or more values and false for all other values. ::
+
+        SELECT ANY_VALUES_MATCH(map(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]), x -> x = 1); -- true
 
 .. function:: all_keys_match(x(K,V), function(K, boolean)) -> boolean
 
@@ -174,12 +197,15 @@ Map Functions
 
         SELECT no_keys_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'd'); -- true
 
+<<<<<<< HEAD
 .. function:: no_values_match(x(K,V), function(V, boolean)) -> boolean
 
     Returns whether no values of a map match the given predicate. Returns true if none of the values match the predicate (a special case is when the map is empty); false if one or more values match; NULL if the predicate function returns NULL for one or more values and false for all other values. ::
 
         SELECT no_values_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'd'); -- true
 
+=======
+>>>>>>> 7f9f905f72 (Adding support for ALL_VALUES_MATCH)
 .. function:: transform_keys(map(K1,V), function(K1,V,K2)) -> map(K2,V)
 
     Returns a map that applies ``function`` to each entry of ``map`` and transforms the keys::

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java
@@ -101,6 +101,20 @@ public class MapSqlFunctions
         return "RETURN ALL_MATCH(MAP_KEYS(input), f)";
     }
 
+<<<<<<< HEAD
+=======
+    @SqlInvokedScalarFunction(value = "all_values_match", deterministic = true, calledOnNullInput = true)
+    @Description("Returns whether all values of a map match the given predicate.")
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlParameters({@SqlParameter(name = "input", type = "map(K, V)"), @SqlParameter(name = "f", type = "function(V, boolean)")})
+    @SqlType("boolean")
+    public static String allValuesMatch()
+    {
+        return "RETURN ALL_MATCH(MAP_VALUES(input), f)";
+    }
+
+>>>>>>> 7f9f905f72 (Adding support for ALL_VALUES_MATCH)
     @SqlInvokedScalarFunction(value = "any_keys_match", deterministic = true, calledOnNullInput = true)
     @Description("Returns whether any key of a map matches the given predicate.")
     @TypeParameter("K")
@@ -133,6 +147,7 @@ public class MapSqlFunctions
     {
         return "RETURN NONE_MATCH(MAP_KEYS(input), f)";
     }
+<<<<<<< HEAD
 
     @SqlInvokedScalarFunction(value = "no_values_match", deterministic = true, calledOnNullInput = true)
     @Description("Returns whether no values of a map match the given predicate.")
@@ -144,4 +159,6 @@ public class MapSqlFunctions
     {
         return "RETURN NONE_MATCH(MAP_VALUES(input), f)";
     }
+=======
+>>>>>>> 7f9f905f72 (Adding support for ALL_VALUES_MATCH)
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAllValuesMatchFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAllValuesMatchFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+
+public class TestAllValuesMatchFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[1, 2, 3], ARRAY[4, 5, 6]), (x) -> x >= 4)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[-1, -2, -3], ARRAY[4, 5, 6]), (x) -> x < 5)",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY['ab', 'bc', 'cd'], ARRAY['xy', 'yz', 'zx']), (x) -> length(x) = 2)",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY[123.0, 99.5, 1000.99]), (x) -> x > 100.0)",
+                BOOLEAN,
+                false);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> x > 0)", BOOLEAN, true);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> x IS NOT NULL)", BOOLEAN, true);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> TRUE)", BOOLEAN, true);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> FALSE)", BOOLEAN, true);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY[], ARRAY[]), (x) -> CAST(NULL AS BOOLEAN))", BOOLEAN, true);
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("ALL_VALUES_MATCH(NULL, (x) -> x LIKE '%ab%')", BOOLEAN, null);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY['x', 'y'], ARRAY[1, 2]), (x) -> CAST(NULL AS BOOLEAN))", BOOLEAN, null);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY['x', 'y'], ARRAY[1, 2]), (x) -> IF(x < 2, true, CAST(NULL AS BOOLEAN)))", BOOLEAN, null);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY[1, 2, 3]), (x) -> IF(x >= 1 AND x <= 3, false, CAST(NULL AS BOOLEAN)))", BOOLEAN, false);
+        assertFunction("ALL_VALUES_MATCH(MAP(ARRAY['x', 'y', 'z'], ARRAY[1, 2, 3]), (x) -> IF(x <= 2, false, IF(x = 3, true, CAST(NULL AS BOOLEAN))))", BOOLEAN, false);
+    }
+
+    @Test
+    public void testComplexKeys()
+    {
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY[ROW('x', 1), ROW('y', 2)]), (x) -> x[1] = 'x')",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[2, 1], ARRAY[ROW('x', 1), ROW('x', -2)]), (x) -> x[2] >= 2)",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[100, 200, 500], ARRAY[ROW('x', 1), ROW('x', -2), ROW('x', 3)]), (x) -> x[1] = 'x')",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[1, 2], ARRAY[ROW('x', 1), ROW('y', 2)]), (x) -> x[2] LIKE '%ab%')",
+                SemanticErrorCode.TYPE_MISMATCH);
+        assertInvalidFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY[1, 2, 3], ARRAY[4, 5, 6]))",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "ALL_VALUES_MATCH(MAP(ARRAY['a', 'b', 'c'], ARRAY[4, 5, 6]), 1)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Test plan -

1. Added unit tests.
2. Build successfully using the following terminal command
    > ./mvnw clean install -Dtest=TestAllValuesMatchFunction -fn -pl presto-main

== RELEASE NOTES ==

- General Changes

   - Add support for ALL_VALUES_MATCH udf in Presto

   - Returns whether all values of a map match the given predicate. Returns true if all the values match the predicate (a special case is when the map is empty); false if one or more values don’t match; NULL if the predicate function returns NULL for one or more values and true for all other values.

   - SQL Syntax:
      > SELECT ALL_VALUES_MATCH(map(ARRAY[1, 2, 3], ARRAY['a', 'b', 'c']), x -> length(x) = 1); -- true