### PR TITLE
Add heartbeat manager

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -29,7 +29,9 @@ add_library(
   ServerOperation.cpp
   SignalHandler.cpp
   TaskManager.cpp
-  TaskResource.cpp)
+  TaskResource.cpp
+  PeriodicHeartbeatManager.cpp
+  PeriodicServiceInventoryManager.cpp)
 
 add_dependencies(presto_server_lib presto_operators presto_protocol
                  presto_types presto_thrift-cpp2 presto_thrift_extra)

--- a/presto-native-execution/presto_cpp/main/CoordinatorDiscoverer.h
+++ b/presto-native-execution/presto_cpp/main/CoordinatorDiscoverer.h
@@ -18,6 +18,8 @@
 
 namespace facebook::presto {
 
+// TODO: Rename to ServiceDiscoverer as this may talk to either
+// Coordinator or Resource Manager.
 class CoordinatorDiscoverer {
  public:
   virtual ~CoordinatorDiscoverer() = default;

--- a/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/PeriodicHeartbeatManager.h"
+#include <velox/common/memory/Memory.h>
+
+namespace facebook::presto {
+PeriodicHeartbeatManager::PeriodicHeartbeatManager(
+    const std::string& address,
+    int port,
+    const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
+    const std::string& clientCertAndKeyPath,
+    const std::string& ciphers,
+    std::function<protocol::NodeStatus()> nodeStatusFetcher,
+    uint64_t frequencyMs)
+    : PeriodicServiceInventoryManager(
+          address,
+          port,
+          coordinatorDiscoverer,
+          clientCertAndKeyPath,
+          ciphers,
+          "Heartbeat",
+          frequencyMs),
+      nodeStatusFetcher_(std::move(nodeStatusFetcher)) {}
+
+std::tuple<proxygen::HTTPMessage, std::string>
+PeriodicHeartbeatManager::httpRequest() {
+  nlohmann::json j;
+  to_json(j, nodeStatusFetcher_());
+  std::string body = j.dump();
+  proxygen::HTTPMessage request;
+  request.setMethod(proxygen::HTTPMethod::PUT);
+  request.setURL("/v1/heartbeat");
+  request.getHeaders().set(
+      proxygen::HTTP_HEADER_HOST, fmt::format("{}:{}", address_, port_));
+  request.getHeaders().set(
+      proxygen::HTTP_HEADER_CONTENT_TYPE, "application/json");
+  request.getHeaders().set(
+      proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));
+  return {request, body};
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/PeriodicServiceInventoryManager.h"
+#include <folly/futures/Retrying.h>
+#include <velox/common/memory/Memory.h>
+
+namespace facebook::presto {
+PeriodicServiceInventoryManager::PeriodicServiceInventoryManager(
+    std::string address,
+    int port,
+    std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer,
+    std::string clientCertAndKeyPath,
+    std::string ciphers,
+    std::string id,
+    uint64_t frequencyMs)
+    : address_(std::move(address)),
+      port_(port),
+      coordinatorDiscoverer_(std::move(coordinatorDiscoverer)),
+      clientCertAndKeyPath_(std::move(clientCertAndKeyPath)),
+      ciphers_(std::move(ciphers)),
+      id_(std::move(id)),
+      frequencyMs_(frequencyMs),
+      pool_(velox::memory::addDefaultLeafMemoryPool(id_)),
+      eventBaseThread_(false /*autostart*/) {}
+
+void PeriodicServiceInventoryManager::start() {
+  eventBaseThread_.start(id_);
+  stopped_ = false;
+  auto* eventBase = eventBaseThread_.getEventBase();
+  eventBase->runOnDestruction([this] { client_.reset(); });
+  eventBase->schedule([this]() { return sendRequest(); });
+}
+
+void PeriodicServiceInventoryManager::stop() {
+  stopped_ = true;
+  eventBaseThread_.stop();
+}
+
+void PeriodicServiceInventoryManager::sendRequest() {
+  // stop() calls EventBase's destructor which executed all pending callbacks;
+  // make sure not to do anything if that's the case
+  if (stopped_) {
+    return;
+  }
+
+  try {
+    folly::SocketAddress newAddress = coordinatorDiscoverer_->getAddress();
+    // Update service address after `updateServiceTimes()` attempts.
+    if (updateServiceTimes() > 0 && (attempts_++) % updateServiceTimes() == 0) {
+      newAddress = coordinatorDiscoverer_->updateAddress();
+    }
+    if (newAddress != serviceAddress_) {
+      LOG(INFO) << "Service Inventory changed to " << newAddress.getAddressStr()
+                << ":" << newAddress.getPort();
+      std::swap(serviceAddress_, newAddress);
+      client_ = std::make_shared<http::HttpClient>(
+          eventBaseThread_.getEventBase(),
+          serviceAddress_,
+          std::chrono::milliseconds(10'000),
+          pool_,
+          clientCertAndKeyPath_,
+          ciphers_);
+    }
+  } catch (const std::exception& ex) {
+    LOG(WARNING) << "Error occurred during updating service address: "
+                 << ex.what();
+    scheduleNext();
+    return;
+  }
+
+  auto [request, body] = httpRequest();
+
+  client_->sendRequest(request, body)
+      .via(eventBaseThread_.getEventBase())
+      .thenValue([this](auto response) {
+        auto message = response->headers();
+        if (message->getStatusCode() != http::kHttpAccepted ||
+            message->getStatusCode() != http::kHttpNoContent) {
+          ++failedAttempts_;
+          LOG(WARNING) << id_ << " failed: HTTP " << message->getStatusCode()
+                       << " - " << response->dumpBodyChain();
+        } else if (response->hasError()) {
+          ++failedAttempts_;
+          LOG(ERROR) << id_ << " failed: " << response->error();
+        } else {
+          failedAttempts_ = 0;
+          LOG(INFO) << id_ << " succeeded: HTTP " << message->getStatusCode();
+        }
+      })
+      .thenError(
+          folly::tag_t<std::exception>{},
+          [this](const std::exception& e) {
+            ++failedAttempts_;
+            LOG(WARNING) << id_ << " failed: " << e.what();
+          })
+      .thenTry([this](auto /*unused*/) { scheduleNext(); });
+}
+
+uint64_t PeriodicServiceInventoryManager::getDelayMs() {
+  if (failedAttempts_ > 0 && retryFailed()) {
+    // For failure cases, execute exponential back off to ping
+    // coordinator with max back off time cap at 'frequencyMs_'.
+    auto rng = folly::ThreadLocalPRNG();
+    return folly::futures::detail::retryingJitteredExponentialBackoffDur(
+               failedAttempts_,
+               std::chrono::milliseconds(50),
+               std::chrono::milliseconds(frequencyMs_),
+               backOffjitterParam_,
+               rng)
+        .count();
+  }
+
+  // Adds some jitter for successful cases so that all workers does not ping
+  // coordinator at the same time
+  return frequencyMs_ - folly::Random::rand32(frequencyMs_ / 10);
+}
+
+void PeriodicServiceInventoryManager::scheduleNext() {
+  if (stopped_) {
+    return;
+  }
+  eventBaseThread_.getEventBase()->scheduleAt(
+      [this]() { return sendRequest(); },
+      std::chrono::steady_clock::now() +
+          std::chrono::milliseconds(getDelayMs()));
+}
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/io/async/EventBaseThread.h>
+#include <presto_cpp/main/http/HttpClient.h>
+#include "presto_cpp/main/CoordinatorDiscoverer.h"
+
+namespace facebook::presto {
+
+class PeriodicServiceInventoryManager {
+ public:
+  PeriodicServiceInventoryManager(
+      std::string address,
+      int port,
+      std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer,
+      std::string clientCertAndKeyPath,
+      std::string ciphers,
+      std::string id,
+      uint64_t frequencyMs);
+
+  void start();
+
+  void stop();
+
+ protected:
+  // Denotes whether we retry failed requests due to network errors.
+  virtual bool retryFailed() {
+    return true;
+  }
+
+  // For every N requests, we update the service address. This might be
+  // needed for cases where we need to send requests so often that we cannot
+  // affort to update service each time.
+  virtual int updateServiceTimes() {
+    return 1;
+  }
+
+  virtual std::tuple<proxygen::HTTPMessage, std::string> httpRequest() = 0;
+
+  void sendRequest();
+
+  void scheduleNext();
+
+  uint64_t getDelayMs();
+
+  const std::string address_;
+  const int port_;
+  const std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
+  const std::string clientCertAndKeyPath_;
+  const std::string ciphers_;
+  const std::string id_;
+  const uint64_t frequencyMs_;
+  const std::shared_ptr<velox::memory::MemoryPool> pool_;
+  /// jitter value for backoff delay time in case of failure
+  const double backOffjitterParam_{0.1};
+
+  folly::EventBaseThread eventBaseThread_;
+  folly::SocketAddress serviceAddress_;
+  std::shared_ptr<http::HttpClient> client_;
+  std::atomic_bool stopped_{true};
+  uint64_t failedAttempts_{0};
+  uint64_t attempts_{0};
+};
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -203,11 +203,22 @@ void PrestoServer::run() {
         nodeId_,
         nodeLocation_,
         catalogNames,
-        systemConfig->announcementMinFrequencyMs(),
         systemConfig->announcementMaxFrequencyMs(),
         clientCertAndKeyPath,
         ciphers);
     announcer_->start();
+    uint64_t heartbeatFrequencyMs = systemConfig->heartbeatFrequencyMs();
+    if (heartbeatFrequencyMs > 0) {
+      heartbeatManager_ = std::make_unique<PeriodicHeartbeatManager>(
+          address_,
+          httpsPort.has_value() ? httpsPort.value() : httpPort,
+          coordinatorDiscoverer_,
+          clientCertAndKeyPath,
+          ciphers,
+          [server = this]() { return server->fetchNodeStatus(); },
+          heartbeatFrequencyMs);
+      heartbeatManager_->start();
+    }
   }
 
   const bool reusePort = SystemConfig::instance()->httpServerReusePort();
@@ -393,6 +404,12 @@ void PrestoServer::run() {
     PRESTO_SHUTDOWN_LOG(INFO) << "Stopping announcer";
     announcer_->stop();
   }
+
+  if (heartbeatManager_ != nullptr) {
+    PRESTO_SHUTDOWN_LOG(INFO) << "Stopping Heartbeat manager";
+    heartbeatManager_->stop();
+  }
+
   PRESTO_SHUTDOWN_LOG(INFO) << "Stopping all periodic tasks...";
   periodicTaskManager_->stop();
 
@@ -861,6 +878,10 @@ void PrestoServer::reportServerInfo(proxygen::ResponseHandler* downstream) {
 }
 
 void PrestoServer::reportNodeStatus(proxygen::ResponseHandler* downstream) {
+  http::sendOkResponse(downstream, json(fetchNodeStatus()));
+}
+
+protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   auto systemConfig = SystemConfig::instance();
   const int64_t nodeMemoryGb = systemConfig->systemMemoryGb();
 
@@ -881,11 +902,11 @@ void PrestoServer::reportNodeStatus(proxygen::ResponseHandler* downstream) {
       (int)std::thread::hardware_concurrency(),
       cpuLoadPct,
       cpuLoadPct,
-      pool_->currentBytes(),
+      pool_ ? pool_->currentBytes() : 0,
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed};
 
-  http::sendOkResponse(downstream, json(nodeStatus));
+  return nodeStatus;
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -21,6 +21,7 @@
 #include <velox/expression/Expr.h>
 #include "presto_cpp/main/CPUMon.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
+#include "presto_cpp/main/PeriodicHeartbeatManager.h"
 #include "presto_cpp/main/PrestoServerOperations.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
@@ -152,6 +153,8 @@ class PrestoServer {
 
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
+  protocol::NodeStatus fetchNodeStatus();
+
   void populateMemAndCPUInfo();
 
   // Periodically yield tasks if there are tasks queued.
@@ -179,6 +182,7 @@ class PrestoServer {
   std::unique_ptr<http::HttpServer> httpServer_;
   std::unique_ptr<SignalHandler> signalHandler_;
   std::unique_ptr<Announcer> announcer_;
+  std::unique_ptr<PeriodicHeartbeatManager> heartbeatManager_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<TaskManager> taskManager_;
   std::unique_ptr<TaskResource> taskResource_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -271,8 +271,8 @@ SystemConfig::SystemConfig() {
           STR_PROP(kSkipRuntimeStatsInRunningTaskInfo, "true"),
           STR_PROP(kLogZombieTaskInfo, "false"),
           NUM_PROP(kLogNumZombieTasks, 20),
-          NUM_PROP(kAnnouncementMinFrequencyMs, 25'000), // 25s
-          NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 35s
+          NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 30s
+          NUM_PROP(kHeartbeatFrequencyMs, 0),
           STR_PROP(kExchangeMaxErrorDuration, "30s"),
           STR_PROP(kExchangeRequestTimeout, "10s"),
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
@@ -530,12 +530,12 @@ uint32_t SystemConfig::logNumZombieTasks() const {
   return optionalProperty<uint32_t>(kLogNumZombieTasks).value();
 }
 
-uint64_t SystemConfig::announcementMinFrequencyMs() const {
-  return optionalProperty<uint64_t>(kAnnouncementMinFrequencyMs).value();
-}
-
 uint64_t SystemConfig::announcementMaxFrequencyMs() const {
   return optionalProperty<uint64_t>(kAnnouncementMaxFrequencyMs).value();
+}
+
+uint64_t SystemConfig::heartbeatFrequencyMs() const {
+  return optionalProperty<uint64_t>(kHeartbeatFrequencyMs).value();
 }
 
 std::chrono::duration<double> SystemConfig::exchangeMaxErrorDuration() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -275,11 +275,13 @@ class SystemConfig : public ConfigBase {
   /// cleanup.
   static constexpr std::string_view kOldTaskCleanUpMs{"old-task-cleanup-ms"};
 
-  static constexpr std::string_view kAnnouncementMinFrequencyMs{
-      "announcement-min-frequency-ms"};
-
   static constexpr std::string_view kAnnouncementMaxFrequencyMs{
       "announcement-max-frequency-ms"};
+
+  /// Time (ms) after which we periodically send heartbeats to discovery
+  /// endpoint.
+  static constexpr std::string_view kHeartbeatFrequencyMs{
+      "heartbeat-frequency-ms"};
 
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
@@ -446,9 +448,9 @@ class SystemConfig : public ConfigBase {
 
   uint32_t logNumZombieTasks() const;
 
-  uint64_t announcementMinFrequencyMs() const;
-
   uint64_t announcementMaxFrequencyMs() const;
+
+  uint64_t heartbeatFrequencyMs() const;
 
   std::chrono::duration<double> exchangeMaxErrorDuration() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -165,7 +165,6 @@ TEST_P(AnnouncerTestSuite, basic) {
       "test-node",
       "test-node-location",
       {"hive", "tpch"},
-      100 /*milliseconds*/,
       500 /*milliseconds*/,
       keyPath,
       ciphers);


### PR DESCRIPTION
## Description
Add a hearbeat manager in C++ which sends regular heartbeats to presto server. This is needed when we use multi coordinator setup.

Extracted common changes from Announcer and HeartbeatManager into PeriodicServiceInventoryManager. Similar naming scheme is used in Java.

Also removed announcement-min-frequency-ms. Name of the config suggests we can make announcements with this frequency - but that is not the case. This is simply a minimum time we wait before retrying failed requests - which can be a in-code constant - as many other libraries do.

Added a config for heartbeat sending.

## Test Plan
Ran changes in a test cluster

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

