### PR TITLE
[Document] how to install Presto on an Intel Mac using homebrew

### DIFF
--- a/presto-docs/src/main/sphinx/installation.rst
+++ b/presto-docs/src/main/sphinx/installation.rst
@@ -12,3 +12,4 @@ Installation
     installation/tableau
     installation/spark
     installation/deploy-docker
+    installation/deploy-brew

--- a/presto-docs/src/main/sphinx/installation/deploy-brew.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-brew.rst
@@ -1,0 +1,82 @@
+============================================
+Deploy Presto on an Intel Mac using Homebrew
+============================================
+
+*Note*: These steps were developed and tested on Mac OS X on Intel. These steps will not work with Apple Silicon CPUs.
+
+Following these steps, you will:
+
+- install the Presto service and CLI on an Intel Mac using `Homebrew <https://formulae.brew.sh/formula/prestodb#default>`_
+- start and stop the Presto service
+- start the Presto CLI
+
+Install Presto
+==============
+
+Follow these steps to install Presto on an Intel CPU Mac using `Homebrew <https://formulae.brew.sh/formula/prestodb#default>`_. 
+
+1. If you do not have brew installed, run the following command:
+
+   ``/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"``
+
+2. To install Presto, run the following command:
+
+   ``brew install prestodb``
+
+   Presto is installed in the directory */usr/local/Cellar/prestodb/<version>.* 
+
+The following files are created in the *libexec/etc* directory in the Presto install directory:
+
+- node.properties
+- jvm.config
+- config.properties
+- log.properties
+- catalog/jmx.properties
+
+For example, the full path to the node.properties file is */usr/local/Cellar/prestodb/0.282/libexec/etc/node.properties* 
+
+The Presto CLI is installed in the *bin* directory of the Presto install directory: */usr/local/Cellar/prestodb/<version>/bin*.
+
+The executables are added to */usr/local/bin* path and should be available as part of $PATH.
+
+Start and Stop Presto
+=====================
+
+To start Presto, use the presto-server helper script. 
+
+To start the Presto service in the background, run the following command: 
+
+``presto-server start``
+
+To start the Presto service in the foreground, run the following command:
+
+``presto-server run``
+
+To stop the Presto service in the background, run the following command:
+
+``presto-server stop``
+
+To stop the Presto service in the foreground, close the terminal or select Ctrl + C until the terminal prompt is shown. 
+
+Access the Presto Web Console
+=============================
+
+After starting Presto, you can access the web UI using the following link in a browser:
+
+``http://localhost:8080``
+
+*Note*: The default port is 8080. To configure the Presto service to use a different port see `Config Properties <deployment.html#config-properties>`_.
+
+.. figure:: ../images/presto_console.png
+   :align: center
+
+Start the Presto CLI
+====================
+
+The Presto CLI is a terminal-based interactive shell for running queries, and is a
+`self-executing <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>`_
+JAR file that acts like a normal UNIX executable.
+
+The Presto CLI is installed in the *bin* directory of the Presto install directory: */usr/local/Cellar/prestodb/<version>/bin*.
+
+To run the Presto CLI and use it to send SQL queries to a local or a remote Presto service, see :doc:`Command Line Interface <cli>`.


### PR DESCRIPTION
## Description
Document how to install Presto on an Intel Mac using homebrew. 

## Motivation and Context
The goal is to support a user to successfully install and run Presto on OS X on Intel. The only requirements are OS X and the ability to open a Terminal window.

## Impact
Users new to Presto will be able to install and run Presto successfully. 

## Test Plan
Developed and tested all steps on an Intel CPU MacBook Pro running OS X. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
== NO RELEASE NOTE ==
