### PR TITLE
[native] Prepare for changes in ExchangeQueue::dequeueLocked

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -532,7 +532,7 @@ TEST_P(PrestoExchangeSourceTestSuite, retries) {
   numTries = -1000000;
   EXPECT_THAT(
       [&]() { waitForNextPage(queue); },
-      ThrowsMessage<std::runtime_error>(HasSubstr("Connection reset by peer")));
+      ThrowsMessage<std::exception>(HasSubstr("Connection reset by peer")));
 }
 
 TEST_P(PrestoExchangeSourceTestSuite, earlyTerminatingConsumer) {
@@ -714,7 +714,7 @@ TEST_P(PrestoExchangeSourceTestSuite, failedProducer) {
   // Stop server to simulate failed connection.
   serverWrapper.stop();
 
-  EXPECT_THROW(waitForNextPage(queue), std::runtime_error);
+  EXPECT_THROW(waitForNextPage(queue), std::exception);
 }
 
 TEST_P(PrestoExchangeSourceTestSuite, exceedingMemoryCapacityForHttpResponse) {

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -388,7 +388,8 @@ public class TestMemoryManager
         queryRunner2.close();
     }
 
-    @Test(timeOut = 300_000, groups = {"outOfMemoryKillerMultiCoordinator"}, expectedExceptions = ExecutionException.class, expectedExceptionsMessageRegExp = ".*Query killed because the cluster is out of memory. Please try again in a few minutes.")
+    // Flaky: https://github.com/prestodb/presto/issues/19679
+    @Test(enabled = false, timeOut = 300_000, groups = {"outOfMemoryKillerMultiCoordinator"}, expectedExceptions = ExecutionException.class, expectedExceptionsMessageRegExp = ".*Query killed because the cluster is out of memory. Please try again in a few minutes.")
     public void testOutOfMemoryKillerMultiCoordinator()
             throws Exception
     {


### PR DESCRIPTION
Velox is changing ExchangeQueue::dequeueLocked to throw VeloxRuntimeException instead of std::runtime_error in https://github.com/facebookincubator/velox/pull/5884

Update PrestoExchangeSourceTest.cpp to expect std::exception.

Also, disable flaky memory.TestMemoryManager#testOutOfMemoryKillerMultiCoordinator. See #19679

```
== NO RELEASE NOTE ==
```

