### PR TITLE
Disable “Product Tests Specific 2.6” and other flaky runs

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -42,8 +42,9 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro
       - name: Product Tests Specific 1.2
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
-      - name: Product Tests Specific 1.3
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
+      # temporarily disable this flaky run. see issue #20388 for details
+      # - name: Product Tests Specific 1.3
+      #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.4
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
@@ -95,7 +96,8 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
-      - name: Product Tests Specific 2.6
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
+      # temporarily disable this flaky run. see issue #20388 for details
+      # - name: Product Tests Specific 2.6
+      #  run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kafka -g kafka


### PR DESCRIPTION
Disable “Product Tests Specific 2.6” and other flaky run from product-tests-specific-environment.yml as this specific run keeps failing. See issue #20388 

Test plan - (Please fill in how you tested your changes)
CI runs

```
== NO RELEASE NOTE ==
```
