### PR TITLE
add merge_tdigest function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -96,3 +96,7 @@ Functions
     values in the digest). This is an inverse of ``destructure_tdigest``.
 
     This function is particularly useful for adding externally-created tdigests to Presto.
+
+ .. function:: merge_tdigest(array<tdigest<double>>) -> tdigest<double>
+     Returns a merged ``tdigest`` of the T-digests in an array. This is the
+     scalar complement to the aggregation function ``merge``.

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -665,6 +665,94 @@ public class TestTDigestFunctions
         assertEquals(constructedSqlVarbinary, sqlVarbinary);
     }
 
+    @Test
+    public void testMergeTDigestNullInput()
+    {
+        functionAssertions.assertFunction("merge_tdigest(null)", TDIGEST_DOUBLE, null);
+    }
+
+    @Test
+    public void testMergeTDigestEmptyArray()
+    {
+        functionAssertions.assertFunction("merge_tdigest(array[])", TDIGEST_DOUBLE, null);
+    }
+
+    @Test
+    public void testMergeTDigestEmptyArrayOfNull()
+    {
+        functionAssertions.assertFunction("merge_tdigest(array[null])", TDIGEST_DOUBLE, null);
+    }
+
+    @Test
+    public void testMergeTDigestEmptyArrayOfNulls()
+    {
+        functionAssertions.assertFunction("merge_tdigest(array[null, null, null])", TDIGEST_DOUBLE, null);
+    }
+
+    @Test
+    public void testMergeTDigests()
+    {
+        TDigest digest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest1, 0.1);
+        TDigest digest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest2, 0.2);
+        SqlVarbinary sqlVarbinary = functionAssertions.selectSingleValue(
+                format("merge_tdigest(cast(array[%s, %s] as array(tdigest(double))))",
+                        toSqlString(digest1),
+                        toSqlString(digest2)),
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+        digest1.merge(digest2);
+        assertEquals(sqlVarbinary, new SqlVarbinary(digest1.serialize().getBytes()));
+    }
+
+    @Test
+    public void testMergeTDigestOneNull()
+    {
+        TDigest digest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest1, 0.1);
+        SqlVarbinary sqlVarbinary = functionAssertions.selectSingleValue(
+                format("merge_tdigest(cast(array[%s, null] as array(tdigest(double))))",
+                        toSqlString(digest1)),
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+        assertEquals(sqlVarbinary, new SqlVarbinary(digest1.serialize().getBytes()));
+    }
+
+    @Test
+    public void testMergeTDigestOneNullFirst()
+    {
+        TDigest digest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest1, 0.1);
+        TDigest digest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest2, 0.2);
+        SqlVarbinary sqlVarbinary = functionAssertions.selectSingleValue(
+                format("merge_tdigest(cast(array[null, %s, %s] as array(tdigest(double))))",
+                        toSqlString(digest1),
+                        toSqlString(digest2)),
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+        digest1.merge(digest2);
+        assertEquals(sqlVarbinary, new SqlVarbinary(digest1.serialize().getBytes()));
+    }
+
+    @Test
+    public void testMergeTDigestOneNullMiddle()
+    {
+        TDigest digest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest1, 0.1);
+        TDigest digest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        addAll(digest2, 0.2);
+        SqlVarbinary sqlVarbinary = functionAssertions.selectSingleValue(
+                format("merge_tdigest(cast(array[%s, null, %s] as array(tdigest(double))))",
+                        toSqlString(digest1),
+                        toSqlString(digest2)),
+                TDIGEST_DOUBLE,
+                SqlVarbinary.class);
+        digest1.merge(digest2);
+        assertEquals(sqlVarbinary, new SqlVarbinary(digest1.serialize().getBytes()));
+    }
+
     // disabled because test takes almost 10s
     @Test(enabled = false)
     public void testBinomialDistribution()


### PR DESCRIPTION
## Description
Adding a scalar function to merge T-digests from an input array.

## Motivation and Context
Existing issue: https://github.com/prestodb/presto/issues/18402

The aggregate function [`MERGE`](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeTDigestFunction.java) has existed for digests, but never the scalar equivalent.

(previously opened in https://github.com/prestodb/presto/pull/20510 but closed due to rebase error)

## Impact
No impact, net-new function.

## Test Plan
Added unit tests.

Built with:
```
./mvnw clean install -Dtest=TestTDigestFunctions -Dmaven.javadoc.skip=true -T1C -fn -pl presto-main
```

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

== RELEASE NOTES ==

General Changes
* Adding the function `MERGE_TDIGEST`.
  * Usage: `MERGE_TDIGEST(CAST(ARRAY[digest1, digest2, ...] AS ARRAY(TDIGEST(DOUBLE))))`