### PR TITLE
Add session property to pick optimizers to enable runtime stats

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -41,6 +41,7 @@ public class RuntimeMetricName
     public static final String GET_SPLITS_TIME_NANOS = "getSplitsTimeNanos";
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String OPTIMIZER_TIME_NANOS = "optimizerTimeNanos";
+    public static final String GET_CANONICAL_INFO_TIME_NANOS = "getCanonicalInfoTimeNanos";
     public static final String FRAGMENT_PLAN_TIME_NANOS = "fragmentPlanTimeNanos";
     public static final String GET_LAYOUT_TIME_NANOS = "getLayoutTimeNanos";
     public static final String REWRITE_AGGREGATION_IF_TO_FILTER_APPLIED = "rewriteAggregationIfToFilterApplied";

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -238,6 +238,7 @@ public final class SystemSessionProperties
     public static final String EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY = "exceeded_memory_limit_heap_dump_file_directory";
     public static final String DISTRIBUTED_TRACING_MODE = "distributed_tracing_mode";
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
+    public static final String OPTIMIZERS_TO_ENABLE_VERBOSE_RUNTIME_STATS = "optimizers_to_enable_verbose_runtime_stats";
     public static final String VERBOSE_OPTIMIZER_INFO_ENABLED = "verbose_optimizer_info_enabled";
     public static final String VERBOSE_OPTIMIZER_RESULTS = "verbose_optimizer_results";
     public static final String STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED = "streaming_for_partial_aggregation_enabled";
@@ -1300,6 +1301,11 @@ public final class SystemSessionProperties
                         VERBOSE_RUNTIME_STATS_ENABLED,
                         "Enable logging all runtime stats",
                         featuresConfig.isVerboseRuntimeStatsEnabled(),
+                        false),
+                stringProperty(
+                        OPTIMIZERS_TO_ENABLE_VERBOSE_RUNTIME_STATS,
+                        "Optimizers to enable verbose runtime stats",
+                        "",
                         false),
                 booleanProperty(
                         VERBOSE_OPTIMIZER_INFO_ENABLED,
@@ -2521,6 +2527,11 @@ public final class SystemSessionProperties
     public static boolean isVerboseRuntimeStatsEnabled(Session session)
     {
         return session.getSystemProperty(VERBOSE_RUNTIME_STATS_ENABLED, Boolean.class);
+    }
+
+    public static String getOptimizersToEnableVerboseRuntimeStats(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZERS_TO_ENABLE_VERBOSE_RUNTIME_STATS, String.class);
     }
 
     public static boolean isVerboseOptimizerResults(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -51,6 +51,7 @@ import com.facebook.presto.split.CloseableSplitSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.Optimizer;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.CanonicalPlanWithInfo;
 import com.facebook.presto.sql.planner.InputExtractor;
 import com.facebook.presto.sql.planner.OutputExtractor;
 import com.facebook.presto.sql.planner.PartitioningHandle;
@@ -86,6 +87,7 @@ import static com.facebook.presto.SystemSessionProperties.isLogInvokedFunctionNa
 import static com.facebook.presto.SystemSessionProperties.isSpoolingOutputBufferEnabled;
 import static com.facebook.presto.SystemSessionProperties.isUseLegacyScheduler;
 import static com.facebook.presto.common.RuntimeMetricName.FRAGMENT_PLAN_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.GET_CANONICAL_INFO_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.LOGICAL_PLANNER_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZER_TIME_NANOS;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BROADCAST_PARTITION_ID;
@@ -544,7 +546,10 @@ public class SqlQueryExecution
             queryPlan.set(plan);
             stateMachine.setPlanStatsAndCosts(plan.getStatsAndCosts());
             stateMachine.setPlanIdNodeMap(plan.getPlanIdNodeMap());
-            stateMachine.setPlanCanonicalInfo(getCanonicalInfo(getSession(), plan.getRoot(), planCanonicalInfoProvider));
+            List<CanonicalPlanWithInfo> canonicalPlanWithInfos = getSession().getRuntimeStats().profileNanos(
+                    GET_CANONICAL_INFO_TIME_NANOS,
+                    () -> getCanonicalInfo(getSession(), plan.getRoot(), planCanonicalInfoProvider));
+            stateMachine.setPlanCanonicalInfo(canonicalPlanWithInfos);
 
             // extract inputs
             List<Input> inputs = new InputExtractor(metadata, stateMachine.getSession()).extractInputs(plan.getRoot());


### PR DESCRIPTION
## Description
Add session property to specify a list of optimizers to track runtime stats.

## Motivation and Context
Some optimizers can takes longer than others. There is a session property `verbose_runtime_stats_enabled` to track the runtime of individual optimizers. However, it's either ON which enable it for all optimizers and is expensive, or OFF which not tracking any optimizers at all.

In this PR, I add a new session property `optimizers_to_enable_verbose_runtime_stats` which can be used to specify a list of optimizers to enable the runtime track. In addition, I also add profiling for the `getCanonicalInfo` function, as I found this step can be long during my debug.

## Impact
Enable to debug and track individual optimizer latency

## Test Plan
[Tested locally](https://www.internalfb.com/intern/presto/query/?query_id=20230819_170013_00005_pfd9i#runtime_stats) end to end, with `"optimizers_to_enable_verbose_runtime_stats": "HistoricalStatisticsEquivalentPlanMarkingOptimizer"` 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add session property `optimizers_to_enable_verbose_runtime_stats` to enable runtime track for a set of optimizers.
```

