### PR TITLE
Split Iceberg tests from test-other-modules.yml

### DIFF
--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -62,4 +62,5 @@ jobs:
             !presto-orc,
             !presto-thrift-connector,
             !presto-native-execution,
-            !presto-test-coverage'
+            !presto-test-coverage,
+            !presto-iceberg'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           - ":presto-spark-base -P presto-spark-tests-smoke"
           - ":presto-spark-base -P presto-spark-tests-all-queries"
           - ":presto-spark-base -P presto-spark-tests-spill-queries"
+          - ":presto-iceberg"
     timeout-minutes: 80
     concurrency:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Description

Iceberg tests often run for over half an hour.  This often causes a timeout in test-other-modules.  By splitting them out, we can better parallelize and reduce timeouts.

## Motivation and Context
Reduce timeouts and flaky test failures.

## Impact
Reduced testing timeouts.

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

