### PR TITLE
[native] Add remote function server end to end tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -120,6 +120,7 @@ jobs:
           root: presto-native-execution
           paths:
             - _build/debug/presto_cpp/main/presto_server
+            - _build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main
 
   linux-presto-e2e-tests:
     executor: build
@@ -147,8 +148,20 @@ jobs:
               export TESTCLASSES="${TESTCLASSES},$test_class"
             done
             export TESTCLASSES=${TESTCLASSES#,}
+
+            # TODO: neeed to enable remote function tests with
+            # "-Ppresto-native-execution-remote-functions" once
+            # > https://github.com/facebookincubator/velox/discussions/6163
+            # is fixed.
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Dtest="${TESTCLASSES}" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-spark-e2e-tests:
@@ -177,7 +190,14 @@ jobs:
             done
             export TESTCLASSES=${TESTCLASSES#,}
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Dtest="${TESTCLASSES}" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-build-all:

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -192,6 +192,7 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <excludedGroups>remote-function</excludedGroups>
                     <systemPropertyVariables>
                         <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
                         <DATA_DIR>/tmp/velox</DATA_DIR>
@@ -200,4 +201,26 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>presto-native-execution-remote-functions</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups combine.self="override" />
+                            <groups>remote-function</groups>
+                            <systemPropertyVariables>
+                                <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
+                                <REMOTE_FUNCTION_SERVER>_build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main</REMOTE_FUNCTION_SERVER>
+                                <DATA_DIR>/tmp/velox</DATA_DIR>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_CATALOG_NAME;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_JSON_SIGNATURES;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.setupJsonFunctionNamespaceManager;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.startRemoteFunctionServer;
+import static java.util.Objects.requireNonNull;
+
+@Test(groups = "remote-function")
+public abstract class AbstractTestNativeRemoteFunctions
+        extends AbstractTestQueryFramework
+{
+    // The unix domain socket (UDS) path to communicate with the remote fuction server.
+    protected String remoteFunctionServerUds;
+
+    // The path to the compiled remote function server binary.
+    private String remoteFunctionServerBinaryPath;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        preInitQueryRunners();
+        super.init();
+        postInitQueryRunners();
+    }
+
+    protected void preInitQueryRunners()
+    {
+        // Initialize the remote function thrift server process.
+        String propertyName = "REMOTE_FUNCTION_SERVER";
+        remoteFunctionServerBinaryPath = System.getenv(propertyName);
+        if (remoteFunctionServerBinaryPath == null) {
+            remoteFunctionServerBinaryPath = System.getProperty(propertyName);
+        }
+
+        requireNonNull(remoteFunctionServerBinaryPath, "Remote function server path missing. Add -DREMOTE_FUNCTION_SERVER=<path/to/binary> to your JVM arguments.");
+        remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
+    }
+
+    protected void postInitQueryRunners()
+    {
+        // Install json function registration namespace manager.
+        setupJsonFunctionNamespaceManager(getQueryRunner(), REMOTE_FUNCTION_JSON_SIGNATURES, REMOTE_FUNCTION_CATALOG_NAME);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        // Create some tpch tables.
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+    }
+
+    @Test
+    public void testRemoteFunction()
+    {
+        assertQuery("SELECT remote.schema.ceil(linenumber) FROM lineitem", "SELECT ceil(linenumber) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount) FROM lineitem", "SELECT ceil(discount) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount * 7) FROM lineitem", "SELECT ceil(discount * 7) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(ceil(discount)) FROM lineitem", "SELECT ceil(ceil(discount * 7)) FROM lineitem");
+
+        assertQuery("SELECT remote.schema.concat(returnflag, linestatus) FROM lineitem", "SELECT concat(returnflag, linestatus) FROM lineitem");
+        assertQuery("SELECT remote.schema.concat('asd', linestatus) FROM lineitem", "SELECT concat('asd', linestatus) FROM lineitem");
+
+        // TODO: `throwOnError` needs to be implemented in the server so we can have remote functions as function parameters.
+        // https://github.com/facebookincubator/velox/issues/5288
+        //
+        // "(?s)" enables DOTALL mode so that "." can match newlines.
+        assertQueryFails("SELECT remote.schema.ceil(remote.schema.ceil(discount)) FROM lineitem", "(?s).*Error.*");
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoNativeRemoteFunctions
+        extends AbstractTestNativeRemoteFunctions
+{
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(remoteFunctionServerUds);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+}

--- a/presto-native-execution/src/test/resources/remote_function_server.json
+++ b/presto-native-execution/src/test/resources/remote_function_server.json
@@ -1,0 +1,51 @@
+{
+  "udfSignatureMap": {
+    "ceil":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "INTEGER",
+        "paramTypes": [
+          "INTEGER"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "DOUBLE",
+        "paramTypes": [
+          "DOUBLE"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "concat":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "VARCHAR",
+        "paramTypes": [
+          "VARCHAR",
+          "VARCHAR"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Because the new test suite requires a remote function server binary to
be available, it's only enabled when `-Ppresto-native-execution-remote-functions`
is passed to maven. When it's enabled, the binary path is configured in
the pom.xml file, or can be overwritten using the REMOTE_FUNCTION_SERVER
env variable.


```
== NO RELEASE NOTE ==
```

