### PR TITLE
Add HTTP endpoint for node heartbeat

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
@@ -43,6 +43,7 @@ public class ResourceManagerConfig
     private Duration memoryPoolFetchInterval = new Duration(1, SECONDS);
     private boolean resourceGroupServiceCacheEnabled;
     private Duration resourceGroupServiceCacheExpireInterval = new Duration(10, SECONDS);
+    private boolean heartbeatHttpEnabled;
     private Duration resourceGroupServiceCacheRefreshInterval = new Duration(1, SECONDS);
 
     private Duration runningTaskCountFetchInterval = new Duration(1, SECONDS);
@@ -276,6 +277,18 @@ public class ResourceManagerConfig
     public ResourceManagerConfig setRunningTaskCountFetchInterval(Duration runningTaskCountFetchInterval)
     {
         this.runningTaskCountFetchInterval = runningTaskCountFetchInterval;
+        return this;
+    }
+
+    public boolean getHeartbeatHttpEnabled()
+    {
+        return heartbeatHttpEnabled;
+    }
+
+    @Config("resource-manager.heartbeat-http-enabled")
+    public ResourceManagerConfig setHeartbeatHttpEnabled(boolean heartbeatHttpEnabled)
+    {
+        this.heartbeatHttpEnabled = heartbeatHttpEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
@@ -38,9 +38,11 @@ public class ResourceManagerServer
     private final ListeningExecutorService executor;
 
     @Inject
-    public ResourceManagerServer(ResourceManagerClusterStateProvider clusterStateProvider, @ForResourceManager ListeningExecutorService executor)
+    public ResourceManagerServer(
+            ResourceManagerClusterStateProvider clusterStateProvider,
+            @ForResourceManager ListeningExecutorService executor)
     {
-        this.clusterStateProvider = requireNonNull(clusterStateProvider, "internalNodeManager is null");
+        this.clusterStateProvider = requireNonNull(clusterStateProvider, "clusterStateProvider is null");
         this.executor = executor;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerHeartbeatResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerHeartbeatResource.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.resourcemanager.ForResourceManager;
+import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/v1/heartbeat")
+public class ResourceManagerHeartbeatResource
+{
+    private final ResourceManagerClusterStateProvider clusterStateProvider;
+    private final ListeningExecutorService executor;
+
+    @Inject
+    public ResourceManagerHeartbeatResource(
+            ResourceManagerClusterStateProvider clusterStateProvider,
+            @ForResourceManager ListeningExecutorService executor)
+    {
+        this.clusterStateProvider = requireNonNull(clusterStateProvider, "clusterStateProvider is null");
+        this.executor = executor;
+    }
+
+    /**
+     * Registers a node heartbeat with the resource manager.
+     */
+    @PUT
+    @Consumes(APPLICATION_JSON)
+    public void nodeHeartbeat(NodeStatus nodeStatus)
+    {
+        executor.execute(() -> clusterStateProvider.registerNodeHeartbeat(nodeStatus));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -432,6 +432,11 @@ public class ServerMainModule
                     public void configure(Binder moduleBinder)
                     {
                         configBinder(moduleBinder).bindConfig(ResourceManagerConfig.class);
+                        // HTTP endpoint for some of ResourceManagerServer methods.
+                        ResourceManagerConfig resourceManagerConfig = buildConfigObject(ResourceManagerConfig.class);
+                        if (resourceManagerConfig.getHeartbeatHttpEnabled()) {
+                            jaxrsBinder(moduleBinder).bind(ResourceManagerHeartbeatResource.class);
+                        }
                         moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
                         if (serverConfig.isCoordinator()) {
                             moduleBinder.bind(ClusterMemoryManagerService.class).in(Scopes.SINGLETON);

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
@@ -49,7 +49,8 @@ public class TestResourceManagerConfig
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(1, SECONDS))
                 .setResourceGroupRuntimeHeartbeatInterval(new Duration(1, SECONDS))
                 .setRunningTaskCountFetchInterval(new Duration(1, SECONDS))
-                .setResourceGroupRuntimeInfoTimeout(new Duration(30, SECONDS)));
+                .setResourceGroupRuntimeInfoTimeout(new Duration(30, SECONDS))
+                .setHeartbeatHttpEnabled(false));
     }
 
     @Test
@@ -74,6 +75,7 @@ public class TestResourceManagerConfig
                 .put("resource-manager.resource-group-runtimeinfo-heartbeat-interval", "6m")
                 .put("resource-manager.running-task-count-fetch-interval", "1m")
                 .put("resource-manager.resource-group-runtimeinfo-timeout", "4s")
+                .put("resource-manager.heartbeat-http-enabled", "true")
                 .build();
 
         ResourceManagerConfig expected = new ResourceManagerConfig()
@@ -94,7 +96,8 @@ public class TestResourceManagerConfig
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(10, MINUTES))
                 .setResourceGroupRuntimeHeartbeatInterval(new Duration(6, MINUTES))
                 .setResourceGroupRuntimeInfoTimeout(new Duration(4, SECONDS))
-                .setRunningTaskCountFetchInterval(new Duration(1, MINUTES));
+                .setRunningTaskCountFetchInterval(new Duration(1, MINUTES))
+                .setHeartbeatHttpEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Add a http endpoint in resource manager for node heartbeat calls. This has been a thrift endpoint before. To integrate this with Presto c++ worker, we need HTTP as our story around thrift in c++ is not clear yet. This is a small non-intrusive change to support worker <-> RM communication using HTTP.


## Test Plan
Ran with c++ changes on a test cluster

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

