### PR TITLE
[native-pos]Fix and update memory related configs

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
@@ -32,9 +32,9 @@ public class NativeExecutionVeloxConfig
 
     private boolean codegenEnabled;
     private boolean spillEnabled = true;
-    private boolean aggregationSpillEnabled;
-    private boolean joinSpillEnabled;
-    private boolean orderBySpillEnabled;
+    private boolean aggregationSpillEnabled = true;
+    private boolean joinSpillEnabled = true;
+    private boolean orderBySpillEnabled = true;
 
     public Map<String, String> getAllProperties()
     {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -40,17 +40,17 @@ public class TestNativeExecutionSystemConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(NativeExecutionVeloxConfig.class)
                 .setCodegenEnabled(false)
                 .setSpillEnabled(true)
-                .setAggregationSpillEnabled(false)
-                .setJoinSpillEnabled(false)
-                .setOrderBySpillEnabled(false));
+                .setAggregationSpillEnabled(true)
+                .setJoinSpillEnabled(true)
+                .setOrderBySpillEnabled(true));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionVeloxConfig expected = new NativeExecutionVeloxConfig()
                 .setCodegenEnabled(true)
                 .setSpillEnabled(false)
-                .setAggregationSpillEnabled(true)
-                .setJoinSpillEnabled(true)
-                .setOrderBySpillEnabled(true);
+                .setAggregationSpillEnabled(false)
+                .setJoinSpillEnabled(false)
+                .setOrderBySpillEnabled(false);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }
@@ -74,12 +74,12 @@ public class TestNativeExecutionSystemConfig
                 .setNumIoThreads(30)
                 .setShutdownOnsetSec(10)
                 .setSystemMemoryGb(10)
-                .setQueryMemoryGb(new DataSize(10, DataSize.Unit.GIGABYTE))
+                .setQueryMemoryGb(new DataSize(8, DataSize.Unit.GIGABYTE))
                 .setUseMmapAllocator(true)
-                .setMemoryArbitratorKind("")
-                .setMemoryPoolInitCapacity(10 << 30)
-                .setMemoryPoolTransferCapacity(512 << 20)
-                .setReservedMemoryPoolCapacityPct(10)
+                .setMemoryArbitratorKind("SHARED")
+                .setMemoryArbitratorCapacityGb(8)
+                .setMemoryPoolInitCapacity(8L << 30)
+                .setMemoryPoolTransferCapacity(2L << 30)
                 .setSpillerSpillPath("")
                 .setConcurrentLifespansPerTask(5)
                 .setMaxDriversPerTask(15)
@@ -108,10 +108,10 @@ public class TestNativeExecutionSystemConfig
                 .setSystemMemoryGb(40)
                 .setQueryMemoryGb(new DataSize(20, DataSize.Unit.GIGABYTE))
                 .setUseMmapAllocator(false)
-                .setMemoryArbitratorKind("SHARED")
-                .setMemoryPoolInitCapacity(32 << 20)
-                .setMemoryPoolTransferCapacity(32 << 20)
-                .setReservedMemoryPoolCapacityPct(20)
+                .setMemoryArbitratorKind("")
+                .setMemoryArbitratorCapacityGb(10)
+                .setMemoryPoolInitCapacity(7L << 30)
+                .setMemoryPoolTransferCapacity(1L << 30)
                 .setSpillerSpillPath("dummy.spill.path")
                 .setMaxDriversPerTask(30)
                 .setShuffleName("custom")


### PR DESCRIPTION
- Set to use shared arbitrator and turn on disk spilling option by default
- Fix a memory arbitration related config integer overflow issue in that cause
   presto cpp server crash
- Simplify the memory related config management
- Add to configure query memory capacity system config in Presto-on-Spark
   which just uses the per-query memory limit as there is only one query to run
   at a time.
- Update the default per-query memory limit in Preso-on-Spark setting with
  2GB reserved from default system memory limit (10GB) for system operation
   memory usage

Followup creates config doc for Prestissimo

```
== NO RELEASE NOTE ==
```

