### PR TITLE
[native] Fix and re-enable testRowNumberWithFilter test

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2324,10 +2324,15 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     limit = *node->maxRowCountPerPartition;
   }
 
+  std::optional<std::string> rowNumberColumnName;
+  if (!node->partial) {
+    rowNumberColumnName = node->rowNumberVariable.name;
+  }
+
   return std::make_shared<core::RowNumberNode>(
       node->id,
       partitionFields,
-      node->rowNumberVariable.name,
+      rowNumberColumnName,
       limit,
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -16,7 +16,6 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -148,7 +147,6 @@ public abstract class AbstractTestNativeWindowQueries
     }
 
     @Test
-    @Ignore
     public void testRowNumberWithFilter()
     {
         assertQuery("SELECT sum(rn) FROM (SELECT row_number() over() rn, * from orders) WHERE rn = 10");


### PR DESCRIPTION
When partial aggregation for the RowNumber operator occurs skip generating the row numbers. This is based on a fix on the Velox side to only optionally generate the row numbers.

Re-enable the test that was disabled when the problem first appeared.

Fixes issue: https://github.com/prestodb/presto/issues/20227


```
== NO RELEASE NOTE ==
```
