### PR TITLE
Fix suspected flaky test due to static ThriftCodecManager variable

### DIFF
--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/HistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/HistoricalStatisticsSerde.java
@@ -34,7 +34,7 @@ public class HistoricalStatisticsSerde
         implements RedisCodec<String, HistoricalPlanStatistics>
 {
     private static final int ESTIMATED_BUFFER_SIZE_BYTES = 100 * 1024;
-    private static final ThriftCodecManager thriftCodecManager = new ThriftCodecManager();
+    private final ThriftCodecManager thriftCodecManager = new ThriftCodecManager();
 
     @Override
     public String decodeKey(ByteBuffer bytes)

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
@@ -25,12 +25,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class TestHistoricalStatisticsSerde
 {
     @Test
-    public void TestSimpleHistoricalStatisticsEncoderDecoder()
+    public void testSimpleHistoricalStatisticsEncoderDecoder()
     {
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
                 new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
@@ -43,11 +45,11 @@ public class TestHistoricalStatisticsSerde
 
         // Test Plan Statistics
         ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
-        historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics);
+        assertEquals(historicalStatisticsEncoderDecoder.decodeValue(encodedValue), samplePlanStatistics);
     }
 
     @Test
-    public void TestHistoricalPlanStatisticsEntryList()
+    public void testHistoricalPlanStatisticsEntryList()
     {
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
@@ -59,22 +61,22 @@ public class TestHistoricalStatisticsSerde
 
         // Test Plan Statistics
         ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
-        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics)) : "Decoded value is different from original encoded value ";
+        assertEquals(historicalStatisticsEncoderDecoder.decodeValue(encodedValue), samplePlanStatistics, "Decoded value is different from original encoded value ");
     }
 
     @Test
-    public void TestHistoricalPlanStatisticsEmptyList()
+    public void testHistoricalPlanStatisticsEmptyList()
     {
         HistoricalPlanStatistics emptySamplePlanStatistics = new HistoricalPlanStatistics(emptyList());
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
 
         // Test Plan Statistics
         ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(emptySamplePlanStatistics);
-        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(emptySamplePlanStatistics)) : "Decoded value is different from original encoded value ";
+        assertEquals(historicalStatisticsEncoderDecoder.decodeValue(encodedValue), emptySamplePlanStatistics, "Decoded value is different from original encoded value ");
     }
 
     @Test
-    public void TestPlanStatisticsList()
+    public void testPlanStatisticsList()
     {
         List<PlanStatistics> planStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
@@ -90,18 +92,19 @@ public class TestHistoricalStatisticsSerde
 
         // Test Plan Statistics
         ByteBuffer encodedValue = historicalStatisticsEncoderDecoder.encodeValue(samplePlanStatistics);
-        assert (historicalStatisticsEncoderDecoder.decodeValue(encodedValue).equals(samplePlanStatistics)) : "Decoded value is different from original encoded value ";
+        assertEquals(historicalStatisticsEncoderDecoder.decodeValue(encodedValue), samplePlanStatistics, "Decoded value is different from original encoded value ");
     }
 
     @Test
-    public void TestHistoricalStatisticsDecodeValueException()
+    public void testHistoricalStatisticsDecodeValueException()
     {
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
 
         // Test PlanHash
         ByteBuffer encodedKey = historicalStatisticsEncoderDecoder.encodeKey("test");
-        assertThrows(
+        RuntimeException exception = expectThrows(
                 RuntimeException.class,
                 () -> historicalStatisticsEncoderDecoder.decodeValue(encodedKey));
+        assertTrue(exception.getMessage().contains("Invalid thrift object"));
     }
 }


### PR DESCRIPTION
## Description
Flaky test [issue](https://github.com/prestodb/presto/issues/20620)
Some other thriftcodecmanagers were not static - [link](https://github.com/prestodb/presto/blob/09c15eb190a66e8924a97e5d806703bf40939b7f/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataUpdateHandleThriftSerde.java#L33).

Could not test the flaky test even after 1000 runs but the stack trace suggests that the ThriftCodecManager could have caused some extremely low probabilistic concurrency issue in tests.

- Made ThriftCodecManager non-static (Please not in production this will still be used in a multithreaded fashion)
- Clean up naming and assertions in TestHistoricalStatisticsSerde 
- Explicitly close the RedisClient and test redis server in TestHistoryBasedRedisStatisticsTracking to avoid future flaky test

== RELEASE NOTES ==

== NO RELEASE NOTE ==

