### PR TITLE
[native] Add remote-function-server.catalog-name config parameter

### DIFF
--- a/presto-docs/src/main/sphinx/develop/presto-native.rst
+++ b/presto-docs/src/main/sphinx/develop/presto-native.rst
@@ -62,6 +62,19 @@ The following properties allow the configuration of remote function execution:
     recursively search, open, parse, and register function definitions from
     these JSON files.
 
+``remote-function-server.catalog-name``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``string``
+    * **Default value:** ``""``
+
+    The catalog name to be added as a prefix to the function names registered
+    in Velox. The function name pattern registered is
+    ``catalog.schema.function_name``, where ``catalog`` is defined by this
+    parameter, and ``schema`` and ``function_name`` are read from the input
+    JSON file.
+
+    If empty, the function is registered as ``schema.function_name``.
 
 ``remote-function-server.thrift.address``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -715,16 +715,18 @@ void PrestoServer::registerFunctions() {
 
 void PrestoServer::registerRemoteFunctions() {
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
-  if (auto dirPath = SystemConfig::instance()
-                         ->remoteFunctionServerSignatureFilesDirectoryPath()) {
+  auto* systemConfig = SystemConfig::instance();
+  if (auto dirPath =
+          systemConfig->remoteFunctionServerSignatureFilesDirectoryPath()) {
     PRESTO_STARTUP_LOG(INFO)
         << "Registering remote functions from path: " << *dirPath;
-    if (auto remoteLocation =
-            SystemConfig::instance()->remoteFunctionServerLocation()) {
-      size_t registeredCount =
-          presto::registerRemoteFunctions(*dirPath, *remoteLocation);
+    if (auto remoteLocation = systemConfig->remoteFunctionServerLocation()) {
+      auto catalogName = systemConfig->remoteFunctionServerCatalogName();
+      size_t registeredCount = presto::registerRemoteFunctions(
+          *dirPath, *remoteLocation, catalogName);
       PRESTO_STARTUP_LOG(INFO)
-          << registeredCount << " remote functions registered.";
+          << registeredCount << " remote functions registered in the '"
+          << catalogName << "' catalog.";
     } else {
       VELOX_FAIL(
           "To register remote functions using a json file path you need to "

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -258,6 +258,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kEnableVeloxExprSetLogging, "false"),
           NUM_PROP(kLocalShuffleMaxPartitionBytes, 268435456),
           STR_PROP(kShuffleName, ""),
+          STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kHttpEnableAccessLog, "false"),
           STR_PROP(kHttpEnableStatsFilter, "false"),
           STR_PROP(kRegisterTestFunctions, "false"),
@@ -361,6 +362,10 @@ SystemConfig::remoteFunctionServerLocation() const {
 folly::Optional<std::string>
 SystemConfig::remoteFunctionServerSignatureFilesDirectoryPath() const {
   return optionalProperty(kRemoteFunctionServerSignatureFilesDirectoryPath);
+}
+
+std::string SystemConfig::remoteFunctionServerCatalogName() const {
+  return optionalProperty(kRemoteFunctionServerCatalogName).value();
 }
 
 int32_t SystemConfig::maxDriversPerTask() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -303,6 +303,11 @@ class SystemConfig : public ConfigBase {
       kRemoteFunctionServerSignatureFilesDirectoryPath{
           "remote-function-server.signature.files.directory.path"};
 
+  /// Optional catalog name to be added as a prefix to the function names
+  /// registered. The patter registered is `catalog.schema.function_name`.
+  static constexpr std::string_view kRemoteFunctionServerCatalogName{
+      "remote-function-server.catalog-name"};
+
   SystemConfig();
 
   static SystemConfig* instance();
@@ -348,6 +353,8 @@ class SystemConfig : public ConfigBase {
 
   folly::Optional<std::string> remoteFunctionServerSignatureFilesDirectoryPath()
       const;
+
+  std::string remoteFunctionServerCatalogName() const;
 
   int32_t maxDriversPerTask() const;
 


### PR DESCRIPTION
Adding one last parameter for remote function registration:

* remote-function-server.catalog-name: The catalog name to be added as a prefix to the function names registered in Velox.

```
== NO RELEASE NOTE ==
```

