### PR TITLE
Make sure to reset primitive writer on parquet writer reset

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -102,6 +102,7 @@ public class ParquetWriter
         ParquetProperties parquetProperties = ParquetProperties.builder()
                 .withWriterVersion(PARQUET_2_0)
                 .withPageSize(writerOption.getMaxPageSize())
+                .withDictionaryPageSize(writerOption.getMaxDictionaryPageSize())
                 .build();
         CompressionCodecName compressionCodecName = getCompressionCodecName(compressionCodecClass);
         this.columnWriters = ParquetWriters.getColumnWriters(messageType, primitiveTypes, parquetProperties, compressionCodecName);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -30,11 +30,13 @@ public class ParquetWriterOptions
 
     private final int maxRowGroupSize;
     private final int maxPageSize;
+    private final int maxDictionaryPageSize;
 
-    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize)
+    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize, DataSize maxDictionaryPageSize)
     {
         this.maxRowGroupSize = toIntExact(requireNonNull(maxRowGroupSize, "maxRowGroupSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
+        this.maxDictionaryPageSize = toIntExact(requireNonNull(maxDictionaryPageSize, "maxDictionaryPageSize is null").toBytes());
     }
 
     public int getMaxRowGroupSize()
@@ -47,10 +49,17 @@ public class ParquetWriterOptions
         return maxPageSize;
     }
 
+    public int getMaxDictionaryPageSize()
+    {
+        return maxDictionaryPageSize;
+    }
+
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
+        // By default, we set maxDictionaryPageSize to the same default value as maxPageSize, to keep consistent with parquet-mr.
+        private DataSize maxDictionaryPageSize = DEFAULT_MAX_PAGE_SIZE;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -64,9 +73,15 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setMaxDictionaryPageSize(DataSize maxDictionaryPageSize)
+        {
+            this.maxDictionaryPageSize = maxDictionaryPageSize;
+            return this;
+        }
+
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize, maxDictionaryPageSize);
         }
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -313,6 +313,7 @@ public class PrimitiveColumnWriter
     public void reset()
     {
         pageBuffer.clear();
+        primitiveValueWriter.reset();
         closed = false;
 
         totalCompressedSize = 0;

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer;
+
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.util.UUID.randomUUID;
+import static org.testng.Assert.fail;
+
+public class TestParquetWriter
+{
+    private File temporaryDirectory;
+    private File parquetFile;
+
+    @Test
+    public void testRowGroupFlushInterleavedColumnWriterFallbacks()
+    {
+        temporaryDirectory = createTempDir();
+        parquetFile = new File(temporaryDirectory, randomUUID().toString());
+        List<Type> types = ImmutableList.of(BIGINT, INTEGER, VARCHAR, BOOLEAN);
+        List<String> names = ImmutableList.of("col_1", "col_2", "col_3", "col_4");
+        ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
+                .setMaxPageSize(DataSize.succinctBytes(1000))
+                .setMaxBlockSize(DataSize.succinctBytes(15000))
+                .setMaxDictionaryPageSize(DataSize.succinctBytes(1000))
+                .build();
+        try (ParquetWriter parquetWriter = createParquetWriter(parquetFile, types, names, parquetWriterOptions, CompressionCodecName.UNCOMPRESSED)) {
+            Random rand = new Random();
+            for (int pageIdx = 0; pageIdx < 10; pageIdx++) {
+                int pageRowCount = 100;
+                PageBuilder pageBuilder = new PageBuilder(pageRowCount, types);
+                for (int rowIdx = 0; rowIdx < pageRowCount; rowIdx++) {
+                    // maintain col_1's dictionary size approximately half of raw data
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(0), pageIdx * 100 + rand.nextInt(50));
+                    INTEGER.writeLong(pageBuilder.getBlockBuilder(1), rand.nextInt(100000000));
+                    VARCHAR.writeString(pageBuilder.getBlockBuilder(2), UUID.randomUUID().toString());
+                    BOOLEAN.writeBoolean(pageBuilder.getBlockBuilder(3), rand.nextBoolean());
+                    pageBuilder.declarePosition();
+                }
+                parquetWriter.write(pageBuilder.build());
+            }
+        }
+        catch (Exception e) {
+            fail("Should not fail, but throw an exception as follows:", e);
+        }
+    }
+
+    public static ParquetWriter createParquetWriter(File outputFile, List<Type> types, List<String> columnNames,
+                                                    ParquetWriterOptions parquetWriterOptions, CompressionCodecName compressionCodecName)
+            throws Exception
+    {
+        checkArgument(types.size() == columnNames.size());
+        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
+                types,
+                columnNames);
+        return new ParquetWriter(
+                new FileOutputStream(outputFile),
+                schemaConverter.getMessageType(),
+                schemaConverter.getPrimitiveTypes(),
+                columnNames,
+                types,
+                parquetWriterOptions,
+                compressionCodecName.getHadoopCompressionCodecClassName());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+    }
+}

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -148,6 +148,10 @@
             <artifactId>kafka-clients</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description

In some scenarios, when we write data to parquet, as events occur in following order:
  1. PrimitiveColumnWriter trigger flushCurrentPageToBuffer() as column buffered bytes exceeding threshold.
  2. Then, the same column trigger its FallbackValuesWriter.fallBack(), as dictionary size exceeding threshold.
  3. After that, ParquetWriter trigger row group level flush, as whole row group size exceeding threshold.
  4. Finally, the same column trigger its FallbackValuesWriter.fallBack() again, as new written data's dictionary size exceeding threshold again. Then it would fail and throw exception.

The reason is, when FallbackValuesWriter execute fallBack() after PrimitiveColumnWriter.flushCurrentPageToBuffer(), it will change currentWriter to fallBackWriter but reserve initialWriter's encodedValues. After that, when whole row group level flush occur, for each column, it will trigger fallbackWriter's reset(), clear the dictionary and reset FallbackValuesWriter's currentWriter to initialWriter, which still contains uncleaned encodedValues. So, when the same column trigger FallbackValuesWriter.fallBack() again before any flush, it would fail to find dictionary for these encoded values.

So we should make sure to invoke reset() for FallbackValuesWriter's initialWriter after each row group level flush.

## Test Plan

```
Newly added unit test TestParquetWriter.testRowGroupFlushInterleavedColumnWriterFallbacks().
```


## Release Notes

```
== NO RELEASE NOTE ==
```

