### PR TITLE
[native] Add e2e test for poisson_cdf scalar function

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
@@ -17,6 +17,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createSupplier;
 
@@ -29,6 +30,7 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
         QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
         createNation(queryRunner);
         createSupplier(queryRunner);
+        createLineitem(queryRunner);
     }
 
     @Test
@@ -106,5 +108,11 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
         assertQuery("SELECT laplace_cdf(acctbal, 0.0, 1.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
         assertQuery("SELECT laplace_cdf(1.0, acctbal, 1.5) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
         assertQuery("SELECT laplace_cdf(11.0, -1.0, acctbal) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+    }
+
+    @Test
+    public void testPoissonCDF()
+    {
+        assertQuery("SELECT poisson_cdf(quantity, linenumber) FROM lineitem WHERE quantity > 0 AND linenumber >= 0");
     }
 }


### PR DESCRIPTION
## Description

This PR adds e2e testing for the scalar function poisson_cdf. (Delivered via https://github.com/facebookincubator/velox/pull/4862)
Fixes https://github.com/prestodb/presto/issues/20591
```
== NO RELEASE NOTE ==
```

