### PR TITLE
[native] Fix error message in exchange

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -287,7 +287,7 @@ void PrestoExchangeSource::processDataError(
 
   onFinalFailure(
       fmt::format(
-          "Failed to fetched data from {}:{} {} - Exhausted retries: {}",
+          "Failed to fetch data from {}:{} {} - Exhausted retries: {}",
           host_,
           port_,
           path,


### PR DESCRIPTION
## Description
The exchange error message has a typo as observed in this issue https://github.com/prestodb/presto/issues/20032
`fetched` must be `fetch`.

```
== NO RELEASE NOTE ==
```

