### PR TITLE
ci: use jobs.<job_id>.if in the GitHub workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,9 @@
-name: spark integration
+name: docs
 
 on:
   pull_request:
+    paths:
+      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -13,29 +15,16 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
+  test:
     runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        filters: |
-          codechange:
-            - '!docs/**'
-  spark-integration:
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.codechange == 'true'
-    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        modules:
+          - ":presto-docs"
+    timeout-minutes: 80
     concurrency:
-      group: ${{ github.workflow }}-spark-integration-${{ github.event.pull_request.number }}
+      group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
@@ -56,6 +45,6 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-spark-launcher,presto-spark-package,presto-spark-testing
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
-        run: ./mvnw test ${MAVEN_TEST} -pl :presto-spark-testing -P test-presto-spark-integration-smoke-test
+        run: ./mvnw test ${MAVEN_TEST} -pl ${{ matrix.modules }}

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -2,8 +2,6 @@ name: hive tests
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -15,8 +13,27 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
+
   hive-tests:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}
@@ -64,6 +81,8 @@ jobs:
 
   hive-dockerized-tests:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 20
     concurrency:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -2,8 +2,6 @@ name: kudu
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -14,8 +12,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
   kudu:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -2,8 +2,6 @@ name: product tests (basic)
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -14,8 +12,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
   product-tests-basic-environment:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-basic-environment-${{ github.event.pull_request.number }}

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -14,8 +12,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
   product-tests-specific-environment1:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment1-${{ github.event.pull_request.number }}
@@ -56,6 +72,8 @@ jobs:
 
   product-tests-specific-environment2:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment2-${{ github.event.pull_request.number }}

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -2,8 +2,6 @@ name: test other modules
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -15,8 +13,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
   test-other-modules:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-test-other-modules-${{ github.event.pull_request.number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,31 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
+
   test:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     strategy:
       fail-fast: false
       matrix:
         modules:
-          - ":presto-docs"
           - ":presto-tests -P presto-tests-execution-memory"
           - ":presto-tests -P presto-tests-general"
           - ":presto-tests -P ci-only-distributed-non-hash-gen"

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -2,8 +2,6 @@ name: web ui checks
 
 on:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -11,8 +9,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!docs/**'
   web-ui-checks:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-web-ui-checks-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Description
Use `jobs.<job_id>.if` condition to control the
job execution instead of `on.pull.paths-ignore`.
In this case, the job status of the skipped jobs
would be `Success` but not `Pending`.

## Motivation and Context
When using `on.pull.paths-ignore`, those jobs which are defined as required would be in `Pending` status.
Using job-level conditions can avoid this situation as well as fine-grain control.

## Impact
Resolve some existing PRs whose jobs stuck in the `Pending` state

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

