### PR TITLE
Upgrade Prometheus JMX Exporter to 0.20.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN dnf install -y java-11-openjdk less procps python3 \
     && mkdir -p /var/lib/presto/data \
         && mkdir -p /usr/lib/presto/utils \
         # Download jmx prometheus exporter \
-        && curl -o /usr/lib/presto/utils/jmx_prometheus_javaagent-0.16.1.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar
+        && curl -o /usr/lib/presto/utils/jmx_prometheus_javaagent-0.20.0.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar
 
 COPY etc $PRESTO_HOME/etc
 COPY entrypoint.sh /opt


### PR DESCRIPTION
## Description
The PR upgrades Prometheus JMX Exporter version to 0.20.0 in the docker image.

## Motivation and Context
The change is needed to be able to use new features of jmx exporter and address [CVE-2022-1471](https://github.com/advisories/GHSA-mjmj-j48q-9wg2) issue.

## Impact
None

## Test Plan
Existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

