### PR TITLE
Adding OSS Redis based Historical Statistics Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
         <module>presto-native-execution</module>
         <module>presto-router</module>
         <module>presto-open-telemetry</module>
+        <module>redis-hbo-provider</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -12,6 +12,7 @@ Presto Documentation
     cache
     optimizer
     connector
+    plugin
     functions
     language
     sql

--- a/presto-docs/src/main/sphinx/plugin.rst
+++ b/presto-docs/src/main/sphinx/plugin.rst
@@ -1,0 +1,11 @@
+**********
+Plugins
+**********
+
+This chapter outlines the plugins in Presto that are available for various use cases.
+
+.. toctree::
+    :maxdepth: 1
+
+    plugin/redis-hbo-provider
+

--- a/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
+++ b/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
@@ -1,0 +1,83 @@
+=======================
+Redis HBO Provider
+=======================
+
+Redis HBO Provider allows loading a custom configured Redis Client for storing/retrieving Historical Stats. The Redis client is stateful and is based on
+`Lettuce <https://github.com/lettuce-io/lettuce-core>`_ . Both RedisClient and RedisClusterClient are supported, RedisClusterAsyncCommandsFactory is meant to be extended by the user for custom configurations
+
+
+Configuration
+-------------
+
+Create ``etc/catalog/hbo-provider.properties`` to mount the Redis HBO Provider Plugin, replacing the properties as appropriate:
+
+Configuration properties
+------------------------
+
+The following configuration properties are available:
+
+====================================== =====================================================================
+Property Name                          Description
+====================================== =====================================================================
+``coordinator``                        Boolean property whether Presto server is a coordinator
+``hbo.redis-provider.server_uri``            Redis Server URI
+``hbo.redis-provider.total-fetch-timeoutms`` Maximum timeout in ms for Redis fetch requests
+``hbo.redis-provider.total-set-timeoutms``   Maximum timeout in ms for Redis set requests
+``hbo.redis-provider.default-ttl-seconds``   TTL in seconds of the Redis data to be stored
+``hbo.redis-provider.enabled``               Boolean property whether this plugin is enabled in production
+``credentials-path``                   Path for Redis credentials
+``hbo.redis-provider.cluster-mode-enabled``  Boolean property whether cluster mode is enabled
+====================================== =====================================================================
+
+Credentials
+-----------
+
+The plugin requires the Redis Server URI property ``hbo.redis-provider.server_uri`` in order to access Redis
+Based on your custom Redis deployment you may need to add additional credentials
+
+Local Test setup
+------------------------
+
+Set up local Redis Cluster with the guideline of `Redis <https://github.com/lettuce-io/lettuce-core>`_
+Add ``../redis-hbo-provider/pom.xml,\`` to ``presto-main/etc/config.properties``.
+
+Add the following config file in ``presto-main/etc/hbo-provider.properties``
+
+.. code-block:: text
+
+    coordinator=true
+    hbo.redis-provider.enabled=true
+    hbo.redis-provider.total-fetch-timeoutms=5000
+    hbo.redis-provider.total-set-timeoutms=5000
+    hbo.redis-provider.default-ttl-seconds=4320000
+    hbo.redis-provider.cluster-mode-enabled=true
+    hbo.redis-provider.server_uri=redis://localhost:7001/
+
+Production Setup
+------------------------
+You should place the JAR file into the plugins directory, insert the required configuration where needed, and it will then be loaded dynamically during runtime.
+
+Steps
+1. Add the following to register the plugin in <fileSets> in presto-server/src/main/assembly/presto.xml
+
+.. code-block:: text
+
+    <fileSet>
+       <directory>${project.build.directory}/dependency/redis-hbo-provider-${project.version}</directory>
+       <outputDirectory>plugin/redis-hbo-provider</outputDirectory>
+    </fileSet>
+
+2. Add META-INF.services file in ``presto-hbo-provider/src/main/resources`` with the Plugin entry class com.facebook.presto.statistic.RedisProviderPlugin
+3. Add dependency on the module in ``presto-server/pom.xml``
+
+.. code-block:: text
+
+    <dependency>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-hbo-provider</artifactId>
+        <version>${project.version}</version>
+        <type>zip</type>
+        <scope>provided</scope>
+    </dependency>
+
+4. You can add your custom Redis client connection login in ``com.facebook.presto.statistic.RedisClusterAsyncCommandsFactory``, just make sure that the AsyncCommands are provided properly

--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.284-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <lettuce.version>6.2.4.RELEASE</lettuce.version>
+        <netty.version>4.1.91.Final</netty.version>
+    </properties>
+
+    <artifactId>redis-hbo-provider</artifactId>
+    <packaging>presto-plugin</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>${lettuce.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.cloud.broker</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.auto.value</groupId>
+                    <artifactId>auto-value-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fppt</groupId>
+            <artifactId>jedis-mock</artifactId>
+            <version>1.0.9</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>redis.clients</groupId>
+                    <artifactId>jedis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud.broker</groupId>
+                    <artifactId>broker-hadoop-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud.broker</groupId>
+                    <artifactId>broker-hadoop-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud.broker</groupId>
+                    <artifactId>broker-hadoop-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <ignoredDependency>*</ignoredDependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>com.google.*$</ignoredResourcePattern>
+                        <ignoredResourcePattern>.*\.proto$</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                        <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>com.google.thirdparty.publicsuffix.*</ignoredClassPattern>
+                        <ignoredClassPattern>com.google.auth.*</ignoredClassPattern>
+                        <ignoredClassPattern>com.google.api.*</ignoredClassPattern>
+                        <ignoredClassPattern>com.google.protobuf.*</ignoredClassPattern>
+                        <ignoredClassPattern>org.apache.commons.*</ignoredClassPattern>
+                        <ignoredClassPattern>io.perfmark.*</ignoredClassPattern>
+                        <ignoredClassPattern>io.grpc.*</ignoredClassPattern>
+                        <ignoredClassPattern>io.opencensus.*</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>com.google.android</groupId>
+                            <artifactId>annotations</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/HistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/HistoricalStatisticsSerde.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.http.client.thrift.ThriftProtocolException;
+import com.facebook.airlift.http.client.thrift.ThriftProtocolUtils;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import io.lettuce.core.codec.RedisCodec;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Redis codec implementation for string keys and HistoricalPlanStatistics values.
+ */
+public class HistoricalStatisticsSerde
+        implements RedisCodec<String, HistoricalPlanStatistics>
+{
+    private static final int ESTIMATED_BUFFER_SIZE_BYTES = 100 * 1024;
+    private static final ThriftCodecManager thriftCodecManager = new ThriftCodecManager();
+
+    @Override
+    public String decodeKey(ByteBuffer bytes)
+    {
+        if (bytes.hasArray()) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+        else {
+            throw new RuntimeException("HistoricalStatisticsSerde: Error decoding key planHash which was of type String");
+        }
+    }
+
+    @Override
+    public ByteBuffer encodeKey(String key)
+    {
+        return ByteBuffer.wrap(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public ByteBuffer encodeValue(HistoricalPlanStatistics historicalPlanStatistics)
+    {
+        ThriftCodec<HistoricalPlanStatistics> writeCodec = thriftCodecManager.getCodec(HistoricalPlanStatistics.class);
+        SliceOutput dynamicSliceOutput = new DynamicSliceOutput(ESTIMATED_BUFFER_SIZE_BYTES);
+        try {
+            ThriftProtocolUtils.write(historicalPlanStatistics, writeCodec, Protocol.BINARY, dynamicSliceOutput);
+            return ByteBuffer.wrap(dynamicSliceOutput.slice().getBytes());
+        }
+        catch (ThriftProtocolException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public HistoricalPlanStatistics decodeValue(ByteBuffer byteBuffer)
+    {
+        ThriftCodec<HistoricalPlanStatistics> readCodec = thriftCodecManager.getCodec(HistoricalPlanStatistics.class);
+        try {
+            return ThriftProtocolUtils.read(readCodec, Protocol.BINARY, Slices.wrappedBuffer(byteBuffer).getInput());
+        }
+        catch (ThriftProtocolException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/PropertiesUtil.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/PropertiesUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.google.common.collect.Maps.fromProperties;
+
+public final class PropertiesUtil
+{
+    private PropertiesUtil() {}
+
+    public static Map<String, String> loadProperties(File file)
+            throws IOException
+    {
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(file.toPath())) {
+            properties.load(in);
+        }
+        return fromProperties(properties);
+    }
+
+    public static Map<String, String> loadAndProcessProperties(String path)
+            throws IOException
+    {
+        Map<String, String> properties = new HashMap<>(loadProperties(new File(path)));
+        // load secrets
+        if (properties.containsKey(RedisProviderConfig.REDIS_CREDENTIALS_PATH)) {
+            File credentialFile = new File(properties.get(RedisProviderConfig.REDIS_CREDENTIALS_PATH));
+            properties.putAll(loadProperties(credentialFile));
+        }
+        return properties;
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisClusterAsyncCommandsFactory.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisClusterAsyncCommandsFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+
+public class RedisClusterAsyncCommandsFactory
+{
+    private RedisClusterAsyncCommandsFactory() {}
+
+    public static RedisClusterClient getRedisClusterClient(RedisProviderConfig redisProviderConfig)
+    {
+        return RedisClusterClient.create(redisProviderConfig.getServerUri());
+    }
+
+    public static RedisClient getRedisClient(RedisProviderConfig redisProviderConfig)
+    {
+        return RedisClient.create(redisProviderConfig.getServerUri());
+    }
+
+    public static RedisClusterAsyncCommands<String, HistoricalPlanStatistics> getRedisClusterAsyncCommands(RedisProviderConfig redisProviderConfig,
+            HistoricalStatisticsSerde historicalStatisticsSerde, AbstractRedisClient redisClient)
+    {
+        if (redisProviderConfig.getClusterModeEnabled()) {
+            assert (redisClient instanceof RedisClusterClient);
+            return ((RedisClusterClient) redisClient).connect(historicalStatisticsSerde).async();
+        }
+        assert (redisClient instanceof RedisClient);
+        return ((RedisClient) redisClient).connect(historicalStatisticsSerde).async();
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisPlanStatisticsProvider.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisPlanStatisticsProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.plan.PlanNodeWithHash;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.lettuce.core.LettuceFutures;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+
+import javax.inject.Inject;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RedisPlanStatisticsProvider
+        implements HistoryBasedPlanStatisticsProvider
+{
+    private static final Logger log = Logger.get(RedisPlanStatisticsProvider.class);
+
+    private final RedisProviderApiStats redisProviderApiStats;
+    private RedisClusterAsyncCommands<String, HistoricalPlanStatistics> commands;
+
+    private final long totalFetchTimeoutMillis;
+
+    private final long totalSetTimeMillis;
+
+    private final long defaultTTLSeconds;
+
+    @Inject
+    public RedisPlanStatisticsProvider(
+            RedisClusterAsyncCommands<String, HistoricalPlanStatistics> commands,
+            RedisProviderApiStats redisProviderApiStats,
+            RedisProviderConfig config)
+    {
+        this.commands = commands;
+        this.totalSetTimeMillis = config.getTotalSetTimeoutMs();
+        this.totalFetchTimeoutMillis = config.getTotalFetchTimeoutMs();
+        this.defaultTTLSeconds = config.getDefaultTtlSeconds();
+        this.redisProviderApiStats = redisProviderApiStats;
+    }
+
+    public RedisPlanStatisticsProvider(RedisProviderApiStats redisProviderApiStats, RedisClusterAsyncCommands<String, HistoricalPlanStatistics> commands, long totalFetchTimeoutMillis, long totalSetTimeoutMillis, long defaultTTLSeconds)
+    {
+        this.commands = commands;
+        this.totalSetTimeMillis = totalSetTimeoutMillis;
+        this.totalFetchTimeoutMillis = totalFetchTimeoutMillis;
+        this.defaultTTLSeconds = defaultTTLSeconds;
+        this.redisProviderApiStats = redisProviderApiStats;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "redis";
+    }
+
+    @Override
+    public Map<PlanNodeWithHash, HistoricalPlanStatistics> getStats(List<PlanNodeWithHash> planNodesWithHash, long timeoutMillis)
+    {
+        Map<PlanNodeWithHash, HistoricalPlanStatistics> result = redisProviderApiStats.execute(() -> {
+            Map<PlanNodeWithHash, RedisFuture<HistoricalPlanStatistics>> redisFutureMap = new HashMap<>();
+            for (PlanNodeWithHash planNodeWithHash : planNodesWithHash) {
+                if (!planNodeWithHash.getHash().isPresent()) {
+                    continue;
+                }
+                RedisFuture<HistoricalPlanStatistics> future = commands.get(planNodeWithHash.getHash().get());
+                redisFutureMap.put(planNodeWithHash, future);
+            }
+            LettuceFutures.awaitAll(Duration.ofMillis(totalFetchTimeoutMillis), redisFutureMap.values().toArray(new RedisFuture[redisFutureMap.values().size()]));
+            Map<PlanNodeWithHash, HistoricalPlanStatistics> output = new HashMap<>();
+            for (Map.Entry<PlanNodeWithHash, RedisFuture<HistoricalPlanStatistics>> redisFutureEntry : redisFutureMap.entrySet()) {
+                if (redisFutureEntry.getValue().isDone()) {
+                    try {
+                        output.put(redisFutureEntry.getKey(), redisFutureEntry.getValue().get());
+                    }
+                    catch (Exception e) {
+                        log.error(String.format("Error reading done Redis future fore key %s", redisFutureEntry.getKey().toString()));
+                        throw e;
+                    }
+                }
+                else {
+                    // cancel
+                    log.debug(String.format("Redis Timeout: Couldn't receive stats for key %s from redis", redisFutureEntry.getKey().toString()));
+                    redisFutureEntry.getValue().cancel(true);
+                }
+            }
+            return output;
+        }, RedisProviderApiStats.Operation.FetchStats);
+
+        return (result == null) ? ImmutableMap.of() : result;
+    }
+
+    @Override
+    public void putStats(Map<PlanNodeWithHash, HistoricalPlanStatistics> hashesAndStatistics)
+    {
+        redisProviderApiStats.execute(() -> {
+            List<RedisFuture> redisFuturesList = new ArrayList<>();
+            hashesAndStatistics.forEach((k, v) -> {
+                if (k.getHash().isPresent()) {
+                    redisFuturesList.add(commands.setex(k.getHash().get(), defaultTTLSeconds, v));
+                }
+            });
+            LettuceFutures.awaitAll(Duration.ofMillis(totalSetTimeMillis), redisFuturesList.toArray(new RedisFuture[redisFuturesList.size()]));
+
+            for (RedisFuture redisFuture : redisFuturesList) {
+                if (!redisFuture.isDone()) {
+                    log.error("Redis Timeout: Couldn't put stats within timeout");
+                    redisFuture.cancel(true);
+                }
+            }
+            return null;
+        }, RedisProviderApiStats.Operation.PutStats);
+    }
+
+    // Only Visible for integration testing
+    @VisibleForTesting
+    public void resetConnection(RedisClusterAsyncCommands<String, HistoricalPlanStatistics> cmds)
+    {
+        commands = cmds;
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderApiStats.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderApiStats.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import io.lettuce.core.RedisException;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@ThreadSafe
+public class RedisProviderApiStats
+{
+    private static final Logger log = Logger.get(RedisProviderApiStats.class);
+
+    enum Operation
+    {
+        FetchStats,
+        PutStats
+    }
+
+    private final TimeStat fetchTime = new TimeStat(MILLISECONDS);
+    private final TimeStat putTime = new TimeStat(MILLISECONDS);
+    private final CounterStat putStatRequest = new CounterStat();
+    private final CounterStat putStatGenericFailure = new CounterStat();
+    private final CounterStat putStatTimeoutFailure = new CounterStat();
+    private final CounterStat putStatRedisFailure = new CounterStat();
+    private final CounterStat fetchStatRequest = new CounterStat();
+    private final CounterStat fetchStatGenericFailure = new CounterStat();
+    private final CounterStat fetchStatTimeoutFailure = new CounterStat();
+    private final CounterStat fetchStatRedisFailure = new CounterStat();
+
+    public TimeStat getTime(Operation operation)
+    {
+        return (operation == Operation.FetchStats) ? fetchTime : putTime;
+    }
+
+    public CounterStat getStatRequest(Operation operation)
+    {
+        return (operation == Operation.FetchStats) ? fetchStatRequest : putStatRequest;
+    }
+
+    public CounterStat getGenericFailureStat(Operation operation)
+    {
+        return (operation == Operation.FetchStats) ? fetchStatGenericFailure : putStatGenericFailure;
+    }
+
+    public CounterStat getTimeoutFailureStat(Operation operation)
+    {
+        return (operation == Operation.FetchStats) ? fetchStatTimeoutFailure : putStatTimeoutFailure;
+    }
+
+    public CounterStat getRedisFailureStat(Operation operation)
+    {
+        return (operation == Operation.FetchStats) ? fetchStatRedisFailure : putStatRedisFailure;
+    }
+
+    public <V> V execute(Callable<V> callable, Operation operation)
+    {
+        try {
+            return wrap(callable, operation).call();
+        }
+        catch (TimeoutException e) {
+            getTimeoutFailureStat(operation).update(1);
+            log.error(String.format("Redis Stat Provider Error:" +
+                    " Request %s failed with Timeout %s", operation, (e.getMessage() == null) ? "" : e.getMessage()));
+        }
+        catch (RedisException e) {
+            getRedisFailureStat(operation).update(1);
+            log.error(String.format("Redis Stat Provider Error:" +
+                    " Request %s failed with RedisException %s", operation, (e.getMessage() == null) ? "" : e.getMessage()));
+        }
+        catch (Exception e) {
+            getGenericFailureStat(operation).update(1);
+            log.error(String.format("Redis Stat Provider Error:" +
+                    " Request %s failed with GenericException %s", operation, (e.getMessage() == null) ? "" : e.getMessage()));
+        }
+        return null;
+    }
+
+    public <V> Callable<V> wrap(Callable<V> callable, Operation operation)
+    {
+        return () -> {
+            try (TimeStat.BlockTimer ignored = getTime(operation).time()) {
+                getStatRequest(operation).update(1);
+                return callable.call();
+            }
+            catch (Exception e) {
+                // Will be caught outside
+                throw e;
+            }
+        };
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getPutStatTimeoutFailure()
+    {
+        return putStatTimeoutFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getPutStatGenericFailure()
+    {
+        return putStatGenericFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getPutStatRequest()
+    {
+        return putStatRequest;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getPutStatRedisFailure()
+    {
+        return putStatRedisFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchStatRedisFailure()
+    {
+        return fetchStatRedisFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchStatRequest()
+    {
+        return fetchStatRequest;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchStatGenericFailure()
+    {
+        return fetchStatGenericFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchStatTimeoutFailure()
+    {
+        return fetchStatTimeoutFailure;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFetchTime()
+    {
+        return fetchTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getPutTime()
+    {
+        return putTime;
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.configuration.Config;
+
+public class RedisProviderConfig
+{
+    // Constants
+    public static final String COORDINATOR_PROPERTY_NAME = "coordinator";
+    public static final String SERVICE_NAME_PROPERTY_NAME = "hbo.redis-provider.config-name";
+    public static final String SERVER_URI_PROPERTY_NAME = "hbo.redis-provider.server_uri";
+    public static final String CLUSTER_PASSWORD_PROPERTY_NAME = "hbo.redis-provider.cluster-password";
+    public static final String TOTAL_FETCH_TIMEOUT_PROPERTY_NAME = "hbo.redis-provider.total-fetch-timeoutms";
+    public static final String DEFAULT_TTL_PROPERTY_NAME = "hbo.redis-provider.default-ttl-seconds";
+    public static final String HBO_PROVIDER_ENABLED_NAME = "hbo.redis-provider.enabled";
+    public static final String TOTAL_SET_TIMEOUT_PROPERTY_NAME = "hbo.redis-provider.total-set-timeoutms";
+    public static final String REDIS_CREDENTIALS_PATH = "credentials-path";
+    public static final String CLUSTER_MODE_ENABLED = "hbo.redis-provider.cluster-mode-enabled";
+    public static final String REDIS_PROPERTIES_PATH = "etc/redis-provider.properties";
+    private String coordinator;
+    private String serviceName;
+    private String serverUri;
+    private String clusterPassword;
+    private long totalFetchTimeoutMs;
+
+    private long defaultTtlSeconds;
+    private boolean hboProviderEnabled;
+
+    private boolean clusterModeEnabled;
+    private long totalSetTimeoutMs;
+    private String credentialsPath;
+    private String redisPropertiesPath;
+
+    @Config("hbo.redis-provider.cluster-mode-enabled")
+    public RedisProviderConfig setClusterModeEnabled(boolean value)
+    {
+        this.clusterModeEnabled = value;
+        return this;
+    }
+
+    public boolean getClusterModeEnabled()
+    {
+        return clusterModeEnabled;
+    }
+
+    @Config("coordinator")
+    public RedisProviderConfig setCoordinator(String value)
+    {
+        this.coordinator = value;
+        return this;
+    }
+
+    public String getCoordinator()
+    {
+        return coordinator;
+    }
+
+    @Config("hbo.redis-provider.config-name")
+    public RedisProviderConfig setServiceName(String value)
+    {
+        this.serviceName = value;
+        return this;
+    }
+
+    public String getServiceName()
+    {
+        return serviceName;
+    }
+
+    @Config("hbo.redis-provider.server_uri")
+    public RedisProviderConfig setServerUri(String value)
+    {
+        this.serverUri = value;
+        return this;
+    }
+
+    public String getServerUri()
+    {
+        return serverUri;
+    }
+
+    @Config("hbo.redis-provider.cluster-password")
+    public RedisProviderConfig setClusterPassword(String value)
+    {
+        this.clusterPassword = value;
+        return this;
+    }
+
+    public String getClusterPassword()
+    {
+        return clusterPassword;
+    }
+
+    @Config("hbo.redis-provider.total-fetch-timeoutms")
+    public RedisProviderConfig setTotalFetchTimeoutMs(long value)
+    {
+        this.totalFetchTimeoutMs = value;
+        return this;
+    }
+
+    public long getTotalFetchTimeoutMs()
+    {
+        return totalFetchTimeoutMs;
+    }
+
+    @Config("hbo.redis-provider.default-ttl-seconds")
+    public RedisProviderConfig setDefaultTtlSeconds(long value)
+    {
+        this.defaultTtlSeconds = value;
+        return this;
+    }
+
+    public long getDefaultTtlSeconds()
+    {
+        return defaultTtlSeconds;
+    }
+
+    @Config("hbo.redis-provider.enabled")
+    public RedisProviderConfig setHboProviderEnabled(boolean value)
+    {
+        this.hboProviderEnabled = value;
+        return this;
+    }
+
+    public boolean getHboProviderEnabled()
+    {
+        return hboProviderEnabled;
+    }
+
+    @Config("hbo.redis-provider.total-set-timeoutms")
+    public RedisProviderConfig setTotalSetTimeoutMs(long value)
+    {
+        this.totalSetTimeoutMs = value;
+        return this;
+    }
+
+    public long getTotalSetTimeoutMs()
+    {
+        return totalSetTimeoutMs;
+    }
+
+    @Config("credentials-path")
+    public RedisProviderConfig setCredentialsPath(String value)
+    {
+        this.credentialsPath = value;
+        return this;
+    }
+
+    public String getCredentialsPath()
+    {
+        return credentialsPath;
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderInjectorFactory.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderInjectorFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+
+public class RedisProviderInjectorFactory
+{
+    private RedisProviderInjectorFactory()
+    {
+    }
+
+    public static Injector create(Map<String, String> propertyMap)
+    {
+        ImmutableList.Builder<Module> modules = ImmutableList.builder();
+        modules.add(
+                new MBeanModule(),
+                new RedisProviderModule());
+        Bootstrap app = new Bootstrap(modules.build());
+        app.setOptionalConfigurationProperties(propertyMap);
+        return app.doNotInitializeLogging()
+                .noStrictConfig()
+                .quiet()
+                .initialize();
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderModule.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderModule.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+
+import javax.management.MBeanServer;
+
+import java.lang.management.ManagementFactory;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class RedisProviderModule
+        extends AbstractConfigurationAwareModule
+{
+    public RedisProviderModule() {}
+
+    @Provides
+    @Singleton
+    public RedisClusterAsyncCommands<String, HistoricalPlanStatistics> provideAsyncCommands(HistoricalStatisticsSerde historicalStatisticsSerde,
+            RedisProviderConfig redisProviderConfig, AbstractRedisClient redisClient)
+    {
+        return RedisClusterAsyncCommandsFactory.getRedisClusterAsyncCommands(redisProviderConfig, historicalStatisticsSerde, redisClient);
+    }
+
+    @Provides
+    @Singleton
+    public AbstractRedisClient provideAbstractRedisClient(RedisProviderConfig redisProviderConfig, RedisProviderConfig config)
+    {
+        if (redisProviderConfig.getClusterModeEnabled()) {
+            return RedisClusterAsyncCommandsFactory.getRedisClusterClient(config);
+        }
+        return RedisClusterAsyncCommandsFactory.getRedisClient(config);
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(RedisProviderConfig.class);
+        MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        binder.bind(MBeanServer.class).toInstance(platformMBeanServer);
+        binder.bind(RedisProviderApiStats.class).in(Scopes.SINGLETON);
+        binder.bind(HistoricalStatisticsSerde.class).toInstance(new HistoricalStatisticsSerde());
+        binder.bind(RedisPlanStatisticsProvider.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(RedisProviderApiStats.class).as(generatedNameOf(RedisProviderApiStats.class));
+    }
+}

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.statistics.EmptyPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import io.lettuce.core.AbstractRedisClient;
+
+import java.util.Map;
+
+import static com.facebook.presto.statistic.PropertiesUtil.loadAndProcessProperties;
+
+public class RedisProviderPlugin
+        implements Plugin, AutoCloseable
+{
+    private static final Logger log = Logger.get(RedisProviderPlugin.class);
+    private final Map<String, String> propertyMap;
+
+    private Injector injector;
+
+    @VisibleForTesting
+    public RedisProviderPlugin(String configPath)
+    {
+        // This plugin cannot be loaded like other plugins because this is not a connector
+        Map<String, String> propertyMap;
+        try {
+            propertyMap = loadAndProcessProperties(configPath);
+        }
+        catch (Exception e) {
+            propertyMap = null;
+            log.info("Redis Provider Plugin was not loaded since config was not loaded properly");
+        }
+        this.propertyMap = propertyMap;
+    }
+
+    public RedisProviderPlugin()
+    {
+        this(RedisProviderConfig.REDIS_PROPERTIES_PATH);
+    }
+
+    public Iterable<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProviders()
+    {
+        if (this.propertyMap == null) {
+            log.info("Redis Provider Plugin returned an empty instance");
+            return ImmutableList.of(EmptyPlanStatisticsProvider.getInstance());
+        }
+        if (!(propertyMap.getOrDefault(RedisProviderConfig.COORDINATOR_PROPERTY_NAME, "false").equals("true") &&
+                propertyMap.getOrDefault(RedisProviderConfig.HBO_PROVIDER_ENABLED_NAME, "false").equals("true"))) {
+            return ImmutableList.of(EmptyPlanStatisticsProvider.getInstance());
+        }
+        injector = RedisProviderInjectorFactory.create(propertyMap);
+        log.info("Redis Provider Plugin could successfully create the Redis Provider");
+        return ImmutableList.of(injector.getInstance(RedisPlanStatisticsProvider.class));
+    }
+
+    @VisibleForTesting
+    public void close()
+    {
+        if (injector != null) {
+            injector.getInstance(AbstractRedisClient.class).close();
+        }
+    }
+}

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
+import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertThrows;
+
+public class TestHistoricalStatisticsSerde
+{
+    @Test
+    public void TestSimpleHistoricalStatisticsEncoderDecoder()
+    {
+        HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
+                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1),
+                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1)))));
+        HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
+
+        // Test PlanHash
+        ByteBuffer encodedKey = historicalStatisticsEncoderDecoder.encodeKey("test");
+        historicalStatisticsEncoderDecoder.decodeKey(encodedKey).equals("test");
+
+        // Test Plan Statistics
+        ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
+        historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics);
+    }
+
+    @Test
+    public void TestHistoricalPlanStatisticsEntryList()
+    {
+        List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1),
+                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0))));
+        }
+        HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);
+        HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
+
+        // Test Plan Statistics
+        ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
+        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics)) : "Decoded value is different from original encoded value ";
+    }
+
+    @Test
+    public void TestHistoricalPlanStatisticsEmptyList()
+    {
+        HistoricalPlanStatistics emptySamplePlanStatistics = new HistoricalPlanStatistics(emptyList());
+        HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
+
+        // Test Plan Statistics
+        ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(emptySamplePlanStatistics);
+        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(emptySamplePlanStatistics)) : "Decoded value is different from original encoded value ";
+    }
+
+    @Test
+    public void TestPlanStatisticsList()
+    {
+        List<PlanStatistics> planStatisticsEntryList = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1));
+        }
+        List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1),
+                    planStatisticsEntryList));
+        }
+        HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);
+        HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
+
+        // Test Plan Statistics
+        ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
+        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics)) : "Decoded value is different from original encoded value ";
+    }
+
+    @Test
+    public void TestHistoricalStatisticsDecodeValueException()
+    {
+        HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
+
+        // Test PlanHash
+        ByteBuffer encodedKey = historicalStatisticsEncoderDecoder.encodeKey("test");
+        assertThrows(
+                RuntimeException.class,
+                () -> historicalStatisticsEncoderDecoder.decodeValue(encodedKey));
+    }
+}

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoryBasedRedisStatisticsTracking.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoryBasedRedisStatisticsTracking.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.HistoryBasedPlanStatisticsCalculator;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.MarkDistinctNode;
+import com.facebook.presto.spi.plan.OutputNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.sql.planner.assertions.MatchResult;
+import com.facebook.presto.sql.planner.assertions.Matcher;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.github.fppt.jedismock.RedisServer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.facebook.presto.SystemSessionProperties.TRACK_HISTORY_BASED_PLAN_STATISTICS;
+import static com.facebook.presto.SystemSessionProperties.USE_HISTORY_BASED_PLAN_STATISTICS;
+import static com.facebook.presto.SystemSessionProperties.USE_PERFECTLY_CONSISTENT_HISTORIES;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.Double.isNaN;
+
+// Based of TestHistoryBasedStatsTracking
+@Test(singleThreaded = true)
+public class TestHistoryBasedRedisStatisticsTracking
+        extends AbstractTestQueryFramework
+{
+    private RedisServer server;
+
+    RedisClusterAsyncCommands redisAsyncCommands;
+    private final long sleepTimeoutMillis = 6000;
+    private final long redisTimeoutMillis = 4000;
+    private final long defaultTTLSeconds = 4000;
+
+    @Override
+    public QueryRunner createQueryRunner()
+            throws Exception
+    {
+        server = RedisServer.newRedisServer();
+        server.start();
+        RedisClient redisClient = RedisClient.create(RedisURI.create(server.getHost(), server.getBindPort()));
+        QueryRunner queryRunner = new DistributedQueryRunner(createSession(), 1);
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", "3"));
+
+        redisAsyncCommands = redisClient.connect(new HistoricalStatisticsSerde()).async();
+        RedisPlanStatisticsProvider redisPlanStatisticsProvider = new RedisPlanStatisticsProvider(
+                new RedisProviderApiStats(),
+                redisAsyncCommands,
+                redisTimeoutMillis, redisTimeoutMillis, defaultTTLSeconds);
+        queryRunner.installPlugin(new Plugin()
+        {
+            @Override
+            public Iterable<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProviders()
+            {
+                return ImmutableList.of(redisPlanStatisticsProvider);
+            }
+        });
+        if (queryRunner.getStatsCalculator() instanceof HistoryBasedPlanStatisticsCalculator) {
+            ((HistoryBasedPlanStatisticsCalculator) queryRunner.getStatsCalculator()).setPrefetchForAllPlanNodes(true);
+        }
+        return queryRunner;
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp()
+            throws Exception
+    {
+        // Delete all keys from the cluster
+        redisAsyncCommands.flushall().get();
+    }
+
+    @Test
+    public void testHistoryBasedStatsCalculator()
+    {
+        // CBO Statistics
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(FilterNode.class, any()).withOutputRowCount(Double.NaN)));
+
+        // HBO Statistics
+        executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) = 'A'");
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(FilterNode.class, any()).withOutputRowCount(2).withOutputSize(199)));
+
+        // CBO Statistics
+        assertPlan(
+                "SELECT max(nationkey) FROM nation where name < 'D' group by regionkey",
+                anyTree(node(ProjectNode.class, node(FilterNode.class, any())).withOutputRowCount(12.5)));
+        assertPlan(
+                "SELECT max(nationkey) FROM nation where name < 'D' group by regionkey",
+                anyTree(node(AggregationNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(Double.NaN)));
+
+        // HBO Statistics
+        executeAndTrackHistory("SELECT max(nationkey) FROM nation where name < 'D' group by regionkey");
+        assertPlan(
+                "SELECT max(nationkey) FROM nation where name < 'D' group by regionkey",
+                anyTree(node(ProjectNode.class, node(FilterNode.class, any())).withOutputRowCount(5).withOutputSize(90)));
+
+        assertPlan(
+                "SELECT max(nationkey) FROM nation where name < 'D' group by regionkey",
+                anyTree(node(AggregationNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(3).withOutputSize(54)));
+    }
+
+    @Test
+    public void testConcurrentHistoryBasedStatsCalculator()
+            throws InterruptedException
+    {
+        // CBO Statistics
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CompletionService<Void> completionService =
+                new ExecutorCompletionService<Void>(executorService);
+
+        for (int i = 0; i < 10; i++) {
+            char letter = (char) ('A' + i);
+            completionService.submit(new Callable<Void>()
+            {
+                @Override
+                public Void call()
+                        throws Exception
+                {
+                    assertPlan(getSession(),
+                            "SELECT * FROM nation where substr(name, 1, 1) = " + "'" + letter + "'",
+                            anyTree(node(FilterNode.class, any()).withOutputRowCount(Double.NaN)));
+                    return null;
+                }
+            });
+        }
+        checkCompletionService(completionService);
+
+        // Collect Statistics
+        for (int i = 0; i < 10; i++) {
+            char letter = (char) ('A' + i);
+            completionService.submit(new Callable<Void>()
+            {
+                @Override
+                public Void call()
+                        throws Exception
+                {
+                    executeAndTrackHistory(
+                            "SELECT * FROM nation where substr(name, 1, 1) = " + "'" + letter + "'");
+                    return null;
+                }
+            });
+        }
+        checkCompletionService(completionService);
+
+        // HBO Stats
+        Map<Character, Integer> rowCountMap = new HashMap<>();
+        rowCountMap.put('A', 2);
+        rowCountMap.put('B', 1);
+        rowCountMap.put('C', 2);
+        rowCountMap.put('D', 0);
+        rowCountMap.put('E', 2);
+        rowCountMap.put('F', 1);
+        rowCountMap.put('G', 1);
+        rowCountMap.put('H', 0);
+        rowCountMap.put('I', 4);
+        rowCountMap.put('J', 2);
+
+        for (int i = 0; i < 10; i++) {
+            char letter = (char) ('A' + i);
+            completionService.submit(new Callable<Void>()
+            {
+                @Override
+                public Void call()
+                        throws Exception
+                {
+                    assertPlan(getSession(),
+                            "SELECT * FROM nation where substr(name, 1, 1) = " + "'" + letter + "'",
+                            anyTree(node(FilterNode.class, any()).withOutputRowCount(rowCountMap.get(letter))));
+                    return null;
+                }
+            });
+        }
+
+        checkCompletionService(completionService);
+    }
+
+    private void checkCompletionService(CompletionService<Void> completionService)
+            throws InterruptedException
+    {
+        for (int i = 0; i < 10; i++) {
+            Future<Void> resultFuture = completionService.take();
+            try {
+                resultFuture.get(); //blocks if none available
+            }
+            catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    public void testUnion()
+    {
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A' UNION ALL SELECT * FROM nation where substr(name, 1, 1) = 'B'",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+
+        executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) = 'A' UNION ALL SELECT * FROM nation where substr(name, 1, 1) = 'B'");
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'B' UNION ALL SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(3)));
+
+        // INTERSECT, EXCEPT are implemented as UNION
+        executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) >= 'B' and substr(name, 1, 1) <= 'E' INTERSECT SELECT * FROM nation where substr(name, 1, 1) <= 'B'");
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) >= 'B' and substr(name, 1, 1) <= 'E' INTERSECT SELECT * FROM nation where substr(name, 1, 1) <= 'B'",
+                anyTree(node(ProjectNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(1)));
+
+        executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) >= 'B' and substr(name, 1, 1) <= 'E' EXCEPT SELECT * FROM nation where substr(name, 1, 1) <= 'B'");
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) >= 'B' and substr(name, 1, 1) <= 'E' EXCEPT SELECT * FROM nation where substr(name, 1, 1) <= 'B'",
+                anyTree(node(ProjectNode.class, node(FilterNode.class, anyTree(anyTree(any()), anyTree(any())))).withOutputRowCount(4)));
+    }
+
+    @Test
+    public void testWindow()
+    {
+        String query1 = "SELECT orderkey, SUM(custkey) OVER (PARTITION BY orderstatus ORDER BY totalprice) FROM orders where orderkey < 1000";
+        String query2 = "SELECT orderkey, SUM(custkey) OVER (PARTITION BY orderstatus ORDER BY totalprice) FROM orders where orderkey < 2000";
+
+        assertPlan(query1 + " UNION ALL " + query2, anyTree(node(WindowNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query1 + " UNION ALL " + query2);
+        assertPlan(
+                query2 + " UNION ALL " + query1,
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(758)));
+    }
+
+    @Test
+    public void testValues()
+    {
+        String query = "SELECT * FROM (SELECT * FROM ( VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)) T1 JOIN (SELECT nationkey FROM nation WHERE substr(name, 1, 1) = 'A') T2 ON T2.nationkey = T1.id";
+
+        assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testSort()
+    {
+        String query = "SELECT * FROM nation where substr(name, 1, 1) = 'A' ORDER BY regionkey";
+
+        assertPlan(query, anyTree(node(SortNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(SortNode.class, anyTree(any())).withOutputRowCount(2)));
+    }
+
+    @Test
+    public void testMarkDistinct()
+    {
+        String query = "SELECT count(*), count(distinct orderstatus) FROM (SELECT * FROM orders WHERE orderstatus = 'F')";
+
+        assertPlan(query, anyTree(node(MarkDistinctNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(MarkDistinctNode.class, anyTree(any())).withOutputRowCount(7304)));
+    }
+
+    @Test
+    public void testAssignUniqueId()
+    {
+        String query = "SELECT name, (SELECT name FROM region WHERE regionkey = nation.regionkey) FROM nation";
+
+        // Stats of AssignUniqueId can be generated from CBO, so test for OutputNode stats which include the whole plan hash
+        assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(Double.NaN));
+        executeAndTrackHistory(query);
+        assertPlan(query, node(OutputNode.class, anyTree(anyTree(any()), anyTree(any()))).withOutputRowCount(25));
+    }
+
+    @Test
+    public void testSemiJoin()
+    {
+        String query = "SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderkey = 2))";
+
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.longBitsToDouble(4616202753553671564L))));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(SemiJoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testRowNumber()
+    {
+        String query = "SELECT nationkey, ROW_NUMBER() OVER (PARTITION BY regionkey) from nation where substr(name, 1, 1) = 'A'";
+
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(RowNumberNode.class, anyTree(any())).withOutputRowCount(2)));
+    }
+
+    @Test
+    public void testUnionMultiple()
+    {
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A' UNION ALL " +
+                        "SELECT * FROM nation where substr(name, 1, 1) = 'B' UNION ALL " +
+                        "SELECT * FROM nation where substr(name, 1, 1) = 'C'",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+
+        executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) = 'A' UNION ALL " +
+                "SELECT * FROM nation where substr(name, 1, 1) = 'B' UNION ALL " +
+                "SELECT * FROM nation where substr(name, 1, 1) = 'C'");
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'B' UNION ALL " +
+                        "SELECT * FROM nation where substr(name, 1, 1) = 'C' UNION ALL " +
+                        "SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any()), anyTree(any())).withOutputRowCount(5)));
+
+        assertPlan(
+                "SELECT nationkey FROM nation where substr(name, 1, 1) = 'A' UNION ALL SELECT nationkey FROM customer where nationkey < 10",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+
+        executeAndTrackHistory("SELECT nationkey FROM nation where substr(name, 1, 1) = 'A' UNION ALL SELECT nationkey FROM customer  where nationkey < 10");
+        assertPlan(
+                "SELECT nationkey FROM customer where nationkey < 10 UNION ALL SELECT nationkey FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(ExchangeNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(601)));
+    }
+
+    @Test
+    public void testJoin()
+    {
+        assertPlan(
+                "SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'",
+                anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(Double.NaN)));
+        assertPlan(
+                "SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'",
+                anyTree(node(JoinNode.class, anyTree(anyTree(any()), anyTree(any())), anyTree(any())).withOutputRowCount(Double.NaN)));
+
+        executeAndTrackHistory("SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'");
+        assertPlan(
+                "SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'",
+                anyTree(node(JoinNode.class, anyTree(node(JoinNode.class, anyTree(any()), anyTree(any())).withOutputRowCount(2204)), anyTree(any()))));
+        assertPlan(
+                "SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'",
+                anyTree(node(JoinNode.class, anyTree(anyTree(any()), anyTree(any())), anyTree(any())).withOutputRowCount(1915)));
+        // Check that output size doesn't include hash variables
+        assertPlan(
+                "SELECT N.name, O.totalprice, C.name FROM orders O, customer C, nation N WHERE N.nationkey = C.nationkey and C.custkey = O.custkey and year(O.orderdate) = 1995 AND substr(N.name, 1, 1) >= 'C'",
+                anyTree(anyTree(anyTree(any()), anyTree(any())), anyTree(node(ProjectNode.class, anyTree(any())).withOutputRowCount(22).withOutputSize(661 - 22 * 8))));
+    }
+
+    @Test
+    public void testLimit()
+    {
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(FilterNode.class, any()).withOutputRowCount(Double.NaN)));
+
+        // Limit nodes may cause workers to break early and not log statistics.
+        // This happens in some runs, so running it a few times should make it likely that some run succeeded in storing
+        // stats.
+        for (int i = 0; i < 10; ++i) {
+            executeAndTrackHistory("SELECT * FROM nation where substr(name, 1, 1) = 'A' LIMIT 1");
+        }
+        // Don't track stats of filter node when limit is not present
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A'",
+                anyTree(node(FilterNode.class, any()).withOutputRowCount(Double.NaN)));
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A' LIMIT 1",
+                anyTree(node(FilterNode.class, any()).with(validOutputRowCountMatcher())));
+        assertPlan(
+                "SELECT * FROM nation where substr(name, 1, 1) = 'A' LIMIT 1",
+                anyTree(node(LimitNode.class, anyTree(any())).withOutputRowCount(1)));
+    }
+
+    @Test
+    public void testTopN()
+    {
+        String query = "SELECT orderkey FROM orders where orderkey < 1000 GROUP BY 1 ORDER BY 1 DESC LIMIT 10000";
+        assertPlan(query, anyTree(node(TopNNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(TopNNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(255)));
+    }
+
+    @Test
+    public void testTopNRowNumber()
+    {
+        String query = "SELECT orderstatus FROM (SELECT orderstatus, row_number() OVER (PARTITION BY orderstatus ORDER BY custkey) n FROM orders) WHERE n = 1";
+        assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(TopNRowNumberNode.class, anyTree(any())).withOutputRowCount(3)));
+    }
+
+    @Test
+    public void testDistinctLimit()
+    {
+        String query = "SELECT distinct regionkey from nation limit 2";
+        assertPlan(query, anyTree(node(DistinctLimitNode.class, anyTree(any())).withOutputRowCount(Double.NaN)));
+        executeAndTrackHistory(query);
+        assertPlan(query, anyTree(node(DistinctLimitNode.class, anyTree(any())).withOutputRowCount(2)));
+    }
+
+    private void executeAndTrackHistory(String sql)
+    {
+        getQueryRunner().execute(getSession(), sql);
+        try {
+            // To avoid the stats collection thread from preempting
+            Thread.sleep(sleepTimeoutMillis);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty(TRACK_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty("task_concurrency", "1")
+                .build();
+    }
+
+    private static Matcher validOutputRowCountMatcher()
+    {
+        return new Matcher()
+        {
+            @Override
+            public boolean shapeMatches(PlanNode node)
+            {
+                return true;
+            }
+
+            @Override
+            public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+            {
+                return new MatchResult(!isNaN(stats.getStats(node).getOutputRowCount()));
+            }
+        };
+    }
+
+    private static Session createSession()
+    {
+        return testSessionBuilder()
+                .setSystemProperty(USE_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty(TRACK_HISTORY_BASED_PLAN_STATISTICS, "true")
+                .setSystemProperty(USE_PERFECTLY_CONSISTENT_HISTORIES, "true")
+                .setSystemProperty("task_concurrency", "1")
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+    }
+}

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestRedisProviderPlugin.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestRedisProviderPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.statistic;
+
+import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.github.fppt.jedismock.RedisServer;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
+
+public class TestRedisProviderPlugin
+{
+    private final String redisHboPropertyFilePath = "src/test/java/resources/test-redis-hbo-provider.properties";
+
+    @Test
+    public void testStartup()
+            throws Exception
+    {
+        RedisServer server = RedisServer.newRedisServer(57872);
+        server.start();
+        RedisProviderPlugin plugin = new RedisProviderPlugin(redisHboPropertyFilePath);
+        HistoryBasedPlanStatisticsProvider hboProvider = plugin.getHistoryBasedPlanStatisticsProviders().iterator().next();
+        assertInstanceOf(hboProvider, RedisPlanStatisticsProvider.class);
+        server.stop();
+        plugin.close();
+    }
+}

--- a/redis-hbo-provider/src/test/java/resources/test-redis-hbo-provider.properties
+++ b/redis-hbo-provider/src/test/java/resources/test-redis-hbo-provider.properties
@@ -1,0 +1,7 @@
+coordinator=true
+hbo.redis-provider.enabled=true
+hbo.redis-provider.total-fetch-timeoutms=5000
+hbo.redis-provider.total-set-timeoutms=5000
+hbo.redis-provider.default-ttl-seconds=4320000
+hbo.redis-provider.cluster-mode-enabled=false
+hbo.redis-provider.server_uri=redis://0.0.0.0:57872


### PR DESCRIPTION
## Description
Adding an Open source Redis based Historical Statistics Provider.
The Redis client is stateful and based on Lettuce [link](https://github.com/lettuce-io/lettuce-core).
There are proper timeouts for fetch/get requests which are  configurable.
Latency and other metrics are available and exported thorough the JMX exporter. 
Redis requests will be pipelined since Lettuce uses [Pipelining](https://redis.io/docs/manual/pipelining/) by default

The provider plugin would need to be configured based on the use case, docs added - [here](presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst)


## Motivation and Context
There is no proper oss implementation of a statistics provider and this PR adds one

## Impact

## Test Plan
Unit tests + production tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Adding an open source redis based historical statistics provider


