### PR TITLE
Add Thrift support for for SqlInvokedFunction and SqlFunctionId

### DIFF
--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -102,5 +102,17 @@
             <artifactId>jackson-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumType.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -78,12 +81,14 @@ public class BigintEnumType
         return enumMap.getTypeName();
     }
 
+    @ThriftStruct
     public static class LongEnumMap
     {
         private final String typeName;
         private final Map<String, Long> enumMap;
         private final Map<Long, String> flippedEnumMap;
 
+        @ThriftConstructor
         @JsonCreator
         public LongEnumMap(@JsonProperty("typeName") String typeName, @JsonProperty("enumMap") Map<String, Long> enumMap)
         {
@@ -94,12 +99,14 @@ public class BigintEnumType
                     .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
         }
 
+        @ThriftField(1)
         @JsonProperty
         public String getTypeName()
         {
             return typeName;
         }
 
+        @ThriftField(2)
         @JsonProperty
         public Map<String, Long> getEnumMap()
         {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DistinctTypeInfo.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DistinctTypeInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,6 +29,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class DistinctTypeInfo
 {
     private final QualifiedObjectName name;
@@ -36,6 +40,7 @@ public class DistinctTypeInfo
     private final List<QualifiedObjectName> otherAncestors;
     private final boolean isOrderable;
 
+    @ThriftConstructor
     @JsonCreator
     public DistinctTypeInfo(
             @JsonProperty("name") QualifiedObjectName name,
@@ -60,24 +65,28 @@ public class DistinctTypeInfo
         this(name, baseType, parent, emptyList(), isOrderable);
     }
 
+    @ThriftField(1)
     @JsonProperty
     public QualifiedObjectName getName()
     {
         return name;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public TypeSignature getBaseType()
     {
         return baseType;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public List<QualifiedObjectName> getOtherAncestors()
     {
         return otherAncestors;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public Optional<QualifiedObjectName> getTopMostAncestor()
     {
@@ -86,6 +95,12 @@ public class DistinctTypeInfo
 
     @JsonProperty
     public boolean isOrderable()
+    {
+        return isOrderable;
+    }
+
+    @ThriftField(5)
+    public boolean getIsOrderable()
     {
         return isOrderable;
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/NamedTypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/NamedTypeSignature.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,11 +25,13 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class NamedTypeSignature
 {
     private final Optional<RowFieldName> fieldName;
     private final TypeSignature typeSignature;
 
+    @ThriftConstructor
     @JsonCreator
     public NamedTypeSignature(
             @JsonProperty("fieldName") Optional<RowFieldName> fieldName,
@@ -36,12 +41,14 @@ public class NamedTypeSignature
         this.typeSignature = requireNonNull(typeSignature, "typeSignature is null");
     }
 
+    @ThriftField(1)
     @JsonProperty
     public Optional<RowFieldName> getFieldName()
     {
         return fieldName;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public TypeSignature getTypeSignature()
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
@@ -13,29 +13,34 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Optional;
 
+@ThriftEnum
 public enum ParameterKind
 {
-    TYPE(Optional.of("TYPE_SIGNATURE")),
-    NAMED_TYPE(Optional.of("NAMED_TYPE_SIGNATURE")),
-    LONG(Optional.of("LONG_LITERAL")),
-    VARIABLE(Optional.empty()),
-    LONG_ENUM(Optional.of("LONG_ENUM")),
-    VARCHAR_ENUM(Optional.of("VARCHAR_ENUM")),
-    DISTINCT_TYPE(Optional.of("DISTINCT_TYPE"));
+    TYPE(Optional.of("TYPE_SIGNATURE"), 1),
+    NAMED_TYPE(Optional.of("NAMED_TYPE_SIGNATURE"), 2),
+    LONG(Optional.of("LONG_LITERAL"), 3),
+    VARIABLE(Optional.empty(), 4),
+    LONG_ENUM(Optional.of("LONG_ENUM"), 5),
+    VARCHAR_ENUM(Optional.of("VARCHAR_ENUM"), 6),
+    DISTINCT_TYPE(Optional.of("DISTINCT_TYPE"), 7);
 
     // TODO: drop special serialization code as soon as all clients
     //       migrate to version which can deserialize new format.
 
     private final Optional<String> oldName;
+    private final int value;
 
-    ParameterKind(Optional<String> oldName)
+    ParameterKind(Optional<String> oldName, int value)
     {
         this.oldName = oldName;
+        this.value = value;
     }
 
     @JsonValue
@@ -56,5 +61,11 @@ public enum ParameterKind
             }
         }
         throw new IllegalArgumentException("Invalid serialized ParameterKind value: " + value);
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return value;
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowFieldName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowFieldName.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -20,11 +23,13 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class RowFieldName
 {
     private final String name;
     private final boolean delimited;
 
+    @ThriftConstructor
     @JsonCreator
     public RowFieldName(
             @JsonProperty("name") String name,
@@ -34,12 +39,14 @@ public class RowFieldName
         this.delimited = delimited;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public boolean isDelimited()
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.BigintEnumType.LongEnumMap;
 import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
@@ -45,6 +48,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Locale.ENGLISH;
 
+@ThriftStruct
 public class TypeSignature
 {
     private final TypeSignatureBase base;
@@ -96,9 +100,10 @@ public class TypeSignature
         this(TypeSignatureBase.of(base), parameters);
     }
 
-    private TypeSignature(TypeSignatureBase base, List<TypeSignatureParameter> parameters)
+    @ThriftConstructor
+    public TypeSignature(TypeSignatureBase typeSignatureBase, List<TypeSignatureParameter> parameters)
     {
-        this.base = base;
+        this.base = typeSignatureBase;
         checkArgument(parameters != null, "parameters is null");
         this.parameters = unmodifiableList(new ArrayList<>(parameters));
 
@@ -110,6 +115,7 @@ public class TypeSignature
         return new TypeSignature(base.getStandardTypeBase(), parameters);
     }
 
+    @ThriftField(1)
     public TypeSignatureBase getTypeSignatureBase()
     {
         return base;
@@ -120,6 +126,7 @@ public class TypeSignature
         return base.toString();
     }
 
+    @ThriftField(2)
     public List<TypeSignatureParameter> getParameters()
     {
         return parameters;

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 
 import java.util.Objects;
@@ -22,6 +25,7 @@ import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
+@ThriftStruct
 public class TypeSignatureBase
 {
     private final Optional<String> standardTypeBase;
@@ -81,6 +85,13 @@ public class TypeSignatureBase
         this.typeName = Optional.of(typeName);
     }
 
+    @ThriftConstructor
+    public TypeSignatureBase(Optional<String> optionalStandardTypeBase, Optional<QualifiedObjectName> optionalQualifiedObjectName)
+    {
+        this.standardTypeBase = optionalStandardTypeBase;
+        this.typeName = optionalQualifiedObjectName;
+    }
+
     public boolean hasStandardType()
     {
         return standardTypeBase.isPresent();
@@ -101,6 +112,18 @@ public class TypeSignatureBase
     {
         checkArgument(standardTypeBase.isPresent(), "TypeSignatureBase %s does not have standard type base", toString());
         return standardTypeBase.get();
+    }
+
+    @ThriftField(1)
+    public Optional<String> getOptionalStandardTypeBase()
+    {
+        return standardTypeBase;
+    }
+
+    @ThriftField(2)
+    public Optional<QualifiedObjectName> getOptionalQualifiedObjectName()
+    {
+        return typeName;
     }
 
     private static boolean validateName(String name)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
@@ -13,19 +13,25 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.BigintEnumType.LongEnumMap;
 import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
 
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.TypeSignatureParameterUnion.convertToTypeSignatureParameterUnion;
+import static com.facebook.presto.common.type.TypeSignatureParameterUnion.convertToValue;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class TypeSignatureParameter
 {
     private final ParameterKind kind;
-    private final Object value;
+    private final TypeSignatureParameterUnion value;
 
     public static TypeSignatureParameter of(TypeSignature typeSignature)
     {
@@ -65,18 +71,32 @@ public class TypeSignatureParameter
     private TypeSignatureParameter(ParameterKind kind, Object value)
     {
         this.kind = requireNonNull(kind, "kind is null");
-        this.value = requireNonNull(value, "value is null");
+        this.value = convertToTypeSignatureParameterUnion(requireNonNull(value, "value is null"));
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameter(ParameterKind kind, TypeSignatureParameterUnion value)
+    {
+        this.kind = kind;
+        this.value = value;
     }
 
     @Override
     public String toString()
     {
-        return value.toString();
+        return convertToValue(value).toString();
     }
 
+    @ThriftField(1)
     public ParameterKind getKind()
     {
         return kind;
+    }
+
+    @ThriftField(2)
+    public TypeSignatureParameterUnion getValue()
+    {
+        return value;
     }
 
     public boolean isTypeSignature()
@@ -119,7 +139,7 @@ public class TypeSignatureParameter
         if (kind != expectedParameterKind) {
             throw new IllegalArgumentException(format("ParameterKind is [%s] but expected [%s]", kind, expectedParameterKind));
         }
-        return target.cast(value);
+        return target.cast(convertToValue(value));
     }
 
     public TypeSignature getTypeSignature()

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameterUnion.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameterUnion.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftUnion;
+import com.facebook.drift.annotations.ThriftUnionId;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+
+import java.util.Objects;
+
+import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
+import static com.facebook.presto.common.type.BigintEnumType.LongEnumMap;
+import static com.facebook.presto.common.type.ParameterKind.DISTINCT_TYPE;
+import static com.facebook.presto.common.type.ParameterKind.LONG;
+import static com.facebook.presto.common.type.ParameterKind.LONG_ENUM;
+import static com.facebook.presto.common.type.ParameterKind.NAMED_TYPE;
+import static com.facebook.presto.common.type.ParameterKind.TYPE;
+import static com.facebook.presto.common.type.ParameterKind.VARCHAR_ENUM;
+import static com.facebook.presto.common.type.ParameterKind.VARIABLE;
+
+@ThriftUnion
+public class TypeSignatureParameterUnion
+{
+    private TypeSignature typeSignature;
+    private Long longLiteral;
+    private NamedTypeSignature namedTypeSignature;
+    private String variable;
+    private BigintEnumType.LongEnumMap longEnumMap;
+    private VarcharEnumMap varcharEnumMap;
+    private DistinctTypeInfo distinctTypeInfo;
+    private final short id;
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(TypeSignature typeSignature)
+    {
+        this.typeSignature = typeSignature;
+        this.id = (short) TYPE.getValue();
+    }
+
+    @ThriftField(value = 1, requiredness = OPTIONAL)
+    public TypeSignature getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(NamedTypeSignature namedTypeSignature)
+    {
+        this.namedTypeSignature = namedTypeSignature;
+        this.id = (short) NAMED_TYPE.getValue();
+    }
+
+    @ThriftField(value = 2, requiredness = OPTIONAL)
+    public NamedTypeSignature getNamedTypeSignature()
+    {
+        return namedTypeSignature;
+    }
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(Long longLiteral)
+    {
+        this.longLiteral = longLiteral;
+        this.id = (short) LONG.getValue();
+    }
+
+    @ThriftField(value = 3, requiredness = OPTIONAL)
+    public Long getLongLiteral()
+    {
+        return longLiteral;
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(String variable)
+    {
+        this.variable = variable;
+        this.id = (short) VARIABLE.getValue();
+    }
+
+    @ThriftField(value = 4, requiredness = OPTIONAL)
+    public String getVariable()
+    {
+        return variable;
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(LongEnumMap longEnumMap)
+    {
+        this.longEnumMap = longEnumMap;
+        this.id = (short) LONG_ENUM.getValue();
+    }
+
+    @ThriftField(value = 5, requiredness = OPTIONAL)
+    public LongEnumMap getLongEnumMap()
+    {
+        return longEnumMap;
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(VarcharEnumMap varcharEnumMap)
+    {
+        this.varcharEnumMap = varcharEnumMap;
+        this.id = (short) VARCHAR_ENUM.getValue();
+    }
+
+    @ThriftField(value = 6, requiredness = OPTIONAL)
+    public VarcharEnumMap getVarcharEnumMap()
+    {
+        return varcharEnumMap;
+    }
+
+    @ThriftConstructor
+    public TypeSignatureParameterUnion(DistinctTypeInfo distinctTypeInfo)
+    {
+        this.distinctTypeInfo = distinctTypeInfo;
+        this.id = (short) DISTINCT_TYPE.getValue();
+    }
+
+    @ThriftField(value = 7, requiredness = OPTIONAL)
+    public DistinctTypeInfo getDistinctTypeInfo()
+    {
+        return distinctTypeInfo;
+    }
+
+    @ThriftUnionId
+    public short getId()
+    {
+        return id;
+    }
+
+    public static TypeSignatureParameterUnion convertToTypeSignatureParameterUnion(Object value)
+    {
+        if (value instanceof TypeSignature) {
+            return new TypeSignatureParameterUnion((TypeSignature) value);
+        }
+        else if (value instanceof Long) {
+            return new TypeSignatureParameterUnion((Long) value);
+        }
+        else if (value instanceof NamedTypeSignature) {
+            return new TypeSignatureParameterUnion((NamedTypeSignature) value);
+        }
+        else if (value instanceof String) {
+            return new TypeSignatureParameterUnion((String) value);
+        }
+        else if (value instanceof LongEnumMap) {
+            return new TypeSignatureParameterUnion((LongEnumMap) value);
+        }
+        else if (value instanceof VarcharEnumMap) {
+            return new TypeSignatureParameterUnion((VarcharEnumMap) value);
+        }
+        else if (value instanceof DistinctTypeInfo) {
+            return new TypeSignatureParameterUnion((DistinctTypeInfo) value);
+        }
+        else {
+            throw new IllegalArgumentException("value is of an unknown type: " + value.getClass().getName());
+        }
+    }
+
+    public static Object convertToValue(TypeSignatureParameterUnion parameterUnion)
+    {
+        if (parameterUnion.getTypeSignature() != null) {
+            return parameterUnion.getTypeSignature();
+        }
+        else if (parameterUnion.getLongLiteral() != null) {
+            return parameterUnion.getLongLiteral();
+        }
+        else if (parameterUnion.getNamedTypeSignature() != null) {
+            return parameterUnion.getNamedTypeSignature();
+        }
+        else if (parameterUnion.getVariable() != null) {
+            return parameterUnion.getVariable();
+        }
+        else if (parameterUnion.getLongEnumMap() != null) {
+            return parameterUnion.getLongEnumMap();
+        }
+        else if (parameterUnion.getVarcharEnumMap() != null) {
+            return parameterUnion.getVarcharEnumMap();
+        }
+        else if (parameterUnion.getDistinctTypeInfo() != null) {
+            return parameterUnion.getDistinctTypeInfo();
+        }
+        else {
+            throw new IllegalArgumentException("TypeSignatureParameterUnion is of an unknown type: " + parameterUnion.getClass().getName());
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeSignatureParameterUnion other = (TypeSignatureParameterUnion) o;
+
+        return Objects.equals(this.typeSignature, other.typeSignature) &&
+                Objects.equals(this.longLiteral, other.longLiteral) &&
+                Objects.equals(this.namedTypeSignature, other.namedTypeSignature) &&
+                Objects.equals(this.variable, other.variable) &&
+                Objects.equals(this.longEnumMap, other.longEnumMap) &&
+                Objects.equals(this.varcharEnumMap, other.varcharEnumMap) &&
+                Objects.equals(this.distinctTypeInfo, other.distinctTypeInfo) &&
+                Objects.equals(this.id, other.id);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(typeSignature, longLiteral, namedTypeSignature, variable, longEnumMap, varcharEnumMap, distinctTypeInfo, id);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.encoding.Base32;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -67,12 +70,14 @@ public class VarcharEnumType
         return enumMap.getTypeName();
     }
 
+    @ThriftStruct
     public static class VarcharEnumMap
     {
         private final String typeName;
         private final Map<String, String> enumMap;
         private final Map<String, String> flippedEnumMap;
 
+        @ThriftConstructor
         @JsonCreator
         public VarcharEnumMap(@JsonProperty("typeName") String typeName, @JsonProperty("enumMap") Map<String, String> enumMap)
         {
@@ -83,12 +88,14 @@ public class VarcharEnumType
                     .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
         }
 
+        @ThriftField(1)
         @JsonProperty
         public String getTypeName()
         {
             return typeName;
         }
 
+        @ThriftField(2)
         @JsonProperty
         public Map<String, String> getEnumMap()
         {

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignatureParameterUnionSerde.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignatureParameterUnionSerde.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.codec.internal.reflection.ReflectionThriftCodecFactory;
+import com.facebook.drift.codec.metadata.ThriftCatalog;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestTypeSignatureParameterUnionSerde
+{
+    private static final ThriftCatalog COMMON_CATALOG = new ThriftCatalog();
+    private static final ThriftCodecManager COMPILER_READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false), COMMON_CATALOG, ImmutableSet.of());
+    private static final ThriftCodecManager COMPILER_WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false), COMMON_CATALOG, ImmutableSet.of());
+    private static final ThriftCodec<TypeSignatureParameterUnion> COMPILER_READ_CODEC = COMPILER_READ_CODEC_MANAGER.getCodec(TypeSignatureParameterUnion.class);
+    private static final ThriftCodec<TypeSignatureParameterUnion> COMPILER_WRITE_CODEC = COMPILER_WRITE_CODEC_MANAGER.getCodec(TypeSignatureParameterUnion.class);
+    private static final ThriftCodecManager REFLECTION_READ_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory(), COMMON_CATALOG, ImmutableSet.of());
+    private static final ThriftCodecManager REFLECTION_WRITE_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory(), COMMON_CATALOG, ImmutableSet.of());
+    private static final ThriftCodec<TypeSignatureParameterUnion> REFLECTION_READ_CODEC = REFLECTION_READ_CODEC_MANAGER.getCodec(TypeSignatureParameterUnion.class);
+    private static final ThriftCodec<TypeSignatureParameterUnion> REFLECTION_WRITE_CODEC = REFLECTION_WRITE_CODEC_MANAGER.getCodec(TypeSignatureParameterUnion.class);
+    private static final TMemoryBuffer transport = new TMemoryBuffer(100 * 1024);
+    private static final TypeSignature FAKE_TYPE_SIGNATURE = new TypeSignature("FAKE_BASE");
+    private TypeSignatureParameterUnion typeSignatureParameterUnion;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        typeSignatureParameterUnion = new TypeSignatureParameterUnion(FAKE_TYPE_SIGNATURE);
+    }
+
+    @DataProvider
+    public Object[][] codecCombinations()
+    {
+        return new Object[][] {
+                {COMPILER_READ_CODEC, COMPILER_WRITE_CODEC},
+                {COMPILER_READ_CODEC, REFLECTION_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, COMPILER_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, REFLECTION_WRITE_CODEC}
+        };
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeBinaryProtocol(ThriftCodec<TypeSignatureParameterUnion> readCodec, ThriftCodec<TypeSignatureParameterUnion> writeCodec)
+            throws Exception
+    {
+        TypeSignatureParameterUnion typeSignatureParameterUnion = getRoundTripSerialize(readCodec, writeCodec, TBinaryProtocol::new);
+        assertSerde(typeSignatureParameterUnion);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTCompactProtocol(ThriftCodec<TypeSignatureParameterUnion> readCodec, ThriftCodec<TypeSignatureParameterUnion> writeCodec)
+            throws Exception
+    {
+        TypeSignatureParameterUnion typeSignatureParameterUnion = getRoundTripSerialize(readCodec, writeCodec, TCompactProtocol::new);
+        assertSerde(typeSignatureParameterUnion);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTFacebookCompactProtocol(ThriftCodec<TypeSignatureParameterUnion> readCodec, ThriftCodec<TypeSignatureParameterUnion> writeCodec)
+            throws Exception
+    {
+        TypeSignatureParameterUnion typeSignatureParameterUnion = getRoundTripSerialize(readCodec, writeCodec, TFacebookCompactProtocol::new);
+        assertSerde(typeSignatureParameterUnion);
+    }
+
+    private TypeSignatureParameterUnion getRoundTripSerialize(ThriftCodec<TypeSignatureParameterUnion> readCodec, ThriftCodec<TypeSignatureParameterUnion> writeCodec, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        TProtocol protocol = protocolFactory.apply(transport);
+        writeCodec.write(typeSignatureParameterUnion, protocol);
+        return readCodec.read(protocol);
+    }
+
+    private void assertSerde(TypeSignatureParameterUnion typeSignatureParameterUnion)
+    {
+        TypeSignature typeSignature = typeSignatureParameterUnion.getTypeSignature();
+        assertEquals(typeSignature, FAKE_TYPE_SIGNATURE);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionKind.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionKind.java
@@ -13,9 +13,26 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
+@ThriftEnum
 public enum FunctionKind
 {
-    SCALAR,
-    AGGREGATE,
-    WINDOW
+    SCALAR(1),
+    AGGREGATE(2),
+    WINDOW(3);
+
+    private final int value;
+
+    FunctionKind(int value)
+    {
+        this.value = value;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return value;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/LongVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/LongVariableConstraint.java
@@ -13,16 +13,21 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@ThriftStruct
 public class LongVariableConstraint
 {
     private final String name;
     private final String expression;
 
+    @ThriftConstructor
     @JsonCreator
     public LongVariableConstraint(
             @JsonProperty("name") String name,
@@ -32,12 +37,14 @@ public class LongVariableConstraint
         this.expression = expression;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public String getExpression()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/Parameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/Parameter.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,9 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,11 +25,13 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class Parameter
 {
     private final String name;
     private final TypeSignature type;
 
+    @ThriftConstructor
     @JsonCreator
     public Parameter(
             @JsonProperty("name") String name,
@@ -35,12 +41,14 @@ public class Parameter
         this.type = requireNonNull(type, "type is null");
     }
 
+    @ThriftField(1)
     @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public TypeSignature getType()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
@@ -13,6 +13,11 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,8 +32,10 @@ import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallCl
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class RoutineCharacteristics
 {
+    @ThriftStruct
     public static class Language
     {
         public static final Language SQL = new Language("SQL");
@@ -36,12 +43,14 @@ public class RoutineCharacteristics
 
         private final String language;
 
+        @ThriftConstructor
         @JsonCreator
         public Language(String language)
         {
             this.language = requireNonNull(language.toUpperCase());
         }
 
+        @ThriftField(1)
         @JsonValue
         public String getLanguage()
         {
@@ -74,16 +83,42 @@ public class RoutineCharacteristics
         }
     }
 
+    @ThriftEnum
     public enum Determinism
     {
-        DETERMINISTIC,
-        NOT_DETERMINISTIC;
+        DETERMINISTIC(1),
+        NOT_DETERMINISTIC(2);
+        private final int value;
+
+        private Determinism(int value)
+        {
+            this.value = value;
+        }
+
+        @ThriftEnumValue
+        public int getValue()
+        {
+            return value;
+        }
     }
 
+    @ThriftEnum
     public enum NullCallClause
     {
-        RETURNS_NULL_ON_NULL_INPUT,
-        CALLED_ON_NULL_INPUT;
+        RETURNS_NULL_ON_NULL_INPUT(1),
+        CALLED_ON_NULL_INPUT(2);
+        private final int value;
+
+        private NullCallClause(int value)
+        {
+            this.value = value;
+        }
+
+        @ThriftEnumValue
+        public int getValue()
+        {
+            return value;
+        }
     }
 
     private final Language language;
@@ -101,19 +136,30 @@ public class RoutineCharacteristics
         this.nullCallClause = nullCallClause.orElse(CALLED_ON_NULL_INPUT);
     }
 
+    @ThriftConstructor
+    public RoutineCharacteristics(Language language, Determinism determinism, NullCallClause nullCallClause)
+    {
+        this.language = language;
+        this.determinism = determinism;
+        this.nullCallClause = nullCallClause;
+    }
+
     @JsonProperty
+    @ThriftField(1)
     public Language getLanguage()
     {
         return language;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public Determinism getDeterminism()
     {
         return determinism;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public NullCallClause getNullCallClause()
     {
         return nullCallClause;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -29,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
+@ThriftStruct
 public final class Signature
 {
     private final QualifiedObjectName name;
@@ -39,6 +43,7 @@ public final class Signature
     private final List<TypeSignature> argumentTypes;
     private final boolean variableArity;
 
+    @ThriftConstructor
     @JsonCreator
     public Signature(
             @JsonProperty("name") QualifiedObjectName name,
@@ -72,6 +77,7 @@ public final class Signature
         this(name, kind, emptyList(), emptyList(), returnType, argumentTypes, false);
     }
 
+    @ThriftField(1)
     @JsonProperty
     public QualifiedObjectName getName()
     {
@@ -83,36 +89,42 @@ public final class Signature
         return name.getObjectName();
     }
 
+    @ThriftField(2)
     @JsonProperty
     public FunctionKind getKind()
     {
         return kind;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public TypeSignature getReturnType()
     {
         return returnType;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public List<TypeSignature> getArgumentTypes()
     {
         return argumentTypes;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public boolean isVariableArity()
     {
         return variableArity;
     }
 
+    @ThriftField(6)
     @JsonProperty
     public List<TypeVariableConstraint> getTypeVariableConstraints()
     {
         return typeVariableConstraints;
     }
 
+    @ThriftField(7)
     @JsonProperty
     public List<LongVariableConstraint> getLongVariableConstraints()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionId.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.api.Experimental;
@@ -30,22 +33,26 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 @Experimental
+@ThriftStruct
 public class SqlFunctionId
 {
     private final QualifiedObjectName functionName;
     private final List<TypeSignature> argumentTypes;
 
+    @ThriftConstructor
     public SqlFunctionId(QualifiedObjectName functionName, List<TypeSignature> argumentTypes)
     {
         this.functionName = requireNonNull(functionName, "functionName is null");
         this.argumentTypes = requireNonNull(argumentTypes, "argumentTypes is null");
     }
 
+    @ThriftField(1)
     public QualifiedObjectName getFunctionName()
     {
         return functionName;
     }
 
+    @ThriftField(2)
     public List<TypeSignature> getArgumentTypes()
     {
         return argumentTypes;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.api.Experimental;
@@ -36,6 +39,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 @Experimental
+@ThriftStruct
 public class SqlInvokedFunction
         implements SqlFunction
 {
@@ -54,6 +58,7 @@ public class SqlInvokedFunction
      */
     private final Optional<AggregationFunctionMetadata> aggregationMetadata;
 
+    @ThriftConstructor
     @JsonCreator
     public SqlInvokedFunction(
             @JsonProperty("parameters") List<Parameter> parameters,
@@ -150,6 +155,7 @@ public class SqlInvokedFunction
     }
 
     @Override
+    @ThriftField(1)
     @JsonProperty
     public Signature getSignature()
     {
@@ -175,30 +181,35 @@ public class SqlInvokedFunction
     }
 
     @Override
+    @ThriftField(2)
     @JsonProperty
     public String getDescription()
     {
         return description;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public List<Parameter> getParameters()
     {
         return parameters;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public RoutineCharacteristics getRoutineCharacteristics()
     {
         return routineCharacteristics;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public String getBody()
     {
         return body;
     }
 
+    @ThriftField(6)
     @JsonProperty
     public SqlFunctionId getFunctionId()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -24,6 +27,7 @@ import java.util.Objects;
 
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 
+@ThriftStruct
 public class TypeVariableConstraint
 {
     private final String name;
@@ -32,6 +36,7 @@ public class TypeVariableConstraint
     private final String variadicBound;
     private final boolean nonDecimalNumericRequired;
 
+    @ThriftConstructor
     @JsonCreator
     public TypeVariableConstraint(
             @JsonProperty("name") String name,
@@ -47,30 +52,35 @@ public class TypeVariableConstraint
         this.nonDecimalNumericRequired = nonDecimalNumericRequired;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public boolean isComparableRequired()
     {
         return comparableRequired;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public boolean isOrderableRequired()
     {
         return orderableRequired;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public String getVariadicBound()
     {
         return variadicBound;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public boolean isNonDecimalNumericRequired()
     {


### PR DESCRIPTION
## Motivation and Context
`SessionRepresentation` has Thrift annotations but some 
of the classes of its member variables do not have Thrift support.
Add annotations to `SqlInvokedFunction` and `SqlFunctionId`.
Work towards Thrift serialization support of `TaskResource`.
https://github.com/prestodb/presto/issues/19839

## Testing
Add serde test for new `TypeSignatureParameterUnion`

```
== NO RELEASE NOTE ==
```

