### PR TITLE
Fix flaky test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -49,7 +49,6 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder.builder;
 import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -130,6 +129,11 @@ public class TestQueryManager
         // Create 3 running queries to guarantee queueing
         createQueries(dispatchManager, 3);
         QueryId queryId = dispatchManager.createQueryId();
+
+        //Wait for the queries to be in running state
+        while (dispatchManager.getStats().getRunningQueries() != 3) {
+            Thread.sleep(1000);
+        }
         dispatchManager.createQuery(
                         queryId,
                         "slug",
@@ -138,7 +142,10 @@ public class TestQueryManager
                         "SELECT * FROM lineitem")
                 .get();
 
-        assertNotEquals(dispatchManager.getStats().getQueuedQueries(), 0L, "Expected 0 queued queries, found: " + dispatchManager.getStats().getQueuedQueries());
+        //Wait for query to be in queued state
+        while (dispatchManager.getStats().getQueuedQueries() != 1) {
+            Thread.sleep(1000);
+        }
 
         Stopwatch stopwatch = Stopwatch.createStarted();
         // wait until it's admitted but fail it before it starts


### PR DESCRIPTION
The test was not waiting for queries to be in running/queued state before moving forward. Given the nature of DispatchManager it takes some time for queries to move to the right state. This resulted in flaky behavior. As part of the fix, we are waiting for the queries to be in right state before moving forward and that fixes the flakiness of the test.

Test plan - unit test with multiple invocationCount locally.

Fixes: https://github.com/prestodb/presto/issues/20408

```
== NO RELEASE NOTE ==
```
