### PR TITLE
Fix ARRAY_SORT to use the correct API to read value for RealType

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.Float.floatToIntBits;
+import static java.lang.Float.intBitsToFloat;
 
 @ScalarFunction("array_sort")
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
@@ -223,13 +224,13 @@ public final class ArraySortFunction
                     nulls++;
                 }
                 else {
-                    values[j++] = (Float) REAL.getObject(array, i);
+                    values[j++] = intBitsToFloat(array.getInt(i));
                 }
             }
         }
         else {
             for (int i = 0; i < array.getPositionCount(); i++) {
-                values[i] = (Float) REAL.getObject(array, i);
+                values[i] = intBitsToFloat(array.getInt(i));
             }
         }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7030,6 +7030,15 @@ public abstract class AbstractTestQueries
 
         result = computeActual("select array_sort(cast(array[null, 5.4,6.1,4.9,null,4.5,7.8,5.2] as array<double>))");
         assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(cast(array[null, 5.4,6.1,4.9,null,4.5,7.8,5.2] as array<real>))");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(cast(array[5.4,6.1,4.9,4.5,7.8,5.2] as array<real>))");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
+
+        result = computeActual("select array_sort(cast(array[5.4,6.1,4.9,4.5,7.8,5.2] as array<double>))");
+        assertSorted(result.getMaterializedRows().get(0).getFields());
     }
 
     private static boolean assertSorted(List<Object> array)


### PR DESCRIPTION
## Description
fixed a bug in ArraySortFunction specialization for RealType. The used API getObject is not supported by RealType. So we use the correct incantation now.


```
== NO RELEASE NOTE ==
```

