### PR TITLE
Fix structural type map render

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.TypeSignature;
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.BING_TILE;
@@ -61,6 +64,9 @@ import static java.util.stream.Collectors.toList;
 
 final class FixJsonDataUtils
 {
+    private static final JsonCodec<List<String>> LIST_JSON_CODEC = listJsonCodec(String.class);
+    private static final JsonCodec<Map<String, String>> MAP_JSON_CODEC = mapJsonCodec(String.class, String.class);
+
     private FixJsonDataUtils() {}
 
     public static Iterable<List<Object>> fixData(List<Column> columns, Iterable<List<Object>> data)
@@ -96,36 +102,59 @@ final class FixJsonDataUtils
             return fixValue(signature.getDistinctTypeInfo().getBaseType(), value);
         }
         if (signature.getBase().equals(ARRAY)) {
-            List<Object> fixedValue = new ArrayList<>();
-            for (Object object : List.class.cast(value)) {
-                fixedValue.add(fixValue(signature.getTypeParametersAsTypeSignatures().get(0), object));
+            if (List.class.isAssignableFrom(value.getClass())) {
+                List<Object> fixedValue = new ArrayList<>();
+                for (Object object : List.class.cast(value)) {
+                    fixedValue.add(fixValue(signature.getTypeParametersAsTypeSignatures().get(0), object));
+                }
+                return fixedValue;
             }
-            return fixedValue;
+            // JSON keys may be serialized and deserialized as simple strings
+            else if (value.getClass() == String.class) {
+                List<String> newValue = LIST_JSON_CODEC.fromJson(value.toString());
+                return fixValue(signature, newValue);
+            }
+            throw new IllegalArgumentException(String.format("Unexpected type found: %s", value.getClass()));
         }
         if (signature.getBase().equals(MAP)) {
-            TypeSignature keySignature = signature.getTypeParametersAsTypeSignatures().get(0);
-            TypeSignature valueSignature = signature.getTypeParametersAsTypeSignatures().get(1);
-            Map<Object, Object> fixedValue = new HashMap<>();
-            for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) Map.class.cast(value).entrySet()) {
-                fixedValue.put(fixValue(keySignature, entry.getKey()), fixValue(valueSignature, entry.getValue()));
+            if (Map.class.isAssignableFrom(value.getClass())) {
+                TypeSignature keySignature = signature.getTypeParametersAsTypeSignatures().get(0);
+                TypeSignature valueSignature = signature.getTypeParametersAsTypeSignatures().get(1);
+                Map<Object, Object> fixedValue = new HashMap<>();
+                for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) Map.class.cast(value).entrySet()) {
+                    fixedValue.put(fixValue(keySignature, entry.getKey()), fixValue(valueSignature, entry.getValue()));
+                }
+                return fixedValue;
             }
-            return fixedValue;
+            // JSON keys may be serialized and deserialized as simple strings
+            else if (value.getClass() == String.class) {
+                Map<String, String> newValue = MAP_JSON_CODEC.fromJson(value.toString());
+                return fixValue(signature, newValue);
+            }
+            throw new IllegalArgumentException(String.format("Unexpected type found: %s", value.getClass()));
         }
         if (signature.getBase().equals(ROW)) {
-            Map<String, Object> fixedValue = new LinkedHashMap<>();
-            List<Object> listValue = List.class.cast(value);
-            checkArgument(listValue.size() == signature.getParameters().size(), "Mismatched data values and row type");
-            for (int i = 0; i < listValue.size(); i++) {
-                TypeSignatureParameter parameter = signature.getParameters().get(i);
-                checkArgument(
-                        parameter.getKind() == ParameterKind.NAMED_TYPE,
-                        "Unexpected parameter [%s] for row type",
-                        parameter);
-                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
-                String key = namedTypeSignature.getName().orElse("field" + i);
-                fixedValue.put(key, fixValue(namedTypeSignature.getTypeSignature(), listValue.get(i)));
+            if (List.class.isAssignableFrom(value.getClass())) {
+                Map<String, Object> fixedValue = new LinkedHashMap<>();
+                List<Object> listValue = List.class.cast(value);
+                checkArgument(listValue.size() == signature.getParameters().size(), "Mismatched data values and row type");
+                for (int i = 0; i < listValue.size(); i++) {
+                    TypeSignatureParameter parameter = signature.getParameters().get(i);
+                    checkArgument(
+                            parameter.getKind() == ParameterKind.NAMED_TYPE,
+                            "Unexpected parameter [%s] for row type",
+                            parameter);
+                    NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
+                    String key = namedTypeSignature.getName().orElse("field" + i);
+                    fixedValue.put(key, fixValue(namedTypeSignature.getTypeSignature(), listValue.get(i)));
+                }
+                return fixedValue;
             }
-            return fixedValue;
+            else if (value.getClass() == String.class) {
+                List<String> newValue = LIST_JSON_CODEC.fromJson(value.toString());
+                return fixValue(signature, newValue);
+            }
+            throw new IllegalArgumentException(String.format("Unexpected type found: %s", value.getClass()));
         }
         if (signature.isVarcharEnum()) {
             return String.class.cast(value);

--- a/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
@@ -56,6 +56,18 @@ public class TestFixJsonDataUtils
         assertQueryResult("ipprefix", "1.2.3.4/32", "1.2.3.4/32");
         assertQueryResult("Geometry", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
         assertQueryResult("map(BingTile,bigint)", ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1), ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
+        // test nested map structure
+        assertQueryResult("map(map(bigint,bigint),bigint)", ImmutableMap.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\",\n  \"5\" : \"6\"\n}", "3"), ImmutableMap.of(ImmutableMap.of(1L, 2L, 3L, 4L, 5L, 6L), 3L));
+        assertQueryResult("map(row(foo bigint,bar double),bigint)", ImmutableMap.of("[ \"4\", \"5.0\" ]", "6", "[ \"1\", \"2.0\" ]", "3"), ImmutableMap.of(ImmutableMap.of("foo", 1L, "bar", 2.0), 3L, ImmutableMap.of("foo", 4L, "bar", 5.0), 6L));
+        assertQueryResult("map(array(bigint),bigint)", ImmutableMap.of("[ \"1\", \"3\", \"2\", \"3\" ]", "3"), ImmutableMap.of(ImmutableList.of(1L, 3L, 2L, 3L), 3L));
+        // test nested array structure
+        assertQueryResult("array(array(bigint))", ImmutableList.of("[ \"1\", \"2\", \"3\" ]", "[ \"4\", \"5\", \"6\" ]"), ImmutableList.of(ImmutableList.of(1L, 2L, 3L), ImmutableList.of(4L, 5L, 6L)));
+        assertQueryResult("array(map(bigint,bigint))", ImmutableList.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\"\n}", "{\n  \"5\" : \"6\",\n  \"7\" : \"8\"\n}"), ImmutableList.of(ImmutableMap.of(1L, 2L, 3L, 4L), ImmutableMap.of(5L, 6L, 7L, 8L)));
+        assertQueryResult("array(row(foo bigint,bar double))", ImmutableList.of("[ \"1\", \"2.0\" ]", "[ \"3\", \"4.0\" ]"), ImmutableList.of(ImmutableMap.of("foo", 1L, "bar", 2.0), ImmutableMap.of("foo", 3L, "bar", 4.0)));
+        // test nested row structure
+        assertQueryResult("row(foo array(bigint),bar double)", ImmutableList.of("[ \"1\", \"2\" ]", "3.0"), ImmutableMap.of("foo", ImmutableList.of(1L, 2L), "bar", 3.0));
+        assertQueryResult("row(foo map(bigint,bigint),bar double)", ImmutableList.of("{\n  \"1\" : \"2\"\n}", "3.0"), ImmutableMap.of("foo", ImmutableMap.of(1L, 2L), "bar", 3.0));
+        assertQueryResult("row(foo row(x bigint,y double),bar double)", ImmutableList.of("[ \"1\", \"2.0\" ]", "3.0"), ImmutableMap.of("foo", ImmutableMap.of("x", 1L, "y", 2.0), "bar", 3.0));
     }
 
     private void assertQueryResult(String type, Object data, Object expected)

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -15,9 +15,14 @@ package com.facebook.presto.server.protocol;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StageStats;
 import com.facebook.presto.client.StatementStats;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.ParameterKind;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.QueryStats;
@@ -38,13 +43,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_SESSION_FUNCTION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
@@ -57,8 +66,16 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_ROLE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 
 public final class QueryResourceUtil
@@ -66,6 +83,8 @@ public final class QueryResourceUtil
     private static final Logger log = Logger.get(QueryResourceUtil.class);
     private static final JsonCodec<SqlFunctionId> SQL_FUNCTION_ID_JSON_CODEC = jsonCodec(SqlFunctionId.class);
     private static final JsonCodec<SqlInvokedFunction> SQL_INVOKED_FUNCTION_JSON_CODEC = jsonCodec(SqlInvokedFunction.class);
+    private static final JsonCodec<List<Object>> LIST_JSON_CODEC = listJsonCodec(Object.class);
+    private static final JsonCodec<Map<Object, Object>> MAP_JSON_CODEC = mapJsonCodec(Object.class, Object.class);
 
     private QueryResourceUtil() {}
 
@@ -138,7 +157,7 @@ public final class QueryResourceUtil
                 prependUri(queryResults.getPartialCancelUri(), xPrestoPrefixUri),
                 prependUri(queryResults.getNextUri(), xPrestoPrefixUri),
                 queryResults.getColumns(),
-                queryResults.getData(),
+                prepareJsonData(queryResults.getColumns(), queryResults.getData()),
                 queryResults.getStats(),
                 queryResults.getError(),
                 queryResults.getWarnings(),
@@ -273,5 +292,76 @@ public final class QueryResourceUtil
             globalUniqueNodes.add(nodeId);
         }
         return stageUniqueNodes.size();
+    }
+
+    /**
+     * Problem: As the type of data defined in QueryResult is `Iterable<List<Object>>`,
+     * when jackson serialize a data with nested data structure in the response, the nested object won't
+     * be serialized but be printed as string. For example the map will be printed as "{1=2}", which cannot
+     * be recognized and deserialized by client side.
+     * Solution: We pre-serialize the data nested in the Object to JSON by following parseTypeSignature,
+     * only Objects contains nested structures will be pre-serialized, otherwise the object will simply
+     * be returned. Then we can deserialize the JSON in the client side.
+     */
+    private static Iterable<List<Object>> prepareJsonData(List<Column> columns, Iterable<List<Object>> data)
+    {
+        if (data == null) {
+            return null;
+        }
+        requireNonNull(columns, "columns is null");
+        List<TypeSignature> signatures = columns.stream()
+                .map(column -> parseTypeSignature(column.getType()))
+                .collect(toList());
+        ImmutableList.Builder<List<Object>> rows = ImmutableList.builder();
+        for (List<Object> row : data) {
+            checkArgument(row.size() == columns.size(), "row/column size mismatch");
+            List<Object> newRow = new ArrayList<>();
+            for (int i = 0; i < row.size(); i++) {
+                newRow.add(parseToJson(signatures.get(i), row.get(i)));
+            }
+            rows.add(unmodifiableList(newRow)); // allow nulls in list
+        }
+        return rows.build();
+    }
+
+    public static Object parseToJson(TypeSignature signature, Object value)
+    {
+        if (value == null) {
+            return null;
+        }
+        if (signature.isDistinctType()) {
+            return parseToJson(signature.getDistinctTypeInfo().getBaseType(), value);
+        }
+        if (signature.getBase().equals(ARRAY)) {
+            List<Object> parsedValue = new ArrayList<>();
+            for (Object object : List.class.cast(value)) {
+                parsedValue.add(parseToJson(signature.getTypeParametersAsTypeSignatures().get(0), object));
+            }
+            return LIST_JSON_CODEC.toJson(parsedValue);
+        }
+        if (signature.getBase().equals(MAP)) {
+            TypeSignature keySignature = signature.getTypeParametersAsTypeSignatures().get(0);
+            TypeSignature valueSignature = signature.getTypeParametersAsTypeSignatures().get(1);
+            Map<Object, Object> parsedValue = new HashMap<>(Map.class.cast(value).size());
+            for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) Map.class.cast(value).entrySet()) {
+                parsedValue.put(parseToJson(keySignature, entry.getKey()), parseToJson(valueSignature, entry.getValue()));
+            }
+            return MAP_JSON_CODEC.toJson(parsedValue);
+        }
+        if (signature.getBase().equals(ROW)) {
+            List<Object> parsedValue = new ArrayList<>();
+            for (int i = 0; i < List.class.cast(value).size(); i++) {
+                Object object = List.class.cast(value).get(i);
+                TypeSignatureParameter parameter = signature.getParameters().get(i);
+                checkArgument(
+                        parameter.getKind() == ParameterKind.NAMED_TYPE,
+                        "Unexpected parameter [%s] for row type",
+                        parameter);
+                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
+                parsedValue.add(parseToJson(namedTypeSignature.getTypeSignature(), object));
+            }
+            return LIST_JSON_CODEC.toJson(parsedValue);
+        }
+        return value;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestParseToJsonData.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestParseToJsonData.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.parseToJson;
+import static org.testng.Assert.assertEquals;
+
+public class TestParseToJsonData
+{
+    @Test
+    public void testParseData()
+    {
+        assertParsingResult("map(map(bigint,bigint),bigint)", ImmutableMap.of(ImmutableMap.of(1L, 2L, 3L, 4L, 5L, 6L), 3L), "{\n  \"{\\n  \\\"1\\\" : 2,\\n  \\\"5\\\" : 6,\\n  \\\"3\\\" : 4\\n}\" : 3\n}");
+        assertParsingResult("map(row(foo bigint,bar double),bigint)", ImmutableMap.of(ImmutableList.of(1L, 2.0), 3L, ImmutableList.of(4L, 5.0), 6L), "{\n  \"[ 4, 5.0 ]\" : 6,\n  \"[ 1, 2.0 ]\" : 3\n}");
+        assertParsingResult("map(array(bigint),bigint)", ImmutableMap.of(ImmutableList.of(1L, 3L, 2L, 3L), 3L), "{\n  \"[ 1, 3, 2, 3 ]\" : 3\n}");
+        // test nested array structure
+        assertParsingResult("array(array(bigint))", ImmutableList.of(ImmutableList.of(1L, 2L, 3L), ImmutableList.of(4L, 5L, 6L)), "[ \"[ 1, 2, 3 ]\", \"[ 4, 5, 6 ]\" ]");
+        assertParsingResult("array(map(bigint,bigint))", ImmutableList.of(ImmutableMap.of(1L, 2L, 3L, 4L), ImmutableMap.of(5L, 6L, 7L, 8L)), "[ \"{\\n  \\\"1\\\" : 2,\\n  \\\"3\\\" : 4\\n}\", \"{\\n  \\\"5\\\" : 6,\\n  \\\"7\\\" : 8\\n}\" ]");
+        assertParsingResult("array(row(foo bigint,bar double))", ImmutableList.of(ImmutableList.of(1L, 2.0), ImmutableList.of(3L, 4.0)), "[ \"[ 1, 2.0 ]\", \"[ 3, 4.0 ]\" ]");
+        // test nested row structure
+        assertParsingResult("row(foo array(bigint),bar double)", ImmutableList.of(ImmutableList.of(1L, 2L), 3.0), "[ \"[ 1, 2 ]\", 3.0 ]");
+        assertParsingResult("row(foo map(bigint,bigint),bar double)", ImmutableList.of(ImmutableMap.of(1L, 2L), 3.0), "[ \"{\\n  \\\"1\\\" : 2\\n}\", 3.0 ]");
+        assertParsingResult("row(foo row(x bigint,y double),bar double)", ImmutableList.of(ImmutableList.of(1L, 2.0), 3.0), "[ \"[ 1, 2.0 ]\", 3.0 ]");
+        // complex json with escape character
+        assertParsingResult("map(row(x map(bigint,bigint), y varchar),bigint)", ImmutableMap.of(ImmutableList.of(ImmutableMap.of(1L, 2L), "{123: 2245}"), 1L), "{\n  \"[ \\\"{\\\\n  \\\\\\\"1\\\\\\\" : 2\\\\n}\\\", \\\"{123: 2245}\\\" ]\" : 1\n}");
+        // nested Json and varchar can be serialized and deserialized correctly
+        assertNestedJson("map(json,bigint)", "{\"123\":\"456\"}");
+        assertNestedJson("map(varchar,bigint)", "{\"12\":\"34\", \"56\":\"78\"}");
+    }
+    private void assertNestedJson(String type, String expected)
+    {
+        Object data = ImmutableMap.of(jsonCodec(String.class).toJson(expected), 1L);
+        Object parsedData = parseToJson(parseTypeSignature(type), data);
+        Map<String, String> fixedValue = mapJsonCodec(String.class, String.class).fromJson((String) parsedData);
+        assertEquals(jsonCodec(String.class).fromJson(fixedValue.keySet().iterator().next()), expected);
+    }
+    private void assertParsingResult(String type, Object data, String expected)
+    {
+        assertEquals(parseToJson(parseTypeSignature(type), data), expected);
+    }
+}


### PR DESCRIPTION
## Description
Fix the issue by parsing the value again via `jsonCodec` for ARRAY and ROW type.
For MAP type, `jsonCodec` cannot recognize the string `{a=b}`. 
I manually created a logic to parse it. Based on the assumption that the value must be a map.

## Motivation and Context
Fix the open issue [Structural Type as Map Key cannot be rendered by CLI](https://github.com/prestodb/presto/issues/7546)

## Impact
N/A

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

