### PR TITLE
[native] Fix In predicate construction for DATE types

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -539,6 +539,7 @@ TypedExprPtr convertBindExpr(const std::vector<TypedExprPtr>& args) {
 
 template <TypeKind KIND>
 velox::ArrayVectorPtr toArrayVector(
+    const velox::TypePtr& elementType,
     std::vector<TypedExprPtr>::const_iterator begin,
     std::vector<TypedExprPtr>::const_iterator end,
     velox::memory::MemoryPool* pool) {
@@ -546,7 +547,7 @@ velox::ArrayVectorPtr toArrayVector(
 
   const auto size = end - begin;
   auto elements = std::dynamic_pointer_cast<velox::FlatVector<T>>(
-      velox::BaseVector::create(velox::CppToType<T>::create(), size, pool));
+      velox::BaseVector::create(elementType, size, pool));
 
   for (auto i = 0; i < size; ++i) {
     auto constant =
@@ -573,13 +574,7 @@ velox::ArrayVectorPtr toArrayVector(
   rawSizes[0] = size;
 
   return std::make_shared<velox::ArrayVector>(
-      pool,
-      ARRAY(velox::Type::create<KIND>()),
-      nullptr,
-      1,
-      offsets,
-      sizes,
-      elements);
+      pool, ARRAY(elementType), nullptr, 1, offsets, sizes, elements);
 }
 
 TypedExprPtr convertInExpr(
@@ -591,6 +586,7 @@ TypedExprPtr convertInExpr(
   auto arrayVector = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
       toArrayVector,
       args[0]->type()->kind(),
+      args[0]->type(),
       args.begin() + 1,
       args.end(),
       pool);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -132,6 +132,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT * FROM lineitem");
         assertQuery("SELECT ceil(discount), ceiling(discount), floor(discount), abs(discount) FROM lineitem");
         assertQuery("SELECT linenumber IN (2, 4, 6) FROM lineitem");
+        assertQuery("SELECT orderdate FROM orders WHERE cast(orderdate as DATE) IN (cast('1997-07-29' as DATE), cast('1993-03-13' as DATE)) ORDER BY orderdate LIMIT 10");
 
         assertQuery("SELECT * FROM orders");
 


### PR DESCRIPTION
## Description
In predicate construction used only the Velox LogicalType during plan conversion between Presto and Velox. This caused issues for DATE since it maps to the INTEGER as a logical type losing the original type information. 

This PR modifies the InPredicate construction to use the original type of the array to construct the Velox expressions faithfully.

## Motivation and Context
SQL 

`SELECT orderdate FROM orders WHERE cast(orderdate as DATE) IN (cast('1997-07-29' as DATE), cast('1993-03-13' as DATE)) LIMIT 10;` 

previously failed with error  "Scalar function in not registered with arguments: (DATE, ARRAY<INTEGER>). " as the expressions were formed incorrectly.

## Test Plan
e2e test for above SQL

```
== NO RELEASE NOTE ==
```

