### PR TITLE
doc: Add GitHub links in the localtoc

### DIFF
--- a/presto-docs/src/main/sphinx/_templates/layout.html
+++ b/presto-docs/src/main/sphinx/_templates/layout.html
@@ -1,0 +1,8 @@
+{# Import the theme's layout. #}
+{% extends '!layout.html' %}
+
+{%- block fonticon %}
+  {# add Font Awesome here #}
+  <link rel="stylesheet" href="{{ pathto('_static/fonts/font-awesome.css', 1) }}"/>
+{{ super() }}
+{%- endblock %}

--- a/presto-docs/src/main/sphinx/_templates/localtoc.html
+++ b/presto-docs/src/main/sphinx/_templates/localtoc.html
@@ -1,0 +1,50 @@
+{# there is no extension block in localtoc.html. copy the original localtoc.html #}
+{% set toc_nodes = derender_toc(toc, True, pagename) if display_toc else [] %}
+<nav class="md-nav md-nav--secondary">
+  {# add github links here #}
+  <ul class="md-nav__list" data-md-scrollfix="">
+    <li class="md-nav__item">
+      <a class="md-nav__link" target="_blank" href="{{ pathto(theme_repo_url + '/tree/master/presto-docs/src/main/sphinx/' + pagename + '.rst', true)|e }}">
+        <i class="fa fa-file-text" aria-hidden="true"></i>
+        {{ _('View page source') }}
+      </a>
+    </li>
+    <li class="md-nav__item">
+      <a class="md-nav__link" target="_blank" href="{{ pathto(theme_repo_url + '/edit/master/presto-docs/src/main/sphinx/' + pagename + '.rst', true)|e }}">
+        <i class="fa fa-pencil-square" aria-hidden="true"></i>
+        {{ _('Edit this page') }}
+      </a>
+    </li>
+    <li class="md-nav__item">
+      <a class="md-nav__link" target="_blank" href="{{ pathto(theme_repo_url + '/issues/new?title=Documentation&labels=docs', true)|e }}">
+        <i class="fa fa-list" aria-hidden="true"></i>
+        {{ _('Create docs issue') }}
+      </a>
+    </li>
+    <li class="md-nav__item">
+      <a class="md-nav__link" target="_blank" href="{{ pathto(theme_repo_url + '/issues/new', true)|e }}">
+        <i class="fa fa-list" aria-hidden="true"></i>
+        {{ _('Create project issue') }}
+      </a>
+    </li>
+  </ul>
+  {%- if display_toc and toc_nodes and sidebars and 'localtoc.html' in sidebars %}
+    <label class="md-nav__title" for="__toc">{{ _('Contents') }}</label>
+  {%- endif %}
+  <ul class="md-nav__list" data-md-scrollfix="">
+    {%- if display_toc and sidebars and 'localtoc.html' in sidebars %}
+      {%- for item in toc_nodes recursive %}
+        <li class="md-nav__item"><a href="{{ item.href|e }}" class="md-nav__link" data-md-state="blur">{{ item.contents }}</a>
+          {%- if item.children -%}
+            <nav class="md-nav">
+              <ul class="md-nav__list">{{ loop(item.children) }}</ul>
+            </nav>
+          {%- endif %}
+        </li>
+      {%- endfor %}
+    {%- endif %}
+    {%- if show_source %}
+    {% include "sourcelink.html" %}
+    {%- endif %}
+  </ul>
+</nav>


### PR DESCRIPTION
## Description
Add 4 GitHub links in the localtoc menu:
- view source: link to current page's source file
- edit source: edit the current page
- create doc issue: create an issue
- create project issue: create an issue

## Motivation and Context
Add GitHub links for each doc page to allow users to see the source code and improve the documentation quality if they
see any typo or incorrect message.

## Impact
N/A

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

