### PR TITLE
Fix NPE from Iceberg while querying system.jdbc.columns

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -155,7 +155,7 @@ public abstract class IcebergAbstractMetadata
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        List<SchemaTableName> tables = prefix.getTableName() != null ? singletonList(prefix.toSchemaTableName()) : listTables(session, Optional.of(prefix.getSchemaName()));
+        List<SchemaTableName> tables = prefix.getTableName() != null ? singletonList(prefix.toSchemaTableName()) : listTables(session, Optional.ofNullable(prefix.getSchemaName()));
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         for (SchemaTableName table : tables) {
@@ -296,7 +296,6 @@ public abstract class IcebergAbstractMetadata
         if (!icebergTable.location().isEmpty()) {
             properties.put(LOCATION_PROPERTY, icebergTable.location());
         }
-
         return properties.build();
     }
 


### PR DESCRIPTION
The below query throws an NPE if Iceberg connector is connected. This is due to the schemaName being empty in this flow, while listing the table columns. A fix has been made in the Iceberg+Hive connector in order to list all schemas and iterate through each of them. Similar logic is used in Hive and other connectors in Presto already.

```
presto> select count(*) from system.jdbc.columns;

Query 20230724_100031_00010_8evfg, FAILED, 1 node
Splits: 18 total, 0 done (0.00%)
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20230724_100031_00010_8evfg failed: Internal error

presto> 
```

```
== NO RELEASE NOTE ==
```

