### PR TITLE
Specialize ARRAY_SORT for simple types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -27,12 +27,17 @@ import com.google.common.primitives.Ints;
 
 import java.lang.invoke.MethodHandle;
 import java.util.AbstractList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.Float.floatToIntBits;
 
 @ScalarFunction("array_sort")
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
@@ -110,6 +115,134 @@ public final class ArraySortFunction
 
         for (int i = 0; i < arrayLength; i++) {
             type.appendTo(block, sortedListOfPositions.get(i), blockBuilder);
+        }
+
+        return blockBuilder.build();
+    }
+
+    @SqlType("array(bigint)")
+    public static Block bigintSort(@SqlType("array(bigint)") Block array)
+    {
+        final int arrayLength = array.getPositionCount();
+        if (arrayLength < 2) {
+            return array;
+        }
+
+        long[] values = new long[array.getPositionCount()];
+        int nulls = 0;
+
+        if (array.mayHaveNull()) {
+            int j = 0;
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                if (array.isNull(i)) {
+                    nulls++;
+                }
+                else {
+                    values[j++] = BIGINT.getLong(array, i);
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                values[i] = BIGINT.getLong(array, i);
+            }
+        }
+
+        Arrays.sort(values, 0, values.length - nulls);
+
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, arrayLength);
+        for (int i = 0; i < values.length - nulls; i++) {
+            BIGINT.writeLong(blockBuilder, values[i]);
+        }
+        // Nulls last
+        for (int i = 0; i < nulls; i++) {
+            blockBuilder.appendNull();
+        }
+
+        return blockBuilder.build();
+    }
+
+    @SqlType("array(double)")
+    public static Block doubleSort(@SqlType("array(double)") Block array)
+    {
+        final int arrayLength = array.getPositionCount();
+        if (arrayLength < 2) {
+            return array;
+        }
+
+        double[] values = new double[array.getPositionCount()];
+        int nulls = 0;
+
+        if (array.mayHaveNull()) {
+            int j = 0;
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                if (array.isNull(i)) {
+                    nulls++;
+                }
+                else {
+                    values[j++] = DOUBLE.getDouble(array, i);
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                values[i] = DOUBLE.getDouble(array, i);
+            }
+        }
+
+        Arrays.sort(values, 0, values.length - nulls);
+
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, arrayLength);
+        for (int i = 0; i < values.length - nulls; i++) {
+            DOUBLE.writeDouble(blockBuilder, values[i]);
+        }
+
+        // Nulls last
+        for (int i = 0; i < nulls; i++) {
+            blockBuilder.appendNull();
+        }
+
+        return blockBuilder.build();
+    }
+
+    @SqlType("array(real)")
+    public static Block floatSort(@SqlType("array(real)") Block array)
+    {
+        final int arrayLength = array.getPositionCount();
+        if (arrayLength < 2) {
+            return array;
+        }
+
+        float[] values = new float[array.getPositionCount()];
+        int nulls = 0;
+
+        if (array.mayHaveNull()) {
+            int j = 0;
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                if (array.isNull(i)) {
+                    nulls++;
+                }
+                else {
+                    values[j++] = (Float) REAL.getObject(array, i);
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < array.getPositionCount(); i++) {
+                values[i] = (Float) REAL.getObject(array, i);
+            }
+        }
+
+        Arrays.sort(values, 0, values.length - nulls);
+
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, arrayLength);
+        for (int i = 0; i < values.length - nulls; i++) {
+            REAL.writeLong(blockBuilder, floatToIntBits(values[i]));
+        }
+
+        // Nulls last
+        for (int i = 0; i < nulls; i++) {
+            blockBuilder.appendNull();
         }
 
         return blockBuilder.build();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7014,8 +7014,38 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testLikePrefix()
+    public void testArraySort()
     {
-        assertQuery("select x like 'abc%' from (values 'abc', 'def', 'bcd') T(x)");
+        assertQuery("select array_sort(cast(array[5,6,4,null,3,7] as array<integer>))", "select array[3, 4, 5, 6, 7, null]");
+        assertQuery("select array_sort(array[5,6,4,null,3,7])", "select array[3, 4, 5, 6, 7, null]");
+
+        MaterializedResult result = computeActual("select array_sort(array[5,6,4,null,3,7, cast(9223372036854775807 as bigint)])");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(array[5.4,6.1,4.9,null,4.5,7.8,5.2])");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(cast(array[5.4,6.1,4.9,null,4.5,7.8,5.2] as array<double>))");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(cast(array[null, 5.4,6.1,4.9,null,4.5,7.8,5.2] as array<double>))");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+    }
+
+    private static boolean assertSorted(List<Object> array)
+    {
+        int i = 1;
+        for (; i < array.size(); i++) {
+            if (array.get(i) == null) {
+                break;
+            }
+            assertThat(((Comparable) array.get(i)).compareTo((Comparable) array.get(i - 1)) >= 0);
+        }
+
+        while (i < array.size()) {
+            assertThat(array.get(i++) == null);
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Currently, ARRAY_SORT with default comparator is implemented in a generic fashion making it too expensive. So we will be specializing it for numeric types (int/bigint/double/real) - the most common use cases.

Test Plan: tests exist and also added new tests

```
== NO RELEASE NOTE ==
```
