### PR TITLE
Exclude new time zones from TestTimeZoneUtils

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -66,6 +66,22 @@ public class TestTimeZoneUtils
                 // http://mm.icann.org/pipermail/tz-announce/2020-October/000059.html
                 continue;
             }
+            if (zoneId.equals("Europe/Zaporozhye")) {
+                // TODO: Remove once minimum Java version is increased 17.0.7
+                continue;
+            }
+            if (zoneId.equals("Europe/Uzhgorod")) {
+                // TODO: Remove once minimum Java version is increased 17.0.7
+                continue;
+            }
+            if (zoneId.equals("Europe/Kiev")) {
+                // TODO: Remove once minimum Java version is increased 17.0.7
+                continue;
+            }
+            if (zoneId.equals("Europe/Kyiv")) {
+                // TODO: Remove once minimum Java version is increased 17.0.7
+                continue;
+            }
 
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));


### PR DESCRIPTION
**Before fix:**
Error : [ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.448 s <<< FAILURE! - in com.facebook.presto.util.TestTimeZoneUtils
[ERROR] com.facebook.presto.util.TestTimeZoneUtils.testNamedZones Time elapsed: 1.293 s <<< FAILURE!
java.time.zone.ZoneRulesException: Unknown time-zone ID: Europe/Kyiv
at java.time.zone.ZoneRulesProvider.getProvider(ZoneRulesProvider.java:272)
at java.time.zone.ZoneRulesProvider.getRules(ZoneRulesProvider.java:227)
at java.time.ZoneRegion.ofId(ZoneRegion.java:120)
at java.time.ZoneId.of(ZoneId.java:411)
at java.time.ZoneId.of(ZoneId.java:359)
at com.facebook.presto.util.TestTimeZoneUtils.assertTimeZone(TestTimeZoneUtils.java:98)
at com.facebook.presto.util.TestTimeZoneUtils.testNamedZones(TestTimeZoneUtils.java:81)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:750)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR] TestTimeZoneUtils.testNamedZones:81->assertTimeZone:98 » ZoneRules Unknown time-zone ID: Europe/Kyiv
[INFO]
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[INFO]

**After fix:**
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.826 s - in com.facebook.presto.util.TestTimeZoneUtils
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:13 min
[INFO] Finished at: 2023-08-23T16:41:58+05:30
[INFO] ------------------------------------------------------------------------