### PR TITLE
Avoid nested loops O(N*N) on DiscoveryNodeManager#refreshNodesInternal

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -276,9 +276,10 @@ public final class DiscoveryNodeManager
     private synchronized void refreshNodesInternal()
     {
         // This is currently a blacklist.
+        final Set<ServiceDescriptor> failures = failureDetector.getFailed();
         // TODO: make it a whitelist (a failure-detecting service selector) and maybe build in support for injecting this in airlift
         Set<ServiceDescriptor> services = serviceSelector.selectAllServices().stream()
-                .filter(service -> !failureDetector.getFailed().contains(service))
+                .filter(service -> !failures.contains(service))
                 .filter(filterRelevantNodes())
                 .collect(toImmutableSet());
 


### PR DESCRIPTION
Avoid unnecessary nested loops O(N*N) on DiscoveryNodeManager#refreshNodesInternal

It does nested loop O(N*N) when services filter out failure nodes on DiscoveryNodeManager#refreshNodesInternal, it's no big deal on small clusters with few nodes, however it consumes quite a lot of cpu cycles on large cluster with over 1000 nodes, that will do 1,000,000 cycles per round of refreshNodeInternal. According to acutal cpu profiling, we found jvm does not optimize the code automatically, so this commit optimize it and avoid nested loop.

Test plan
- compile success
- run success
- services filter out with failure nodes expectedly

```
== RELEASE NOTES ==

General Changes
* Reduce unnecessary nested loops overhead on DiscoveryNodeManager#refreshNodesInternal.
   This can avoid unnecessary nested loops while services filtering out failure nodes on DiscoveryNodeManager.

```

