### PR TITLE
Enable ORC flat map writer by default

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -295,7 +295,7 @@ public final class HiveSessionProperties
                         ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED,
                         "ORC: Enable flat map writer",
                         orcFileWriterConfig.isFlatMapWriterEnabled(),
-                        false),
+                        true),
                 integerProperty(
                         ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL,
                         "Experimental: ORC: Compression level, works only for ZSTD and ZLIB compression kinds",


### PR DESCRIPTION
## Description
This change enables ORC flat map writer by default to remove the need
of setting additional session properties when writing flattened tables.

## Motivation and Context
During the initial flat map writer rollout we disabled ORC flat map writer
by default using the session property. Now that it is widely used having it 
disabled by default just adds customer frustration because they need to set 
addition flags for their queries. By enabling the flat map writer by default
we remove users' frustration. 

## Impact
No impact

## Test Plan
Existing test

## Contributor checklist

- [ x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x ] Adequate tests were added if applicable.
- [ x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

