### PR TITLE
Support notification for host shutting down

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/NodeStatusNotificationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NodeStatusNotificationManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.spi.nodestatus.NoOpNodeStatusNotificationProvider;
+import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProvider;
+import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class NodeStatusNotificationManager
+{
+    private static final File NODE_STATUS_NOTIFICATION_CONFIG = new File("etc/node-status-notification.properties");
+    private NodeStatusNotificationProviderFactory notificationProviderFactory;
+    private NodeStatusNotificationProvider notificationProvider = new NoOpNodeStatusNotificationProvider();
+    private boolean isNotificationProviderAdded;
+
+    public void addNodeStatusNotificationProviderFactory(NodeStatusNotificationProviderFactory notificationProviderFactory)
+    {
+        this.notificationProviderFactory = requireNonNull(notificationProviderFactory, "notificationProviderFactory is null");
+    }
+
+    public void loadNodeStatusNotificationProvider()
+            throws IOException
+    {
+        if (this.notificationProviderFactory == null) {
+            return;
+        }
+        checkState(!isNotificationProviderAdded, "NotificationProvider can only be set once");
+        this.notificationProvider = this.notificationProviderFactory.create(getConfig());
+        this.isNotificationProviderAdded = true;
+    }
+
+    private Map<String, String> getConfig()
+            throws IOException
+    {
+        if (NODE_STATUS_NOTIFICATION_CONFIG.exists()) {
+            return loadProperties(NODE_STATUS_NOTIFICATION_CONFIG);
+        }
+        return ImmutableMap.of();
+    }
+
+    public NodeStatusNotificationProvider getNotificationProvider()
+    {
+        return this.notificationProvider;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
@@ -123,6 +124,7 @@ public class PluginManager
     private final HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager;
     private final TracerProviderManager tracerProviderManager;
     private final AnalyzerProviderManager analyzerProviderManager;
+    private final NodeStatusNotificationManager nodeStatusNotificationManager;
 
     @Inject
     public PluginManager(
@@ -142,7 +144,8 @@ public class PluginManager
             NodeTtlFetcherManager nodeTtlFetcherManager,
             ClusterTtlProviderManager clusterTtlProviderManager,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
-            TracerProviderManager tracerProviderManager)
+            TracerProviderManager tracerProviderManager,
+            NodeStatusNotificationManager nodeStatusNotificationManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -172,6 +175,7 @@ public class PluginManager
         this.historyBasedPlanStatisticsManager = requireNonNull(historyBasedPlanStatisticsManager, "historyBasedPlanStatisticsManager is null");
         this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
         this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
+        this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
     }
 
     public void loadPlugins()
@@ -316,6 +320,11 @@ public class PluginManager
         for (AnalyzerProvider analyzerProvider : plugin.getAnalyzerProviders()) {
             log.info("Registering analyzer provider %s", analyzerProvider.getType());
             analyzerProviderManager.addAnalyzerProvider(analyzerProvider);
+        }
+
+        for (NodeStatusNotificationProviderFactory nodeStatusNotificationProviderFactory : plugin.getNodeStatusNotificationProviderFactory()) {
+            log.info("Registering node status notification provider %s", nodeStatusNotificationProviderFactory.getName());
+            nodeStatusNotificationManager.addNodeStatusNotificationProviderFactory(nodeStatusNotificationProviderFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -175,7 +175,8 @@ public class PrestoServer
             injector.getInstance(NodeTtlFetcherManager.class).loadNodeTtlFetcher();
             injector.getInstance(ClusterTtlProviderManager.class).loadClusterTtlProvider();
             injector.getInstance(TracerProviderManager.class).loadTracerProvider();
-
+            injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
+            injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -769,6 +769,7 @@ public class ServerMainModule
 
         //Optional Status Detector
         newOptionalBinder(binder, NodeStatusService.class);
+        binder.bind(NodeStatusNotificationManager.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -119,6 +119,7 @@ import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.server.ConnectorMetadataUpdateHandleJsonSerde;
+import com.facebook.presto.server.NodeStatusNotificationManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.SessionPropertyDefaults;
@@ -504,7 +505,8 @@ public class LocalQueryRunner
                 new ThrowingNodeTtlFetcherManager(),
                 new ThrowingClusterTtlProviderManager(),
                 historyBasedPlanStatisticsManager,
-                new TracerProviderManager(new TracingConfig()));
+                new TracerProviderManager(new TracingConfig()),
+                new NodeStatusNotificationManager());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -136,6 +136,7 @@ public class TestThriftServerInfoIntegration
             configBinder(binder).bindConfig(ServerConfig.class);
             //Bind noop QueryManager similar to the binding done for TaskManager here
             binder.bind(QueryManager.class).to(NoOpQueryManager.class).in(Scopes.SINGLETON);
+            binder.bind(NodeStatusNotificationManager.class).in(Scopes.SINGLETON);
             binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
             binder.bind(ShutdownAction.class).to(TestingPrestoServer.TestShutdownAction.class).in(Scopes.SINGLETON);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -96,6 +96,7 @@ import com.facebook.presto.resourcemanager.NoopResourceGroupService;
 import com.facebook.presto.resourcemanager.ResourceGroupService;
 import com.facebook.presto.server.ConnectorMetadataUpdateHandleJsonSerde;
 import com.facebook.presto.server.ForJsonMetadataUpdateHandle;
+import com.facebook.presto.server.NodeStatusNotificationManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.QuerySessionSupplier;
@@ -501,6 +502,7 @@ public class PrestoSparkModule
         binder.bind(ResourceGroupService.class).to(NoopResourceGroupService.class).in(Scopes.SINGLETON);
         binder.bind(NodeTtlFetcherManager.class).to(ThrowingNodeTtlFetcherManager.class).in(Scopes.SINGLETON);
         binder.bind(ClusterTtlProviderManager.class).to(ThrowingClusterTtlProviderManager.class).in(Scopes.SINGLETON);
+        binder.bind(NodeStatusNotificationManager.class).in(Scopes.SINGLETON);
 
         // TODO: Decouple and remove: required by SessionPropertyDefaults, PluginManager, InternalResourceGroupManager, ConnectorManager
         configBinder(binder).bindConfig(NodeConfig.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
@@ -127,6 +128,11 @@ public interface Plugin
     }
 
     default Iterable<AnalyzerProvider> getAnalyzerProviders()
+    {
+        return emptyList();
+    }
+
+    default Iterable<NodeStatusNotificationProviderFactory> getNodeStatusNotificationProviderFactory()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/GracefulShutdownEventListener.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/GracefulShutdownEventListener.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.nodestatus;
+
+@FunctionalInterface
+public interface GracefulShutdownEventListener
+{
+    void onNodeShuttingDown();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NoOpNodeStatusNotificationProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NoOpNodeStatusNotificationProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.nodestatus;
+
+public class NoOpNodeStatusNotificationProvider
+        implements NodeStatusNotificationProvider
+{
+    @Override
+    public void registerGracefulShutdownEventListener(GracefulShutdownEventListener listener)
+    {
+    }
+
+    @Override
+    public void removeGracefulShutdownEventListener(GracefulShutdownEventListener listener)
+    {
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NodeStatusNotificationProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NodeStatusNotificationProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.nodestatus;
+
+/**
+ * The {@code NodeStatusNotificationProvider} interface provides a registry for node status listeners.
+ * Implementations of this interface can listen to node status events and notify all registered listeners,
+ * especially when a node goes down.
+ *
+ * <p>It is essential for implementations to ensure proper synchronization if the registry is accessed
+ * by multiple threads.</p>
+ */
+public interface NodeStatusNotificationProvider
+{
+    void registerGracefulShutdownEventListener(GracefulShutdownEventListener listener);
+
+    void removeGracefulShutdownEventListener(GracefulShutdownEventListener listener);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NodeStatusNotificationProviderFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/nodestatus/NodeStatusNotificationProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.nodestatus;
+
+import java.util.Map;
+
+public interface NodeStatusNotificationProviderFactory
+{
+    String getName();
+
+    NodeStatusNotificationProvider create(Map<String, String> config);
+}


### PR DESCRIPTION
## Description
We want to enable a custom notification mechanism for quicker recognition of worker drain signals. This mechanism is currently intended for use with both the exchange client and supporting a faster graceful shutdown of workers.

## Motivation and Context
At present, we lack an efficient method for downstream workers to detect when an upstream worker is preparing for shutdown. This early detection is crucial, especially given the narrow window available for a graceful shutdown. In some of our environments, we have just 60 seconds to gracefully shut down a worker. Hence, having this notification system in place for downstream workers becomes essential to expedite the draining of upstream workers.

## Impact
The customizable notification mechanism permits integration with different internal infrastructures. Downstream workers will receive immediate alerts when an upstream worker becomes unavailable, contingent on the responsiveness of the selected membership protocol.

## Test Plan
CI
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

