### PR TITLE
[native] Remove legacy task id parsing and tests.

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -38,16 +38,6 @@ TEST_F(PrestoTaskTest, basicTaskId) {
   EXPECT_EQ(id.attemptNumber(), 4);
 }
 
-TEST_F(PrestoTaskTest, legacyTaskId) {
-  PrestoTaskId id("20201107_130540_00011_wrpkw.1.2.3");
-
-  EXPECT_EQ(id.queryId(), "20201107_130540_00011_wrpkw");
-  EXPECT_EQ(id.stageId(), 1);
-  EXPECT_EQ(id.stageExecutionId(), 2);
-  EXPECT_EQ(id.id(), 3);
-  EXPECT_EQ(id.attemptNumber(), 0);
-}
-
 TEST_F(PrestoTaskTest, malformedTaskId) {
   VELOX_ASSERT_THROW(PrestoTaskId(""), "Malformed task ID: ");
   VELOX_ASSERT_THROW(

--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -23,9 +23,7 @@ class PrestoTaskId {
     std::vector<std::string> taskIdParts;
     folly::split('.', taskId, taskIdParts);
 
-    // TODO (adutta): Remove taskIdParts.size() < 4 after presto
-    // release with new taskid format.
-    if (taskIdParts.size() < 4 || taskIdParts.size() > 5) {
+    if (taskIdParts.size() != 5) {
       VELOX_USER_FAIL("Malformed task ID: {}", taskId);
     }
 
@@ -33,9 +31,7 @@ class PrestoTaskId {
     stageId_ = folly::to<int32_t>(taskIdParts[1]);
     stageExecutionId_ = folly::to<int32_t>(taskIdParts[2]);
     id_ = folly::to<int32_t>(taskIdParts[3]);
-    if (taskIdParts.size() == 5) {
-      attemptNumber_ = folly::to<int32_t>(taskIdParts[4]);
-    }
+    attemptNumber_ = folly::to<int32_t>(taskIdParts[4]);
   }
 
   const std::string& queryId() const {


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

