### PR TITLE
Fix EXPLAIN(TYPE VALIDATE) of EXPLAIN queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
@@ -90,7 +90,7 @@ final class ExplainRewrite
                 throws SemanticException
         {
             if (isTypeValidate(node)) {
-                return node.getStatement();
+                return process(node.getStatement());
             }
 
             if (node.isAnalyze()) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2561,6 +2561,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testExplainValidateOfExplain()
+    {
+        String query = "EXPLAIN SELECT 1";
+        MaterializedResult result = computeActual("EXPLAIN (TYPE VALIDATE) " + query);
+        assertEquals(result.getOnlyValue(), true);
+    }
+
+    @Test
     public void testExplainDdl()
     {
         assertExplainDdl("CREATE TABLE foo (pk bigint)", "CREATE TABLE foo");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Previously queries like `EXPLAIN (TYPE VALIDATE) EXPLAIN (TYPE IO) SELECT 1`  would fail with the error "Non analyze explain should be rewritten to Query". This adds proper support for such queries.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Previously queries like `EXPLAIN (TYPE VALIDATE) EXPLAIN (TYPE IO) SELECT 1`  would fail with the error "Non analyze explain should be rewritten to Query".  However, other types of EXPLAIN queries support explaining EXPLAIN queries.

## Impact
Queries like `EXPLAIN (TYPE VALIDATE) EXPLAIN (TYPE IO) SELECT 1` will now be supported

## Test Plan
New unit test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for ``EXPLAIN (TYPE VALIDATE)`` of ``EXPLAIN`` queries. Previously such queries would fail with an error.
```

