### PR TITLE
Revert "Update Drift dependency to use Header transport by default"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
-        <dep.drift.version>1.37</dep.drift.version>
+        <dep.drift.version>1.36</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
         <dep.joda.version>2.12.2</dep.joda.version>


### PR DESCRIPTION
This reverts https://github.com/prestodb/presto/pull/20282 as we are seeing errors in verifier runs 

```
== NO RELEASE NOTE ==
```

