### PR TITLE
Fix NaN/Infinity value for double/float partition columns

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -139,10 +139,22 @@ public class PartitionData
                 if (partitionValue.asText().equalsIgnoreCase("NaN")) {
                     return Float.NaN;
                 }
+                if (partitionValue.asText().equalsIgnoreCase("Infinity")) {
+                    return Float.POSITIVE_INFINITY;
+                }
+                if (partitionValue.asText().equalsIgnoreCase("-Infinity")) {
+                    return Float.NEGATIVE_INFINITY;
+                }
                 return partitionValue.floatValue();
             case DOUBLE:
                 if (partitionValue.asText().equalsIgnoreCase("NaN")) {
                     return Double.NaN;
+                }
+                if (partitionValue.asText().equalsIgnoreCase("Infinity")) {
+                    return Double.POSITIVE_INFINITY;
+                }
+                if (partitionValue.asText().equalsIgnoreCase("-Infinity")) {
+                    return Double.NEGATIVE_INFINITY;
                 }
                 return partitionValue.doubleValue();
             case STRING:

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -136,8 +136,14 @@ public class PartitionData
             case TIME:
                 return partitionValue.asLong();
             case FLOAT:
+                if (partitionValue.asText().equalsIgnoreCase("NaN")) {
+                    return Float.NaN;
+                }
                 return partitionValue.floatValue();
             case DOUBLE:
+                if (partitionValue.asText().equalsIgnoreCase("NaN")) {
+                    return Double.NaN;
+                }
                 return partitionValue.doubleValue();
             case STRING:
                 return partitionValue.asText();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -792,27 +792,43 @@ public class IcebergDistributedSmokeTestBase
     }
 
     @Test
-    public void testPartitionedByRealWithNaN()
+    public void testPartitionedByRealWithNaNInf()
     {
         Session session = getSession();
         String tableName = "test_partitioned_by_real";
-        assertUpdate("CREATE TABLE " + tableName + " WITH(partitioning = ARRAY['part']) AS SELECT 1 AS id, real 'NaN' AS part", 1);
 
-        assertQuery("SELECT part FROM " + tableName, "VALUES cast('NaN' as real)");
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, part real) WITH(partitioning = ARRAY['part'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, real 'NaN')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, real 'Infinity')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, real '-Infinity')", 1);
+
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 1", "VALUES cast('NaN' as real)");
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 2", "VALUES cast('Infinity' as real)");
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 3", "VALUES cast('-Infinity' as real)");
+
         assertQuery("SELECT id FROM " + tableName + " WHERE is_nan(part)", "VALUES 1");
+        assertQuery("SELECT id FROM " + tableName + " WHERE is_infinite(part) ORDER BY id", "VALUES (2),(3)");
 
         dropTable(session, tableName);
     }
 
     @Test
-    public void testPartitionedByDoubleWithNaN()
+    public void testPartitionedByDoubleWithNaNInf()
     {
         Session session = getSession();
         String tableName = "test_partitioned_by_double";
-        assertUpdate("CREATE TABLE " + tableName + " WITH(partitioning = ARRAY['part']) AS SELECT 1 AS id, double 'NaN' AS part", 1);
 
-        assertQuery("SELECT part FROM " + tableName, "VALUES cast('NaN' as double)");
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, part double) WITH(partitioning = ARRAY['part'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, double 'NaN')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, double 'Infinity')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, double '-Infinity')", 1);
+
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 1", "VALUES cast('NaN' as double)");
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 2", "VALUES cast('Infinity' as double)");
+        assertQuery("SELECT part FROM " + tableName + " WHERE id = 3", "VALUES cast('-Infinity' as double)");
+
         assertQuery("SELECT id FROM " + tableName + " WHERE is_nan(part)", "VALUES 1");
+        assertQuery("SELECT id FROM " + tableName + " WHERE is_infinite(part) ORDER BY id", "VALUES (2),(3)");
 
         dropTable(session, tableName);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -790,4 +790,30 @@ public class IcebergDistributedSmokeTestBase
 
         dropTable(session, tableName);
     }
+
+    @Test
+    public void testPartitionedByRealWithNaN()
+    {
+        Session session = getSession();
+        String tableName = "test_partitioned_by_real";
+        assertUpdate("CREATE TABLE " + tableName + " WITH(partitioning = ARRAY['part']) AS SELECT 1 AS id, real 'NaN' AS part", 1);
+
+        assertQuery("SELECT part FROM " + tableName, "VALUES cast('NaN' as real)");
+        assertQuery("SELECT id FROM " + tableName + " WHERE is_nan(part)", "VALUES 1");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testPartitionedByDoubleWithNaN()
+    {
+        Session session = getSession();
+        String tableName = "test_partitioned_by_double";
+        assertUpdate("CREATE TABLE " + tableName + " WITH(partitioning = ARRAY['part']) AS SELECT 1 AS id, double 'NaN' AS part", 1);
+
+        assertQuery("SELECT part FROM " + tableName, "VALUES cast('NaN' as double)");
+        assertQuery("SELECT id FROM " + tableName + " WHERE is_nan(part)", "VALUES 1");
+
+        dropTable(session, tableName);
+    }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/15727 (https://github.com/trinodb/trino/pull/15727)

Co-authored-by: ebyhr <ebyhry@gmail.com>

Cherry-pick : NaN value for double/float partition columns
Presto fix : Infinity value for double/float partition columns

issue - https://github.com/prestodb/presto/issues/20366
Test plan - (Please fill in how you tested your changes)
- Added tests for NaN and Infinity cases 

create table test.part_double (c1 varchar, c2 double) with (partitioning =array['c2']);
insert into test.part_double values ('fix', real 'NaN');
insert into test.part_double values ('fix', double 'NaN');
presto:test> select * from part_double where c1 = 'fix';
 c1  | c2  
-----+-----
 fix | NaN 
 fix | NaN 
(2 rows)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Iceberg Changes 

* Fix incorrect results when reading or writing `NaN`, 'Infinity', '-Infinity' with `real` or `double` types on partitioned columns.

```


