### PR TITLE
Add support for memoizing the cluster stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
@@ -17,10 +17,12 @@ import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.server.BasicQueryInfo;
-import com.facebook.presto.server.ClusterStatsResource;
+import com.facebook.presto.server.ClusterStatsResource.ClusterStats;
+import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
+import io.airlift.units.Duration;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
@@ -31,11 +33,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Path("/v1/cluster")
@@ -45,18 +50,30 @@ public class DistributedClusterStatsResource
     private final boolean isIncludeCoordinator;
     private final ResourceManagerClusterStateProvider clusterStateProvider;
     private final InternalNodeManager internalNodeManager;
+    private final Supplier<ClusterStats> clusterStatsSupplier;
 
     @Inject
-    public DistributedClusterStatsResource(NodeSchedulerConfig nodeSchedulerConfig, ResourceManagerClusterStateProvider clusterStateProvider, InternalNodeManager internalNodeManager)
+    public DistributedClusterStatsResource(
+            NodeSchedulerConfig nodeSchedulerConfig,
+            ServerConfig serverConfig,
+            ResourceManagerClusterStateProvider clusterStateProvider,
+            InternalNodeManager internalNodeManager)
     {
         this.isIncludeCoordinator = requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator();
         this.clusterStateProvider = requireNonNull(clusterStateProvider, "nodeStateManager is null");
         this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        Duration expirationDuration = requireNonNull(serverConfig, "serverConfig is null").getClusterStatsExpirationDuration();
+        this.clusterStatsSupplier = expirationDuration.getValue() > 0 ? memoizeWithExpiration(this::calculateClusterStats, expirationDuration.toMillis(), MILLISECONDS) : this::calculateClusterStats;
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getClusterStats()
+    {
+        return Response.ok(clusterStatsSupplier.get()).build();
+    }
+
+    private ClusterStats calculateClusterStats()
     {
         long runningQueries = 0;
         long blockedQueries = 0;
@@ -99,7 +116,7 @@ public class DistributedClusterStatsResource
                 runningTasks += query.getQueryStats().getRunningTasks();
             }
         }
-        return Response.ok(new ClusterStatsResource.ClusterStats(
+        return new ClusterStats(
                 runningQueries,
                 blockedQueries,
                 queuedQueries,
@@ -110,8 +127,7 @@ public class DistributedClusterStatsResource
                 totalInputRows,
                 totalInputBytes,
                 totalCpuTimeSecs,
-                clusterStateProvider.getAdjustedQueueSize()))
-                .build();
+                clusterStateProvider.getAdjustedQueueSize());
     }
 
     @GET

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -20,6 +20,7 @@ import io.airlift.units.Duration;
 import javax.validation.constraints.NotNull;
 
 import static com.facebook.presto.spi.NodePoolType.DEFAULT;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ServerConfig
@@ -37,6 +38,7 @@ public class ServerConfig
     private boolean enhancedErrorReporting = true;
     private boolean queryResultsCompressionEnabled = true;
     private NodePoolType poolType = DEFAULT;
+    private Duration clusterStatsExpirationDuration = new Duration(0, MILLISECONDS);
 
     public boolean isResourceManager()
     {
@@ -185,6 +187,18 @@ public class ServerConfig
     public ServerConfig setPoolType(NodePoolType poolType)
     {
         this.poolType = poolType;
+        return this;
+    }
+
+    public Duration getClusterStatsExpirationDuration()
+    {
+        return clusterStatsExpirationDuration;
+    }
+
+    @Config("cluster-stats-expiration-duration")
+    public ServerConfig setClusterStatsExpirationDuration(Duration clusterStatsExpirationDuration)
+    {
+        this.clusterStatsExpirationDuration = clusterStatsExpirationDuration;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -24,7 +24,9 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.presto.spi.NodePoolType.DEFAULT;
 import static com.facebook.presto.spi.NodePoolType.LEAF;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestServerConfig
 {
@@ -43,7 +45,8 @@ public class TestServerConfig
                 .setResourceManager(false)
                 .setCatalogServer(false)
                 .setCatalogServerEnabled(false)
-                .setPoolType(DEFAULT));
+                .setPoolType(DEFAULT)
+                .setClusterStatsExpirationDuration(new Duration(0, MILLISECONDS)));
     }
 
     @Test
@@ -62,6 +65,7 @@ public class TestServerConfig
                 .put("catalog-server-enabled", "true")
                 .put("catalog-server", "true")
                 .put("pool-type", "LEAF")
+                .put("cluster-stats-expiration-duration", "10s")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -76,7 +80,8 @@ public class TestServerConfig
                 .setResourceManager(true)
                 .setCatalogServer(true)
                 .setCatalogServerEnabled(true)
-                .setPoolType(LEAF);
+                .setPoolType(LEAF)
+                .setClusterStatsExpirationDuration(new Duration(10, SECONDS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
This PR adds support for memoizing in the clusterStats endpoint. This will help not overwhelm the coordinator when there are a high number of services that are polling these clusterStats from the coordinator

## Motivation and Context
This will help solve the issue of contention in coordinator when high number of services poll the clusterStats endpoint on coordinator.

## Impact
Less contention on coordinator from clusterStats endpoint

## Test Plan
existing tests

```
== RELEASE NOTES ==

General Changes
* Add support for memoizing in cluster stats endpoint. This can be enabled by setting `cluster-stats-cache-expiration-duration` to a non-zero duration.
```

