### PR TITLE
Add release notes for 0.283

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.283 [2023-08-08] <release/release-0.283>
     release/release-0.282
     release/release-0.281
     release/release-0.280

--- a/presto-docs/src/main/sphinx/release/release-0.283.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.283.rst
@@ -1,0 +1,55 @@
+=============
+Release 0.283
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix Queued Query Count JMX Metrics (:issue:`19929`). Expose the QueryManagerStats metrics under the ``com.facebook.presto.dispatcher:name=DispatchManager`` namespace.
+* Fix issue while using the iceberg table property ``format_version`` when ``iceberg.catalog.type`` is hive (:issue:`19778`).
+* Fix join output for CrossJoinWithOrFilterToInnerJoin optimizer rule. It will fix potential failures with the message "Not all left output variables are before right output variables" when ``rewrite_cross_join_or_to_inner_join`` is enabled.
+* Fix join output in RandomizeNullKeyInOuterJoin rule. It will fix failures with the message "Not all left output variables are before right output variables" when ``randomize_outer_join_null_key`` is enabled.
+* Fix join re-ordering issues observed when dynamic filtering is turned on.
+* Improve performance of getting resource group metrics.
+* Add a optimizer rule ``RemoveIdentityProjectionsBelowProjection`` to remove identity projections under project node.
+* Add a session parameter ``use_broadcast_when_buildsize_small_probeside_unknown`` to choose join distribution type This session is default to false. When enabled, broadcast join will be chosen when one side of input is within broadcast limit and the other side is unknow.
+* Add function :func:`any_keys_match`.
+* Add function :func:`any_values_match`.
+* Add option to add partial row number node for row number node with max count limit, enabled by session parameter ``add_partial_node_for_row_number_node_with_limit``.
+* Add string functions :func:`starts_with` and :func:`ends_with`.
+* Add support for broadcast join in Presto-on-Spark/Velox execution path.
+* Add support for internal authentication using JWT. Can be configured using configs ``internal-communication.jwt.enabled=[true/false]`` and ``internal-communication.shared-secret=<shared-secret-value>``.
+* Add support for worker isolation by configuring leaf and intermediate worker pools.
+* Add timeout for HBO optimizer, timeout set by session parameter ``history_based_optimizer_timeout_limit``.
+* Added new property ``native-execution-broadcast-base-path``, which is used to specify base path for temporary storage of broadcast data for presto-on-spark native execution.
+* Remove support for Presto Server RPM.
+* Remove ``Experimental`` prefix from Dynamic Filtering.
+* Add support for Hive S3 configuration to Iceberg Hadoop and Nessie catalogs.
+
+Hive Changes
+____________
+* Fix a bug where the ParquetWriter throws "Size is greater than maximum int value" error when the table is large.
+* Add Prestissimo support to write Parquet table storage format.
+* Add support for the TTL of Alluxio SDK cache.
+
+JDBC Changes
+____________
+* Add cache support for JDBC metadata calls. This can be enabled by configuring parameter ``metadata-cache-ttl``, ``metadata-cache-refresh-interval`` and ``metadata-cache-size``.
+
+Native Changes
+______________
+* Add TPC-DS tests for native execution based on Parquet files.
+
+Presto on Spark Changes
+_______________________
+* Add optimization to switch the build and probe sides of a join at runtime when a query runs with adaptive execution. This optimizer can be enabled by setting the session property ``adaptive_join_side_switching_enabeld = true`` or configuration property ``optimizer.adaptive-join-side-switching-enabled = true``.
+
+**Credits**
+===========
+
+Ajay George, Ali Parsaei, Amit Dutta, Anant Aneja, Ankur Pathela, Ann Rose Benny, Arin Mathew, Avinash Jain, Beinan, Bikramjeet Vig, Bin Fan, Chandrashekhar Kumar Singh, Chunxu Tang, Deepak Majeti, Dongsheng Wang, Eduard Tudenhoefner, Elliotte Rusty Harold, Facebook Community Bot, Ge Gao, Haritha Koloth, Hunter Madison, Ivan Sadikov, Jalpreet Singh Nanda (:imjalpreet), Jaromir Vanek, Jialiang Tan, Jiayan Wei, Jimmy Lu, Karteekmurthys, Ke, Linsong Wang, Lyublena Antova, Mahadevuni Naveen Kumar, Masha Basmanova, Maxim Korolyov, Melissa Guo, Miaojiang (MJ) Deng, Michael Shang, Miguel Blanco Godón, Mikhail Slavoshevskii, Nikhil Collooru, Pedro Eugenio Rocha Pedreira, Pramod, Pranjal Shankhdhar, Pratyush Verma, Rebecca Schlussel, Reetika Agrawal, Rohan Pednekar, Rohit Jain, Sergey Pershin, Shrinidhi Joshi, Sotirios Delimanolis, Sreeni Viswanadha, Sudheesh, Timothy Meehan, Wei He, Zac, abhiseksaikia, aditi-pandit, feilong-liu, frankobe, jaystarshot, pratyakshsharma, v-jizhang, wypb, xiaoxmeng, yingsu00


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/20376 [native] Fix spill config name. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20025 Revert "[native] set allow table drop option in hive config" (Merged by: Amit Dutta)

## Ankur Pathela
- [ ] https://github.com/prestodb/presto/pull/19934 Revert drift version upgrade to fix netty errors (Merged by: Maria Basmanova)

## Avinash Jain
- [ ] https://github.com/prestodb/presto/pull/20320 Add support for NO_VALUES_MATCH UDF (Merged by: Rebecca Schlussel)
- [ ] https://github.com/prestodb/presto/pull/19838 Adding support for NO_KEYS_MATCH udf in presto (Merged by: Rebecca Schlussel)
- [ ] https://github.com/prestodb/presto/pull/19853 Adding support for all_key_match (Merged by: Rebecca Schlussel)

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/20231 Convert DATE to logical type (#5015) (Merged by: Michael Shang)

## Eduard Tudenhoefner
- [ ] https://github.com/prestodb/presto/pull/19761 Update Iceberg from 1.2.1 to 1.3.0 (Merged by: Chunxu Tang)

## Elliotte Rusty Harold
- [ ] https://github.com/prestodb/presto/pull/20302 Notify elharo on language changes (Merged by: Rebecca Schlussel)

## Jaromir Vanek
- [ ] https://github.com/prestodb/presto/pull/20313 Enable Presto-on-Spark to use multiple retry strategies after failure (Merged by: Jaromir Vanek)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/20372 [native] Remove inheritence relationship between AsyncDataCache and MemoryAllo… (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/20345 Remove IMemoryManager interface (Merged by: tanjialiang)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/19924 [native] Pass data columns to Velox (Merged by: Maria Basmanova)

## Karteekmurthys
- [ ] https://github.com/prestodb/presto/pull/20055 [native] Add ANALYZE STATS support (Merged by: Karteek)

## Linsong Wang
- [ ] 8d10f04eb05bef421124cad1a43091521e01fb16 Merge branch 'master' of https://github.com/prestodb/presto

## Lyublena Antova
- [ ] https://github.com/prestodb/presto/pull/20035 Introduce a session property to print the before and after plan node of specified optimizations (Merged by: Lyublena Antova)
- [ ] https://github.com/prestodb/presto/pull/19985 Add missing setter for optimizePayloadJoins in FeatureConfig (Merged by: Rebecca Schlussel)
- [ ] https://github.com/prestodb/presto/pull/19902 Track applicable optimizer rules (Merged by: Lyublena Antova)
- [ ] https://github.com/prestodb/presto/pull/19772 Track applicable optimizations that were disabled with a flag (Merged by: Lyublena Antova)

## Masha Basmanova
- [ ] https://github.com/prestodb/presto/pull/19941 Fix build (Merged by: Maria Basmanova)

## Miguel Blanco Godón
- [ ] https://github.com/prestodb/presto/pull/20262 Remove SocketChannelSocketFactory (Merged by: Timothy Meehan)

## Pedro Eugenio Rocha Pedreira
- [ ] https://github.com/prestodb/presto/pull/20298 [native pos] Add tests for json registration of functions with complex types (Merged by: Maria Basmanova)

## Pratyush Verma
- [ ] https://github.com/prestodb/presto/pull/20038 Revert "[native] Revert NULLIF specialForm support" (Merged by: Pratyush Verma)

## Rohan Pednekar
- [ ] https://github.com/prestodb/presto/pull/19919 Add release notes for 0.282 (Merged by: Linsong Wang)

## Sotirios Delimanolis
- [ ] https://github.com/prestodb/presto/pull/20282 Update Drift dependency to use Header transport by default and provide "thrift" ALPN (Merged by: Ajay George)
- [ ] https://github.com/prestodb/presto/pull/19953 Update Drift version to 1.36 (second attempt) (Merged by: Ajay George)
- [ ] https://github.com/prestodb/presto/pull/19782 Update Drift and Netty dependencies to support TLS 1.3  (Merged by: Ajay George)

## wypb
- [ ] https://github.com/prestodb/presto/pull/20342 [native] Advance Velox (Merged by: Deepak Majeti)

# Extracted Release Notes
- #19342 (Author: abhiseksaikia): Supporting worker isolation using worker pool
  - Add support for worker isolation by configuring leaf and intermediate worker pools.
- #19563 (Author: Rebecca Schlussel): Add ability to run AQE with optimizations end-to-end
  - Add optimization to switch the build and probe sides of a join at runtime when a query runs with adaptive execution.  This optimizer can be enabled by setting the session property ``adaptive_join_side_switching_enabeld = true`` or configuration property ``optimizer.adaptive-join-side-switching-enabled = true``.
- #19646 (Author: frankobe): [Native] Enable Tpcds Test for Parquet File
  - Add TPC-DS tests for native execution based on Parquet files.
- #19706 (Author: Mahadevuni Naveen Kumar): Add JWT for internal communication
  - Add support for internal authentication using JWT. Can be configured using configs "internal-communication.jwt.enabled=[true/false]" and "internal-communication.shared-secret=<shared-secret-value>".
- #19715 (Author: jaystarshot): Remove 'Experimental' Prefix from Dynamic Filtering as It's Now Stable
  - Emove 'Experimental' Prefix from Dynamic Filtering as It's Now Stable.
- #19759 (Author: Mikhail Slavoshevskii): Adding `starts_with` and `ends_with`
  - Add string functions :func:`starts_with` and :func:`ends_with`.
- #19779 (Author: Jalpreet Singh Nanda (:imjalpreet)): Fix issue while using iceberg table property format_version
  - Fix issue while using the iceberg table property ``format_version`` when ``iceberg.catalog.type`` is hive (:issue:`19778`).
- #19814 (Author: Avinash Jain): Adding support for ANY_KEYS_MATCH udf in presto
  - Add function :func:`any_keys_match`.
- #19835 (Author: feilong-liu): Add partial row_number node for row_number with max count limit
  - Add option to add partial row number node for row number node with max count limit, enabled by session parameter `add_partial_node_for_row_number_node_with_limit`.
- #19854 (Author: feilong-liu): Add optimization rule to remove identity projection under project node
  - Add a optimizer rule `RemoveIdentityProjectionsBelowProjection` to remove identity projections under project node.
- #19883 (Author: feilong-liu): Fix randomize null join key optimizer
  - Fix join output in RandomizeNullKeyInOuterJoin rule. It will fix failures with the message "Not all left output variables are before right output variables" when ``randomize_outer_join_null_key`` is enabled.
- #19889 (Author: feilong-liu): Fix join output order for cross join or optimizer rule
  - Fix join output for CrossJoinWithOrFilterToInnerJoin optimizer rule. It will fix potential failures with the message "Not all left output variables are before right output variables" when ``rewrite_cross_join_or_to_inner_join`` is enabled.
- #19905 (Author: Beinan): Add configs for ttl of Alluxio cache
  - Add support for the TTL of Alluxio SDK cache.
- #19916 (Author: Deepak Majeti): [native] Add support for Parquet Writer
  - Add Prestissimo support to write Parquet table storage format.
- #19917 (Author: Chandrashekhar Kumar Singh): [native pos] Add end to end functionality for file based broadcast
  - Add support for broadcast join in Presto-on-Spark/Velox execution path.
  - Added new property `native-execution-broadcast-base-path` which is used to specify base path for temporary storage of broadcast data for presto-on-spark native execution.
- #19930 (Author: Jalpreet Singh Nanda (:imjalpreet)): Fix computation of QueuedQueries JMX metrics
  - Fix Queued Query Count JMX Metrics (:issue:`19929`). Expose the QueryManagerStats metrics under the ``com.facebook.presto.dispatcher:name=DispatchManager`` namespace.
- #19933 (Author: feilong-liu): Add timeout for HBO stats fetch
  - Add timeout for HBO optimizer, timeout set by session parameter `history_based_optimizer_timeout_limit`.
- #19969 (Author: Anant Aneja): Remove unneeded identity projects
  - Fix join re-ordering issues observed when dynamic filtering is turned on.
- #19978 (Author: feilong-liu): Choose broadcast join when one side is small the other side is unknown
  - Add a session parameter `use_broadcast_when_buildsize_small_probeside_unknown` to choose join distribution type This session is default to false. When enabled, broadcast join will be chosen when one side of input is within broadcast limit and the other side is unknow.
- #20045 (Author: yingsu00): Fix ParquetWriter.getWrittenBytes()
  - Fix a bug where the ParquetWriter throws "Size is greater than maximum int value" error when the table is large.
- #20245 (Author: Melissa Guo): Add support for ANY_VALUES_MATCH function
  - Add function :func:`any_values_match`.
- #20269 (Author: Dongsheng Wang): Fix the performance problem of InternalResourceGroup.getActiveWorkCount
  - Improve performance of getting resource group metrics.
- #20352 (Author: Hunter Madison): Support S3FileIO in Hadoop and Nessie backed Iceberg tables.
  - Iceberg catalogues which use Hadoop or Nessie as catalogs now support reading from and writing to S3 with the same configuration options as the Hive catalog.
- #20354 (Author: Rebecca Schlussel): Remove Presto Server RPM
  - Remove support for Presto Server RPM.
- #20359 (Author: Nikhil Collooru): Add cache for jdbc metadata calls
  - Add cache support for jdbc metadata calls. This can be enabled by configuring parameter `metadata-cache-ttl`, `metadata-cache-refresh-interval` and `metadata-cache-size`.

# All Commits
- 6bb3164330ee1152e032d3342e0b25627662b1e8 Expose QueryManagerStats in JMX under DispatchManager namespace (Jalpreet Singh Nanda (:imjalpreet))
- ae36752423654a5f40345a6922d17e77e92e8da6 Fix computation of QueuedQueries JMX metric (Jalpreet Singh Nanda (:imjalpreet))
- e81cfb49822de2e4c9089c322697e75e892c25cc Stop computing queued queries in QueryManagerStats#trackQueryStats (Jalpreet Singh Nanda (:imjalpreet))
- 39b4d0586848079e0ca9ba62d1f12ff75bbfe214 Add documentation on how to invalidate hive metastore cache and list files cache (Jalpreet Singh Nanda (:imjalpreet))
- 28fb8dbf76d09f665fa8811ef54befd73b63df6d Revert "Upgrade Alluxio version to 301" (Rohit Jain)
- 3db67b039ba1ce8fb22f6e554d71c182bf1b3c08 [Native] Add scaled-writer support in prestissimo (Ke)
- 8f9f9ba319435bf46715d190d7960310836176bb Introduce AlternativeNullableLongStateSerializer for presto native (Ke)
- f852f66f3fba119241b11d158928c317619a02f8 [native pos] Use CompactRow serde for shuffle (Masha Basmanova)
- 7708096a4e83c6582e205a8cee3ce4240f280b4b [native] Add all parquet tests to a test group (Michael Shang)
- e1719d0964b4d9c8f5391644ac271b55533e666e Disable “Product Tests Specific 2.6” run (Michael Shang)
- 406a05c7a77016372bc6c6091a06b5902b424395 Remove inheritence relationship between AsyncDataCache and MemoryAllo… (#20372) (Jialiang Tan)
- 9d6a45f002b4e9ec601e4bcb928cb9de49705761 [native] Add support for SYSTEM TABLESAMPLE (aditi-pandit)
- c0c7b586c4a8f3e8fbb1554945c2a2a2c87b2b25 [native] Fix spill config name. (Amit Dutta)
- 6e969d9288e1c7cb3642a851386013094c1abdec [native pos] Fail the query if timed out fetching results from Velox (Masha Basmanova)
- 497d51fd9e9031958545941bc735480ff9afa9bd [native] Advance Velox (Masha Basmanova)
- 6f1ba2a698035daca548cc4ab1f679e9b0220608 Add Shrinidhi as codeowner for presto-spark* modules (Rebecca Schlussel)
- e532e7930dc5f4c9d7d5dcd9e5b6fb90c9cf6577 [native pos] Refactor TestPrestoSparkHttpClient (Masha Basmanova)
- ebee09c0e188ed54f883d86f96f8eb2a8d3a4d53 [native] Make node optional in spill path. (Amit Dutta)
- fbc8f74c4ab137376e2089bee12626ff5c182257 [native]Advance velox version (xiaoxmeng)
- 342dd5fbf335401c5884988d2809422c2d9febc3 Add timeout for HBO stats fetch (feilong-liu)
- c5e69ed77e14c8c71c3bceeb891a86e400033f13 Add optimizer failure field to PlanOptimizerInformation (feilong-liu)
- 7cd1a41f9f2ed0a24cb96efae381449c2e8eba25 Add cache for jdbc metadata calls (Nikhil Collooru)
- bc477b2c62dee45577b176d68eddd71f4d579f11 [native pos] Remove unused member variable (Masha Basmanova)
- c55c23edd5dadecd104970b6b692f0ad53d0dd54 [native pos] Fix log message (Masha Basmanova)
- c49fe112b2f23f57a92887564ccea3543a9f5ef8 Enable Presto-on-Spark to use multiple retry strategies after failure (Jaromir Vanek)
- 532e77f395f0a0782a843b441c071e27e073b392 Support S3FileIO in Hadoop and Nessie backed Iceberg tables. (Hunter Madison)
- fe4d5abe5068dba209472f5519dde84ef54e77ee [native] Reduce histogram counter width (Pranjal Shankhdhar)
- 336db7ea0344539ef4d61855d79a3a7188f07c41 Remove Presto Server RPM (Rebecca Schlussel)
- 88b4348b76f73051e4edde85ecd22bd8344fa715 [native pos] Add end to end functionality for file based broadcast (Chandrashekhar Kumar Singh)
- 2753a20595a1f71e7e2f285486e3ef3af9493322 [native] Advance velox version (Pranjal Shankhdhar)
- 26cfa7ed5f5798a5288ef92ba36c57c635605598 [native] Remove dependency on nodeConfig.nodeMemoryGb (Jialiang Tan)
- cfc51c036c0402e07e847d9e0e960eb1e8625e9d Remove IMemoryManager interface (Jialiang Tan)
- e1b6f768b549fb48fffa7287f2780ff8a5de29c2 [native] Map internal aggregate function names (Karteekmurthys)
- d541525b28f1da0f99a20e50482ecae4189bb57d Add to configure reclaimer for arbitration (xiaoxmeng)
- 8f6b2aba3d8e4a06fbf0891ce69f760dc5965b45 Fix the positin read in ByteArraySeekableStream in local cache test code (Beinan)
- 32864ecfd4b5087376a476cb0ca7f97a2de12dfe Upgrade Alluxio version to 301 (Beinan)
- e87320b9a484be9c41565e3e31e1f78d6a7e981b HBO: add cache for input table statistics (feilong-liu)
- c19003e051ea0bdd2fef53c0e04c10f4d306ffab [native] Add e2e test for aggregation companion function (Wei He)
- dca39c2135c6aa4e774e54ef48f834ecd55f330d [native] Fix presto_server_test build failure on MacOS (wypb)
- 3e573ec5f752962e2b956926ea00623d96c42a78 Fix critical severity security vulnarabilities (Haritha Koloth)
- 2ced880e0dc4079fb93dad43d30e2a48594aa6b1 Minor formatting fixes for ParquetReader (yingsu00)
- bbd729327bfaa430849093b36d12e498c42c2ad5 Fix ParquetWriter.getWrittenBytes() (yingsu00)
- 25194356bdb387814eb6178c0cca8269b032f0ec [native] Add e2e tests for window value functions (Pramod)
- 1ea75d97ae2098f14e031f911575036bffade435 Update Jenkinsfile to upload build artifacts to public repos (Linsong Wang)
- aae13e8dca9d5315e1863f0b93ddf1ec5474a144 Use custom executor for Exchange (Pranjal Shankhdhar)
- 4670d50bce813c2654d8a12d7c15f338a70f5935 Remove unneeded identity projects (Anant Aneja)
- ee896c8c3f902b1975cc305ff178e9cd5577b3eb [native] Add support for distinct aggregations (Masha Basmanova)
- ef5520c5530e7d2d8b51719bf19d8925f5207479 [native]Advance velox version (wypb)
- 094ca501ecbc689963ca2c775a4df4482d8a7148 Add support for NO_VALUES_MATCH UDF (Avinash Jain)
- 9cf9cc8efaea8b37f96a7d7678e9e6a6f78acfa6 [native]Advance velox version (xiaoxmeng)
- 0cbc9311b9979d887c6e70ddab880362bdc73c57 [native] Advance Velox (Deepak Majeti)
- 6156d4afcf983cee6a9f33e52ed88554d0374b4e Update Drift dependency to use Header transport by default (Sotirios Delimanolis)
- 0022a2eea7e8e3e933003e08b7dbebb53461480d Presto on Spark log functions invoked in query (Jiayan Wei)
- 2a831dc1c52c91da77b0378afdd0e2ac4b1b596e [native]Rename memory arbitration related configs (xiaoxmeng)
- 8a281d32cfb7f6d55abe44f229e4dca95614105c [native] Fix the problem that the Python.h file cannot be found when executing the setup-centos.sh script. (wypb)
- a2c35e424fc6b97975bf1f5ab30393871d3440a6 [native pos] Add serializedBytes runtime stats to PartitionAndSerialize (Masha Basmanova)
- 5ff964c96c272ec04651c9b09df8e3d9fa673d50 Add stats for Metastore table and partition names cache (Nikhil Collooru)
- 40fb5515216fd57495fac94fa9a950163b976350 [native] Add first version of json function signature parser (Pedro Eugenio Rocha Pedreira)
- fe508012940ad3b19ab38418d4996a8cfe310503 [native] Add e2e test for array flatten function (Zac)
- 984ad88b834dd12f37bf769a00180723e28af9ef [native] Remove unnecessary prefix in e2e test (Zac)
- 59ea9dc0542f8621dacf3aa1e719bd9a8db5618b [native]Add multi table writer driver support (xiaoxmeng)
- 57b056294a84080998c503a3707ff28f0e64e690 Add server operation to print task debug details (Pranjal Shankhdhar)
- 58848080e1161df27ddb1e5e88557aec7369779d Remove SocketChannelSocketFactory (Miguel Blanco Godón)
- 00ed8e236af5598da2e856d2d1e35f234a053a9d [native] Disable Q64 in tpc-ds due to flakiness in CI (frankobe)
- f375af2118e2a9f7b686946409d91fe75eac69ea [native] Add node information in spill path. (Amit Dutta)
- a536555447f0cfb5e74af5220513d1a36ca49d20 Add a pereiodic yield signal to Prestissimo (Ge Gao)
- 7a0616a8d686efd5931b9c7ec89024c40b85c15f Notify aditi-pandit on SQL language changes (aditi-pandit)
- 62bb876cfa693609ad25508d3c97a5bb6462a272 [native pos] Make sure to drain page buffer on success (Masha Basmanova)
- 1a67372d5d5c059bede10320261f19c3e387a820 [native pos] Add logging to help root cause data loss (Masha Basmanova)
- 650ca5de0b443df499f66b7b43ec31538bd8e2ce [Native] Pass down column stats aggregation info into TableWriterNode (Ke)
- b65b50032258eb4a2a8a9269d74f54737e767387 Change the function name for MaxDataSize and SumDataSize (Ke)
- 8d86ad911f0a094e15066c54c03d059ba802f7ba Add tests for json registration of functions with complex types (#20298) (Pedro Eugenio Rocha Pedreira)
- 66c897a1b5731a017d33044297fd7f87b6394d2e Introduce a session property to print the before and after plan node of specified optimizations (Lyublena Antova)
- 8e66c15eadab7065ee1c56cb9ecc2a1157547092 Notify elharo on language changes (Elliotte Rusty Harold)
- f08fe8d6e3be9b2bdca3a3c7984ad3679b48d2b4 [native pos] Detect CPP process crash and fail native task (Shrinidhi Joshi)
- a050f31dbf2426b7cd929c386da3be7dfd395d56 [native pos] Refactor HttpNativeExecutionTaskInfoFetcher (Shrinidhi Joshi)
- 5bac9d45cfb1e4a1133dbd82a2cd8928cbaa2202 [native pos] Fix warning on failure to update metrics (Masha Basmanova)
- 14560626cb39d9d59318d2aed8e101e08f2b1c4a Add helper method getValueLowerCase in Identifier (Ajay George)
- 79b291ee35e19f19373b7859b5a54944f89dc893 [native pos] Fix presto protocol generation by correcting java file path (Chandrashekhar Kumar Singh)
- f6064ba30fb8d1d8ccdb6fa4c8c4d5d28f3c63b4 Add support for ANY_VALUES_MATCH function (Melissa Guo)
- 1250341e05ac3b53f1d8146fe5808deb6e93c28a [pos] Remove BatchTaskUpdateRequest log line to mitigate TimeoutException (Ali Parsaei)
- 1817a0ef2853d71a43a850a9c4ea3276db9cdfdb Add codenotify workflow and rule for sql changes (Rebecca Schlussel)
- 76863c17ae5ef75ea88b59a8180b2f36f055415a [native pos] Propagate taskInfo updates to Spark metrics (Shrinidhi Joshi)
- 8f663522429e8ea0786cdda7c6525f781e65e5c7 Fix the performance problem of InternalResourceGroup.getActiveWorkCount (Dongsheng Wang)
- 9f2f540ee7bc6c07b9beb2531e3c2bfa621f54b9 [Native] Add physicalWrittenBytes in task status (Ke)
- 872b599851f1523152c04594aeb97998460bb58a [native pos] update README for presto_protocol generation (Chandrashekhar Kumar Singh)
- c1e31937624b8785be4cc15b60c99ea4d5c660c0 [native] Add e2e tests for array_sort lambda function (Masha Basmanova)
- b2803216ebabf6df4193dd1976ae78b1b65fe5ff [native] Advance Velox (Masha Basmanova)
- 8a66e0ea49eafa8f47527db725e77271a2df348f [native] Advance velox. (Amit Dutta)
- 96c0dcdb3b8c0f6e8ca49dad00364e8adea9c1d2 Minor SqlQueryExecution refactoring (Ajay George)
- c76c9f9fbaa90e0ef04390b9d55c282307cf0c39 [native] Advance Velox (Masha Basmanova)
- bac1a7825a6a505fa80d96c7c66988f1aafddc63 [native] Add e2e test for array concat presto function (Zac)
- 40d010904c8313d64afdb49c40b2a0524a8dd69e [native pos] Refactor dependency injection wiring for extensibility (Pratyush Verma)
- 7bb39882af0aedb67ec1ccba2956197b85f507f6 [native] Fail fast on distinct aggregations (Masha Basmanova)
- ef253199d38b3d891cf9b36ea6826a14ebe22aa4 Do not repartition in local exchange for partial row number node (feilong-liu)
- 388a942eb31c3822283fadc3441e4b40db2c5eab [native] Address nits in PrestoExchangeSource (Pranjal Shankhdhar)
- caa5acbda75ecff624b14b0bb3fdce4b28756023 [native] Pass data columns to Velox (Jimmy Lu)
- 5534a43f9fe1b843a5b011c446a659f559565d32 Update release-0.282.rst (Rohan Pednekar)
- 3271f7a728aec926e99e08d9c6457e7ee319c4c0 Optimize LIKE for simple prefix matches (Sreeni Viswanadha)
- 2e19564d0f36c212517647214a20850abad0b2b2 [native] Minor log fixes. (Amit Dutta)
- 2074845abfad60d91743f6130cad2109ed55bc00 [native]Advance velox version (xiaoxmeng)
- b6e98da3989519b2c4dca1dc439b21d7c16f2d7a Skip duplicate merge in hll. (Amit Dutta)
- a4abedd6cf39d05a8bd24687e8c1ce79d3a54ea0 Print plan cost estimation source in query plan (feilong-liu)
- 425c38d14323fce17f0dd40d843dc83269ad6c6e Update Jenkins pipeline to support deploying a cluster based on a PR as branch name (Linsong Wang)
- 49998a066daad41cfc478e27aeba1b9f5f400042 Add backoff to Exchange requests (Pranjal Shankhdhar)
- 6602fd8c648b67531e83189ea9db2f1a2c2ccdaf Update Velox submodule (Bikramjeet Vig)
- 507ca0c3b9572d8c68ddad57ca9a1eb5d1fa439c Convert DATE to logical type (#5015) (Aditi Pandit)
- d3a994642b8d5458e1a03f184fffed073c528132 [native] Fail fast when dereferencing anonymous fields (Masha Basmanova)
- bf923f64c4cedfc6a73e6e6d249e960dc2046ae5 [native] Disable flaky test (pratyakshsharma)
- 8a708e67f7e876232de97bab53d75365b59622b9 [native pos] Refactor package structure of presto-spark-base (Pratyush Verma)
- 32d1b12159356ae3bc8a16a38ce236e52eb1c525 [native pos] Skip creating empty broadcast files (Chandrashekhar Kumar Singh)
- a7fe2a9143a5f396e45c81a251d050e21bd58e1a Describe ScyllaDB storage support in connectors docs (Maxim Korolyov)
- 6717dd0e0ad8527edd843d8e78ba8fe7a9776abd [native pos] Check null pointer before use in spark test (Ke)
- e1013718fb3d0d87f6aeb09b359ba77eecf4cdbd [native] Expose getLocalIp to support ip per task. (Amit Dutta)
- 73d64a9065c0c55b241f04b243e094e861a29d10 Fix critical severity security vulnerabilities (Arin Mathew)
- 864619df81857c61db353af99455369452771f8f Optimize CASE expressions using only literals (Sreeni Viswanadha)
- 4d1bb73e7bddf4b59523ab621074843c0f0c09e5 [native]Add TableWriterMergeNode node (xiaoxmeng)
- 230eb3d210f81679c880451194978871ce34131a [native] Add e2e test for 3 arg min_by/max_by aggregate function (Pratyush Verma)
- a7dda16f9ac99187cef3cba73864587364e0c5ee [native] Advance velox (Pratyush Verma)
- 78c7c319ef275ce50b74c07bf19d243988b7c609 Add option to add partial row number node (feilong-liu)
- 319c2d1eb3cbea3f0935ddb229daa0583164fd33 Add is partial field to row number node (feilong-liu)
- 18e047bd95409470963c0d82a49eeef55a93c8cd [native] Handle same type NULLIF argument (Pratyush Verma)
- 56b3dfbfbed19c94760d5ed26f876956314f185f Choose broadcast join when one side is small the other side is unknown (feilong-liu)
- 1d331e04e0dcab30a6be1849db51089cd22506c3 [native] Advance velox and disable nullif tests. (Amit Dutta)
- 82a5692bcec8f247eb5d14312959a98ba35e8c73 Revert "[native] Revert NULLIF specialForm support" (Pratyush Verma)
- dee970509a04f1b9c05ceb3c7b33633b096a355a [native] Revert NULLIF specialForm support (Pratyush Verma)
- 952d2a6f4b3a0b97cbc162384c4cfafe1218343e update oracle connector docs (Linsong Wang)
- 420af675d1a372520eaf871664b0d9535dc62f4e [native] Random delay in announcement. (Amit Dutta)
- e2913293aee319fd49c5c967ab30732923a8277f [native] Handle NULLIF without the need for specialForm (Pratyush Verma)
- 2f351ff6b1fe9131c1511ccab8c2792bd76116d7 [refactor] Pass functionAndTypeManager to SqlToRowExpressionTranslator (Pratyush Verma)
- 1d50e608edcbcf603437207c2699dd3d6628d700 Revert "[native] set allow table drop option in hive config" (Amit Dutta)
- a87de0ee8f00219e1fa7c4def78dd2714e083af7 [native]Add to config memory arbitration in Prestissimo (xiaoxmeng)
- 88c548544df80a8d97e60349e2195f42cdea6706 Support worker isolation using worker pool (abhiseksaikia)
- c3dbf9a6655a36321dc595222f256f5e52889547 [Native] Add e2e test for table writer special partition name (Ke)
- cbf7a7776cc91a7e22fc8565956ece07b9fc4f50 [native] set allow table drop option in hive config (xiaoxmeng)
- 9e1e15903dd928b55132d2c12b8b52b14f6096a5 [native] Use different commit strategies in Velox query plan converters (Ge Gao)
- 6570b002459db60784c9235c98752625fc6498c3 [native]Add non-sorted bucket write support (xiaoxmeng)
- c275241b7ad476902c5a0d20ee0e5dddca5b3bf7 [Native] Introduce outputVariables in StatisticAggregations (Ke)
- 4b267a06e445c2d19eac9051533c6c399f5163de Introduce outputVariables in StatisticAggregations (Ke)
- b31b6e5e29f39c0d01ec75d2a2fe213cc6b5f76c [native] Fix TestTypeSignature (Pratyush Verma)
- 435ca0c5cf98430054d35664c23102abf4134cd1 [native] Log Zombie task info (Pranjal Shankhdhar)
- 662d8749876846c4f981164775fecb874035df96 Expose 'partial' flag for TopNRowNumberNode in PlanPrinter (Masha Basmanova)
- fec326b07c593d8ba268a4dd102b9f70022dc6ca [native] Enable Q2, Q78 in tpc-ds (frankobe)
- a8fa471f290a39526b20dbd8987d3a9f9175db4d [native] Add type convert for IntervalYearMonthType (Ke)
- d7e653defb460dca550b2771a59e811df86f1852 [native pos] Fix dropping of columns in PartitionAndSerialize (Masha Basmanova)
- cb15ac08f9541a76c75408f962ed5a7c5a7f62bc [native] Fix translation for TopNRowNumberNode (Masha Basmanova)
- 71ea71c0406398f03d363ec6926390a009fa9089 [native] Advance Velox version. (Sergey Pershin)
- 5919a5a6d4abad09955c66830b12e45ba2ba077b Update Drift and Netty dependencies to support TLS 1.3 (Sotirios Delimanolis)
- c1cc78174352ee94fe4a6e7b7be834adf9bc7baa Add missing setter for optimizePayloadJoins in FeatureConfig (Lyublena Antova)
- c5db90521f62ce9ed51c4fa98ea9696c3bea4b77 Add support for no_keys_match function (Avinash Jain)
- aaab9152f2d9ee292d028d8486c20c271d7735fc [native pos] Enable testDateFilter and testCreateUnpartitionedTableAsSelect (Masha Basmanova)
- 4522def7c862df304105488d64958fd52c63dae1 [native] Remove PRESTO_ENABLE_PARQUET definition (Deepak Majeti)
- 14c50ef6f9e477903388701ba4977fbc6b396555 Add support for any_keys_match function (Avinash Jain)
- bc2ec7399a7fb630d4f172ea2e4be346b3cc8a48 Remove redundant throws clause (Ajay George)
- 05dcda3c503c9b57c93654afb3304ae6d6670a71 [native] Link velox_dwio_parquet_reader/writer unconditionally (Masha Basmanova)
- 529dd4c5567a94537bb555e482b018a0c4a6c941 [native pos] Simplify replicate-nulls-and-any logic (Masha Basmanova)
- d7d472be0d393b97ec4d3f951d7656feafb28c92 [native] Remove PRESTO_ENABLE_PARQUET logic from PrestoServer.cpp (Masha Basmanova)
- b77ffc5f3fe1494b53e4368b5ac2b782ba04e2bb [Native] Enable reorder warning (Deepak Majeti)
- 28f3ee03abcf2c2d6272ce12fd4756c8835a759d [native] Add e2e test for insert into partitioned table (Ge Gao)
- 2a1ce0b0d1643f1ff5fd8536a8486ec0e22aceea [native pos] Remove busy-waiting-loop to reduce the CPU usage (Miaojiang (MJ) Deng)
- d4df80b822e4a25ad6f846e8266cdd7566310bf1 Revert "[native] Randomize retry time with jitter after worker announcement failure." (frankobe)
- 6e1f475584393372bb89c295692fec011b6908e9 Add support for all_keys_match function (Avinash Jain)
- 4dc0826f8f727963c7b310f49f290b5f31234f7c Fix MergeJoinNode does not have a Graphviz visitor (Masha Basmanova)
- 0fd63de3d48365039d0b9e5e270896f03616f6b1 [native] Add support for SemiJoinNode (Masha Basmanova)
- 535ece0d1dd20a56ab7e85efc92fd56e4fc6ce25 Fix build (Masha Basmanova)
- f2d55d11f4f4ab4702878bca3c22c2cfe7f2521a Revert drift version upgrade to fix netty errors (Ankur Pathela)
- 8855a05d4d425e2776d76148497388484ab9701f Add JWT for internal communication (Mahadevuni Naveen Kumar)
- dda198381ee176eedde0c9f27442ea00324f9602 [native] Add support for ValuesNode with expressions (Masha Basmanova)
- edabfe048b8b67bf63d1f838a328ad06f1f78652 [native] Add support and E2E tests for Parquet Writer (Deepak Majeti)
- 675125eba51b94a43bfe72a6eeacead7251a1a92 Fix issue while using iceberg table property format_version (imjalpreet)
- b893d88031352b9a4bae896daa1ef0f69809d88c Add configs for ttl of Alluxio cache (Beinan)
- e7f67da2023637c0b8996c543a64501073cd1454 [native pos] Change thread pool initial size to 1 to reduce the CPU time (Miaojiang (MJ) Deng)
- bfc8e3b438072f45e7a663f9cf2e61ccc39df9d1 [native]Add to call file sink registration in server startup (xiaoxmeng)
- b0cde2e4a2ab9fe2c3576dd50acc330938cff6e3 [native] Randomize retry time with jitter after worker announcement failure. (Amit Dutta)
- c0eedcb5718850a1ffa03642cd0b8ac701b57af3 [native] Add retry logic to Spark tests (v-jizhang)
- 3b26dcd3f7ed7677d079074695354e8b838b6b2f [Native] Add TPC-DS for parquet in presto-native-execution (frankobe)
- 40554ce4e2e1999ac51aaf1da5d67c9eb40c51e3 [native]Add register file sink interface to presto server (xiaoxmeng)
- 5bb31622cfea1235174bfbc45ad6cc10be6a0885 Track applicable optimizations that were disabled with a flag (Lyublena Antova)
- 0fcc287b3e25d0adb5ef25061c04c5cd6aa90f94 [native] Make CircleCI linux build run only once for all tests containers (v-jizhang)
- b5e27f4b484f5c53eef37c4918d222194617d976 [native] Disable native github actions job (Michael Shang)
- 293277f5cc794c1165a67b06b4a3ebe5c9374711 [native] Advance velox. (Amit Dutta)
- e8bcfeff25a3c3c102f776ab7ffe4d730b097fc7 Update Iceberg from 1.2.1 to 1.3.0 (Eduard Tudenhoefner)
- 024b79239473df8a60cf67ea3d06a649c42032c8 Revert "Track applicable optimizations that were disabled with a flag" (Ge Gao)
- 8a6ea3171dd2519fe76e64011a0c1f018d40ca53 [native] Fix presto-native-execution README for running setup-adapters script (imjalpreet)
- 0b83c8dbeef3523f165d3496fef4e8faa09cf5db Add join output order check in JoinNode constructor (feilong-liu)
- a4331546ab611a9c8c9889788ebd3a3656727b76 Update Drift and Netty dependencies to support TLS 1.3 (Sotirios Delimanolis)
- a26bdf21acfd1160c7b28e20f5c50dce7859bb77 [native] Add e2e tests for array trim. (Amit Dutta)
- b0384b141f7e65e51ecb0faf464d1ae04d37ef9b [native pos] Move ShuffleWriter creation out of Task creation (Masha Basmanova)
- 5ce9598e6f0b35ad0b5db7c319d7f8248e6c9b95 [native] Advance velox. (Amit Dutta)
- 829d711494ecddc9f0efe34ada87f37a3b64044f [native]Update Prestissimo code according to velox change (xiaoxmeng)
- 089bbb1964c0a17d36b39022bcfb6876d5b92549 [native] Add mappings for $internal$json_string_to_array/map/row_cast (Masha Basmanova)
- ac8b3f65a3ed2399d740d3ff72ade879bafdbae7 [native pos] Enable TestPrestoSparkNativeGeneralQueries#testUnionAll (Miaojiang (MJ) Deng)
- 38a404c218ba6f5faa8eada6ac077aa7feb1f4cc Fix join output for cross join or optimizer rule (feilong-liu)
- bc1273ab91e03618f2c5e126d6e94306e947cc06 Fix randomize null join key optimizer (feilong-liu)
- 4e020ff3ac57227467cbf69c64534f314715decc Fix use-after-free in HTTP callbacks (#19863) (#19865) (Pranjal Shankhdhar)
- 8f9b5d4cde20baf6a1eb4f51bcfd3e6c1f34091a [native] Add ccache to speed up build (v-jizhang)
- 9969ee18da501f492a262014d016c8303a96338e [native pos] allow drop table for native java test runner (Miaojiang (MJ) Deng)
- 517d570304f8955edd1f893a2f6a39fa9fbeeff5 Add optimization rule to remove identity projection under project node (feilong-liu)
- 23222a559ef6f632059cc79373f03eb91291e2db [Native] Update CI Image and advance Velox (Michael Shang)
- 07b9712d444db1e01512ca977f9e3ee1d90de817 adding starts_with and ends_with (Mikhail Slavoshevskii)
- 4be65df67ac9c163d0773d008dcd002000fcee01 [native] Add table name to pushdown enable check error message (Jimmy Lu)
- 140a891419b29c2643e7276ef08166e543d2484d [native pos] Add broadcast read support for file based broadcast (Chandrashekhar Kumar Singh)
- e4c8fb439bcd9c7b5563734a33316adbbb9a4a73 add e2etesting for beta_cdf (Ann Rose Benny)
- bcdb21dd4ef0bd38d5f56f90789aa923d755d4cb [native]turn on bigint compile option for folly to support velox (xiaoxmeng)
- 54149b892d7ae5e215be9997b05fd72dd3135547 [native] Split tests in E2E and run in parallel (v-jizhang)
- 5039ce54123ecc8d9c3c4ca843f4442bce19a887 Track applicable optimizations that were disabled with a flag (Lyublena Antova)
- a2ee05cfc7c4d22ebaf969a57b136a209dcec589 Iceberg connector document update about metadata tables (Reetika Agrawal)
- c0eb1b22544190cd8bca8f8295d766fb21a1e8db Remove documentation about Alluxio Structured Data Service (Bin Fan)
- fa07644175b10d9fe6eb00eb29bd17b98d3ba6e9 [native pos] Add close method to IPrestoSparkTaskExecutorFactory (Shrinidhi Joshi)
- 74b78abac1b2d1f84b208680b4b5b1ac0f3efe9c [native pos] Remove NativeExecutionInfo special handling (Shrinidhi Joshi)
- d00c77f49f42101cf8c3a61105c604c4ec0671c9 [native pos] Remove NativeExecutionNode and NativeExecutionOperator (Shrinidhi Joshi)
- f65fd092966c05c7eba3e6716236be2b442b4ca4 [native pos] Update SparkMetrics integration to work with NativeTaskExecutorFactory (Shrinidhi Joshi)
- 767b330b90c63316b521a37b41c11159781a0137 [native pos] Remove NativeExecutionNode plan rewrite (Shrinidhi Joshi)
- 4c0ed652ae164b8a6be7a73f4a124a6f9790bd6c [native pos] Add PrestoSparkNativeTaskExecutorFactory (Shrinidhi Joshi)
- 37a05171308cde8478a3bced0bc51613afaa64de [native] Handle Date type in toFilter function (Ivan Sadikov)
- 9f35166218fa8ec4d9cd6482a37cbfca32ea8f31 Remove 'Experimental' Prefix from Dynamic Filtering as It's Now Stable (jaystarshot)
- 8ec175617d5c51e8d4ae0ddca9fd6dcce41c7d50 Remove unused field in PrestoSparkAdaptiveQueryExecution (Rebecca Schlussel)
- e63d3597332ee6a4addd548966fb0c47cb71a336 Move shared methods to JoinSwappingUtils (Rebecca Schlussel)
- cb83306c6bfe812aa72217e9f41d07d07ec3b1a7 Add re-optimization step for AQE (Rebecca Schlussel)
- b9bdd105a91b591f9ecf740fc087035f439f3cfa Fix PickJoinSides handling of local exchanges (Rebecca Schlussel)
- 3b631b40d02a02109bc637b98dea003551191e67 Fix formatting in DetermineJoinDistributionType (Rebecca Schlussel)
- e4190fc40d9984fad8d6ab43f2fb48b63b7442a5 Add RemoteSourceNode as option for size-based join (Rebecca Schlussel)
- d4a459fc2393b866cf37b10bdbd469f27e77c453 Add PrestoSparkStatsCalculator to combine runtime and HBO stats (Rebecca Schlussel)
- 297b6921730bf61718562d22beb01a5fb05bdde3 Propagate statsEquivalentPlanNode for RemoteSource (Rebecca Schlussel)
- c46279732a949c91a94457d84f980c5cf30efcaa Upgrade jansi to 1.18 (Chunxu Tang)
- 8d10f04eb05bef421124cad1a43091521e01fb16 Merge branch 'master' of https://github.com/prestodb/presto (Linsong Wang)
- fc3ccc8f840f0dc8a63f62036b31d4188e6f0941 [native]Add bucket table check on write in Prestissimo (xiaoxmeng)