### PR TITLE
ci: fix typo for the `presto-docs` in the GitHub workflow files

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
 
   hive-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   product-tests-basic-environment:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   product-tests-specific-environment1:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   spark-integration:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   test-other-modules:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   web-ui-checks:
     runs-on: ubuntu-latest
     needs: changes


### PR DESCRIPTION
## Description
The directory name is `presto-docs`. This change fixes the typo in the workflow files.

## Motivation and Context
fix typo in PR: #20524

## Impact
It should be able to properly filter the changed files in a PR

## Test Plan
This can only be verified by the new PR which contains this change. I will keep monitoring the new PRs' jobs when this PR is landed.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

