### PR TITLE
[native]Fix async data cache shutdown

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -436,8 +436,10 @@ void PrestoServer::run() {
         << pGlobalIOExecutor->numThreads();
   }
 
-  PRESTO_SHUTDOWN_LOG(INFO) << "Release resources in AsyncDataCache";
-  cache_->prepareShutdown();
+  if (cache_ != nullptr) {
+    PRESTO_SHUTDOWN_LOG(INFO) << "Shutdown AsyncDataCache";
+    cache_->prepareShutdown();
+  }
 }
 
 void PrestoServer::yieldTasks() {
@@ -496,6 +498,8 @@ void PrestoServer::initializeVeloxMemory() {
           asyncCacheSsdCheckpointGb << 30,
           asyncCacheSsdDisableFileCow);
     }
+    PRESTO_STARTUP_LOG(INFO)
+        << "Setup AsyncDataCache" << (ssd != nullptr ? " with SSD cache" : "");
     cache_ = cache::AsyncDataCache::create(allocator_.get(), std::move(ssd));
     cache::AsyncDataCache::setInstance(cache_.get());
   } else {


### PR DESCRIPTION
Async data cache might not always be set and also add async data cache
startup log.

```
== NO RELEASE NOTE ==
```

