### PR TITLE
fix(sec): upgrade org.xerial.snappy:snappy-java to 1.1.10.1

### DIFF
--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
+            <version>1.1.10.1</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.xerial.snappy:snappy-java 1.1.1.7
- [CVE-2023-34454](https://www.oscs1024.com/hd/CVE-2023-34454)


### What did I do？
Upgrade org.xerial.snappy:snappy-java from 1.1.1.7 to 1.1.10.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS