### PR TITLE
[native] Refresh velox::Filesystem access token before starting task

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -328,6 +328,12 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTask(
     std::shared_ptr<velox::core::QueryCtx> queryCtx) {
   std::shared_ptr<exec::Task> execTask;
   bool startTask = false;
+
+  // Refresh token for all registered file system.
+  auto fileSystems = filesystems::getRegisteredFileSystems();
+  for (const auto& fileSystem : fileSystems) {
+    fileSystem->refreshAccessToken();
+  }
   auto prestoTask = findOrCreateTask(taskId);
   {
     std::lock_guard<std::mutex> l(prestoTask->mutex);


### PR DESCRIPTION
## Description
Extension of https://github.com/facebookincubator/velox/pull/5943
Before starting a velox::Task refresh access token for all velox::Filesystem

## Motivation and Context
Some filesystem have token based authorization model.
Add refreshAccessToken method to allow filesystem to implement their token
fetch mechanism.


## Test Plan
End 2 end test.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

