### PR TITLE
Add cause to SemanticException when rethrowing

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/SemanticException.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/SemanticException.java
@@ -39,11 +39,15 @@ public class SemanticException
 
     public SemanticException(SemanticErrorCode code, Optional<NodeLocation> location, String format, Object... args)
     {
-        super(formatMessage(format, location, args));
-        requireNonNull(code, "code is null");
+        this(code, null, location, format, args);
+    }
 
-        this.code = code;
-        this.location = location;
+    public SemanticException(SemanticErrorCode code, Throwable cause, Optional<NodeLocation> location, String format, Object... args)
+    {
+        super(formatMessage(format, location, args), cause);
+
+        this.code = requireNonNull(code, "code is null");
+        this.location = requireNonNull(location, "location is null");
     }
 
     // TODO: Should be replaced with analyzer agnostic location

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2690,7 +2690,7 @@ class StatementAnalyzer
             }
             catch (RuntimeException e) {
                 throwIfInstanceOf(e, PrestoException.class);
-                throw new SemanticException(VIEW_ANALYSIS_ERROR, node, "Failed analyzing stored view '%s': %s", name, e.getMessage());
+                throw new SemanticException(VIEW_ANALYSIS_ERROR, e, node.getLocation(), "Failed analyzing stored view '%s': %s", name, e.getMessage());
             }
         }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Add cause to Semantic exception when we throw it after catching a different exception.

## Motivation and Context
Previously, we were catching any runtime exception and just taking the message to add to the Semantic exception but losing all other context.  This made debugging the root cause of the error difficult.  

## Impact
Now the previously caught exception will be added as the cause of the SemanticException

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

