### PR TITLE
[native] Ensure openssl@1.1 is being picked up.

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -116,7 +116,6 @@ find_package(
   system
   date_time
   atomic)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(gflags COMPONENTS shared)
 
@@ -160,8 +159,26 @@ endif()
 include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 # Include third party header files
-find_path(OPT_OPENSSL_DIR NAMES opt/openssl@1.1)
-set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl@1.1")
+
+# Find openssl@1.1 folder.
+if(NOT DEFINED OPENSSL_ROOT_DIR)
+  find_path(OPT_OPENSSL_DIR NAMES opt/openssl@1.1)
+  if(NOT ${OPT_OPENSSL_DIR} STREQUAL "OPT_OPENSSL_DIR-NOTFOUND")
+    set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl@1.1")
+  else()
+    find_path(OPT_OPENSSL_DIR NAMES ../opt/openssl@1.1)
+    if(NOT ${OPT_OPENSSL_DIR} STREQUAL "OPT_OPENSSL_DIR-NOTFOUND")
+      set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/../opt/openssl@1.1")
+    endif()
+  endif()
+endif()
+if(NOT DEFINED OPENSSL_ROOT_DIR)
+  message(
+    WARNING
+      "'OPENSSL_ROOT_DIR' is not defined. Issues are possible with finding and linking to openssl@1.1."
+  )
+endif()
+include_directories(SYSTEM ${OPENSSL_ROOT_DIR}/include)
 find_package(OpenSSL REQUIRED)
 
 find_library(LIBSODIUM_LIBRARY NAMES sodium)
@@ -190,6 +207,8 @@ include_directories(${CMAKE_BINARY_DIR})
 
 # set this for backwards compatibility, will be overwritten in velox/
 set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
+
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 add_subdirectory(velox)
 


### PR DESCRIPTION
## Description
Many people are having issues with setting up native build when having openssl@1 and openssl@3 installed.
This change modifies the cmake file, so you have have both versions installed:
- Add openssl@1 include directory BEFORE we add boost include directory, which happens to be "/Users/<username>/homebrew/include" and causes headers of openssl@3 being used instead of openssl@1.
- Search for "opt/openssl@1.1" twice, the 2nd time with "../", because on my system only "/Users/<username>/homebrew/bin" and "/Users/<username>/homebrew/sbin" are in the $path, but not "/Users/<username>/homebrew/".

## Motivation and Context
Many people are having issues with setting up native build when having openssl@1 and openssl@3 installed.

## Test Plan
Tested locally on my M1 laptop, which took lots of time to setup.
Now it works fine.

```
== NO RELEASE NOTE ==
```

