### PR TITLE
[native pos] Fix NPE in PrestoSparkQueryRunner

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -695,9 +695,16 @@ public class PrestoSparkQueryRunner
             throw new RuntimeException(e);
         }
 
-        if (instanceId != null) {
-            instances.get(instanceId).getPrestoSparkService().getTaskExecutorFactory().close();
-            instances.get(instanceId).getPrestoSparkService().getNativeTaskExecutorFactory().close();
+        if (instanceId != null && instances.get(instanceId) != null) {
+            PrestoSparkService prestoSparkService = instances.get(instanceId).getPrestoSparkService();
+            if (prestoSparkService != null) {
+                if (prestoSparkService.getTaskExecutorFactory() != null) {
+                    prestoSparkService.getTaskExecutorFactory().close();
+                }
+                if (prestoSparkService.getNativeTaskExecutorFactory() != null) {
+                    prestoSparkService.getNativeTaskExecutorFactory().close();
+                }
+            }
             instances.remove(instanceId);
         }
     }


### PR DESCRIPTION
PrestoSparkQueryRunner close method is missing null checks causing NPE
in cases where the closeable objects are not present.
Adding null check to prevent this

```
== NO RELEASE NOTE ==
```

