### PR TITLE
[native] Add e2e tests for global aggregate with no grouping keys and no aggregates.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -103,6 +103,9 @@ public abstract class AbstractTestNativeAggregations
 
         // distinct limit
         assertQueryResultCount("SELECT orderkey FROM lineitem GROUP BY 1 LIMIT 17", 17);
+
+        // aggregation with no grouping keys and no aggregates
+        assertQuery("with a as (select sum(nationkey) from nation) select x from a, unnest(array[1, 2,3]) as t(x)");
     }
 
     @Test


### PR DESCRIPTION
Adding an e2e tests as a follow up from https://github.com/facebookincubator/velox/pull/5895. This query was failing with `Caused by: VeloxRuntimeError: !groupingKeys_.empty() || !aggregates_.empty() Aggregation must specify either grouping keys or aggregates` before the Velox fix was added.