### PR TITLE
Fix join reordering for non-trivial equi join conditions

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
@@ -2,6 +2,22 @@ remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
+                remote exchange (REPARTITION, HASH, [subtract_400])
+                    join (INNER, PARTITIONED):
+                        final aggregation over (d_week_seq_232)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [d_week_seq_232])
+                                    partial aggregation over (d_week_seq_232)
+                                        join (INNER, REPLICATED):
+                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                scan web_sales
+                                                scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [d_week_seq_316])
+                                scan date_dim
                 join (INNER, PARTITIONED):
                     final aggregation over (d_week_seq)
                         local exchange (GATHER, SINGLE, [])
@@ -17,20 +33,3 @@ remote exchange (GATHER, SINGLE, [])
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [d_week_seq_83])
                             scan date_dim
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, [subtract])
-                        join (INNER, PARTITIONED):
-                            final aggregation over (d_week_seq_232)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [d_week_seq_232])
-                                        partial aggregation over (d_week_seq_232)
-                                            join (INNER, REPLICATED):
-                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                    scan web_sales
-                                                    scan catalog_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [d_week_seq_316])
-                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q59.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q59.plan.txt
@@ -1,7 +1,7 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, [d_week_seq, s_store_id])
+            remote exchange (REPARTITION, HASH, [d_week_seq, d_week_seq_267, s_store_id])
                 join (INNER, REPLICATED):
                     join (INNER, REPLICATED):
                         final aggregation over (d_week_seq, ss_store_sk)
@@ -20,7 +20,7 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             scan store
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, [s_store_id_235, subtract])
+                remote exchange (REPARTITION, HASH, [d_week_seq_147, d_week_seq_63, s_store_id_235])
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
                             final aggregation over (d_week_seq_147, ss_store_sk_127)

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression.Form;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -519,6 +520,17 @@ public final class LogicalRowExpressions
         public ConvertNormalFormVisitorContext childContext()
         {
             return new ConvertNormalFormVisitorContext(expectedClauseJoiner, depth + 1);
+        }
+    }
+
+    private static class VariableReferenceBuilderVisitor
+            extends DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<VariableReferenceExpression>>
+    {
+        @Override
+        public Void visitVariableReference(VariableReferenceExpression variable, ImmutableSet.Builder<VariableReferenceExpression> builder)
+        {
+            builder.add(variable);
+            return null;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -287,6 +287,7 @@ public final class SystemSessionProperties
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
     public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
+    public static final String HANDLE_COMPLEX_EQUI_JOINS = "handle_complex_equi_joins";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1673,6 +1674,11 @@ public final class SystemSessionProperties
                         INFER_INEQUALITY_PREDICATES,
                         "Infer nonequality predicates for joins",
                         featuresConfig.getInferInequalityPredicates(),
+                        false),
+                booleanProperty(
+                        HANDLE_COMPLEX_EQUI_JOINS,
+                        "Handle complex equi-join conditions to open up join space for join reordering",
+                        featuresConfig.getHandleComplexEquiJoins(),
                         false));
     }
 
@@ -2820,5 +2826,10 @@ public final class SystemSessionProperties
     public static boolean shouldInferInequalityPredicates(Session session)
     {
         return session.getSystemProperty(INFER_INEQUALITY_PREDICATES, Boolean.class);
+    }
+
+    public static boolean shouldHandleComplexEquiJoins(Session session)
+    {
+        return session.getSystemProperty(HANDLE_COMPLEX_EQUI_JOINS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -278,6 +278,7 @@ public class FeaturesConfig
     private boolean rewriteConstantArrayContainsToIn;
 
     private boolean preProcessMetadataCalls;
+    private boolean handleComplexEquiJoins = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2749,6 +2750,19 @@ public class FeaturesConfig
     public FeaturesConfig setRewriteConstantArrayContainsToInEnabled(boolean rewriteConstantArrayContainsToIn)
     {
         this.rewriteConstantArrayContainsToIn = rewriteConstantArrayContainsToIn;
+        return this;
+    }
+
+    public boolean getHandleComplexEquiJoins()
+    {
+        return handleComplexEquiJoins;
+    }
+
+    @Config("optimizer.handle-complex-equi-joins")
+    @ConfigDescription("Handle complex equi-join conditions to open up join space for join reordering")
+    public FeaturesConfig setHandleComplexEquiJoins(boolean handleComplexEquiJoins)
+    {
+        this.handleComplexEquiJoins = handleComplexEquiJoins;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -243,7 +243,8 @@ public class TestFeaturesConfig
                 .setAddPartialNodeForRowNumberWithLimitEnabled(true)
                 .setInferInequalityPredicates(false)
                 .setPullUpExpressionFromLambdaEnabled(false)
-                .setRewriteConstantArrayContainsToInEnabled(false));
+                .setRewriteConstantArrayContainsToInEnabled(false)
+                .setHandleComplexEquiJoins(true));
     }
 
     @Test
@@ -435,6 +436,7 @@ public class TestFeaturesConfig
                 .put("optimizer.infer-inequality-predicates", "true")
                 .put("optimizer.pull-up-expression-from-lambda", "true")
                 .put("optimizer.rewrite-constant-array-contains-to-in", "true")
+                .put("optimizer.handle-complex-equi-joins", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -623,7 +625,8 @@ public class TestFeaturesConfig
                 .setAddPartialNodeForRowNumberWithLimitEnabled(false)
                 .setInferInequalityPredicates(true)
                 .setPullUpExpressionFromLambdaEnabled(true)
-                .setRewriteConstantArrayContainsToInEnabled(true);
+                .setRewriteConstantArrayContainsToInEnabled(true)
+                .setHandleComplexEquiJoins(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
@@ -439,6 +439,7 @@ public class TestDynamicFilter
                 "SELECT 1 FROM part t0, part t1, part t2 " +
                         "WHERE t0.partkey = t1.partkey AND t0.partkey = t2.partkey " +
                         "AND t0.size + t1.size = t2.size",
+                noJoinReordering(),
                 anyTree(
                         join(
                                 INNER,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -100,7 +100,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * RowExpression visitor which verifies if given expression (actual) is matching other RowExpression given as context (expected).
  */
-final class RowExpressionVerifier
+public final class RowExpressionVerifier
         extends AstVisitor<Boolean, RowExpression>
 {
     // either use variable or input reference for symbol mapping
@@ -110,7 +110,7 @@ final class RowExpressionVerifier
     private final FunctionResolution functionResolution;
     private final Set<String> lambdaArguments;
 
-    RowExpressionVerifier(SymbolAliases symbolAliases, Metadata metadata, Session session)
+    public RowExpressionVerifier(SymbolAliases symbolAliases, Metadata metadata, Session session)
     {
         this.symbolAliases = requireNonNull(symbolAliases, "symbolLayout is null");
         this.metadata = requireNonNull(metadata, "metadata is null");

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -15,46 +15,69 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.cost.CachingCostProvider;
 import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.CostProvider;
 import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.LogicalPropertiesProvider;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.assertions.RowExpressionVerifier;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerationResult;
 import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerator;
+import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerator.JoinCondition;
 import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.MultiJoinNode;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.expressions.RowExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerator.generatePartitions;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.sql.planner.optimizations.JoinNodeUtils.toRowExpression;
+import static com.facebook.presto.sql.relational.Expressions.variable;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestJoinEnumerator
 {
@@ -62,14 +85,20 @@ public class TestJoinEnumerator
     private Metadata metadata;
     private DeterminismEvaluator determinismEvaluator;
     private FunctionResolution functionResolution;
+    private PlanBuilder planBuilder;
+    private TestingRowExpressionTranslator rowExpressionTranslator;
+    private Session session;
 
     @BeforeClass
     public void setUp()
     {
-        queryRunner = new LocalQueryRunner(testSessionBuilder().build());
+        session = testSessionBuilder().build();
+        queryRunner = new LocalQueryRunner(session);
         metadata = queryRunner.getMetadata();
         determinismEvaluator = new RowExpressionDeterminismEvaluator(metadata);
         functionResolution = new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver());
+        planBuilder = new PlanBuilder(session, new PlanNodeIdAllocator(), metadata);
+        rowExpressionTranslator = new TestingRowExpressionTranslator(metadata);
     }
 
     @AfterClass(alwaysRun = true)
@@ -109,7 +138,8 @@ public class TestJoinEnumerator
         MultiJoinNode multiJoinNode = new MultiJoinNode(
                 new LinkedHashSet<>(ImmutableList.of(p.values(a1), p.values(b1))),
                 TRUE_CONSTANT,
-                ImmutableList.of(a1, b1));
+                ImmutableList.of(a1, b1),
+                Assignments.builder().build());
         JoinEnumerator joinEnumerator = new JoinEnumerator(
                 new CostComparator(1, 1, 1),
                 multiJoinNode.getFilter(),
@@ -120,6 +150,94 @@ public class TestJoinEnumerator
         JoinEnumerationResult actual = joinEnumerator.createJoinAccordingToPartitioning(multiJoinNode.getSources(), multiJoinNode.getOutputVariables(), ImmutableSet.of(0));
         assertFalse(actual.getPlanNode().isPresent());
         assertEquals(actual.getCost(), PlanCostEstimate.infinite());
+    }
+
+    @Test
+    public void testJoinClauseAndFilterInference()
+    {
+        ImmutableMap.Builder<String, Type> builder = ImmutableMap.builder();
+        builder.put("a", BIGINT);
+        builder.put("b", BIGINT);
+        builder.put("c", BIGINT);
+        builder.put("d", BIGINT);
+        Map<String, Type> variableMap = builder.build();
+        VariableReferenceExpression a = variable("a", variableMap.get("a"));
+        VariableReferenceExpression b = variable("b", variableMap.get("b"));
+        VariableReferenceExpression c = variable("c", variableMap.get("c"));
+        VariableReferenceExpression d = variable("d", variableMap.get("d"));
+
+        SymbolAliases.Builder newAliases = SymbolAliases.builder();
+        newAliases.put("A", new SymbolReference("a"));
+        newAliases.put("B", new SymbolReference("b"));
+        newAliases.put("C", new SymbolReference("c"));
+        newAliases.put("D", new SymbolReference("d"));
+        SymbolAliases symbolAliases = newAliases.build();
+
+        // Simple join predicates on variable references
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b"), ImmutableSet.of(a), ImmutableSet.of(b, c), "A = B", null);
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b", "c = d"), ImmutableSet.of(a, c), ImmutableSet.of(b, d), "A = B AND C = D", null);
+        // Complex join predicate - All variables must be from one join side to have the predicate be an equi-join clause
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b + c"), ImmutableSet.of(a), ImmutableSet.of(b, c), "A = B + C", null);
+        // Left and right side designation can be switched
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b + c"), ImmutableSet.of(b, c), ImmutableSet.of(a), "A = B + C", null);
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b + c + 1"), ImmutableSet.of(a), ImmutableSet.of(b, c), "A = B + C + 1", null);
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = b + c + 1"), ImmutableSet.of(b, c), ImmutableSet.of(a), "A = B + C + 1", null);
+        // If a predicate has a mix of variables from left & right sides, the predicate is treated as a filter
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a + b = c"), ImmutableSet.of(a), ImmutableSet.of(b, c), null, "A + B = C");
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a + b = 1"), ImmutableSet.of(a), ImmutableSet.of(b), null, "A + B = 1");
+        // Test with multiple equi-join conditions and filters
+        assertJoinCondition(symbolAliases, toRowExpressionList(variableMap, "a = ABS(b)", "a = ceil(b-c)", "b = c + 10"),
+                ImmutableSet.of(a), ImmutableSet.of(b, c), "A = abs(B) AND A = ceil(B-C)", "B = C + 10");
+    }
+
+    private List<RowExpression> toRowExpressionList(Map<String, Type> variableTypeMap, String... predicates)
+    {
+        return Arrays.stream(predicates)
+                .map(p -> rowExpressionTranslator.translate(p, variableTypeMap))
+                .collect(Collectors.toList());
+    }
+
+    private void assertJoinCondition(SymbolAliases symbolAliases, List<RowExpression> joinPredicates, Set<VariableReferenceExpression> leftVariables,
+            Set<VariableReferenceExpression> rightVariables, String expectedEquiJoinClause, String expectedJoinFilter)
+    {
+        RowExpressionVerifier verifier = new RowExpressionVerifier(symbolAliases, metadata, session);
+        JoinEnumerator joinEnumerator = new JoinEnumerator(
+                new CostComparator(1, 1, 1),
+                TRUE_CONSTANT,
+                createContext(),
+                determinismEvaluator,
+                functionResolution,
+                metadata);
+
+        JoinCondition joinConditions = joinEnumerator.extractJoinConditions(joinPredicates,
+                leftVariables, rightVariables, new VariableAllocator());
+
+        Optional<RowExpression> equiJoinExpressionInlined = joinConditions.getJoinClauses().stream()
+                .map(criteria -> toRowExpression(criteria, functionResolution))
+                // We may have made left or right assignments to build the equi join clause
+                // We inline these assignments for building the equi join clause to verify
+                .map(expression -> replaceExpression(expression, joinConditions.getNewLeftAssignments()))
+                .map(expression -> replaceExpression(expression, joinConditions.getNewRightAssignments()))
+                .reduce(LogicalRowExpressions::and);
+
+        if (equiJoinExpressionInlined.isPresent()) {
+            assertNotNull(expectedEquiJoinClause);
+            assertTrue(verifier.process(expression(expectedEquiJoinClause), equiJoinExpressionInlined.get()));
+        }
+        else {
+            assertNull(expectedEquiJoinClause);
+        }
+
+        Optional<RowExpression> joinFilter = joinConditions.getJoinFilters().stream()
+                .reduce(LogicalRowExpressions::and);
+
+        if (joinFilter.isPresent()) {
+            assertNotNull(expectedJoinFilter);
+            assertTrue(verifier.process(expression(expectedJoinFilter), joinFilter.get()));
+        }
+        else {
+            assertNull(expectedJoinFilter);
+        }
     }
 
     private Rule.Context createContext()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
@@ -32,12 +33,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
+import static com.facebook.presto.SystemSessionProperties.HANDLE_COMPLEX_EQUI_JOINS;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
@@ -49,8 +52,13 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.AUTOMATIC;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
@@ -59,6 +67,7 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.variable;
 
 public class TestReorderJoins
+        extends BasePlanTest
 {
     private RuleTester tester;
     private FunctionResolution functionResolution;
@@ -67,6 +76,37 @@ public class TestReorderJoins
     private static final ImmutableList<List<RowExpression>> TWO_ROWS = ImmutableList.of(ImmutableList.of(), ImmutableList.of());
     private static final QualifiedName RANDOM = QualifiedName.of("random");
 
+    @DataProvider
+    public static Object[][] tableSpecificationPermutations()
+    {
+        return new Object[][] {
+                {"supplier s, partsupp ps, customer c, orders o"},
+                {"supplier s, partsupp ps, orders o, customer c"},
+                {"supplier s, customer c, partsupp ps, orders o"},
+                {"supplier s, customer c, orders o, partsupp ps"},
+                {"supplier s, orders o, partsupp ps, customer c"},
+                {"supplier s, orders o, customer c, partsupp ps"},
+                {"partsupp ps, supplier s, customer c, orders o"},
+                {"partsupp ps, supplier s, orders o, customer c"},
+                {"partsupp ps, customer c, supplier s, orders o"},
+                {"partsupp ps, customer c, orders o, supplier s"},
+                {"partsupp ps, orders o, supplier s, customer c"},
+                {"partsupp ps, orders o, customer c, supplier s"},
+                {"customer c, supplier s, partsupp ps, orders o"},
+                {"customer c, supplier s, orders o, partsupp ps"},
+                {"customer c, partsupp ps, supplier s, orders o"},
+                {"customer c, partsupp ps, orders o, supplier s"},
+                {"customer c, orders o, supplier s, partsupp ps"},
+                {"customer c, orders o, partsupp ps, supplier s"},
+                {"orders o, supplier s, partsupp ps, customer c"},
+                {"orders o, supplier s, customer c, partsupp ps"},
+                {"orders o, partsupp ps, supplier s, customer c"},
+                {"orders o, partsupp ps, customer c, supplier s"},
+                {"orders o, customer c, supplier s, partsupp ps"},
+                {"orders o, customer c, partsupp ps, supplier s"}
+        };
+    }
+
     @BeforeClass
     public void setUp()
     {
@@ -74,7 +114,8 @@ public class TestReorderJoins
                 ImmutableList.of(),
                 ImmutableMap.of(
                         JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name(),
-                        JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name()),
+                        JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name(),
+                        HANDLE_COMPLEX_EQUI_JOINS, "true"),
                 Optional.of(4));
         this.functionResolution = new FunctionResolution(tester.getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver());
     }
@@ -548,6 +589,119 @@ public class TestReorderJoins
                         Optional.of(REPLICATED),
                         values(ImmutableMap.of("B1", 0)),
                         values(ImmutableMap.of("A1", 0))));
+    }
+
+    /**
+     * This test asserts that join re-ordering works as expected for complex equi join clauses ('s.acctbal = c.acctbal + o.totalprice')
+     * and works irrespective of the order in which tables are specified in the FROM clause
+     *
+     * @param tableSpecificationOrder The table specification order
+     */
+    @Test(dataProvider = "tableSpecificationPermutations")
+    public void testComplexEquiJoinCriteria(String tableSpecificationOrder)
+    {
+        // For a full connected join graph, we don't see any CrossJoins
+        String query = "select 1 from " + tableSpecificationOrder + " where s.suppkey = ps.suppkey and c.custkey = o.custkey and s.acctbal = c.acctbal + o.totalprice";
+        PlanMatchPattern expectedPlan =
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
+                                anyTree(tableScan("partsupp", ImmutableMap.of("PS_SUPPKEY", "suppkey"))),
+                                anyTree(
+                                        join(INNER,
+                                                ImmutableList.of(equiJoinClause("SUM", "S_ACCTBAL")),
+                                                anyTree(
+                                                        project(ImmutableMap.of("SUM", expression("C_ACCTBAL + O_TOTALPRICE")),
+                                                                join(INNER,
+                                                                        ImmutableList.of(equiJoinClause("O_CUSTKEY", "C_CUSTKEY")),
+                                                                        anyTree(
+                                                                                tableScan("orders", ImmutableMap.of("O_CUSTKEY", "custkey", "O_TOTALPRICE", "totalprice"))),
+                                                                        anyTree(
+                                                                                tableScan("customer", ImmutableMap.of("C_CUSTKEY", "custkey", "C_ACCTBAL", "acctbal")))))),
+                                                anyTree(
+                                                        tableScan("supplier", ImmutableMap.of("S_ACCTBAL", "acctbal", "S_SUPPKEY", "suppkey")))))));
+        assertPlan(query, expectedPlan);
+
+        // The plan is identical to the plan for the fully spelled out version of the Join
+        String fullQuery = "select 1 from (supplier s inner join partsupp ps on s.suppkey = ps.suppkey) inner join (orders o inner join customer c on c.custkey = o.custkey) " +
+                " on  s.acctbal = c.acctbal + o.totalprice";
+        assertPlan(fullQuery, expectedPlan);
+    }
+
+    @Test
+    public void testComplexEquiJoinCriteriaForDisjointGraphs()
+    {
+        // If the join clause is written with the Left/Right side referring to both sides of a Join node, an equi-join condition cannot be inferred
+        // and the join space is broken up. Hence, we observe a CrossJoin node
+        assertPlan("select 1 from supplier s, partsupp ps, customer c, orders o  where s.suppkey = ps.suppkey and c.custkey = o.custkey and s.acctbal - c.acctbal = o.totalprice",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("C_CUSTKEY", "O_CUSTKEY"), equiJoinClause("SUBTRACT", "O_TOTALPRICE")),
+                                anyTree(
+                                        project(ImmutableMap.of("SUBTRACT", expression("S_ACCTBAL - C_ACCTBAL")),
+                                                join(INNER,
+                                                        ImmutableList.of(), //CrossJoin
+                                                        join(INNER,
+                                                                ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
+                                                                anyTree(tableScan("partsupp", ImmutableMap.of("PS_SUPPKEY", "suppkey"))),
+                                                                anyTree(
+                                                                        tableScan("supplier", ImmutableMap.of("S_ACCTBAL", "acctbal", "S_SUPPKEY", "suppkey")))),
+                                                        anyTree(
+                                                                tableScan("customer", ImmutableMap.of("C_CUSTKEY", "custkey", "C_ACCTBAL", "acctbal")))))),
+                                anyTree(
+                                        tableScan("orders", ImmutableMap.of("O_CUSTKEY", "custkey", "O_TOTALPRICE", "totalprice"))))));
+
+        // The table specification order determines the join order for such cases
+        // With the below table specification order, the planner adds the complex equi-join condition as a FilterNode on top of a JoinNode
+        assertPlan("select 1 from orders o, customer c, supplier s, partsupp ps where s.suppkey = ps.suppkey and c.custkey = o.custkey and s.acctbal - c.acctbal = o.totalprice",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
+                                anyTree(
+                                        tableScan("partsupp", ImmutableMap.of("PS_SUPPKEY", "suppkey"))),
+                                anyTree(
+                                        filter("O_TOTALPRICE = S_ACCTBAL - C_ACCTBAL",
+                                                join(INNER,
+                                                        ImmutableList.of(), //CrossJoin
+                                                        join(INNER,
+                                                                ImmutableList.of(equiJoinClause("O_CUSTKEY", "C_CUSTKEY")),
+                                                                anyTree(tableScan("orders", ImmutableMap.of("O_CUSTKEY", "custkey", "O_TOTALPRICE", "totalprice"))),
+                                                                anyTree(
+                                                                        tableScan("customer", ImmutableMap.of("C_CUSTKEY", "custkey", "C_ACCTBAL", "acctbal")))),
+                                                        anyTree(
+                                                                tableScan("supplier", ImmutableMap.of("S_ACCTBAL", "acctbal", "S_SUPPKEY", "suppkey")))))))));
+
+        // For sub-graphs that are fully connected, join-reordering works with complex predicates as expected
+        // The rest of the join graph is connected using a CrossJoin
+        assertPlan("select 1 " +
+                "from orders o, customer c, supplier s, partsupp ps, part p " +
+                "where s.suppkey = ps.suppkey " +
+                "    and c.custkey = o.custkey " +
+                "    and s.acctbal = c.acctbal + o.totalprice" +
+                "    and ps.partkey - p.partkey = 0 ",
+                anyTree(
+                        filter("PS_PARTKEY - P_PARTKEY = 0",
+                                join(INNER,
+                                        ImmutableList.of(), // CrossJoin
+                                        join(INNER,
+                                                ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
+                                                anyTree(
+                                                        tableScan("partsupp", ImmutableMap.of("PS_SUPPKEY", "suppkey", "PS_PARTKEY", "partkey"))),
+                                                anyTree(
+                                                        join(INNER,
+                                                                ImmutableList.of(equiJoinClause("SUM", "S_ACCTBAL")),
+                                                                anyTree(
+                                                                        project(ImmutableMap.of("SUM", expression("C_ACCTBAL + O_TOTALPRICE")),
+                                                                                join(INNER,
+                                                                                        ImmutableList.of(equiJoinClause("O_CUSTKEY", "C_CUSTKEY")),
+                                                                                        anyTree(
+                                                                                                tableScan("orders", ImmutableMap.of("O_CUSTKEY", "custkey", "O_TOTALPRICE", "totalprice"))),
+                                                                                        anyTree(
+                                                                                                tableScan("customer", ImmutableMap.of("C_CUSTKEY", "custkey", "C_ACCTBAL", "acctbal")))))),
+                                                                anyTree(
+                                                                        tableScan("supplier", ImmutableMap.of("S_ACCTBAL", "acctbal", "S_SUPPKEY", "suppkey")))))),
+                                        anyTree(
+                                                tableScan("part", ImmutableMap.of("P_PARTKEY", "partkey")))))));
     }
 
     private RuleAssert assertReorderJoins()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -169,6 +169,12 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuery(queryRunner, session, actual, queryRunner, expected, false, false);
     }
 
+    protected void assertQueryWithSameQueryRunner(Session actualSession, @Language("SQL") String actual, Session expectedSession, @Language("SQL") String expected)
+    {
+        checkArgument(!actual.equals(expected));
+        QueryAssertions.assertQuery(queryRunner, actualSession, actual, queryRunner, expectedSession, expected, false, false);
+    }
+
     protected void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, expectedQueryRunner, expected, false, false);


### PR DESCRIPTION
## Description
Enhance join-reordering to work with non-simple equi-join predicates

## Motivation and Context
Join predicates like `left.key = right0.key1 + right1.key2` can reduce the join space by appearing as Project nodes or Join noes with no equi-join clauses in the join graph. This commit fixes this behavior by removing any intermediate Projects in the join graph and only creating them on-the-fly while choosing the join order

## Impact
Queries with completely connected join graphs would have CrossJoin's in them, depending on the order of specification of the FROM clause
```
presto:tiny> explain select count(*) from customer c, partsupp ps, orders o, supplier s where s.suppkey = ps.suppkey and c.custkey = o.custkey and s.nationkey + ps.partkey = c.nationkey;
                                                                                                                               Query Plan                                                                                               >
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[_col0] => [count:bigint]                                                                                                                                                                                                      >
         _col0 := count (1:16)                                                                                                                                                                                                          >
     - Aggregate(FINAL) => [count:bigint]                                                                                                                                                                                               >
             count := "presto.default.count"((count_16)) (1:16)                                                                                                                                                                         >
         - LocalExchange[SINGLE] () => [count_16:bigint]                                                                                                                                                                                >
             - RemoteStreamingExchange[GATHER] => [count_16:bigint]                                                                                                                                                                     >
                 - Aggregate(PARTIAL) => [count_16:bigint]                                                                                                                                                                              >
                         count_16 := "presto.default.count"(*) (1:16)                                                                                                                                                                   >
                     - InnerJoin[("suppkey" = "suppkey_5") AND (nationkey) = ((nationkey_8) + (partkey))][$hashvalue_20, $hashvalue_21] => []                                                                                           >
                             Estimates: {source: CostBasedSourceInfo, rows: 2400 (21.09kB), cpu: 11881391400.00, memory: 178200.00, network: 178200.00}                                                                                 >
                             Distribution: REPLICATED                                                                                                                                                                                   >
                         - Project[projectLocality = LOCAL] => [partkey:bigint, suppkey:bigint, nationkey:bigint, $hashvalue_20:bigint]                                                                                                 >
                                 Estimates: {source: CostBasedSourceInfo, rows: 120000000 (1.01GB), cpu: 7561381500.00, memory: 175500.00, network: 175500.00}                                                                          >
                                 $hashvalue_20 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(suppkey), BIGINT'0')) (1:43)                                                                                                     >
                             - CrossJoin => [partkey:bigint, suppkey:bigint, nationkey:bigint]                                                                                                                                          >
                                     Estimates: {source: CostBasedSourceInfo, rows: 120000000 (1.01GB), cpu: 3241381500.00, memory: 175500.00, network: 175500.00}                                                                      >
                                     Distribution: REPLICATED                                                                                                                                                                           >
                                 - TableScan[TableHandle {connectorId='tpch', connectorHandle='partsupp:sf0.01', layout='Optional[partsupp:sf0.01]'}] => [partkey:bigint, suppkey:bigint]                                               >
                                         Estimates: {source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 144000.00, memory: 0.00, network: 0.00}                                                                                    >
                                         partkey := tpch:partkey (1:42)                                                                                                                                                                 >
                                         suppkey := tpch:suppkey (1:42)                                                                                                                                                                 >
                                 - LocalExchange[SINGLE] () => [nationkey:bigint]                                                                                                                                                       >
                                         Estimates: {source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 958500.00, memory: 40500.00, network: 175500.00}                                                                         >
                                     - RemoteStreamingExchange[REPLICATE] => [nationkey:bigint]                                                                                                                                         >
                                             Estimates: {source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 958500.00, memory: 40500.00, network: 175500.00}                                                                     >
                                         - InnerJoin[("custkey_2" = "custkey")][$hashvalue, $hashvalue_17] => [nationkey:bigint]                                                                                                        >
                                                 Estimates: {source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 958500.00, memory: 40500.00, network: 40500.00}                                                                  >
                                                 Distribution: REPLICATED                                                                                                                                                               >
                                             - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='orders:sf0.01', layout='Optional[orders:sf0.01]'}, projectLocality = LOCAL] => [custkey_2:bigint, $hashvalue:bigint>
                                                     Estimates: {source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 135000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 405000.00,>
                                                     $hashvalue := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_2), BIGINT'0')) (1:56)                                                                                  >
                                                     custkey_2 := tpch:custkey (1:55)                                                                                                                                                   >
                                                     tpch:orderstatus                                                                                                                                                                   >
                                                         :: [["F"], ["O"], ["P"]]                                                                                                                                                       >
                                             - LocalExchange[HASH][$hashvalue_17] (custkey) => [custkey:bigint, nationkey:bigint, $hashvalue_17:bigint]                                                                                 >
                                                     Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 108000.00, memory: 0.00, network: 40500.00}                                                                    >
                                                 - RemoteStreamingExchange[REPLICATE] => [custkey:bigint, nationkey:bigint, $hashvalue_18:bigint]                                                                                       >
                                                         Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 67500.00, memory: 0.00, network: 40500.00}                                                                 >
                                                     - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='customer:sf0.01', layout='Optional[customer:sf0.01]'}, projectLocality = LOCAL] => [custkey:bigint, nationk>
                                                             Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 27000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 67500.0>
                                                             $hashvalue_19 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:30)                                                                         >
                                                             nationkey := tpch:nationkey (1:30)                                                                                                                                         >
                                                             custkey := tpch:custkey (1:30)                                                                                                                                             >
                         - LocalExchange[HASH][$hashvalue_21] (suppkey_5) => [suppkey_5:bigint, nationkey_8:bigint, $hashvalue_21:bigint]                                                                                               >
                                 Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 7200.00, memory: 0.00, network: 2700.00}                                                                                               >
                             - RemoteStreamingExchange[REPLICATE] => [suppkey_5:bigint, nationkey_8:bigint, $hashvalue_22:bigint]                                                                                                       >
                                     Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 4500.00, memory: 0.00, network: 2700.00}                                                                                           >
                                 - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='supplier:sf0.01', layout='Optional[supplier:sf0.01]'}, projectLocality = LOCAL] => [suppkey_5:bigint, nationkey_8:bigint, $hash>
                                         Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 1800.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 100 (900B), cpu: 4500.00, memory: 0.00, network: 0.00>
                                         $hashvalue_23 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(suppkey_5), BIGINT'0')) (1:65)                                                                                           >
                                         suppkey_5 := tpch:suppkey (1:65)                                                                                                                                                               >
                                         nationkey_8 := tpch:nationkey (1:65)                                                                                                                                                           >
                                                                                                                                                                                                                                        >
(1 row)

``` 

This is fixed after this PR, and a cheaper plan with only inner joins is chosen :
```
presto:tiny> explain select count(*) from customer c, partsupp ps, orders o, supplier s where s.suppkey = ps.suppkey and c.custkey = o.custkey and s.nationkey + ps.partkey = c.nationkey;
                                                                                                                                     Query Plan                                                                                         >
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[_col0] => [count:bigint]                                                                                                                                                                                                      >
         _col0 := count (1:16)                                                                                                                                                                                                          >
     - Aggregate(FINAL) => [count:bigint]                                                                                                                                                                                               >
             count := "presto.default.count"((count_18)) (1:16)                                                                                                                                                                         >
         - LocalExchange[SINGLE] () => [count_18:bigint]                                                                                                                                                                                >
             - RemoteStreamingExchange[GATHER] => [count_18:bigint]                                                                                                                                                                     >
                 - Aggregate(PARTIAL) => [count_18:bigint]                                                                                                                                                                              >
                         count_18 := "presto.default.count"(*) (1:16)                                                                                                                                                                   >
                     - InnerJoin[("custkey_2" = "custkey")][$hashvalue, $hashvalue_19] => []                                                                                                                                            >
                             Estimates: {source: CostBasedSourceInfo, rows: 59289 (521.09kB), cpu: 2286917.79, memory: 149919.37, network: 149919.37}                                                                                   >
                             Distribution: REPLICATED                                                                                                                                                                                   >
                         - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='orders:sf0.01', layout='Optional[orders:sf0.01]'}, projectLocality = LOCAL] => [custkey_2:bigint, $hashvalue:bigint]                   >
                                 Estimates: {source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 135000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 15000 (131.84kB), cpu: 405000.00, memory: 0.00, netwo>
                                 $hashvalue := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_2), BIGINT'0')) (1:56)                                                                                                      >
                                 custkey_2 := tpch:custkey (1:55)                                                                                                                                                                       >
                                 tpch:orderstatus                                                                                                                                                                                       >
                                     :: [["F"], ["O"], ["P"]]                                                                                                                                                                           >
                         - LocalExchange[HASH][$hashvalue_19] (custkey) => [custkey:bigint, $hashvalue_19:bigint]                                                                                                                       >
                                 Estimates: {source: CostBasedSourceInfo, rows: 5929 (52.11kB), cpu: 1505198.42, memory: 43200.00, network: 149919.37}                                                                                  >
                             - RemoteStreamingExchange[REPLICATE] => [custkey:bigint, $hashvalue_20:bigint]                                                                                                                             >
                                     Estimates: {source: CostBasedSourceInfo, rows: 5929 (52.11kB), cpu: 1398479.05, memory: 43200.00, network: 149919.37}                                                                              >
                                 - Project[projectLocality = LOCAL] => [custkey:bigint, $hashvalue_29:bigint]                                                                                                                           >
                                         Estimates: {source: CostBasedSourceInfo, rows: 5929 (52.11kB), cpu: 1398479.05, memory: 43200.00, network: 43200.00}                                                                           >
                                         $hashvalue_29 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:30)                                                                                             >
                                     - InnerJoin[("add_17" = "nationkey")][$hashvalue_25, $hashvalue_26] => [custkey:bigint]                                                                                                            >
                                             Estimates: {source: CostBasedSourceInfo, rows: 5929 (52.11kB), cpu: 1291759.68, memory: 43200.00, network: 43200.00}                                                                       >
                                             Distribution: REPLICATED                                                                                                                                                                   >
                                         - Project[projectLocality = LOCAL] => [add_17:bigint, $hashvalue_25:bigint]                                                                                                                    >
                                                 Estimates: {source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 945900.00, memory: 2700.00, network: 2700.00}                                                                      >
                                                 $hashvalue_25 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(add_17), BIGINT'0')) (1:66)                                                                                      >
                                             - Project[projectLocality = LOCAL] => [add_17:bigint]                                                                                                                                      >
                                                     Estimates: {source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 801900.00, memory: 2700.00, network: 2700.00}                                                                  >
                                                     add_17 := (nationkey_8) + (partkey) (1:66)                                                                                                                                         >
                                                 - InnerJoin[("suppkey" = "suppkey_5")][$hashvalue_21, $hashvalue_22] => [partkey:bigint, nationkey_8:bigint]                                                                           >
                                                         Estimates: {source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 729900.00, memory: 2700.00, network: 2700.00}                                                              >
                                                         Distribution: REPLICATED                                                                                                                                                       >
                                                     - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='partsupp:sf0.01', layout='Optional[partsupp:sf0.01]'}, projectLocality = LOCAL] => [partkey:bigint, suppkey>
                                                             Estimates: {source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 144000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 8000 (70.31kB), cpu: 360000>
                                                             $hashvalue_21 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(suppkey), BIGINT'0')) (1:43)                                                                         >
                                                             partkey := tpch:partkey (1:42)                                                                                                                                             >
                                                             suppkey := tpch:suppkey (1:42)                                                                                                                                             >
                                                     - LocalExchange[HASH][$hashvalue_22] (suppkey_5) => [suppkey_5:bigint, nationkey_8:bigint, $hashvalue_22:bigint]                                                                   >
                                                             Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 7200.00, memory: 0.00, network: 2700.00}                                                                   >
                                                         - RemoteStreamingExchange[REPLICATE] => [suppkey_5:bigint, nationkey_8:bigint, $hashvalue_23:bigint]                                                                           >
                                                                 Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 4500.00, memory: 0.00, network: 2700.00}                                                               >
                                                             - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='supplier:sf0.01', layout='Optional[supplier:sf0.01]'}, projectLocality = LOCAL] => [suppkey_5:bigin>
                                                                     Estimates: {source: CostBasedSourceInfo, rows: 100 (900B), cpu: 1800.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 100 (900B), cpu: 4500.00,>
                                                                     $hashvalue_24 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(suppkey_5), BIGINT'0')) (1:65)                                                               >
                                                                     suppkey_5 := tpch:suppkey (1:65)                                                                                                                                   >
                                                                     nationkey_8 := tpch:nationkey (1:65)                                                                                                                               >
                                         - LocalExchange[HASH][$hashvalue_26] (nationkey) => [custkey:bigint, nationkey:bigint, $hashvalue_26:bigint]                                                                                   >
                                                 Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 108000.00, memory: 0.00, network: 40500.00}                                                                        >
                                             - RemoteStreamingExchange[REPLICATE] => [custkey:bigint, nationkey:bigint, $hashvalue_27:bigint]                                                                                           >
                                                     Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 67500.00, memory: 0.00, network: 40500.00}                                                                     >
                                                 - ScanProject[table = TableHandle {connectorId='tpch', connectorHandle='customer:sf0.01', layout='Optional[customer:sf0.01]'}, projectLocality = LOCAL] => [custkey:bigint, nationkey:b>
                                                         Estimates: {source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 27000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 1500 (13.18kB), cpu: 67500.00, m>
                                                         $hashvalue_28 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(nationkey), BIGINT'0')) (1:30)                                                                           >
                                                         custkey := tpch:custkey (1:30)                                                                                                                                                 >
                                                         nationkey := tpch:nationkey (1:30)                                                                                                                                             >
                                                                                                                                                                                                                                        >
(1 row)

```


## Test Plan
New unit tests added

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Enhance join-reordering to work with non-simple equi-join predicates
```