### PR TITLE
Add support for replace_first function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -88,6 +88,11 @@ String Functions
     If ``search`` is an empty string, inserts ``replace`` in front of every
     character and at the end of the ``string``.
 
+.. function:: replace_first(string, search, replace) -> varchar
+    Replaces the first instances of ``search`` with ``replace`` in ``string``.
+
+    If ``search`` is an empty string, it inserts ``replace`` at the beginning of the ``string``.
+
 .. function:: reverse(string) -> varchar
 
     Returns ``string`` with the characters in reverse order.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -184,6 +184,7 @@ import com.facebook.presto.operator.scalar.sql.ArraySqlFunctions;
 import com.facebook.presto.operator.scalar.sql.MapNormalizeFunction;
 import com.facebook.presto.operator.scalar.sql.MapSqlFunctions;
 import com.facebook.presto.operator.scalar.sql.SimpleSamplingPercent;
+import com.facebook.presto.operator.scalar.sql.StringSqlFunctions;
 import com.facebook.presto.operator.window.CumulativeDistributionFunction;
 import com.facebook.presto.operator.window.DenseRankFunction;
 import com.facebook.presto.operator.window.FirstValueFunction;
@@ -904,6 +905,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .sqlInvokedScalars(ArrayIntersectFunction.class)
                 .sqlInvokedScalars(MapSqlFunctions.class)
                 .sqlInvokedScalars(SimpleSamplingPercent.class)
+                .sqlInvokedScalars(StringSqlFunctions.class)
                 .scalar(DynamicFilterPlaceholderFunction.class)
                 .scalars(EnumCasts.class)
                 .scalars(LongEnumOperators.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
+import com.facebook.presto.spi.function.SqlType;
+
+public class StringSqlFunctions
+{
+    private StringSqlFunctions() {}
+
+    @SqlInvokedScalarFunction(value = "replace_first", deterministic = true, calledOnNullInput = true)
+    @Description("Replaces the first occurrence of a substring that matches the given pattern with the given replacement.")
+    @SqlParameters({@SqlParameter(name = "str", type = "varchar"), @SqlParameter(name = "search", type = "varchar"), @SqlParameter(name = "replace", type = "varchar")})
+    @SqlType("varchar")
+    public static String replaceFirst()
+    {
+        return "RETURN IF(replace IS NULL, NULL, IF(STRPOS(str, search) = 0, str, SUBSTR(str, 1, STRPOS(str, search) - 1) || replace || SUBSTR(str, STRPOS(str, search) + LENGTH(search))))";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestReplaceFirstFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestReplaceFirstFunction.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestReplaceFirstFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction(
+                "REPLACE_FIRST('aaa', 'a', 'b')",
+                VARCHAR,
+                "baa");
+        assertFunction(
+                "REPLACE_FIRST('replace_all', 'all', 'first')",
+                VARCHAR,
+                "replace_first");
+        assertFunction(
+                "REPLACE_FIRST('The quick brown dog jumps over a lazy dog', 'dog', 'fox')",
+                VARCHAR,
+                "The quick brown fox jumps over a lazy dog");
+        assertFunction(
+                "REPLACE_FIRST('John  Doe', ' ', '')",
+                VARCHAR,
+                "John Doe");
+        assertFunction(
+                "REPLACE_FIRST('We will fight for our rights, for our rights.', ', for our rights', '')",
+                VARCHAR,
+                "We will fight for our rights.");
+        assertFunction(
+                "REPLACE_FIRST('Testcases test cases', 'cases', '')",
+                VARCHAR,
+                "Test test cases");
+        assertFunction(
+                "REPLACE_FIRST('test cases', '', 'Add ')",
+                VARCHAR,
+                "Add test cases");
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("REPLACE_FIRST('', 'a', 'b')", VARCHAR, "");
+        assertFunction("REPLACE_FIRST('', '', 'test')", VARCHAR, "test");
+        assertFunction("REPLACE_FIRST('', 'a', '')", VARCHAR, "");
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("REPLACE_FIRST(NULL, 'foo', 'bar')", VARCHAR, null);
+        assertFunction("REPLACE_FIRST('foo', NULL, 'bar')", VARCHAR, null);
+        assertFunction("REPLACE_FIRST('foo', 'bar', NULL)", VARCHAR, null);
+        assertFunction("REPLACE_FIRST(NULL, NULL, 'test')", VARCHAR, null);
+        assertFunction("REPLACE_FIRST('foo', 'NULL', NULL)", VARCHAR, null);
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "REPLACE_FIRST(1000, '1000', '100')",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "REPLACE_FIRST('1000.0', 1000.0, '100')",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "REPLACE_FIRST('1000', '1000', 100)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "REPLACE_FIRST('replace first')",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "REPLACE_FIRST('replace first', 'first')",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Test plan

Added unit tests.
Build successfully using the following terminal command
- `./mvnw clean install -Dtest=TestReplaceFirstFunction -Dmaven.javadoc.skip=true -T1C -fn -pl presto-main`

== RELEASE NOTES ==

General Changes
- Add function :func:`replace_first`

  - `SELECT REPLACE_FIRST('bar bar', 'bar', 'foo'); -- 'foo bar'`