### PR TITLE
[native pos] revert TaskMetrics update to end of task

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
@@ -18,7 +18,6 @@ import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.server.RequestErrorTracker;
 import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
-import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -118,11 +117,6 @@ public class HttpNativeExecutionTaskInfoFetcher
         taskInfo.set(result.getValue());
 
         errorTracker.requestSucceeded();
-
-        // Update Spark Accumulators for spark internal metrics
-        // Note: Updating here also serves as a heartbeat to spark scheduler
-        // that the task is making progress
-        PrestoSparkStatsCollectionUtils.collectMetrics(taskInfo.get());
 
         if (result.getValue().getTaskStatus().getState().isDone()) {
             synchronized (taskFinished) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -53,6 +53,7 @@ import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcessFactory;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTranslator;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleWriteInfo;
+import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spark.util.PrestoSparkUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.PagesSerde;
@@ -311,6 +312,9 @@ public class PrestoSparkNativeTaskExecutorFactory
         }
         SerializedTaskInfo serializedTaskInfo = new SerializedTaskInfo(serializeZstdCompressed(taskInfoCodec, taskInfoOptional.get()));
         taskInfoCollector.add(serializedTaskInfo);
+
+        // Update Spark Accumulators for spark internal metrics
+        PrestoSparkStatsCollectionUtils.collectMetrics(taskInfoOptional.get());
     }
 
     private static void processTaskInfoForErrorsOrCompletion(TaskInfo taskInfo)


### PR DESCRIPTION
Reverting (https://github.com/prestodb/presto/pull/20295) until
we figure out why metrics aren't updating.

Current investigation shows that TaskContext object, which is
needed during metrics update, is not available in the
HttpNativeExecutionTaskInfoFetcher thread. So reverting to doing
the task metrics update in the PrestoNativeTaskExecutorFactory
until we investigate and come with a fix.

```
== NO RELEASE NOTE ==
```
