### PR TITLE
[native] Don't aquire taskMap lock when operting on prestoTask

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -170,11 +170,6 @@ class TaskManager {
       const protocol::TaskId& taskId,
       long startProcessCpuTime = 0);
 
-  std::shared_ptr<PrestoTask> findOrCreateTaskLocked(
-      TaskMap& taskMap,
-      const protocol::TaskId& taskId,
-      long startProcessCpuTime = 0);
-
   std::string baseUri_;
   std::string nodeId_;
   std::string baseSpillDir_;


### PR DESCRIPTION
taskMap_ is accessed by each io request and we better not lock it for potentially long time. This PR decouples locking for taskMap_ and prestoTask so that lock waiting on prestoTask does not block taskMap_'s lock. It removes the findOrCreateLocked() method and make findOrCreate() the only impl that acquires the taskMap_ lock only when it's needed.
```
== NO RELEASE NOTE ==
```

