### PR TITLE
Fix inappropriately set attribute of ParquetWriterOptions by IcebergFileWriterFactory.

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -141,7 +141,7 @@ public class IcebergFileWriterFactory
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
-                    .setMaxPageSize(getParquetWriterBlockSize(session))
+                    .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .build();
 
             return new IcebergParquetFileWriter(


### PR DESCRIPTION

## Description

In IcebergFileWriterFactory, when build and set attribute for ParquetWriterOptions, it set "maxBlockSize" inappropriately.


## Release Notes

```
== NO RELEASE NOTE ==
```

