### PR TITLE
[native] Add back cache counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -241,7 +241,38 @@ void PeriodicTaskManager::updateCacheStats() {
       kCounterMemoryCacheTotalPrefetchBytes, memoryCacheStats.prefetchBytes);
   REPORT_ADD_STAT_VALUE(
       kCounterMemoryCacheSumEvictScore, memoryCacheStats.sumEvictScore);
-  
+
+  // Interval cumulatives.
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumHit,
+      memoryCacheStats.numHit - lastMemoryCacheHits_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheHitBytes,
+      memoryCacheStats.hitBytes - lastMemoryCacheHitsBytes_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumNew,
+      memoryCacheStats.numNew - lastMemoryCacheInserts_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumEvict,
+      memoryCacheStats.numEvict - lastMemoryCacheEvictions_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumEvictChecks,
+      memoryCacheStats.numEvictChecks - lastMemoryCacheEvictionChecks_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumWaitExclusive,
+      memoryCacheStats.numWaitExclusive - lastMemoryCacheStalls_);
+  REPORT_ADD_STAT_VALUE(
+      kCounterMemoryCacheNumAllocClocks,
+      memoryCacheStats.allocClocks - lastMemoryCacheAllocClocks_);
+
+  lastMemoryCacheHits_ = memoryCacheStats.numHit;
+  lastMemoryCacheHitsBytes_ = memoryCacheStats.hitBytes;
+  lastMemoryCacheInserts_ = memoryCacheStats.numNew;
+  lastMemoryCacheEvictions_ = memoryCacheStats.numEvict;
+  lastMemoryCacheEvictionChecks_ = memoryCacheStats.numEvictChecks;
+  lastMemoryCacheStalls_ = memoryCacheStats.numWaitExclusive;
+  lastMemoryCacheAllocClocks_ = memoryCacheStats.allocClocks;
+
   // All time cumulatives.
   REPORT_ADD_STAT_VALUE(
       kCounterMemoryCacheNumCumulativeHit, memoryCacheStats.numHit);

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -104,6 +104,15 @@ class PeriodicTaskManager {
       std::string,
       std::shared_ptr<velox::connector::Connector>>& connectors_;
 
+  // Cache related stats
+  int64_t lastMemoryCacheHits_{0};
+  int64_t lastMemoryCacheHitsBytes_{0};
+  int64_t lastMemoryCacheInserts_{0};
+  int64_t lastMemoryCacheEvictions_{0};
+  int64_t lastMemoryCacheEvictionChecks_{0};
+  int64_t lastMemoryCacheStalls_{0};
+  int64_t lastMemoryCacheAllocClocks_{0};
+
   // Operating system related stats.
   int64_t lastUserCpuTimeUs_{0};
   int64_t lastSystemCpuTimeUs_{0};

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -133,20 +133,34 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeHit, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumHit, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheCumulativeHitBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheHitBytes, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeNew, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumNew, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeEvict, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEvict, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeEvictChecks,
       facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumEvictChecks, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeWaitExclusive,
       facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumWaitExclusive, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterMemoryCacheNumCumulativeAllocClocks,
       facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterMemoryCacheNumAllocClocks, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeReadEntries, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -178,27 +178,53 @@ constexpr folly::StringPiece kCounterMemoryCacheSumEvictScore{
 /// does not count.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeHit{
     "presto_cpp.memory_cache_num_cumulative_hit"};
+/// Number of hits (saved IO) since last counter retrieval. The first hit to a
+/// prefetched entry does not count.
+constexpr folly::StringPiece kCounterMemoryCacheNumHit{
+    "presto_cpp.memory_cache_num_hit"};
 /// Cumulated amount of hit bytes (saved IO). The first hit to a prefetched
 /// entry does not count.
 constexpr folly::StringPiece kCounterMemoryCacheCumulativeHitBytes{
     "presto_cpp.memory_cache_cumulative_hit_bytes"};
+/// Amount of hit bytes (saved IO) since last counter retrieval. The first hit
+/// to a prefetched entry does not count.
+constexpr folly::StringPiece kCounterMemoryCacheHitBytes{
+    "presto_cpp.memory_cache_hit_bytes"};
 /// Cumulated number of new entries created.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeNew{
     "presto_cpp.memory_cache_num_cumulative_new"};
+/// Number of new entries created since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumNew{
+    "presto_cpp.memory_cache_num_new"};
 /// Cumulated number of times a valid entry was removed in order to make space.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvict{
     "presto_cpp.memory_cache_num_cumulative_evict"};
+/// Number of times a valid entry was removed in order to make space, since last
+/// counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumEvict{
+    "presto_cpp.memory_cache_num_evict"};
 /// Cumulated number of entries considered for evicting.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvictChecks{
     "presto_cpp.memory_cache_num_cumulative_evict_checks"};
+/// Number of entries considered for evicting, since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumEvictChecks{
+    "presto_cpp.memory_cache_num_evict_checks"};
 /// Cumulated number of times a user waited for an entry to transit from
 /// exclusive to shared mode.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeWaitExclusive{
     "presto_cpp.memory_cache_num_cumulative_wait_exclusive"};
+/// Number of times a user waited for an entry to transit from exclusive to
+/// shared mode, since last counter retrieval.
+constexpr folly::StringPiece kCounterMemoryCacheNumWaitExclusive{
+    "presto_cpp.memory_cache_num_wait_exclusive"};
 /// Cumulative clocks spent in allocating or freeing memory for backing cache
 /// entries.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAllocClocks{
     "presto_cpp.memory_cache_num_cumulative_alloc_clocks"};
+/// Clocks spent in allocating or freeing memory for backing cache entries,
+/// since last counter retrieval
+constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
+    "presto_cpp.memory_cache_num_alloc_clocks"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadEntries{
     "presto_cpp.ssd_cache_cumulative_read_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadBytes{


### PR DESCRIPTION
These counters are needed to debug memory issues in batch cluster

```
== NO RELEASE NOTE ==
```

