### PR TITLE
Add ascii functionality

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -28,6 +28,12 @@ String Functions
     some languages. Specifically, this will return incorrect results for
     Lithuanian, Turkish and Azeri.
 
+.. function:: ascii(n) -> integer
+
+    Returns the ASCII code of the first character of a given parameter.
+    Parameter `n` needs to be convertible to `varchar`, which in this case are:
+    varchar, integer, double, varbinary, date, timestamp, and boolean.
+
 .. function:: chr(n) -> varchar
 
     Returns the Unicode code point ``n`` as a single character string.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
@@ -24,6 +24,78 @@ public class StringSqlFunctions
 {
     private StringSqlFunctions() {}
 
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "varchar")
+    @SqlType("int")
+    public static String ascii()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(input, 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "int")
+    @SqlType("int")
+    public static String asciiInt()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "date")
+    @SqlType("int")
+    public static String asciiDate()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "timestamp")
+    @SqlType("int")
+    public static String asciiTimestamp()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "double")
+    @SqlType("int")
+    public static String asciiDouble()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "boolean")
+    @SqlType("int")
+    public static String asciiBoolean()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "unknown")
+    @SqlType("int")
+    public static String asciiNull()
+    {
+        return "RETURN NULL";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "varbinary")
+    @SqlType("int")
+    public static String asciiVarbinary()
+    {
+        return "RETURN cast(from_base(to_hex(to_utf8(substr(to_base64(input), 1, 1))), 16) as int)";
+    }
+
     @SqlInvokedScalarFunction(value = "replace_first", deterministic = true, calledOnNullInput = true)
     @Description("Replaces the first occurrence of a substring that matches the given pattern with the given replacement.")
     @SqlParameters({@SqlParameter(name = "str", type = "varchar"), @SqlParameter(name = "search", type = "varchar"), @SqlParameter(name = "replace", type = "varchar")})

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestStringSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestStringSqlFunctions.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+
+public class TestStringSqlFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testAscii()
+    {
+        assertFunction("ascii(123)", INTEGER, 49);
+        assertFunction("ascii(3.14)", INTEGER, 51);
+        assertFunction("ascii('a')", INTEGER, 97);
+        assertFunction("ascii(cast('2023-01-01' as date))", INTEGER, 50);
+        assertFunction("ascii(cast('2023-01-01 10:12:33' as timestamp))", INTEGER, 50);
+        assertFunction("ascii(cast('1990-01-01 10:12:33' as timestamp))", INTEGER, 49);
+        assertFunction("ascii(true)", INTEGER, 116);
+        assertFunction("ascii(false)", INTEGER, 102);
+        assertFunction("ascii('')", INTEGER, 0);
+        assertFunction("ascii(null)", INTEGER, null);
+        assertFunction("ascii(cast('Test' as varbinary))", INTEGER, 86);
+    }
+}

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -15,6 +15,7 @@
 
 #include <folly/experimental/FunctionScheduler.h>
 #include "velox/common/memory/Memory.h"
+#include "velox/exec/Spill.h"
 
 namespace folly {
 class CPUThreadPoolExecutor;
@@ -94,6 +95,9 @@ class PeriodicTaskManager {
   void addOperatingSystemStatsUpdateTask();
   void updateOperatingSystemStats();
 
+  void addSpillStatsUpdateTask();
+  void updateSpillStatsTask();
+
   folly::FunctionScheduler scheduler_;
   folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
   folly::IOThreadPoolExecutor* const httpExecutor_;
@@ -120,6 +124,7 @@ class PeriodicTaskManager {
   int64_t lastHardPageFaults_{0};
   int64_t lastVoluntaryContextSwitches_{0};
   int64_t lastForcedContextSwitches_{0};
+  velox::exec::SpillStats lastSpillStats_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -195,6 +195,28 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSsdCacheCumulativeReadCheckpointErrors,
       facebook::velox::StatType::AVG);
+  // Disk spilling stats.
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillRuns, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpilledFiles, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpilledRows, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpilledBytes, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillFillTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillSortTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillSerializationTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillDiskWrites, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillFlushTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillWriteTimeUs, facebook::velox::StatType::SUM);
+
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters
   // have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -135,6 +135,40 @@ constexpr folly::StringPiece kCounterMmapRawAllocBytesSmall{
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
 
+/// ================== Disk Spilling Counters =================
+
+/// The number of times that spilling runs on a velox operator.
+constexpr folly::StringPiece kCounterSpillRuns{"presto_cpp.spill_run_count"};
+/// The number of bytes spilled to disks.
+///
+/// NOTE: if compression is enabled, this counts the compressed bytes.
+constexpr folly::StringPiece kCounterSpilledFiles{
+    "presto_cpp.spilled_file_count"};
+/// The number of spilled rows.
+constexpr folly::StringPiece kCounterSpilledRows{
+    "presto_cpp.spilled_row_count"};
+/// The number of spilled files.
+constexpr folly::StringPiece kCounterSpilledBytes{"presto_cpp.spilled_bytes"};
+/// The time spent on filling rows for spilling.
+constexpr folly::StringPiece kCounterSpillFillTimeUs{
+    "presto_cpp.spill_fill_time_us"};
+/// The time spent on sorting rows for spilling.
+constexpr folly::StringPiece kCounterSpillSortTimeUs{
+    "presto_cpp.spill_sort_time_us"};
+/// The time spent on serializing rows for spilling.
+constexpr folly::StringPiece kCounterSpillSerializationTimeUs{
+    "presto_cpp.spill_serialization_time_us"};
+/// The number of disk writes to spill rows.
+constexpr folly::StringPiece kCounterSpillDiskWrites{
+    "presto_cpp.spill_disk_write_count"};
+/// The time spent on copy out serialized rows for disk write. If compression
+/// is enabled, this includes the compression time.
+constexpr folly::StringPiece kCounterSpillFlushTimeUs{
+    "presto_cpp.spill_flush_time_us"};
+/// The time spent on writing spilled rows to disk.
+constexpr folly::StringPiece kCounterSpillWriteTimeUs{
+    "presto_cpp.spill_write_time_us"};
+
 /// ================== Cache Counters ==================
 
 /// Total number of cache entries.

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
@@ -66,4 +66,12 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
         assertQuery("SELECT chi_squared_cdf(acctbal, 2.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 500.0");
         assertQuery("SELECT chi_squared_cdf(acctbal, 40.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 500.0");
     }
+
+    @Test
+    public void testGammaCDF()
+    {
+        assertQuery("SELECT gamma_cdf(acctbal, 3.5, 0.5) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+        assertQuery("SELECT gamma_cdf(1.0, acctbal, 7.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+        assertQuery("SELECT gamma_cdf(10.0, 2.0, acctbal) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+    }
 }


### PR DESCRIPTION
## Description
Add ascii function to return the ASCII code of the first character

## Test Plan
Test ran successfully in local machine
```
./mvnw clean install -Dtest=TestStringSqlFunctions -Dmaven.javadoc.skip=true -T1C -fn -pl presto-main
```
Test cases are also compared with results from running `ascii` function in Spark.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* add :func:`ascii` to return ASCII code of the first character.
```
