### PR TITLE
Allow null constantValues for OrcSelectiveRecordReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -91,10 +91,11 @@ import static java.util.Objects.requireNonNull;
 public class OrcSelectiveRecordReader
         extends AbstractOrcRecordReader<SelectiveStreamReader>
 {
+    // Marks a SQL null when occurring in constantValues.
+    public static final byte[] NULL_MARKER = new byte[0];
+
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OrcSelectiveRecordReader.class).instanceSize();
 
-    // Marks a SQL null when occurring in constantValues.
-    private static final byte[] NULL_MARKER = new byte[0];
     private static final Page EMPTY_PAGE = new Page(0);
 
     private final int[] hiveColumnIndices;                            // elements are hive column indices


### PR DESCRIPTION
## Description
Make a private constant variable `NULL_MARKER` public.

## Motivation and Context
Today, we cannot pass a NULL placeholder for the missing columns/blocks because we comparing the references: `constantValue == NULL_MARKER`. We want to allow passing a NULL constant value for the new columns added to the table schema.

**Usage**:
```
orcReader.createOrcSelectiveRecordReader(..., constantValues = Map.of(1, NULL_MARKER), ...);
```

## Impact
No functionality or performance impact.

## Test Plan
No extra test is needed.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```


Differential Revision: D48212218

