### PR TITLE
Update q02.sql

### DIFF
--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/tpch/q02.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/tpch/q02.sql
@@ -41,4 +41,5 @@ ORDER BY
   n.name,
   s.name,
   p.partkey
+LIMIT 100
 ;

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
@@ -1,40 +1,39 @@
-remote exchange (GATHER, SINGLE, [])
-    local exchange (GATHER, UNKNOWN, [])
-        remote exchange (REPARTITION, ROUND_ROBIN, [])
-            join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, [suppkey_4])
+local exchange (GATHER, SINGLE, [])
+    remote exchange (GATHER, SINGLE, [])
+        join (INNER, PARTITIONED):
+            remote exchange (REPARTITION, HASH, [suppkey_4])
+                join (INNER, PARTITIONED):
+                    remote exchange (REPARTITION, HASH, [partkey_3])
+                        scan partsupp
                     join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, [partkey_3])
-                            scan partsupp
-                        join (INNER, PARTITIONED):
-                            final aggregation over (partkey_15)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [partkey_15])
-                                        partial aggregation over (partkey_15)
-                                            join (INNER, REPLICATED):
-                                                scan partsupp
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        join (INNER, REPLICATED):
-                                                            scan supplier
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan nation
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan region
+                        final aggregation over (partkey_15)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [partkey])
-                                    scan part
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, [suppkey])
-                        join (INNER, REPLICATED):
-                            scan supplier
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    join (INNER, REPLICATED):
-                                        scan nation
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan region
+                                remote exchange (REPARTITION, HASH, [partkey_15])
+                                    partial aggregation over (partkey_15)
+                                        join (INNER, REPLICATED):
+                                            scan partsupp
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    join (INNER, REPLICATED):
+                                                        scan supplier
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                join (INNER, REPLICATED):
+                                                                    scan nation
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan region
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [partkey])
+                                scan part
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPARTITION, HASH, [suppkey])
+                    join (INNER, REPLICATED):
+                        scan supplier
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
+                                join (INNER, REPLICATED):
+                                    scan nation
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan region


### PR DESCRIPTION
Based on https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf Page 30. Section 2.4.2 Minimum Cost Supplier Query (Q2) The Q02 should return the first 100 selected rows.

Changes to TPCH Q02 plan

```
== NO RELEASE NOTE ==
```

