### PR TITLE
[native pos] Track process-wide CPU usage for the JVM process

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -67,6 +67,7 @@ struct ResultRequest {
 
 struct PrestoTask {
   const PrestoTaskId id;
+  const long startProcessCpuTime;
   std::shared_ptr<velox::exec::Task> task;
 
   // Has the task been normally created and started.
@@ -98,7 +99,14 @@ struct PrestoTask {
   /// Info request. May arrive before there is a Task.
   PromiseHolderWeakPtr<std::unique_ptr<protocol::TaskInfo>> infoRequest;
 
-  explicit PrestoTask(const std::string& taskId, const std::string& nodeId);
+  /// @param taskId Task ID.
+  /// @param nodeId Node ID.
+  /// @param startCpuTime CPU time in nanoseconds recorded when request to
+  /// create this task arrived.
+  PrestoTask(
+      const std::string& taskId,
+      const std::string& nodeId,
+      long startProcessCpuTime = 0);
 
   /// Updates when this task was touched last time.
   void updateHeartbeatLocked();
@@ -121,10 +129,18 @@ struct PrestoTask {
   static std::string taskNumbersToString(
       const std::array<size_t, 5>& taskNumbers);
 
+  /// Returns process-wide CPU time in nanoseconds.
+  static long getProcessCpuTime();
+
   protocol::TaskStatus updateStatusLocked();
   protocol::TaskInfo updateInfoLocked();
 
   std::string toJsonString() const;
+
+ private:
+  void recordProcessCpuTime();
+
+  long processCpuTime_{0};
 };
 
 using TaskMap =

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -53,19 +53,22 @@ class TaskManager {
   // next time coordinator checks for the status it retrieves the error.
   std::unique_ptr<protocol::TaskInfo> createOrUpdateErrorTask(
       const protocol::TaskId& taskId,
-      const std::exception_ptr& exception);
+      const std::exception_ptr& exception,
+      long startProcessCpuTime);
 
   std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
       const protocol::TaskId& taskId,
       const protocol::TaskUpdateRequest& updateRequest,
       const velox::core::PlanFragment& planFragment,
-      std::shared_ptr<velox::core::QueryCtx> queryCtx);
+      std::shared_ptr<velox::core::QueryCtx> queryCtx,
+      long startProcessCpuTime);
 
   std::unique_ptr<protocol::TaskInfo> createOrUpdateBatchTask(
       const protocol::TaskId& taskId,
       const protocol::BatchTaskUpdateRequest& batchUpdateRequest,
       const velox::core::PlanFragment& planFragment,
-      std::shared_ptr<velox::core::QueryCtx> queryCtx);
+      std::shared_ptr<velox::core::QueryCtx> queryCtx,
+      long startProcessCpuTime);
 
   // Iterates through a map of resultRequests and fetches data from
   // buffer manager. This method uses the getData() global call to fetch
@@ -162,13 +165,17 @@ class TaskManager {
       const velox::core::PlanFragment& planFragment,
       const std::vector<protocol::TaskSource>& sources,
       const protocol::OutputBuffers& outputBuffers,
-      std::shared_ptr<velox::core::QueryCtx> queryCtx);
+      std::shared_ptr<velox::core::QueryCtx> queryCtx,
+      long startProcessCpuTime);
 
-  std::shared_ptr<PrestoTask> findOrCreateTask(const protocol::TaskId& taskId);
+  std::shared_ptr<PrestoTask> findOrCreateTask(
+      const protocol::TaskId& taskId,
+      long startProcessCpuTime = 0);
 
   std::shared_ptr<PrestoTask> findOrCreateTaskLocked(
       TaskMap& taskMap,
-      const protocol::TaskId& taskId);
+      const protocol::TaskId& taskId,
+      long startProcessCpuTime = 0);
 
   std::string baseUri_;
   std::string nodeId_;

--- a/presto-native-execution/presto_cpp/main/TaskResource.h
+++ b/presto-native-execution/presto_cpp/main/TaskResource.h
@@ -68,7 +68,8 @@ class TaskResource {
       const std::vector<std::string>& pathMatch,
       const std::function<std::unique_ptr<protocol::TaskInfo>(
           const protocol::TaskId&,
-          const std::string&)>& createOrUpdateFunc);
+          const std::string&,
+          long)>& createOrUpdateFunc);
 
   proxygen::RequestHandler* deleteTask(
       proxygen::HTTPMessage* message,

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -570,7 +570,7 @@ class TaskManagerTest : public testing::Test {
         taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
             taskId, updateRequest.session);
     return taskManager_->createOrUpdateTask(
-        taskId, updateRequest, planFragment, std::move(queryCtx));
+        taskId, updateRequest, planFragment, std::move(queryCtx), 0);
   }
 
   std::shared_ptr<memory::MemoryPool> rootPool_;
@@ -645,7 +645,7 @@ TEST_F(TaskManagerTest, taskCleanupWithPendingResultData) {
           .getVia(folly::EventBaseManager::get()->getEventBase());
 
   std::exception e;
-  taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e));
+  taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e), 0);
   taskManager_->deleteTask(taskId, true);
   for (int i = 0; i < 10; ++i) {
     // 'results' holds a reference on the presto task which prevents the old
@@ -693,12 +693,12 @@ TEST_F(TaskManagerTest, tableScanOneSplitAtATime) {
 
     protocol::TaskUpdateRequest updateRequest;
     updateRequest.sources.push_back(source);
-    taskManager_->createOrUpdateTask(taskId, updateRequest, {}, nullptr);
+    taskManager_->createOrUpdateTask(taskId, updateRequest, {}, nullptr, 0);
   }
 
   protocol::TaskUpdateRequest updateRequest;
   updateRequest.sources.push_back(makeSource("0", {}, true, splitSequenceId));
-  taskManager_->createOrUpdateTask(taskId, updateRequest, {}, nullptr);
+  taskManager_->createOrUpdateTask(taskId, updateRequest, {}, nullptr, 0);
 
   assertResults(taskId, rowType_, "SELECT * FROM tmp WHERE c0 % 5 = 1");
 }
@@ -1020,7 +1020,7 @@ TEST_F(TaskManagerTest, getDataOnAbortedTask) {
 TEST_F(TaskManagerTest, getResultsErrorPropagation) {
   const protocol::TaskId taskId = "error-task.0.0.0.0";
   std::exception e;
-  taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e));
+  taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e), 0);
 
   // We expect the exception type VeloxException to be reserved still.
   EXPECT_THROW(
@@ -1101,7 +1101,8 @@ TEST_F(TaskManagerTest, checkBatchSplits) {
   auto queryCtx =
       taskManager_->getQueryContextManager()->findOrCreateQueryCtx(taskId, {});
   VELOX_ASSERT_THROW(
-      taskManager_->createOrUpdateBatchTask(taskId, {}, planFragment, queryCtx),
+      taskManager_->createOrUpdateBatchTask(
+          taskId, {}, planFragment, queryCtx, 0),
       "Expected all splits and no-more-splits message for all plan nodes");
 
   // Splits for scan node on the probe side.
@@ -1110,7 +1111,7 @@ TEST_F(TaskManagerTest, checkBatchSplits) {
       makeSource(probeId, {}, true));
   VELOX_ASSERT_THROW(
       taskManager_->createOrUpdateBatchTask(
-          taskId, batchRequest, planFragment, queryCtx),
+          taskId, batchRequest, planFragment, queryCtx, 0),
       "Expected all splits and no-more-splits message for all plan nodes: " +
           buildId);
 
@@ -1120,13 +1121,13 @@ TEST_F(TaskManagerTest, checkBatchSplits) {
       makeSource(buildId, {}, false));
   VELOX_ASSERT_THROW(
       taskManager_->createOrUpdateBatchTask(
-          taskId, batchRequest, planFragment, queryCtx),
+          taskId, batchRequest, planFragment, queryCtx, 0),
       "Expected no-more-splits message for plan node " + buildId);
 
   // All splits.
   batchRequest.taskUpdateRequest.sources.back().noMoreSplits = true;
   ASSERT_NO_THROW(taskManager_->createOrUpdateBatchTask(
-      taskId, batchRequest, planFragment, queryCtx));
+      taskId, batchRequest, planFragment, queryCtx, 0));
   auto resultOrFailure = fetchAllResults(taskId, ROW({BIGINT()}), {});
   ASSERT_EQ(resultOrFailure.status, nullptr);
 }


### PR DESCRIPTION
Presto-on-Spark queries launch 2 processes on the workers: JVM process
responsible for communicating with the Spark driver and native process
responsible for query processing. It is expected that JVM process is
light-weight and doesn't consume much CPU time. However, we are seeing the
opposite. Also, we are seeing that there is non-negligible CPU time spend in
background threads in the native process. To get a better picture of CPU time,
we introduce 2 additional counters: javaProcessCpuTime and
nativeProcessCpuTime. These counters report process-wide CPU time spent while a
task was executing. PoS-on-Velox runs tasks sequentially, hence, process-wide
CPU time matches per-task CPU time.

Note that the new counters still do not account for the CPU time spent while
starting both processes before the first task arrives. We'll monitor the new
counters while running production workloads to see how much CPU time is left
unaccounted. We'll make follow-up changes if that time turns out to be
significant.

The new counters are reported per task and are aggregated into per-stage values. 

When query completes, runtime stats include S0-javaProcessCpuTime,
S0-nativeProcessCpuTime, S1-javaProcessCpuTime, S1-nativeProcessCpuTime, etc. 2
counters per stage.

```
== NO RELEASE NOTE ==
```

