### PR TITLE
Handle empty directories with content-type application/octet-stream also as directories

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -414,7 +414,7 @@ public class TestPrestoS3FileSystem
             s3.setGetObjectMetadataHttpCode(HTTP_NOT_FOUND);
             fs.initialize(new URI("s3n://test-bucket/"), new Configuration());
             fs.setS3Client(s3);
-            assertEquals(fs.getS3ObjectMetadata(new Path("s3n://test-bucket/test")), null);
+            assertEquals(fs.getS3ObjectMetadata(new Path("s3n://test-bucket/test")).getObjectMetadata(), null);
         }
     }
 


### PR DESCRIPTION
## Description
Certain systems create empty directories with content-type as `application/octet-stream` rather than `application/x-directory` due to which we see failures when trying to create an external table on top of such directories as Presto does not recognize them as directories.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #20310

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
This PR will allow Presto to recognize such directories

## Test Plan
<!---Please fill in how you tested your change-->
Tested the fix with Minio.
Before this fix, got the below error while trying to create an external table with the location as an empty directory in Minio
```
presto:imjalpreet_db> create table imjalpreet_content_type(a int, b int) WITH (external_location='s3a://imjalpreet-minio/imjalpreet-content-type/');
Query 20230818_102509_00006_8ppz6 failed: External location must be a directory
```

After the fix, create table ran successfully on the same empty directory:
```
presto:imjalpreet_db> create table imjalpreet_content_type(a int, b int) WITH (external_location='s3a://imjalpreet-minio/imjalpreet-content-type/');
CREATE TABLE
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Changes
* Handle empty directories with content-type application/octet-stream also as directories (:issue:`20310`)

```


