### PR TITLE
ci: simplify GH actions for doc change

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -2,6 +2,8 @@ name: hive tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -2,6 +2,8 @@ name: kudu
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -2,6 +2,8 @@ name: product tests (basic)
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -2,6 +2,8 @@ name: spark integration
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -2,6 +2,8 @@ name: test other modules
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -2,6 +2,8 @@ name: web ui checks
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment


### PR DESCRIPTION
## Description
Reduce the GH actions when the PR only contains
doc changes that reside under the `presto-docs` directory.

## Motivation and Context
No need to waste the time/computation for running code-related test cases for documentation changes

## Impact
speed up the GA actions for doc-only change

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

