### PR TITLE
Add DWRF to min, max filtering for special column types

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5372,6 +5372,95 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testPartialAggregatePushdownDWRF()
+    {
+        @Language("SQL") String createTable = "" +
+                "CREATE TABLE test_dwrf_table (" +
+                " _boolean BOOLEAN" +
+                ", _tinyint TINYINT" +
+                ", _smallint SMALLINT" +
+                ", _integer INTEGER" +
+                ", _bigint BIGINT" +
+                ", _real REAL" +
+                ", _double DOUBLE" +
+                ", _string VARCHAR" +
+                ", _varchar VARCHAR(10)" +
+                ", _varbinary VARBINARY" +
+                ", _timestamp TIMESTAMP" +
+                ")" +
+                "WITH (format = 'DWRF')";
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "partial_aggregation_pushdown_enabled", "true")
+                .setCatalogSessionProperty(catalog, "partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true")
+                .build();
+        try {
+            assertUpdate(session, createTable);
+
+            TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_dwrf_table");
+            assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), HiveStorageFormat.DWRF);
+
+            assertUpdate(session, "INSERT INTO test_dwrf_table VALUES (" +
+                    "true" +
+                    ", cast(1 as tinyint)" +
+                    ", cast(2 as smallint)" +
+                    ", 3" +
+                    ", 4" +
+                    ", 1.2" +
+                    ", 2.3" +
+                    ", 'abc'" +
+                    ", 'def'" +
+                    ", cast('klm' as varbinary)" +
+                    ", cast('2020-06-04 16:55:40.777' as timestamp)" +
+                    ")", 1);
+
+            assertUpdate(session, "INSERT INTO test_dwrf_table VALUES (" +
+                    "false" +
+                    ", cast(10 as tinyint)" +
+                    ", cast(20 as smallint)" +
+                    ", 30" +
+                    ", 40" +
+                    ", 10.25" +
+                    ", 25.334" +
+                    ", 'foo'" +
+                    ", 'bar'" +
+                    ", cast('qux' as varbinary)" +
+                    ", cast('2020-05-01 18:34:23.88' as timestamp)" +
+                    ")", 1);
+            String rowCount = "SELECT 2";
+
+            assertQuery(session, "SELECT COUNT(*) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_boolean) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_tinyint) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_smallint) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_integer) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_bigint) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_real) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_double) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_string) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_varchar) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_varbinary) FROM test_dwrf_table", rowCount);
+            assertQuery(session, "SELECT COUNT(_timestamp) FROM test_dwrf_table", rowCount);
+
+            assertQuery(session, "SELECT MIN(_boolean), MAX(_boolean) FROM test_dwrf_table", "select false, true");
+            assertQuery(session, "SELECT MIN(_tinyint), MAX(_tinyint) FROM test_dwrf_table", "select 1, 10");
+            assertQuery(session, "SELECT MIN(_smallint), MAX(_smallint) FROM test_dwrf_table", "select 2, 20");
+            assertQuery(session, "SELECT MIN(_integer), MAX(_integer) FROM test_dwrf_table", "select 3, 30");
+            assertQuery(session, "SELECT MIN(_bigint), MAX(_bigint) FROM test_dwrf_table", "select 4, 40");
+            assertQuery(session, "SELECT MIN(_real), MAX(_real) FROM test_dwrf_table", "select 1.2, 10.25");
+            assertQuery(session, "SELECT MIN(_double), MAX(_double) FROM test_dwrf_table", "select 2.3, 25.334");
+            assertQuery(session, "SELECT MIN(_string), MAX(_string) FROM test_dwrf_table", "select 'abc', 'foo'");
+            assertQuery(session, "SELECT MIN(_varchar), MAX(_varchar) FROM test_dwrf_table", "select 'bar', 'def'");
+            assertQuery(session, "SELECT MIN(_varbinary), MAX(_varbinary) FROM test_dwrf_table", "select X'6b6c6d', X'717578'");
+            assertQuery(session, "SELECT MIN(_timestamp), MAX(_timestamp) FROM test_dwrf_table", "select cast('2020-05-01 18:34:23.88' as timestamp), cast('2020-06-04 16:55:40.777' as timestamp)");
+        }
+        finally {
+            assertUpdate(session, "DROP TABLE test_dwrf_table");
+        }
+        assertFalse(getQueryRunner().tableExists(session, "test_dwrf_table"));
+    }
+
+    @Test
     public void testPartialAggregatePushdownParquet()
     {
         @Language("SQL") String createTable = "" +


### PR DESCRIPTION
## Description
Add DWRF to min, max filtering for special column types

## Motivation and Context
It fixes an issue with using min, max functions with partial aggregation push down turned on.
For the TableScanOperator, we write the stats to the block.
see https://github.com/prestodb/presto/blob/c0b38fe9c9e9c1b5b194c359f3f63eeb13c671b8/presto-hive/src/main/java/com/facebook/presto/hive/orc/AggregatedOrcPageSource.java#L116
Since we do not support min, max for special cols such as timestamp we want to skip applying agg push down for these col types.

## Impact
Users will be able to use min, max functions for special col types such as timestamp, with partial aggregation push down turned on without running to errors.

## Test Plan
Failure run without the fix. https://www.internalfb.com/intern/presto/query/?query_id=20230823_005408_00010_vmjkx#stack_trace
```
java.lang.NullPointerException
	at com.facebook.presto.hive.orc.AggregatedOrcPageSource.writeMinMax(AggregatedOrcPageSource.java:158)
	at com.facebook.presto.hive.orc.AggregatedOrcPageSource.getNextPage(AggregatedOrcPageSource.java:116)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:266)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:428)
	at com.facebook.presto.operator.Driver.lambda$processFor$9(Driver.java:311)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:732)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:304)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
```
Successful run with the fix. 
https://www.internalfb.com/intern/presto/query/?query_id=20230823_003537_00015_7a9p4#sql

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.


```
== RELEASE NOTES ==

Hive Changes
* Add DWRF filetype to min, max filtering for special column types such as tinyint, varbinary and timestamp.
```

