### PR TITLE
Add ascii functionality

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -28,6 +28,12 @@ String Functions
     some languages. Specifically, this will return incorrect results for
     Lithuanian, Turkish and Azeri.
 
+.. function:: ascii(n) -> integer
+
+    Returns the ASCII code of the first character of a given parameter.
+    Parameter `n` must be convertible to `varchar`, which means that `n` must be one of the following data types:
+    varchar, integer, double, varbinary, date, timestamp, and boolean.
+
 .. function:: chr(n) -> varchar
 
     Returns the Unicode code point ``n`` as a single character string.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/StringSqlFunctions.java
@@ -24,6 +24,78 @@ public class StringSqlFunctions
 {
     private StringSqlFunctions() {}
 
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "varchar")
+    @SqlType("int")
+    public static String ascii()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(input, 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "int")
+    @SqlType("int")
+    public static String asciiInt()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "date")
+    @SqlType("int")
+    public static String asciiDate()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "timestamp")
+    @SqlType("int")
+    public static String asciiTimestamp()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "double")
+    @SqlType("int")
+    public static String asciiDouble()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "boolean")
+    @SqlType("int")
+    public static String asciiBoolean()
+    {
+        return "RETURN IF(cast(input as varchar) = '', 0, cast(from_base(to_hex(to_utf8(substr(cast(input as varchar), 1, 1))), 16) as int))";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "unknown")
+    @SqlType("int")
+    public static String asciiNull()
+    {
+        return "RETURN NULL";
+    }
+
+    @SqlInvokedScalarFunction(value = "ascii", deterministic = true, calledOnNullInput = true)
+    @Description("Returns the ascii code of the first letter.")
+    @SqlParameter(name = "input", type = "varbinary")
+    @SqlType("int")
+    public static String asciiVarbinary()
+    {
+        return "RETURN cast(from_base(to_hex(to_utf8(substr(to_base64(input), 1, 1))), 16) as int)";
+    }
+
     @SqlInvokedScalarFunction(value = "replace_first", deterministic = true, calledOnNullInput = true)
     @Description("Replaces the first occurrence of a substring that matches the given pattern with the given replacement.")
     @SqlParameters({@SqlParameter(name = "str", type = "varchar"), @SqlParameter(name = "search", type = "varchar"), @SqlParameter(name = "replace", type = "varchar")})

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAsciiFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestAsciiFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+
+public class TestAsciiFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testAscii()
+    {
+        assertFunction("ascii(123)", INTEGER, 49);
+        assertFunction("ascii(3.14)", INTEGER, 51);
+        assertFunction("ascii('a')", INTEGER, 97);
+        assertFunction("ascii(cast('2023-01-01' as date))", INTEGER, 50);
+        assertFunction("ascii(cast('2023-01-01 10:12:33' as timestamp))", INTEGER, 50);
+        assertFunction("ascii(cast('1990-01-01 10:12:33' as timestamp))", INTEGER, 49);
+        assertFunction("ascii(true)", INTEGER, 116);
+        assertFunction("ascii(false)", INTEGER, 102);
+        assertFunction("ascii('')", INTEGER, 0);
+        assertFunction("ascii(null)", INTEGER, null);
+        assertFunction("ascii(cast('Test' as varbinary))", INTEGER, 86);
+    }
+}


### PR DESCRIPTION
## Description
Add ascii function to return the ASCII code of the first character

## Test Plan
Test ran successfully in local machine
```
./mvnw clean install -Dtest=TestStringSqlFunctions -Dmaven.javadoc.skip=true -T1C -fn -pl presto-main
```
Test cases are also compared with results from running `ascii` function in Spark.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* add :func:`ascii` to return ASCII code of the first character.
```
