### PR TITLE
[native]Improve task manager shutdown logging

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -32,6 +32,10 @@ class TaskManager {
  public:
   TaskManager();
 
+  /// Invoked by Presto server shutdown to wait for all the tasks to complete
+  /// and cleanup the completed tasks.
+  void shutdown();
+
   void setBaseUri(const std::string& baseUri) {
     baseUri_ = baseUri;
   }
@@ -87,9 +91,6 @@ class TaskManager {
   /// Remove old Finished, Cancelled, Failed and Aborted tasks.
   /// Old is being defined by the lifetime of the task.
   size_t cleanOldTasks();
-
-  /// Invoked by Presto server shutdown to wait for all the tasks to complete.
-  void waitForTasksToComplete();
 
   folly::Future<std::unique_ptr<protocol::TaskInfo>> getTaskInfo(
       const protocol::TaskId& taskId,
@@ -152,14 +153,13 @@ class TaskManager {
       const protocol::TaskId& taskId,
       bool includeNodeInSpillPath);
 
- public:
+ private:
   static constexpr folly::StringPiece kMaxDriversPerTask{
       "max_drivers_per_task"};
   static constexpr folly::StringPiece kConcurrentLifespansPerTask{
       "concurrent_lifespans_per_task"};
   static constexpr folly::StringPiece kSessionTimezone{"session_timezone"};
 
- private:
   std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
       const protocol::TaskId& taskId,
       const velox::core::PlanFragment& planFragment,

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -253,6 +253,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kUseMmapArena, "false"),
           NUM_PROP(kMmapArenaCapacityRatio, 10),
           STR_PROP(kUseMmapAllocator, "true"),
+          STR_PROP(kMemoryArbitratorKind, ""),
           STR_PROP(kEnableVeloxTaskLogging, "false"),
           STR_PROP(kEnableVeloxExprSetLogging, "false"),
           NUM_PROP(kLocalShuffleMaxPartitionBytes, 268435456),
@@ -430,6 +431,10 @@ bool SystemConfig::useMmapAllocator() const {
 
 bool SystemConfig::enableMemoryArbitration() const {
   return optionalProperty<bool>(kEnableMemoryArbitration).value_or(false);
+}
+
+std::string SystemConfig::memoryArbitratorKind() const {
+  return optionalProperty<std::string>(kMemoryArbitratorKind).value_or("");
 }
 
 uint64_t SystemConfig::memoryPoolInitCapacity() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -205,6 +205,12 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kEnableMemoryArbitration{
       "enable-memory-arbitration"};
+
+  /// Specifies the memory arbitrator kind. If it is empty, then there is no
+  /// memory arbitration.
+  static constexpr std::string_view kMemoryArbitratorKind{
+      "memory-arbitrator-kind"};
+
   /// The initial memory pool capacity in bytes allocated on creation.
   ///
   /// NOTE: this config only applies if the memory arbitration has been enabled.
@@ -372,6 +378,8 @@ class SystemConfig : public ConfigBase {
   bool useMmapAllocator() const;
 
   bool enableMemoryArbitration() const;
+
+  std::string memoryArbitratorKind() const;
 
   uint64_t memoryPoolInitCapacity() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -29,13 +29,14 @@ class PrestoTaskTest : public testing::Test {
 };
 
 TEST_F(PrestoTaskTest, basicTaskId) {
-  PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3.4");
-
-  EXPECT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
-  EXPECT_EQ(id.stageId(), 1);
-  EXPECT_EQ(id.stageExecutionId(), 2);
-  EXPECT_EQ(id.id(), 3);
-  EXPECT_EQ(id.attemptNumber(), 4);
+  const std::string taskIdStr("20201107_130540_00011_wrpkw.1.2.3.4");
+  PrestoTaskId id(taskIdStr);
+  ASSERT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
+  ASSERT_EQ(id.stageId(), 1);
+  ASSERT_EQ(id.stageExecutionId(), 2);
+  ASSERT_EQ(id.id(), 3);
+  ASSERT_EQ(id.attemptNumber(), 4);
+  ASSERT_EQ(id.toString(), taskIdStr);
 }
 
 TEST_F(PrestoTaskTest, malformedTaskId) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -54,6 +54,16 @@ class PrestoTaskId {
     return attemptNumber_;
   }
 
+  std::string toString() const {
+    return fmt::format(
+        "{}.{}.{}.{}.{}",
+        queryId_,
+        stageId_,
+        stageExecutionId_,
+        id_,
+        attemptNumber_);
+  }
+
  private:
   std::string queryId_;
   int32_t stageId_{0};


### PR DESCRIPTION
Improve task manager shutdown logging by printing out
the task ids with pending references.

```
== NO RELEASE NOTE ==
```

