### PR TITLE
Refactor HiveConnector.h to cleanup includes

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/Driver.h"
+#include "velox/common/caching/SsdCache.h"
 
 #include <sys/resource.h>
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -30,6 +30,9 @@
 #include "presto_cpp/main/operators/ShuffleRead.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include <velox/core/Expressions.h>
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/expression/Expr.h"
 // clang-format on
 
 #include <folly/container/F14Set.h>

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -26,6 +26,7 @@
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/connectors/hive/TableHandle.h"
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
Summary:
Includes in public header files can result in header leaks and result in unnecessary dependencies
on the clients. This change removes Protobuf header requirement in Prestissimo.

X-link: https://github.com/facebookincubator/velox/pull/5781

Reviewed By: xiaoxmeng

Differential Revision: D47727923

Pulled By: kgpai

