### PR TITLE
[native] Fix task delete remote source endpoint

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -882,7 +882,9 @@ folly::Future<std::unique_ptr<protocol::TaskStatus>> TaskManager::getTaskStatus(
 
 void TaskManager::removeRemoteSource(
     const TaskId& taskId,
-    const TaskId& remoteSourceTaskId) {}
+    const TaskId& remoteSourceTaskId) {
+  VELOX_NYI();
+}
 
 std::shared_ptr<PrestoTask> TaskManager::findOrCreateTask(
     const TaskId& taskId,

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -88,6 +88,13 @@ void TaskResource::registerUris(http::HttpServer& server) {
       });
 
   server.registerDelete(
+      R"(/v1/task/(.+)/remote-source/(.+))",
+      [&](proxygen::HTTPMessage* message,
+          const std::vector<std::string>& pathMatch) {
+        return removeRemoteSource(message, pathMatch);
+      });
+
+  server.registerDelete(
       R"(/v1/task/(.+))",
       [&](proxygen::HTTPMessage* message,
           const std::vector<std::string>& pathMatch) {
@@ -120,13 +127,6 @@ void TaskResource::registerUris(http::HttpServer& server) {
       [&](proxygen::HTTPMessage* message,
           const std::vector<std::string>& pathMatch) {
         return getTaskInfo(message, pathMatch);
-      });
-
-  server.registerGet(
-      R"(/v1/task/(.+)/remote-source/(.+))",
-      [&](proxygen::HTTPMessage* message,
-          const std::vector<std::string>& pathMatch) {
-        return removeRemoteSource(message, pathMatch);
       });
 }
 


### PR DESCRIPTION
Previous implementation gives "GET" to the delete endpoint of remote source. It should be "DELETE" to be consistent with Java.
```
== NO RELEASE NOTE ==
```

