### PR TITLE
Add committers as codeowners where missing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,5 +3,5 @@
 /presto-native-execution @prestodb/team-velox
 /presto-parquet @shangxinli @prestodb/committers
 /presto-orc @sdruzkin @prestodb/committers
-/presto-hive/**/com/facebook/presto/hive/security/ranger @agrawalreetika
-/presto-spark* @shrinidhijoshi
+/presto-hive/**/com/facebook/presto/hive/security/ranger @agrawalreetika @prestodb/committers
+/presto-spark* @shrinidhijoshi @prestodb/committers


### PR DESCRIPTION
## Description
Add prestodb/committers group to all listed codeowners.  Looks like https://github.com/prestodb/presto/pull/19153 wasn't able to be merged even with committer approval because it was missing codeowner approval.

## Motivation and Context
Committers should always be able to approve PRs

## Impact
Changes in presto-spark* and ranger will be able to be merged with committer approval

## Test Plan
None

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

