### PR TITLE
[Native] Add e2e testing for f_cdf function

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
@@ -49,4 +49,12 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
     {
         assertQuery("SELECT beta_cdf(nationkey, 0.2, 0.2) from nation where nationkey > 0");
     }
+
+    @Test
+    public void testFCDF()
+    {
+        assertQuery("SELECT f_cdf(nationKey, 1, 0) FROM nation WHERE nationKey > 0");
+        assertQuery("SELECT f_cdf(nationKey, regionKey, 1) FROM nation WHERE nationKey > 0 AND regionkey > 0");
+        assertQuery("SELECT f_cdf(nationKey, 1, regionKey) FROM nation WHERE nationKey > 0 AND regionkey > 0");
+    }
 }


### PR DESCRIPTION
## Description

This PR adds e2e testing for the new scalar function f_cdf. (Delivered via https://github.com/facebookincubator/velox/pull/5800)

```
== NO RELEASE NOTE ==
```

