### PR TITLE
[native] Add support for flow control to PrestoExchangeSource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -526,7 +526,7 @@ void PrestoServer::initializeVeloxMemory() {
         systemConfig->memoryPoolTransferCapacity();
   }
 #endif
-  const auto& manager = memory::MemoryManager::getInstance(options, true);
+  const auto& manager = memory::MemoryManager::getInstance(options);
   PRESTO_STARTUP_LOG(INFO) << "Memory manager has been setup: "
                            << manager.toString();
   if (systemConfig->spillerSpillPath().has_value()) {

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -340,15 +340,6 @@ void waitForEndMarker(const std::shared_ptr<exec::ExchangeQueue>& queue) {
   }
 }
 
-folly::Uri makeProducerUri(const folly::SocketAddress& address, bool useHttps) {
-  std::string protocol = useHttps ? "https" : "http";
-  return folly::Uri(fmt::format(
-      "{}://{}:{}/v1/task/20201007_190402_00000_r5erw.1.0.0/results/3",
-      protocol,
-      address.getAddressStr(),
-      address.getPort()));
-}
-
 static std::unique_ptr<http::HttpServer> createHttpServer(bool useHttps) {
   if (useHttps) {
     std::string certPath = getCertsPath("test_cert1.pem");
@@ -362,6 +353,15 @@ static std::unique_ptr<http::HttpServer> createHttpServer(bool useHttps) {
         std::make_unique<http::HttpConfig>(
             folly::SocketAddress("127.0.0.1", 0)));
   }
+}
+
+folly::Uri makeProducerUri(const folly::SocketAddress& address, bool useHttps) {
+  std::string protocol = useHttps ? "https" : "http";
+  return folly::Uri(fmt::format(
+      "{}://{}:{}/v1/task/20201007_190402_00000_r5erw.1.0.0/results/3",
+      protocol,
+      address.getAddressStr(),
+      address.getPort()));
 }
 
 static std::string getCiphers(bool useHttps) {
@@ -399,6 +399,29 @@ class PrestoExchangeSourceTestSuite : public ::testing::TestWithParam<Params> {
     TestValue::disable();
   }
 
+  std::shared_ptr<exec::ExchangeQueue> makeSingleSourceQueue() {
+    auto queue = std::make_shared<exec::ExchangeQueue>();
+    queue->addSourceLocked();
+    queue->noMoreSources();
+    return queue;
+  }
+
+  std::shared_ptr<PrestoExchangeSource> makeExchangeSource(
+      const folly::SocketAddress& producerAddress,
+      bool useHttps,
+      int destination,
+      const std::shared_ptr<exec::ExchangeQueue>& queue,
+      memory::MemoryPool* pool = nullptr) {
+    return std::make_shared<PrestoExchangeSource>(
+        makeProducerUri(producerAddress, useHttps),
+        destination,
+        queue,
+        pool != nullptr ? pool : pool_.get(),
+        exchangeExecutor_,
+        getClientCa(useHttps),
+        getCiphers(useHttps));
+  }
+
   void requestNextPage(
       const std::shared_ptr<exec::ExchangeQueue>& queue,
       const std::shared_ptr<exec::ExchangeSource>& exchangeSource) {
@@ -406,7 +429,7 @@ class PrestoExchangeSourceTestSuite : public ::testing::TestWithParam<Params> {
       std::lock_guard<std::mutex> l(queue->mutex());
       ASSERT_TRUE(exchangeSource->shouldRequestLocked());
     }
-    exchangeSource->request();
+    exchangeSource->request(1 << 20);
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -428,20 +451,10 @@ TEST_P(PrestoExchangeSourceTestSuite, basic) {
 
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
-  auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
+  auto queue = makeSingleSourceQueue();
 
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      producerUri,
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
 
   size_t beforePoolSize = pool_->currentBytes();
   size_t beforeQueueSize = queue->totalBytes();
@@ -463,8 +476,7 @@ TEST_P(PrestoExchangeSourceTestSuite, basic) {
 
   const auto stats = exchangeSource->stats();
   ASSERT_EQ(stats.size(), 1);
-  const auto it = stats.find("prestoExchangeSource.numPages");
-  ASSERT_EQ(it->second, 2);
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), 2);
 }
 
 TEST_P(PrestoExchangeSourceTestSuite, retryState) {
@@ -485,6 +497,7 @@ TEST_P(PrestoExchangeSourceTestSuite, retries) {
   std::vector<std::string> pages = {"page1 - xx", "page2 - xxxx"};
   const auto useHttps = GetParam().useHttps;
   std::atomic<int> numTries(0);
+
   auto shouldFail = [&]() {
     ++numTries;
     // On the third try, simulate network delay by sleeping for longer than the
@@ -507,20 +520,10 @@ TEST_P(PrestoExchangeSourceTestSuite, retries) {
 
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
-  auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
+  auto queue = makeSingleSourceQueue();
 
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      producerUri,
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
 
   requestNextPage(queue, exchangeSource);
   {
@@ -551,20 +554,10 @@ TEST_P(PrestoExchangeSourceTestSuite, earlyTerminatingConsumer) {
 
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
-  auto producerUri = makeProducerUri(producerAddress, useHttps);
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
+  auto queue = makeSingleSourceQueue();
 
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      makeProducerUri(producerAddress, useHttps),
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
   exchangeSource->close();
 
   producer->waitForDeleteResults();
@@ -573,8 +566,7 @@ TEST_P(PrestoExchangeSourceTestSuite, earlyTerminatingConsumer) {
 
   const auto stats = exchangeSource->stats();
   ASSERT_EQ(stats.size(), 1);
-  const auto it = stats.find("prestoExchangeSource.numPages");
-  ASSERT_EQ(it->second, 0);
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), 0);
 }
 
 TEST_P(PrestoExchangeSourceTestSuite, slowProducer) {
@@ -589,17 +581,8 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      makeProducerUri(producerAddress, useHttps),
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto queue = makeSingleSourceQueue();
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
 
   size_t beforePoolSize = pool_->currentBytes();
   size_t beforeQueueSize = queue->totalBytes();
@@ -623,8 +606,7 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducer) {
 
   const auto stats = exchangeSource->stats();
   ASSERT_EQ(stats.size(), 1);
-  const auto it = stats.find("prestoExchangeSource.numPages");
-  ASSERT_EQ(it->second, pages.size());
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), pages.size());
 }
 
 TEST_P(PrestoExchangeSourceTestSuite, slowProducerAndEarlyTerminatingConsumer) {
@@ -642,17 +624,8 @@ TEST_P(PrestoExchangeSourceTestSuite, slowProducerAndEarlyTerminatingConsumer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      makeProducerUri(producerAddress, useHttps),
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto queue = makeSingleSourceQueue();
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
 
   requestNextPage(queue, exchangeSource);
 
@@ -697,17 +670,8 @@ TEST_P(PrestoExchangeSourceTestSuite, failedProducer) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      makeProducerUri(producerAddress, useHttps),
-      3,
-      queue,
-      pool_.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto queue = makeSingleSourceQueue();
+  auto exchangeSource = makeExchangeSource(producerAddress, useHttps, 3, queue);
 
   requestNextPage(queue, exchangeSource);
   producer->enqueue(pages[0]);
@@ -733,17 +697,9 @@ TEST_P(PrestoExchangeSourceTestSuite, exceedingMemoryCapacityForHttpResponse) {
   test::HttpServerWrapper serverWrapper(std::move(producerServer));
   auto producerAddress = serverWrapper.start().get();
 
-  auto queue = std::make_shared<exec::ExchangeQueue>();
-  queue->addSourceLocked();
-  queue->noMoreSources();
-  auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-      makeProducerUri(producerAddress, useHttps),
-      3,
-      queue,
-      leafPool.get(),
-      exchangeExecutor_,
-      getClientCa(useHttps),
-      getCiphers(useHttps));
+  auto queue = makeSingleSourceQueue();
+  auto exchangeSource =
+      makeExchangeSource(producerAddress, useHttps, 3, queue, leafPool.get());
 
   requestNextPage(queue, exchangeSource);
   const std::string largePayload(2 * memoryCapBytes, 'L');
@@ -776,17 +732,9 @@ TEST_P(PrestoExchangeSourceTestSuite, memoryAllocationAndUsageCheck) {
     test::HttpServerWrapper serverWrapper(std::move(producerServer));
     auto producerAddress = serverWrapper.start().get();
 
-    auto queue = std::make_shared<exec::ExchangeQueue>();
-    queue->addSourceLocked();
-    queue->noMoreSources();
-    auto exchangeSource = std::make_shared<PrestoExchangeSource>(
-        makeProducerUri(producerAddress, useHttps),
-        3,
-        queue,
-        leafPool.get(),
-        exchangeExecutor_,
-        getClientCa(useHttps),
-        getCiphers(useHttps));
+    auto queue = makeSingleSourceQueue();
+    auto exchangeSource =
+        makeExchangeSource(producerAddress, useHttps, 3, queue, leafPool.get());
 
     const std::string smallPayload(7 << 10, 'L');
     producer->enqueue(smallPayload);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -668,8 +668,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT substr(comment, 1, 10), length(comment), ltrim(comment) FROM orders");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), rtrim(comment) FROM orders");
 
-        assertQueryFails("SELECT trim(comment, '.') FROM orders",
-                ".*Scalar function presto.default.trim not registered with arguments.*\n.*");
+        assertQuery("SELECT trim(comment, ' ns'), ltrim(comment, 'a b c'), rtrim(comment, 'l y') FROM orders");
 
         // Split
         assertQueryOrdered("SELECT shipmode, comment, split(comment, 'ly') FROM lineitem order by 1,2");


### PR DESCRIPTION
PrestoExchangeSource now participates in Exchange flow control by implementing
new request API:

``` 
velox::ContinueFuture request(uint32_t maxBytes) override; 
```

PrestoExchangeSource limits the size of the response by passing 'maxBytes' to
upstream worker (it used to hard-code this value to 32MB). This helps control 
total amount of data queued in ExchangeQueue.

PrestoExchangeSource::request() returns a future that completes when successful
possibly empty response has been received. PrestoExchangeSource no longer
retries on empty responses, but rather waits until ExchangeClient
calls 'request()' again. This allows ExchangeClient to limit the number of sources 
that are fetching data concurrently.

See https://github.com/facebookincubator/velox/issues/6005

```
== NO RELEASE NOTE ==
```

