### PR TITLE
fix bug when use parquet column index filter

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -556,7 +556,7 @@ public class TupleDomainParquetPredicate
                 return false;
             }
             List<Range> ranges = new ArrayList<>();
-            ranges.add(Range.range(columnDomain.getType(), statistic.getMin(), true, statistic.getMax(), true));
+            ranges.add(getRange(columnDomain.getType(), statistic.getMin(), statistic.getMax()));
             return canDropWithRangeStatistics(ranges);
         }
 
@@ -573,6 +573,24 @@ public class TupleDomainParquetPredicate
             checkArgument(!ranges.isEmpty(), "cannot use empty ranges");
             Domain domain = Domain.create(ValueSet.ofRanges(ranges), true);
             return columnDomain.intersect(domain).isNone();
+        }
+    }
+
+    @VisibleForTesting
+    public static Range getRange(Type type, Object min, Object max)
+    {
+        if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT)) {
+            long minValue = asLong(min);
+            long maxValue = asLong(max);
+            return Range.range(type, minValue, true, maxValue, true);
+        }
+        else if (type.equals(REAL)) {
+            long minValue = floatToRawIntBits((float) min);
+            long maxValue = floatToRawIntBits((float) max);
+            return Range.range(type, minValue, true, maxValue, true);
+        }
+        else {
+            return Range.range(type, min, true, max, true);
         }
     }
 
@@ -672,7 +690,7 @@ public class TupleDomainParquetPredicate
                 case BOOLEAN:
                     return buffer -> ((ByteBuffer) buffer).get(0) != 0;
                 case INT32:
-                    return buffer -> ((ByteBuffer) buffer).order(LITTLE_ENDIAN).getInt(0);
+                    return buffer -> (long) ((ByteBuffer) buffer).order(LITTLE_ENDIAN).getInt(0);
                 case INT64:
                     return buffer -> ((ByteBuffer) buffer).order(LITTLE_ENDIAN).getLong(0);
                 case FLOAT:

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.parquet;
 
 import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.Type;
@@ -62,6 +63,7 @@ import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.hive.HiveWarningCode.HIVE_FILE_STATISTICS_CORRUPTION;
 import static com.facebook.presto.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate.getDomain;
+import static com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate.getRange;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.NaN;
@@ -390,6 +392,20 @@ public class TestTupleDomainParquetPredicate
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
         DictionaryPage page = new DictionaryPage(Slices.wrappedBuffer(new byte[] {0, 0, 0, 0}), 1, PLAIN_DICTIONARY);
         assertTrue(parquetPredicate.matches(new DictionaryDescriptor(column, Optional.of(page))));
+    }
+
+    @Test
+    public void testGetRange()
+    {
+        Range range1 = getRange(INTEGER, 1, 2);
+        Range range2 = getRange(REAL, 1.0f, 2.0f);
+        Range range3 = getRange(DOUBLE, 1.0, 2.0);
+        assertEquals(range1.getLow().getValue(), 1L);
+        assertEquals(range1.getHigh().getValue(), 2L);
+        assertEquals(range2.getLow().getValue(), (long) floatToRawIntBits(1.0f));
+        assertEquals(range2.getHigh().getValue(), (long) floatToRawIntBits(2.0f));
+        assertEquals(range3.getLow().getValue(), 1.0);
+        assertEquals(range3.getHigh().getValue(), 2.0);
     }
 
     private TupleDomain<ColumnDescriptor> getEffectivePredicate(RichColumnDescriptor column, VarcharType type, Slice value)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
When "parquet-column-index-filter-enabled" is set to true, there is a bug when using column index to filter columns of type int or float. The error message is as follows:
Query 20230818_035302_00000_3vack failed: Error opening Hive split xxx (offset=0, length=299): java.lang.Integer cannot be cast to java.lang.Long
`
at com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createParquetPageSource(ParquetPageSourceFactory.java:355)
	at com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createPageSource(ParquetPageSourceFactory.java:555)
	at com.facebook.presto.hive.HivePageSourceProvider.createHivePageSource(HivePageSourceProvider.java:431)
	at com.facebook.presto.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:187)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:63)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:80)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:250)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:428)
	at com.facebook.presto.operator.Driver.lambda$processFor$9(Driver.java:311)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:732)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:304)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:603)
	at com.facebook.presto.$gen.Presto_null__testversion____20230818_035204_1.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
	at com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate$ColumnIndexValueConverter.getValuesAsLong(TupleDomainParquetPredicate.java:626)
	at com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate$ColumnIndexValueConverter.getMinValuesAsLong(TupleDomainParquetPredicate.java:593)
	at com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate.getDomain(TupleDomainParquetPredicate.java:425)
	at com.facebook.presto.parquet.predicate.TupleDomainParquetPredicate.matches(TupleDomainParquetPredicate.java:385)
	at com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatches(PredicateUtils.java:127)
	at com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createParquetPageSource(ParquetPageSourceFactory.java:254)
`


```
== NO RELEASE NOTE ==
```

