### PR TITLE
Rewrite array contains to in expression

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRewriteConstantArrayContainsToInExpressionBenchmarks.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlRewriteConstantArrayContainsToInExpressionBenchmarks.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlRewriteConstantArrayContainsToInExpressionBenchmarks
+{
+    private SqlRewriteConstantArrayContainsToInExpressionBenchmarks() {}
+
+    public static void main(String[] args)
+    {
+        String sql = "";
+
+        // This is a dummy run, as I found that the first run always shows worse performance no matter which query is put here
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where contains(array[1], orderkey)";
+        System.out.println("The first run is a dummy run, ignore this run");
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where contains(array[1], orderkey)";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where contains(array[1, 2, 3, 4, 5, 6, 7, 8], orderkey)";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where contains(array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32], orderkey)";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where contains(array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, " +
+                "32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56], orderkey)";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1], x -> contains(array[1], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, " +
+                "32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8], x))";
+        runQuery(sql);
+
+        sql = "select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1, orderkey+2, partkey+2, suppkey+2, orderkey+3, partkey+3, suppkey+3], x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8], x))";
+        runQuery(sql);
+    }
+
+    private static void runQuery(String sql)
+    {
+        System.out.println(sql);
+        System.out.println("Without optimization");
+        new SqlRewriteConstantArrayContainsToInExpressionBenchmark(
+                createLocalQueryRunner(ImmutableMap.of("rewrite_constant_array_contains_to_in_expression", "false")), sql).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        System.out.println("With optimization");
+        new SqlRewriteConstantArrayContainsToInExpressionBenchmark(
+                createLocalQueryRunner(ImmutableMap.of("rewrite_constant_array_contains_to_in_expression", "true")), sql).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+
+    public static class SqlRewriteConstantArrayContainsToInExpressionBenchmark
+            extends AbstractSqlBenchmark
+    {
+        public SqlRewriteConstantArrayContainsToInExpressionBenchmark(LocalQueryRunner localQueryRunner, String sql)
+        {
+            super(localQueryRunner, "sql_rewrite_constant_array_contains_to_in_expression", 10, 20, sql);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -282,6 +282,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_CASE_TO_MAP_ENABLED = "rewrite_case_to_map_enabled";
     public static final String FIELD_NAMES_IN_JSON_CAST_ENABLED = "field_names_in_json_cast_enabled";
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
+    public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1643,6 +1644,11 @@ public final class SystemSessionProperties
                         PULL_EXPRESSION_FROM_LAMBDA_ENABLED,
                         "Rewrite case with constant WHEN/THEN/ELSE clauses to use map literals",
                         featuresConfig.isPullUpExpressionFromLambdaEnabled(),
+                        false),
+                booleanProperty(
+                        REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION,
+                        "Rewrite contant array contains to IN expression",
+                        true,
                         false));
     }
 
@@ -2765,5 +2771,10 @@ public final class SystemSessionProperties
     public static boolean isPullExpressionFromLambdaEnabled(Session session)
     {
         return session.getSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, Boolean.class);
+    }
+
+    public static boolean isRwriteConstantArrayContainsToInExpressionEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -112,6 +112,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteAggregationIfToFilter;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseExpressionPredicate;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseToMap;
+import com.facebook.presto.sql.planner.iterative.rule.RewriteConstantArrayContainsToInExpression;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.RuntimeReorderJoinSides;
@@ -313,6 +314,13 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 new RewriteCaseToMap(metadata.getFunctionAndTypeManager()).rules());
 
+        IterativeOptimizer containsToInRewriter = new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                estimatedExchangesCostCalculator,
+                new RewriteConstantArrayContainsToInExpression(metadata.getFunctionAndTypeManager()).rules());
+
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser));
         PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata, statsCalculator));
 
@@ -480,6 +488,7 @@ public class PlanOptimizers
         builder.add(
                 caseToMapRewriter,
                 caseExpressionPredicateRewriter,
+                containsToInRewriter,
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteConstantArrayContainsToInExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteConstantArrayContainsToInExpression.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.expressions.RowExpressionRewriter;
+import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isRwriteConstantArrayContainsToInExpressionEnabled;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class RewriteConstantArrayContainsToInExpression
+        extends RowExpressionRewriteRuleSet
+{
+    public RewriteConstantArrayContainsToInExpression(FunctionAndTypeManager functionAndTypeManager)
+    {
+        super(new Rewriter(functionAndTypeManager));
+    }
+
+    @Override
+    public boolean isRewriterEnabled(Session session)
+    {
+        return isRwriteConstantArrayContainsToInExpressionEnabled(session);
+    }
+
+    @Override
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(filterRowExpressionRewriteRule(), projectRowExpressionRewriteRule());
+    }
+
+    private static class Rewriter
+            implements PlanRowExpressionRewriter
+    {
+        private final ContainsToInRewriter containsToInRewriter;
+
+        public Rewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.containsToInRewriter = new ContainsToInRewriter(functionAndTypeManager);
+        }
+
+        @Override
+        public RowExpression rewrite(RowExpression expression, Rule.Context context)
+        {
+            return RowExpressionTreeRewriter.rewriteWith(containsToInRewriter, expression);
+        }
+    }
+
+    private static class ContainsToInRewriter
+            extends RowExpressionRewriter<Void>
+    {
+        private final FunctionResolution functionResolution;
+
+        private ContainsToInRewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        }
+
+        // contains(array[array[1, null]], array[1, null]) throw exception, but array[1, null] IN (array[1, null]) returns NULL.
+        // We limit the optimization for simple primitive type here for safety and simplicity
+        private boolean isSupportedType(Type type)
+        {
+            return isExactNumericType(type) || type instanceof VarcharType || type.equals(DATE) || type.equals(TIMESTAMP) || type.equals(TIMESTAMP_MICROSECONDS);
+        }
+
+        @Override
+        public RowExpression rewriteCall(CallExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (functionResolution.isArrayContainsFunction(node.getFunctionHandle()) && node.getArguments().get(0) instanceof ConstantExpression) {
+                checkState(((ConstantExpression) node.getArguments().get(0)).getValue() instanceof Block && node.getArguments().get(0).getType() instanceof ArrayType);
+                Block arrayValue = (Block) ((ConstantExpression) node.getArguments().get(0)).getValue();
+                if (arrayValue.getPositionCount() == 0) {
+                    return null;
+                }
+                Type arrayElementType = ((ArrayType) node.getArguments().get(0).getType()).getElementType();
+                if (!isSupportedType(arrayElementType)) {
+                    return null;
+                }
+                ImmutableList.Builder arguments = ImmutableList.builder();
+                arguments.add(node.getArguments().get(1));
+                for (int i = 0; i < arrayValue.getPositionCount(); ++i) {
+                    arguments.add(constant(readNativeValue(arrayElementType, arrayValue, i), arrayElementType));
+                }
+                return new SpecialFormExpression(node.getSourceLocation(), SpecialFormExpression.Form.IN, node.getType(), arguments.build());
+            }
+            return null;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -338,4 +338,9 @@ public final class FunctionResolution
     {
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getOperatorType().map(EQUAL::equals).orElse(false);
     }
+
+    public boolean isArrayContainsFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "contains"));
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestRewriteConstantArrayContainsToInExpression
+        extends BaseRuleTest
+{
+    @Test
+    public void testNoNull()
+    {
+        tester().assertThat(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BOOLEAN);
+                    VariableReferenceExpression b = p.variable("b");
+                    return p.project(
+                            assignment(a, p.rowExpression("contains(array[1, 2, 3], b)")),
+                            p.values(b));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("b IN (1, 2, 3)")),
+                                values("b")));
+    }
+
+    @Test
+    public void testDoesNotFireForNestedArray()
+    {
+        tester().assertThat(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).projectRowExpressionRewriteRule())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BOOLEAN);
+                    VariableReferenceExpression b = p.variable("b", new ArrayType(BIGINT));
+                    return p.project(
+                            assignment(a, p.rowExpression("contains(array[array[1, 2], array[3]], b)")),
+                            p.values(b));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNotFire()
+    {
+        tester().assertThat(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BOOLEAN);
+                    VariableReferenceExpression b = p.variable("b");
+                    VariableReferenceExpression c = p.variable("c");
+                    return p.project(
+                            assignment(a, p.rowExpression("contains(array[1, 2, c], b)")),
+                            p.values(b, c));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("contains(array[1, 2, c], b)")),
+                                values("b", "c")));
+    }
+
+    @Test
+    public void testWithNull()
+    {
+        tester().assertThat(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BOOLEAN);
+                    VariableReferenceExpression b = p.variable("b");
+                    return p.project(
+                            assignment(a, p.rowExpression("contains(array[1, 2, 3, null], b)")),
+                            p.values(b));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("b IN (1, 2, 3, null)")),
+                                values("b")));
+    }
+
+    @Test
+    public void testLambda()
+    {
+        tester().assertThat(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BOOLEAN);
+                    VariableReferenceExpression b = p.variable("b", new ArrayType(BIGINT));
+                    return p.project(
+                            assignment(a, p.rowExpression("any_match(b, x -> contains(array[1, 2, 3, null], x))")),
+                            p.values(b));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("any_match(b, x -> x IN (1, 2, 3, null))")),
+                                values("b")));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7087,4 +7087,14 @@ public abstract class AbstractTestQueries
                 "values array[array[array[1, 2, 3], array[1, 2, 3], array[1, 2, 3], array[1, 2, 3], array[1, 2, 3]], array[array[1, 2, 3], array[1, 2, 3], array[1, 2, 3], array[1, 2, 3], array[1, 2, 3]]], " +
                         "array[array[array[0, 1, 2], array[0, 1, 2], array[0, 1, 2], array[0, 1, 2]], array[array[0, 1, 2], array[0, 1, 2], array[0, 1, 2], array[0, 1, 2]], array[array[0, 1, 2], array[0, 1, 2], array[0, 1, 2], array[0, 1, 2]]]");
     }
+
+    @Test
+    public void testRewriteContainsToIn()
+    {
+        assertQuery("select k from (values 1, 2, 3, 4, 5) t(k) where contains(array[1, 3, 4], k)", "values 1, 3, 4");
+        assertQuery("select filter(arr, x -> contains(array[1,5], x)) from (values array[1, 2, 3, 4], array[1,3,5,7]) t(arr)", "values array[1], array[1, 5]");
+        assertQuery("select x, contains(array[null], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, null), (2, null), (3, null), (4, null), (null, null)");
+        assertQuery("select x, contains(array[null, 1], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, true), (2, null), (3, null), (4, null), (null, null)");
+        assertQuery("select x, contains(array[], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, false), (2, false), (3, false), (4, false), (null, null)");
+    }
 }


### PR DESCRIPTION
## Description
For expressions like contains(constant_array, col), rewrite it to "col IN (arra[1], array[2], ...)"

## Motivation and Context
Contains function does a for loop on the array and is linear in execution time.
For IN function, constant arguments will be put into a hash set for lookup, which is constant execution time.
This is especially helpful when the constant array is large and the contains function is used in a lambda function, i.e. called multiple times for one row.

The reason why we want to limit it to only constant arrays, is because constant arrays will be compiled to this hashset during query compilation. For non constant elements, it will be compiled to multiple IF ELSE block, which is the same as iterating through all elements.

## Impact
Benchmarks shows that the rewrite always have comparable or better performance.
For the test benchmark, `select orderkey from lineitem cross join unnest(array[1, 2, 3, 4])t(idx) where any_match(array[orderkey, partkey, suppkey, orderkey+1, partkey+1, suppkey+1, orderkey+2, partkey+2, suppkey+2, orderkey+3, partkey+3, suppkey+3] ,x -> contains(array[1, 2, 3, 4, 5, 6, 7, 8], x))`, the benchmark shows 15% of performance improvement.

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an optimizer to rewrite contains(constant_array, col) to IN expression. It's controlled by session `rewrite_constant_array_contains_to_in_expression` and default to enabled
```


