### PR TITLE
Pull expressions in lambda out

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -281,6 +281,7 @@ public final class SystemSessionProperties
     public static final String ADD_PARTIAL_NODE_FOR_ROW_NUMBER_WITH_LIMIT = "add_partial_node_for_row_number_with_limit";
     public static final String REWRITE_CASE_TO_MAP_ENABLED = "rewrite_case_to_map_enabled";
     public static final String FIELD_NAMES_IN_JSON_CAST_ENABLED = "field_names_in_json_cast_enabled";
+    public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1637,6 +1638,11 @@ public final class SystemSessionProperties
                         REWRITE_CASE_TO_MAP_ENABLED,
                         "Rewrite case with constant WHEN/THEN/ELSE clauses to use map literals",
                         TRUE,
+                        false),
+                booleanProperty(
+                        PULL_EXPRESSION_FROM_LAMBDA_ENABLED,
+                        "Rewrite case with constant WHEN/THEN/ELSE clauses to use map literals",
+                        featuresConfig.isPullUpExpressionFromLambdaEnabled(),
                         false));
     }
 
@@ -2754,5 +2760,10 @@ public final class SystemSessionProperties
     public static boolean isRewriteCaseToMapEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_CASE_TO_MAP_ENABLED, Boolean.class);
+    }
+
+    public static boolean isPullExpressionFromLambdaEnabled(Session session)
+    {
+        return session.getSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -272,6 +272,7 @@ public class FeaturesConfig
     private boolean leftJoinNullFilterToSemiJoin = true;
     private boolean broadcastJoinWithSmallBuildUnknownProbe;
     private boolean addPartialNodeForRowNumberWithLimit = true;
+    private boolean pullUpExpressionFromLambda = true;
 
     private boolean preProcessMetadataCalls;
 
@@ -2693,6 +2694,19 @@ public class FeaturesConfig
     public FeaturesConfig setAddPartialNodeForRowNumberWithLimitEnabled(boolean addPartialNodeForRowNumberWithLimit)
     {
         this.addPartialNodeForRowNumberWithLimit = addPartialNodeForRowNumberWithLimit;
+        return this;
+    }
+
+    public boolean isPullUpExpressionFromLambdaEnabled()
+    {
+        return this.pullUpExpressionFromLambda;
+    }
+
+    @Config("optimizer.pull-up-expression-from-lambda")
+    @ConfigDescription("Pull up expression from lambda which does not refer to arguments of the lambda function")
+    public FeaturesConfig setPullUpExpressionFromLambdaEnabled(boolean pullUpExpressionFromLambda)
+    {
+        this.pullUpExpressionFromLambda = pullUpExpressionFromLambda;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -75,6 +75,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PullConstantsAboveGroupBy;
+import com.facebook.presto.sql.planner.iterative.rule.PullUpExpressionInLambdaRules;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushDownDereferences;
 import com.facebook.presto.sql.planner.iterative.rule.PushDownFilterExpressionEvaluationThroughCrossJoin;
@@ -323,6 +324,21 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(new InlineSqlFunctions(metadata, sqlParser).rules())
+                                .build()),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(new PullUpExpressionInLambdaRules(metadata.getFunctionAndTypeManager()).rules()) // Run before DesugarLambdaExpression
+                                .build()),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.<Rule<?>>builder()
                                 .addAll(new DesugarLambdaExpression().rules())
                                 .addAll(new SimplifyCardinalityMap(metadata.getFunctionAndTypeManager()).rules())
                                 .build()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullUpExpressionInLambdaRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullUpExpressionInLambdaRules.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlannerUtils;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.SystemSessionProperties.isPullExpressionFromLambdaEnabled;
+import static com.facebook.presto.sql.planner.VariablesExtractor.extractAll;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+/**
+ * If there are expressions in the body of a lambda function, which does not refer to the arguments of the lambda function, it can be
+ * evaluated outside of the lambda function, hence avoid evaluating multiple times inside lambda body. An example of the optimization is:
+ * Before:
+ * <pre>
+ *     - Project
+ *          expr := filter(array, x -> x > id1+id2)
+ *          - TableScan
+ *              array: array(bigint)
+ *              id1: bigint
+ *              id2: bigint
+ * </pre>
+ * After:
+ * <pre>
+ *     - Project
+ *          expr: filter(array, x -> x > sum)
+ *          - Project:
+ *              sum := id1+id2
+ *              - TableScan
+ *                  array: array(bigint)
+ *                  id1: bigint
+ *                  id2: bigint
+ * </pre>
+ */
+public class PullUpExpressionInLambdaRules
+{
+    private final RowExpressionDeterminismEvaluator determinismEvaluator;
+    private final FunctionResolution functionResolution;
+
+    public PullUpExpressionInLambdaRules(FunctionAndTypeManager functionAndTypeManager)
+    {
+        requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    }
+
+    private static Set<RowExpression> getCandidateRowExpression(RowExpressionDeterminismEvaluator determinismEvaluator, FunctionResolution functionResolution, List<VariableReferenceExpression> inputVariables,
+            RowExpression rowExpression)
+    {
+        ImmutableSet.Builder<RowExpression> candidateBuilder = ImmutableSet.builder();
+        ValidExpressionExtractor validCallExpressionExtractor = new ValidExpressionExtractor(determinismEvaluator, functionResolution, inputVariables, candidateBuilder);
+        rowExpression.accept(validCallExpressionExtractor, false);
+        // If row expression has no variable reference, i.e. is constant, do not pull out
+        return candidateBuilder.build().stream().filter(x -> !extractAll(x).isEmpty()).collect(toImmutableSet());
+    }
+
+    public boolean isRuleEnabled(Session session)
+    {
+        return isPullExpressionFromLambdaEnabled(session);
+    }
+
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                filterNodeRule(),
+                projectNodeRule());
+    }
+
+    public Rule<FilterNode> filterNodeRule()
+    {
+        return new FilterNodeRule();
+    }
+
+    public Rule<ProjectNode> projectNodeRule()
+    {
+        return new ProjectNodeRule();
+    }
+
+    private final class ProjectNodeRule
+            implements Rule<ProjectNode>
+    {
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return isRuleEnabled(session);
+        }
+
+        @Override
+        public Pattern<ProjectNode> getPattern()
+        {
+            return project();
+        }
+
+        @Override
+        public Result apply(ProjectNode node, Captures captures, Context context)
+        {
+            List<VariableReferenceExpression> inputVariables = node.getSource().getOutputVariables();
+            ImmutableMap.Builder<VariableReferenceExpression, RowExpression> pulledExpressionMapBuilder = ImmutableMap.builder();
+            Assignments.Builder newProjectWithLambda = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : node.getAssignments().getMap().entrySet()) {
+                RowExpression rowExpression = entry.getValue();
+                Set<RowExpression> candidates = getCandidateRowExpression(determinismEvaluator, functionResolution, inputVariables, rowExpression);
+                if (candidates.isEmpty()) {
+                    newProjectWithLambda.put(entry.getKey(), entry.getValue());
+                }
+                else {
+                    Map<RowExpression, VariableReferenceExpression> mapping = candidates.stream().collect(toImmutableMap(identity(), x -> context.getVariableAllocator().newVariable(x)));
+                    pulledExpressionMapBuilder.putAll(mapping.entrySet().stream().collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey)));
+                    RowExpression rewrittenExpression = rowExpression.accept(new ExpressionRewriter(mapping), null);
+                    newProjectWithLambda.put(entry.getKey(), rewrittenExpression);
+                }
+            }
+
+            Map<VariableReferenceExpression, RowExpression> pulledExpressionMap = pulledExpressionMapBuilder.build();
+            if (pulledExpressionMap.isEmpty()) {
+                return Result.empty();
+            }
+
+            PlanNode planNode = PlannerUtils.addProjections(node.getSource(), context.getIdAllocator(), pulledExpressionMap);
+            return Result.ofPlanNode(new ProjectNode(context.getIdAllocator().getNextId(), planNode, newProjectWithLambda.build()));
+        }
+    }
+
+    private final class FilterNodeRule
+            implements Rule<FilterNode>
+    {
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return isRuleEnabled(session);
+        }
+
+        @Override
+        public Pattern<FilterNode> getPattern()
+        {
+            return filter();
+        }
+
+        @Override
+        public Result apply(FilterNode filterNode, Captures captures, Context context)
+        {
+            RowExpression predicate = filterNode.getPredicate();
+            List<VariableReferenceExpression> inputVariables = filterNode.getSource().getOutputVariables();
+            Set<RowExpression> candidates = getCandidateRowExpression(determinismEvaluator, functionResolution, inputVariables, predicate);
+            if (candidates.isEmpty()) {
+                return Result.empty();
+            }
+            Map<RowExpression, VariableReferenceExpression> mapping = candidates.stream().collect(toImmutableMap(identity(), x -> context.getVariableAllocator().newVariable(x)));
+            ImmutableMap.Builder<VariableReferenceExpression, RowExpression> pulledExpressionMapBuilder = ImmutableMap.builder();
+            pulledExpressionMapBuilder.putAll(mapping.entrySet().stream().collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey)));
+            RowExpression rewrittenExpression = predicate.accept(new ExpressionRewriter(mapping), null);
+            PlanNode planNode = PlannerUtils.addProjections(filterNode.getSource(), context.getIdAllocator(), pulledExpressionMapBuilder.build());
+            return Result.ofPlanNode(
+                    new ProjectNode(
+                            context.getIdAllocator().getNextId(),
+                            new FilterNode(filterNode.getSourceLocation(), context.getIdAllocator().getNextId(), planNode, rewrittenExpression),
+                            identityAssignments(filterNode.getOutputVariables())));
+        }
+    }
+
+    private static class ValidExpressionExtractor
+            implements RowExpressionVisitor<Boolean, Boolean>
+    {
+        private final RowExpressionDeterminismEvaluator determinismEvaluator;
+        private final FunctionResolution functionResolution;
+        private final List<VariableReferenceExpression> inputVariables;
+        private final ImmutableSet.Builder<RowExpression> candidates;
+
+        public ValidExpressionExtractor(RowExpressionDeterminismEvaluator determinismEvaluator,
+                FunctionResolution functionResolution,
+                List<VariableReferenceExpression> inputVariables,
+                ImmutableSet.Builder<RowExpression> candidates)
+        {
+            this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
+            this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+            this.inputVariables = requireNonNull(inputVariables, "inputVariables is null");
+            this.candidates = requireNonNull(candidates, "candidates is null");
+        }
+
+        @Override
+        public Boolean visitCall(CallExpression call, Boolean context)
+        {
+            if (functionResolution.isTryFunction(call.getFunctionHandle())) {
+                return false;
+            }
+            Map<RowExpression, Boolean> validRowExpressionMap = call.getArguments().stream().distinct().collect(toImmutableMap(identity(), x -> x.accept(this, context)));
+            if (context.equals(Boolean.TRUE)) {
+                boolean allArgumentsValid = validRowExpressionMap.values().stream().allMatch(x -> x.equals(Boolean.TRUE));
+                if (!allArgumentsValid) {
+                    candidates.addAll(validRowExpressionMap.entrySet().stream()
+                            .filter(x -> x.getValue().equals(Boolean.TRUE))
+                            .filter(x -> x.getKey() instanceof CallExpression || x.getKey() instanceof SpecialFormExpression)
+                            .map(Map.Entry::getKey)
+                            .collect(toImmutableList()));
+                }
+                return allArgumentsValid && determinismEvaluator.isDeterministic(call);
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitSpecialForm(SpecialFormExpression specialForm, Boolean context)
+        {
+            // Bind expression will complicate the lambda expression, we apply this optimization before DesugarLambdaRule. And if there are bind expression, skip
+            if (specialForm.getForm().equals(SpecialFormExpression.Form.BIND)) {
+                return false;
+            }
+            Map<RowExpression, Boolean> validRowExpressionMap = specialForm.getArguments().stream().distinct().collect(toImmutableMap(identity(), x -> x.accept(this, context)));
+            if (context.equals(Boolean.TRUE)) {
+                boolean allArgumentsValid = validRowExpressionMap.values().stream().allMatch(x -> x.equals(Boolean.TRUE));
+                if (!allArgumentsValid) {
+                    candidates.addAll(validRowExpressionMap.entrySet().stream()
+                            .filter(x -> x.getValue().equals(Boolean.TRUE))
+                            .filter(x -> x.getKey() instanceof CallExpression || x.getKey() instanceof SpecialFormExpression)
+                            .map(Map.Entry::getKey)
+                            .collect(toImmutableList()));
+                }
+                return allArgumentsValid && determinismEvaluator.isDeterministic(specialForm);
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitLambda(LambdaDefinitionExpression lambda, Boolean context)
+        {
+            if (lambda.getBody().accept(this, true) && (lambda.getBody() instanceof CallExpression || lambda.getBody() instanceof SpecialFormExpression)) {
+                candidates.add(lambda.getBody());
+            }
+            // For simplicity, we do not pull out lambda expressions
+            return false;
+        }
+
+        @Override
+        public Boolean visitVariableReference(VariableReferenceExpression reference, Boolean context)
+        {
+            return inputVariables.contains(reference);
+        }
+
+        @Override
+        public Boolean visitConstant(ConstantExpression literal, Boolean context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitInputReference(InputReferenceExpression reference, Boolean context)
+        {
+            return false;
+        }
+    }
+
+    private static class ExpressionRewriter
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final Map<RowExpression, VariableReferenceExpression> expressionMap;
+
+        public ExpressionRewriter(Map<RowExpression, VariableReferenceExpression> expressionMap)
+        {
+            this.expressionMap = ImmutableMap.copyOf(expressionMap);
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            List<RowExpression> rewrittenArguments = call.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList());
+            RowExpression rewritten = new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    rewrittenArguments);
+            if (expressionMap.containsKey(rewritten)) {
+                return expressionMap.get(rewritten);
+            }
+            if (rowExpressionsNotChanged(call.getArguments(), rewrittenArguments)) {
+                return call;
+            }
+            return rewritten;
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Void context)
+        {
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return new LambdaDefinitionExpression(lambda.getSourceLocation(), lambda.getArgumentTypes(), lambda.getArguments(), lambda.getBody().accept(this, context));
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> rewrittenArguments = specialForm.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList());
+            SpecialFormExpression rewritten = new SpecialFormExpression(
+                    specialForm.getForm(),
+                    specialForm.getType(),
+                    rewrittenArguments);
+            if (expressionMap.containsKey(rewritten)) {
+                return expressionMap.get(rewritten);
+            }
+            if (rowExpressionsNotChanged(specialForm.getArguments(), rewrittenArguments)) {
+                return specialForm;
+            }
+            return rewritten;
+        }
+
+        private boolean rowExpressionsNotChanged(List<RowExpression> original, List<RowExpression> rewritten)
+        {
+            checkArgument(original.size() == rewritten.size());
+            return IntStream.range(0, original.size()).boxed().allMatch(idx -> original.get(idx).equals(rewritten.get(idx)));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -239,7 +239,8 @@ public class TestFeaturesConfig
                 .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(true)
                 .setLeftJoinNullFilterToSemiJoin(true)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(false)
-                .setAddPartialNodeForRowNumberWithLimitEnabled(true));
+                .setAddPartialNodeForRowNumberWithLimitEnabled(true)
+                .setPullUpExpressionFromLambdaEnabled(true));
     }
 
     @Test
@@ -427,6 +428,7 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-left-join-with-null-filter-to-semi-join", "false")
                 .put("experimental.optimizer.broadcast-join-with-small-build-unknown-probe", "true")
                 .put("optimizer.add-partial-node-for-row-number-with-limit", "false")
+                .put("optimizer.pull-up-expression-from-lambda", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -611,7 +613,8 @@ public class TestFeaturesConfig
                 .setRewriteCrossJoinWithArrayContainsFilterToInnerJoin(false)
                 .setLeftJoinNullFilterToSemiJoin(false)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(true)
-                .setAddPartialNodeForRowNumberWithLimitEnabled(false);
+                .setAddPartialNodeForRowNumberWithLimitEnabled(false)
+                .setPullUpExpressionFromLambdaEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullUpExpressionInLambdaRules.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullUpExpressionInLambdaRules.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.compose;
+import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
+
+public class TestPullUpExpressionInLambdaRules
+        extends BaseRuleTest
+{
+    private static final MethodHandle KEY_NATIVE_EQUALS = getOperatorMethodHandle(OperatorType.EQUAL, BIGINT, BIGINT);
+    private static final MethodHandle KEY_BLOCK_EQUALS = compose(KEY_NATIVE_EQUALS, nativeValueGetter(BIGINT), nativeValueGetter(BIGINT));
+    private static final MethodHandle KEY_NATIVE_HASH_CODE = getOperatorMethodHandle(OperatorType.HASH_CODE, BIGINT);
+    private static final MethodHandle KEY_BLOCK_HASH_CODE = compose(KEY_NATIVE_HASH_CODE, nativeValueGetter(BIGINT));
+
+    @Test
+    public void testProjection()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr"), p.rowExpression("map_filter(idmap, (k, v) -> array_position(array_sort(map_keys(idmap)), k) <= 200)")).build(),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("expr", expression("map_filter(idmap, (k, v) -> (array_position(array_sort, k)) <= (INTEGER'200'))")),
+                                project(ImmutableMap.of("array_sort", expression("array_sort(map_keys(idmap))")),
+                                        values("idmap"))));
+    }
+
+    @Test
+    public void testFilter()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.filter(
+                            p.rowExpression("cardinality(map_filter(idmap, (k, v) -> array_position(array_sort(map_keys(idmap)), k) <= 200)) > 0"),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("idmap", expression("idmap")),
+                                filter(
+                                        "(cardinality(map_filter(idmap, (k, v) -> (array_position(array_sort, k)) <= (INTEGER'200')))) > (INTEGER'0')",
+                                        project(ImmutableMap.of("array_sort", expression("array_sort(map_keys(idmap))")),
+                                                values("idmap")))));
+    }
+
+    @Test
+    public void testNonDeterministicProjection()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr"), p.rowExpression("map_filter(idmap, (k, v) -> array_position(array[random()], k) <= 200)")).build(),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNonDeterministicFilter()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.filter(
+                            p.rowExpression("cardinality(map_filter(idmap, (k, v) -> array_position(array_sort(array[random(), random()]), k) <= 200)) > 0"),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNoValidProjection()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr"), p.rowExpression("map_filter(idmap, (k, v) -> array_position(array_sort(array[v]), k) <= 200)")).build(),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoValidFilter()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .on(p ->
+                {
+                    p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.filter(
+                            p.rowExpression("cardinality(map_filter(idmap, (k, v) -> array_position(array_sort(array[v, k]), k) <= 200)) > 0"),
+                            p.values(p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNestedLambdaInProjection()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("expr", new ArrayType(new ArrayType(BIGINT)));
+                    p.variable("arr1", new ArrayType(BIGINT));
+                    p.variable("arr2", new ArrayType(BIGINT));
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr", new ArrayType(new ArrayType(BIGINT))), p.rowExpression("transform(arr1, x->transform(arr2, y->slice(arr2, 1, 10)))")).build(),
+                            p.values(p.variable("arr1", new ArrayType(BIGINT)), p.variable("arr2", new ArrayType(BIGINT))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("expr", expression("transform(arr1, (x) -> transform(arr2, (y) -> slice))")),
+                                project(
+
+                                        ImmutableMap.of("slice", expression("slice(arr2, 1, 10)")),
+                                        values("arr1", "arr2"))));
+    }
+
+    @Test
+    public void testInvalidNestedLambdaInProjection()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("expr", new ArrayType(new ArrayType(BIGINT)));
+                    p.variable("arr1", new ArrayType(BIGINT));
+                    p.variable("arr2", new ArrayType(BIGINT));
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr", new ArrayType(new ArrayType(BIGINT))), p.rowExpression("transform(arr1, x->transform(arr2, y->slice(arr2, 1, x)))")).build(),
+                            p.values(p.variable("arr1", new ArrayType(BIGINT)), p.variable("arr2", new ArrayType(BIGINT))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testSkipTryFunction()
+    {
+        tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .on(p ->
+                {
+                    p.variable("x");
+                    return p.project(
+                            Assignments.builder().put(p.variable("expr", VARCHAR), p.rowExpression("JSON_FORMAT(CAST(TRY(MAP(ARRAY[NULL], ARRAY[x])) AS JSON))")).build(),
+                            p.values(p.variable("x")));
+                }).doesNotFire();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_PAYLOAD_JOINS;
+import static com.facebook.presto.SystemSessionProperties.PULL_EXPRESSION_FROM_LAMBDA_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
@@ -1015,7 +1016,11 @@ public abstract class AbstractTestDistributedQueries
     @Test
     public void testExtraLargeQuerySuccess()
     {
-        assertQuery("SELECT " + Joiner.on(" AND ").join(nCopies(1000, "1 = 1")), "SELECT true");
+        // Will have stack overflow if enabled
+        Session pullLambdaExpressionDisabled = Session.builder(getSession())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "false")
+                .build();
+        assertQuery(pullLambdaExpressionDisabled, "SELECT " + Joiner.on(" AND ").join(nCopies(1000, "1 = 1")), "SELECT true");
     }
 
     @Test


### PR DESCRIPTION
## Description
If an expression does not refer to arguments of lambda function, it can be pull out so that it will only be evaluated once and used in the lambda functions.

## Motivation and Context

An example query `select map_filter(idmap, (k, v) -> array_position(array_sort(map_keys(idmap)), k) <= 3) from (values map(array[1, 4, 2, 8, 0],  array['a', 'a', 'a', 'a', 'a'])) t(idmap)`, here `array_sort(map_keys(idmap))` will be evaluated for every element of idmap, however it's not necessary.

The optimization will rewrite it to an equivalent query of `select map_filter(idmap, (k, v) -> array_position(sorted_array, k) <= 3) from (select *, array_sort(map_keys(idmap)) sorted_array from (values map(array[1, 4, 2, 8, 0],  array['a', 'a', 'a', 'a', 'a'])) t(idmap))`

## Impact

Improve query performance

## Test Plan
Unit tests and [e2e test](https://www.internalfb.com/intern/presto/query/?query_id=20230804_201758_00007_4em3x#plan) and [verifier suite](https://fburl.com/presto/f252u5je)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* Add an optimization for lambda functions which has expression not referring to arguments of the lambda function. Controlled by session parameter `pull_expression_from_lambda_enabled` and default to enabled.

```


