### PR TITLE
[native] Speed up PrestoExchangeSourceTestSuite

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
   AnnouncerTest.cpp
   CoordinatorDiscovererTest.cpp
   HttpServerWrapper.cpp
+  MutableConfigs.cpp
   PrestoExchangeSourceTest.cpp
   PrestoTaskTest.cpp
   QueryContextCacheTest.cpp

--- a/presto-native-execution/presto_cpp/main/tests/MultableConfigs.h
+++ b/presto-native-execution/presto_cpp/main/tests/MultableConfigs.h
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::presto::test {
+
+void setupMutableSystemConfig();
+
+}

--- a/presto-native-execution/presto_cpp/main/tests/MutableConfigs.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/MutableConfigs.cpp
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/tests/MultableConfigs.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+using namespace facebook::velox;
+
+namespace facebook::presto::test {
+
+void setupMutableSystemConfig() {
+  auto dir = exec::test::TempDirectoryPath::create();
+  auto sysConfigFilePath = fmt::format("{}/config.properties", dir->path);
+  auto fileSystem = filesystems::getFileSystem(sysConfigFilePath, nullptr);
+  auto sysConfigFile = fileSystem->openFileForWrite(sysConfigFilePath);
+  sysConfigFile->append(fmt::format("{}=true\n", ConfigBase::kMutableConfig));
+  sysConfigFile->append(
+      fmt::format("{}=4GB\n", SystemConfig::kQueryMaxMemoryPerNode));
+  sysConfigFile->close();
+  SystemConfig::instance()->initialize(sysConfigFilePath);
+}
+
+} // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -18,6 +18,7 @@
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/TaskResource.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
+#include "presto_cpp/main/tests/MultableConfigs.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
@@ -39,9 +40,9 @@
 DECLARE_int32(old_task_ms);
 DECLARE_bool(velox_memory_leak_check_enabled);
 
-using namespace ::testing;
 using namespace facebook::velox;
-using namespace facebook::presto;
+
+namespace facebook::presto {
 
 namespace {
 int64_t sumOpSpillBytes(
@@ -59,7 +60,6 @@ int64_t sumOpSpillBytes(
   }
   return sum;
 }
-} // namespace
 
 class Cursor {
  public:
@@ -541,18 +541,6 @@ class TaskManagerTest : public testing::Test {
     return spillDirectory;
   }
 
-  static void setupMutableSystemConfig() {
-    auto dir = exec::test::TempDirectoryPath::create();
-    auto sysConfigFilePath = fmt::format("{}/config.properties", dir->path);
-    auto fileSystem = filesystems::getFileSystem(sysConfigFilePath, nullptr);
-    auto sysConfigFile = fileSystem->openFileForWrite(sysConfigFilePath);
-    sysConfigFile->append(fmt::format("{}=true\n", ConfigBase::kMutableConfig));
-    sysConfigFile->append(
-        fmt::format("{}=4GB\n", SystemConfig::kQueryMaxMemoryPerNode));
-    sysConfigFile->close();
-    SystemConfig::instance()->initialize(sysConfigFilePath);
-  }
-
   std::shared_ptr<exec::Task> createDummyExecTask(
       const std::string& taskId,
       const core::PlanFragment& planFragment) {
@@ -789,7 +777,7 @@ TEST_F(TaskManagerTest, countAggregation) {
 }
 
 TEST_F(TaskManagerTest, outOfQueryUserMemory) {
-  setupMutableSystemConfig();
+  test::setupMutableSystemConfig();
   auto filePaths = makeFilePaths(5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (auto i = 0; i < filePaths.size(); i++) {
@@ -1133,3 +1121,5 @@ TEST_F(TaskManagerTest, checkBatchSplits) {
 }
 
 // TODO: add disk spilling test for order by and hash join later.
+} // namespace
+} // namespace facebook::presto


### PR DESCRIPTION
PrestoExchangeSourceTestSuite::retries used to take 44 seconds. Now it runs in 4 seconds.

This is a parameterized test which runs for 4 sets of parameters. It used to
take 4 * 44s ~= 3min. Now it completes in 12s.

Similar improvement applied to PrestoExchangeSourceTestSuite::failedProducer.

```
== NO RELEASE NOTE ==
```

