### PR TITLE
ci: fix matrix.modules case in a GitHub workflow

### DIFF
--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         filters: |
           codechange:
-            - '!docs/**'
+            - '!presto-docs/**'
   kudu:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -73,10 +72,13 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
+        if: needs.changes.outputs.codechange == 'true'
       - uses: actions/setup-java@v1
+        if: needs.changes.outputs.codechange == 'true'
         with:
           java-version: 8
       - name: Cache local Maven repository
+        if: needs.changes.outputs.codechange == 'true'
         id: cache-maven
         uses: actions/cache@v2
         with:
@@ -85,11 +87,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-2-
       - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
+        if: steps.cache-maven.outputs.cache-hit != 'true' && needs.changes.outputs.codechange == 'true'
         run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
       - name: Maven Install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl ${{ matrix.modules }}


### PR DESCRIPTION
## Description
When using matrix.modules in a workflow, the condition check should be put in step level to allow all modules' statuses to be properly populated.

## Motivation and Context
doc only PR still needs the success statuses from the required jobs. when a workflow contains a set of matrix.modules, putting the condition check in job level would prevent all the modules to be executed. Moving down the condition check into the step level can solve this issue.

## Impact
improve doc-change only PR to get proper job status for those matrix.modules workflow.

## Test Plan
need to rely on the new PR to verify it

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

