### PR TITLE
[native] Add http endpoint latency filter

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -98,6 +98,10 @@ class PeriodicTaskManager {
   void addSpillStatsUpdateTask();
   void updateSpillStatsTask();
 
+  // Adds task that periodically prints http endpoint latency metrics.
+  void addHttpEndpointLatencyStatsTask();
+  void printHttpEndpointLatencyStats();
+
   folly::FunctionScheduler scheduler_;
   folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
   folly::IOThreadPoolExecutor* const httpExecutor_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -261,6 +261,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kHttpEnableAccessLog, "false"),
           STR_PROP(kHttpEnableStatsFilter, "false"),
+          STR_PROP(kHttpEnableEndpointLatencyFilter, "false"),
           STR_PROP(kRegisterTestFunctions, "false"),
           NUM_PROP(kHttpMaxAllocateBytes, 65536),
           STR_PROP(kQueryMaxMemoryPerNode, "4GB"),
@@ -489,6 +490,10 @@ bool SystemConfig::enableHttpAccessLog() const {
 
 bool SystemConfig::enableHttpStatsFilter() const {
   return optionalProperty<bool>(kHttpEnableStatsFilter).value();
+}
+
+bool SystemConfig::enableHttpEndpointLatencyFilter() const {
+  return optionalProperty<bool>(kHttpEnableEndpointLatencyFilter).value();
 }
 
 bool SystemConfig::registerTestFunctions() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -237,6 +237,8 @@ class SystemConfig : public ConfigBase {
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
       "http-server.enable-stats-filter"};
+  static constexpr std::string_view kHttpEnableEndpointLatencyFilter{
+      "http-server.enable-endpoint-latency-filter"};
   static constexpr std::string_view kRegisterTestFunctions{
       "register-test-functions"};
 
@@ -416,6 +418,8 @@ class SystemConfig : public ConfigBase {
   bool enableHttpAccessLog() const;
 
   bool enableHttpStatsFilter() const;
+
+  bool enableHttpEndpointLatencyFilter() const;
 
   bool registerTestFunctions() const;
 

--- a/presto-native-execution/presto_cpp/main/http/filters/HttpEndpointLatencyFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/HttpEndpointLatencyFilter.cpp
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::presto::http::filters {
+
+HttpEndpointLatencyFilter::HttpEndpointLatencyFilter(
+    proxygen::RequestHandler* upstream,
+    const std::shared_ptr<std::unordered_map<
+        proxygen::HTTPMethod,
+        std::vector<std::unique_ptr<EndPoint>>>>& endpoints)
+    : Filter(upstream), endpoints_(endpoints) {}
+
+// static
+void HttpEndpointLatencyFilter::updateLatency(
+    const std::string& endpoint,
+    uint64_t latencyUs) {
+  metricMap().withWLock([&](std::unordered_map<std::string, EndPointMetrics>&
+                                map) {
+    auto itr = map.find(endpoint);
+    if (itr != map.end()) {
+      auto& metrics = itr->second;
+      metrics.maxLatencyUs = std::max(metrics.maxLatencyUs, latencyUs);
+      metrics.avgLatencyUs =
+          (metrics.avgLatencyUs * metrics.count + latencyUs) /
+          (metrics.count + 1);
+      ++metrics.count;
+    } else {
+      map.emplace(endpoint, EndPointMetrics{endpoint, latencyUs, latencyUs, 1});
+    }
+  });
+}
+
+// static
+std::vector<HttpEndpointLatencyFilter::EndPointMetrics>
+HttpEndpointLatencyFilter::retrieveLatencies() {
+  std::vector<HttpEndpointLatencyFilter::EndPointMetrics> result;
+  metricMap().withWLock([&](std::unordered_map<
+                            std::string,
+                            HttpEndpointLatencyFilter::EndPointMetrics>& map) {
+    result.reserve(map.size());
+    for (const auto& pair : map) {
+      result.push_back(pair.second);
+    }
+    map.clear();
+  });
+  std::sort(result.begin(), result.end(), [](const auto& lhs, const auto& rhs) {
+    return lhs.maxLatencyUs > rhs.maxLatencyUs;
+  });
+  return result;
+}
+
+void HttpEndpointLatencyFilter::onRequest(
+    std::unique_ptr<proxygen::HTTPMessage> msg) noexcept {
+  auto path = msg->getPath();
+  const auto method = msg->getMethod().value();
+  const auto& endpoints = endpoints_->at(method);
+
+  // Allocate vector outside of loop to avoid repeated alloc/free.
+  std::vector<std::string> matches(4);
+  std::vector<RE2::Arg> args(4);
+  std::vector<RE2::Arg*> argPtrs(4);
+
+  for (const auto& endpoint : endpoints) {
+    if (endpoint->check(path, matches, args, argPtrs)) {
+      requestEndpoint_ = methodToString(method) + " " + endpoint->pattern();
+      break;
+    }
+  }
+  VELOX_CHECK(!requestEndpoint_.empty());
+
+  // Starts the timer.
+  timer_ = std::make_unique<velox::MicrosecondTimer>(&timeUs_);
+  proxygen::Filter::onRequest(std::move(msg));
+}
+
+void HttpEndpointLatencyFilter::requestComplete() noexcept {
+  timer_.reset();
+  updateLatency(requestEndpoint_, timeUs_);
+  proxygen::Filter::requestComplete();
+}
+
+void HttpEndpointLatencyFilter::onError(proxygen::ProxygenError err) noexcept {
+  timer_.reset();
+  updateLatency(requestEndpoint_, timeUs_);
+  proxygen::Filter::onError(err);
+}
+
+} // namespace facebook::presto::http::filters

--- a/presto-native-execution/presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h
+++ b/presto-native-execution/presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <proxygen/httpserver/Filters.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+#include "presto_cpp/main/http/HttpServer.h"
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/time/Timer.h"
+
+namespace facebook::presto::http::filters {
+
+class HttpEndpointLatencyFilter : public proxygen::Filter {
+ public:
+  struct EndPointMetrics {
+    /// The endpoint of interest, with method and path information in it. e.g.
+    /// "GET /v1/task"
+    std::string endpoint;
+
+    /// Maximum latency of the request on this endpoint
+    uint64_t maxLatencyUs;
+
+    /// Average latency of the request on this endpoint
+    uint64_t avgLatencyUs;
+
+    /// Number of requests on this endpoint
+    uint64_t count;
+
+    std::string toString() const {
+      std::stringstream oss;
+      oss << "{'" << endpoint << "' : " << velox::succinctMicros(maxLatencyUs)
+          << "(max) " << velox::succinctMicros(avgLatencyUs) << "(avg) "
+          << count << "(count)}";
+      return oss.str();
+    }
+  };
+
+  HttpEndpointLatencyFilter(
+      proxygen::RequestHandler* upstream,
+      const std::shared_ptr<std::unordered_map<
+          proxygen::HTTPMethod,
+          std::vector<std::unique_ptr<EndPoint>>>>& endpoints);
+
+  static std::vector<EndPointMetrics> retrieveLatencies();
+
+  void onRequest(std::unique_ptr<proxygen::HTTPMessage> msg) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  static void updateLatency(const std::string& endpoint, uint64_t latencyMs);
+
+  static folly::Synchronized<std::unordered_map<std::string, EndPointMetrics>>&
+  metricMap() {
+    static folly::Synchronized<std::unordered_map<std::string, EndPointMetrics>>
+        metricMap_;
+    return metricMap_;
+  }
+
+  // The endpoints the server is listening on. This is used to match the current
+  // request's endpoint.
+  const std::shared_ptr<std::unordered_map<
+      proxygen::HTTPMethod,
+      std::vector<std::unique_ptr<EndPoint>>>>
+      endpoints_;
+
+  // The http endpoint of this request
+  std::string requestEndpoint_;
+
+  // The timer used for keeping track of the duration of the request.
+  std::unique_ptr<velox::MicrosecondTimer> timer_;
+
+  // The duration in us this request takes.
+  uint64_t timeUs_{0};
+};
+
+class HttpEndpointLatencyFilterFactory
+    : public proxygen::RequestHandlerFactory {
+ public:
+  explicit HttpEndpointLatencyFilterFactory(http::HttpServer* httpServer)
+      : endpoints_(std::make_shared<std::unordered_map<
+                       proxygen::HTTPMethod,
+                       std::vector<std::unique_ptr<EndPoint>>>>(
+            httpServer->endpoints())) {}
+
+  void onServerStart(folly::EventBase* /*evb*/) noexcept override {}
+
+  void onServerStop() noexcept override {}
+
+  proxygen::RequestHandler* onRequest(
+      proxygen::RequestHandler* handler,
+      proxygen::HTTPMessage*) noexcept override {
+    return new HttpEndpointLatencyFilter(handler, endpoints_);
+  }
+
+ private:
+  const std::shared_ptr<std::unordered_map<
+      proxygen::HTTPMethod,
+      std::vector<std::unique_ptr<EndPoint>>>>
+      endpoints_;
+};
+
+} // namespace facebook::presto::http::filters

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
@@ -10,11 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(http_filters AccessLogFilter.cpp HttpEndpointLatencyFilter.cpp
-                         StatsFilter.cpp)
+add_executable(presto_http_filter_test HttpFilterTest.cpp)
 
-target_link_libraries(http_filters presto_common ${PROXYGEN_LIBRARIES})
+add_test(
+  NAME presto_http_filter_test
+  COMMAND presto_http_filter_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(PRESTO_ENABLE_TESTING)
-  add_subdirectory(tests)
-endif()
+target_link_libraries(presto_http_filter_test http_filters presto_http gtest
+                      gtest_main)

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/HttpFilterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/HttpFilterTest.cpp
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include "presto_cpp/main/http/HttpServer.h"
+#include "presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h"
+
+using namespace facebook::presto::http::filters;
+using namespace facebook::presto::http;
+
+class HttpFilterTest : public ::testing::Test {};
+
+class DummyRequestHandler : public proxygen::RequestHandler {
+ public:
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> /*unused*/) noexcept override {}
+
+  void onBody(std::unique_ptr<folly::IOBuf> /*unused*/) noexcept override {}
+
+  void onUpgrade(proxygen::UpgradeProtocol /*unused*/) noexcept override {}
+
+  void requestComplete() noexcept override {}
+
+  void onError(proxygen::ProxygenError /*unused*/) noexcept override {}
+
+  void onEOM() noexcept override {}
+};
+
+namespace {
+// Builds endpoint map for all methods specified by 'methods'. 'size' specifies
+// the number of endpoints for each method.
+std::shared_ptr<std::unordered_map<
+    proxygen::HTTPMethod,
+    std::vector<std::unique_ptr<EndPoint>>>>
+buildEndpoints(
+    const std::vector<proxygen::HTTPMethod>& methods,
+    uint64_t size) {
+  std::shared_ptr<std::unordered_map<
+      proxygen::HTTPMethod,
+      std::vector<std::unique_ptr<EndPoint>>>>
+      result = std::make_shared<std::unordered_map<
+          proxygen::HTTPMethod,
+          std::vector<std::unique_ptr<EndPoint>>>>(methods.size());
+  for (const auto& method : methods) {
+    (*result)[method] = std::vector<std::unique_ptr<EndPoint>>();
+    auto& endpoints = result->at(method);
+    for (uint32_t i = 0; i < size; ++i) {
+      endpoints.emplace_back(
+          std::make_unique<EndPoint>(fmt::format("/v1/ep{}", i), nullptr));
+    }
+  }
+  return result;
+}
+
+std::unique_ptr<proxygen::HTTPMessage> buildRequestMsg(
+    const proxygen::HTTPMethod& method,
+    const std::string& path) {
+  auto msg = std::make_unique<proxygen::HTTPMessage>();
+  msg->setMethod(method);
+  msg->setURL("127.0.0.1:7777" + path);
+  return msg;
+}
+} // namespace
+
+TEST_F(HttpFilterTest, testEndpointLatencyFilter) {
+  DummyRequestHandler handler;
+  std::vector<proxygen::HTTPMethod> methods{
+      proxygen::HTTPMethod::GET,
+      proxygen::HTTPMethod::POST,
+      proxygen::HTTPMethod::DELETE,
+      proxygen::HTTPMethod::HEAD};
+  // For 'GET', 'POST', 'DELETE', 'HEAD'
+  // /v1/ep0
+  // ...
+  // /v1/ep4
+  const auto endpoints = buildEndpoints(methods, 5);
+
+  std::vector<HttpEndpointLatencyFilter*> filters;
+  const auto numMethods = methods.size();
+  for (uint32_t i = 0; i < 100; i++) {
+    filters.emplace_back(new HttpEndpointLatencyFilter(&handler, endpoints));
+    const auto path = "/v1/ep" + std::to_string(i % 5);
+    const auto& method = methods[i % numMethods];
+    filters.back()->onRequest(buildRequestMsg(method, path));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  for (uint32_t i = 0; i < filters.size(); i++) {
+    auto& filter = filters[i];
+    if (i % 2 == 0) {
+      filter->requestComplete();
+    } else {
+      filter->onError(proxygen::ProxygenError());
+    }
+  }
+
+  auto latencyMetrics = HttpEndpointLatencyFilter::retrieveLatencies();
+  ASSERT_EQ(latencyMetrics.size(), 20);
+  // After first time retrieval, it should be reset. Second time retrieval
+  // should be empty set.
+  ASSERT_EQ(HttpEndpointLatencyFilter::retrieveLatencies().size(), 0);
+
+  for (const auto& metrics : latencyMetrics) {
+    ASSERT_GT(metrics.maxLatencyUs, 0);
+    ASSERT_GT(metrics.avgLatencyUs, 0);
+    ASSERT_LE(metrics.avgLatencyUs, metrics.maxLatencyUs);
+    ASSERT_GT(metrics.count, 0);
+  }
+}
+
+TEST_F(HttpFilterTest, testConcurrentEndpointLatencyFilter) {
+  DummyRequestHandler handler;
+  std::vector<proxygen::HTTPMethod> methods{
+      proxygen::HTTPMethod::GET, proxygen::HTTPMethod::POST};
+  // GET /v1/ep0
+  // POST /v1/ep0
+  const auto endpoints = buildEndpoints(methods, 1);
+
+  const uint64_t numRequests = 1000;
+  std::vector<HttpEndpointLatencyFilter*> filters;
+  filters.reserve(numRequests);
+  const auto numMethods = methods.size();
+  for (uint32_t i = 0; i < numRequests; i++) {
+    filters.emplace_back(new HttpEndpointLatencyFilter(&handler, endpoints));
+    const auto path = "/v1/ep0";
+    const auto& method = methods[i % numMethods];
+    filters.back()->onRequest(buildRequestMsg(method, path));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(numRequests);
+  for (uint32_t i = 0; i < numRequests; i++) {
+    threads.emplace_back([&filters, i]() { filters[i]->requestComplete(); });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  auto latencyMetrics = HttpEndpointLatencyFilter::retrieveLatencies();
+  ASSERT_EQ(latencyMetrics.size(), 2);
+  // After first time retrieval, it should be reset. Second time retrieval
+  // should be empty set.
+  ASSERT_EQ(HttpEndpointLatencyFilter::retrieveLatencies().size(), 0);
+
+  for (const auto& metrics : latencyMetrics) {
+    ASSERT_GT(metrics.maxLatencyUs, 0);
+    ASSERT_GT(metrics.avgLatencyUs, 0);
+    ASSERT_LE(metrics.avgLatencyUs, metrics.maxLatencyUs);
+    ASSERT_EQ(metrics.count, numRequests / 2);
+  }
+}


### PR DESCRIPTION
Adds EndpointLatencyFilter, when enabled, record requests to each registered endpoint with latency tracking. 
```
== NO RELEASE NOTE ==
```

