### PR TITLE
[native] Add config parameters for remote function execution

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -81,7 +81,8 @@ endif()
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   set(VELOX_ENABLE_REMOTE_FUNCTIONS
       ON
-      CACHE BOOL "Enable remote function support")
+      CACHE BOOL "Enable remote function support in Velox")
+  add_compile_definitions(PRESTO_ENABLE_REMOTE_FUNCTIONS)
 endif()
 
 set(VELOX_BUILD_TESTING

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -90,6 +90,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
 
   target_link_libraries(presto_server_remote_function velox_expression
                         velox_functions_remote ${FOLLY_WITH_DEPENDENCIES})
+  target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -54,6 +54,10 @@
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 #include "velox/serializers/PrestoSerializer.h"
 
+#ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
+#include "presto_cpp/main/RemoteFunctionRegisterer.h"
+#endif
+
 namespace facebook::presto {
 using namespace facebook::velox;
 
@@ -705,7 +709,29 @@ void PrestoServer::registerFunctions() {
   }
 }
 
-void PrestoServer::registerRemoteFunctions() {}
+void PrestoServer::registerRemoteFunctions() {
+#ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
+  if (auto dirPath = SystemConfig::instance()
+                         ->remoteFunctionServerSignatureFilesDirectoryPath()) {
+    PRESTO_STARTUP_LOG(INFO)
+        << "Registering remote functions from path: " << *dirPath;
+    if (auto remoteLocation =
+            SystemConfig::instance()->remoteFunctionServerLocation()) {
+      size_t registeredCount =
+          presto::registerRemoteFunctions(*dirPath, *remoteLocation);
+      PRESTO_STARTUP_LOG(INFO)
+          << registeredCount << " remote functions registered.";
+    } else {
+      VELOX_FAIL(
+          "To register remote functions using a json file path you need to "
+          "specify the remote server location using '{}', '{}' or '{}'.",
+          SystemConfig::kRemoteFunctionServerThriftAddress,
+          SystemConfig::kRemoteFunctionServerThriftPort,
+          SystemConfig::kRemoteFunctionServerThriftUdsPath);
+    }
+  }
+#endif
+}
 
 void PrestoServer::registerVectorSerdes() {
   if (!velox::isRegisteredVectorSerde()) {

--- a/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
+++ b/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
@@ -45,7 +45,7 @@ size_t processFile(
 
 } // namespace
 
-size_t registerRemoteFuctions(
+size_t registerRemoteFunctions(
     const std::string& inputPath,
     const folly::SocketAddress& location) {
   size_t signaturesCount = 0;

--- a/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.h
+++ b/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.h
@@ -27,7 +27,7 @@ namespace facebook::presto {
 /// to.
 ///
 /// Returns the number of signatures registered.
-size_t registerRemoteFuctions(
+size_t registerRemoteFunctions(
     const std::string& inputPath,
     const folly::SocketAddress& location);
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -328,12 +328,38 @@ folly::Optional<std::string> SystemConfig::discoveryUri() const {
 
 folly::Optional<folly::SocketAddress>
 SystemConfig::remoteFunctionServerLocation() const {
+  // First check if there is a UDS path registered. If there's one, use it.
+  auto remoteServerUdsPath =
+      optionalProperty(kRemoteFunctionServerThriftUdsPath);
+  if (remoteServerUdsPath.hasValue()) {
+    return folly::SocketAddress::makeFromPath(remoteServerUdsPath.value());
+  }
+
+  // Otherwise, check for address and port parameters.
+  auto remoteServerAddress =
+      optionalProperty(kRemoteFunctionServerThriftAddress);
   auto remoteServerPort =
       optionalProperty<uint16_t>(kRemoteFunctionServerThriftPort);
+
   if (remoteServerPort.hasValue()) {
-    return folly::SocketAddress{"::1", remoteServerPort.value()};
+    // Fallback to localhost if address is not specified.
+    return remoteServerAddress.hasValue()
+        ? folly::
+              SocketAddress{remoteServerAddress.value(), remoteServerPort.value()}
+        : folly::SocketAddress{"::1", remoteServerPort.value()};
+  } else if (remoteServerAddress.hasValue()) {
+    VELOX_FAIL(
+        "Remote function server port not provided using '{}'.",
+        kRemoteFunctionServerThriftPort);
   }
+
+  // No remote function server configured.
   return folly::none;
+}
+
+folly::Optional<std::string>
+SystemConfig::remoteFunctionServerSignatureFilesDirectoryPath() const {
+  return optionalProperty(kRemoteFunctionServerSignatureFilesDirectoryPath);
 }
 
 int32_t SystemConfig::maxDriversPerTask() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -249,10 +249,6 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kEnableMemoryLeakCheck{
       "enable-memory-leak-check"};
 
-  /// Port used by the remote function thrift server.
-  static constexpr std::string_view kRemoteFunctionServerThriftPort{
-      "remote-function-server.thrift.port"};
-
   /// Do not include runtime stats in the returned task info if the task is
   /// in running state.
   static constexpr std::string_view kSkipRuntimeStatsInRunningTaskInfo{
@@ -279,6 +275,27 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kIncludeNodeInSpillPath{
       "include-node-in-spill-path"};
+
+  /// Remote function server configs.
+
+  /// Port used by the remote function thrift server.
+  static constexpr std::string_view kRemoteFunctionServerThriftPort{
+      "remote-function-server.thrift.port"};
+
+  /// Address (ip or hostname) used by the remote function thrift server
+  /// (fallback to localhost if not specified).
+  static constexpr std::string_view kRemoteFunctionServerThriftAddress{
+      "remote-function-server.thrift.address"};
+
+  /// UDS (unix domain socket) path used by the remote function thrift server.
+  static constexpr std::string_view kRemoteFunctionServerThriftUdsPath{
+      "remote-function-server.thrift.uds-path"};
+
+  /// Path where json files containing signatures for remote functions can be
+  /// found.
+  static constexpr std::string_view
+      kRemoteFunctionServerSignatureFilesDirectoryPath{
+          "remote-function-server.signature.files.directory.path"};
 
   SystemConfig();
 
@@ -322,6 +339,9 @@ class SystemConfig : public ConfigBase {
   folly::Optional<std::string> discoveryUri() const;
 
   folly::Optional<folly::SocketAddress> remoteFunctionServerLocation() const;
+
+  folly::Optional<std::string> remoteFunctionServerSignatureFilesDirectoryPath()
+      const;
 
   int32_t maxDriversPerTask() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
@@ -66,7 +66,7 @@ TEST_F(RemoteFunctionRegistererTest, singleFile) {
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock2") == std::nullopt);
 
   // Read and register functions in that file.
-  EXPECT_EQ(registerRemoteFuctions(path->path, {}), 2);
+  EXPECT_EQ(registerRemoteFunctions(path->path, {}), 2);
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock1") != std::nullopt);
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock2") != std::nullopt);
 }
@@ -97,7 +97,7 @@ TEST_F(RemoteFunctionRegistererTest, directory) {
   fs::create_directory(tempSubdir);
   writeToFile(tempSubdir + "/remote3.json", getJson("mock3"));
 
-  EXPECT_EQ(registerRemoteFuctions(tempDir->path, {}), 3);
+  EXPECT_EQ(registerRemoteFunctions(tempDir->path, {}), 3);
 }
 
 } // namespace


### PR DESCRIPTION
## Description
Adding more configuration parameters in native executor to support remote function server configuration. The following parameters were added:
* remote-function-server.thrift.address: ip or dns address of a remote function server (default to loopback address)
* remote-function-server.thrift.port: its port
* remote-function-server.thrift.uds-path: alternatively, specify a unix domain socket file path for communication (if local)
* remote-function-server.signature.files.directory.path: path containing json signature function files.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Unit tests added. The next PR will include a framework and end-to-end tests. 

```
== NO RELEASE NOTE ==
```

