### PR TITLE
Fix codenotify to work for PRs coming from forks

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -3,7 +3,7 @@
 name: codenotify
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 jobs:


### PR DESCRIPTION
## Description
Codenotify was failing to post a comment on PRs that come from outside forks (so basically all PRs) due to missing permissions when using the github-actions `pull_request` trigger. This changes to use `pull_request_target`, which allows access to repo secrets and thus permission to comment on PRs.  See example failure: https://github.com/prestodb/presto/actions/runs/5802193798/job/15729419532?pr=20520 and solution description: https://github.com/sourcegraph/codenotify/pull/23


## Motivation and Context
Codenotify support was broken

## Impact
Fixes codenotify

## Test Plan
Tested on my personal fork with a PR from Tim's fork: https://github.com/rschlussel/presto/pull/4

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.e:

```
== NO RELEASE NOTE ==
```

