### PR TITLE
Fix CVE-2022-42889: Upgrade org.apache.commons:commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1318,7 +1318,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.9</version>
+                <version>1.10.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION

org.apache.commons commons-text 1.9 In pom.xml (presto-root) we have the above dependency, we have to change this version to 1.10.0.
Security vulnerability with 1.9 version -> [CVE-2022-42889](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889)
and got the above CVE from https://mvnrepository.com/artifact/org.apache.commons/commons-text/1.9


![image](https://github.com/prestodb/presto/assets/89628774/0a8a858b-e844-4e7b-828a-1f4fa38fe583)

