### PR TITLE
[native] Add node.internal-address to support hostname and FQDN

### DIFF
--- a/presto-native-execution/etc/node.properties
+++ b/presto-native-execution/etc/node.properties
@@ -1,4 +1,4 @@
 node.environment=testing
 node.id=e4901aae-a1c9-4ff7-97a9-5687835ad54c
-node.ip=127.0.0.1
+node.internal-address=127.0.0.1
 node.location=testing-location

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -83,7 +83,7 @@ PrestoExchangeSource::PrestoExchangeSource(
       clientCertAndKeyPath_(clientCertAndKeyPath),
       ciphers_(ciphers),
       exchangeExecutor_(executor) {
-  folly::SocketAddress address(folly::IPAddress(host_).str(), port_, true);
+  folly::SocketAddress address(host_, port_, true);
   auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(
       SystemConfig::instance()->exchangeRequestTimeout());
   VELOX_CHECK_NOT_NULL(exchangeExecutor_.get());

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -158,7 +158,8 @@ void PrestoServer::run() {
     httpExecThreads = systemConfig->httpExecThreads();
     environment_ = nodeConfig->nodeEnvironment();
     nodeId_ = nodeConfig->nodeId();
-    address_ = nodeConfig->nodeIp(std::bind(&PrestoServer::getLocalIp, this));
+    address_ = nodeConfig->nodeInternalAddress(
+        std::bind(&PrestoServer::getLocalIp, this));
     // Add [] to an ipv6 address.
     if (address_.find(':') != std::string::npos && address_.front() != '[') {
       address_ = fmt::format("[{}]", address_);

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -55,7 +55,7 @@ static void maybeSetupTaskSpillDirectory(
 
   const auto taskSpillDirPath = TaskManager::buildTaskSpillDirectoryPath(
       baseSpillDirectory,
-      nodeConfig->nodeIp(),
+      nodeConfig->nodeInternalAddress(),
       nodeConfig->nodeId(),
       execTask.queryCtx()->queryId(),
       execTask.taskId(),

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -564,6 +564,7 @@ NodeConfig::NodeConfig() {
           NONE_PROP(kNodeEnvironment),
           NONE_PROP(kNodeId),
           NONE_PROP(kNodeIp),
+          NONE_PROP(kNodeInternalAddress),
           NONE_PROP(kNodeLocation),
           NONE_PROP(kNodeMemoryGb),
       };
@@ -586,16 +587,21 @@ std::string NodeConfig::nodeLocation() const {
   return requiredProperty(kNodeLocation);
 }
 
-std::string NodeConfig::nodeIp(
+std::string NodeConfig::nodeInternalAddress(
     const std::function<std::string()>& defaultIp) const {
-  auto resultOpt = optionalProperty(kNodeIp);
+  auto resultOpt = optionalProperty(kNodeInternalAddress);
+  /// node.ip(kNodeIp) is legacy config replaced with node.internal-address, but
+  /// still valid config in Presto, so handling both.
+  if (!resultOpt.hasValue()) {
+    resultOpt = optionalProperty(kNodeIp);
+  }
   if (resultOpt.has_value()) {
     return resultOpt.value();
   } else if (defaultIp != nullptr) {
     return defaultIp();
   } else {
     VELOX_FAIL(
-        "Node IP was not found in NodeConfigs. Default IP was not provided "
+        "Node Internal Address or IP was not found in NodeConfigs. Default IP was not provided "
         "either.");
   }
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -466,7 +466,10 @@ class NodeConfig : public ConfigBase {
  public:
   static constexpr std::string_view kNodeEnvironment{"node.environment"};
   static constexpr std::string_view kNodeId{"node.id"};
+  // "node.ip" is Legacy Config. It is replaced with "node.internal-address"
   static constexpr std::string_view kNodeIp{"node.ip"};
+  static constexpr std::string_view kNodeInternalAddress{
+      "node.internal-address"};
   static constexpr std::string_view kNodeLocation{"node.location"};
   static constexpr std::string_view kNodeMemoryGb{"node.memory_gb"};
 
@@ -478,7 +481,7 @@ class NodeConfig : public ConfigBase {
 
   std::string nodeId() const;
 
-  std::string nodeIp(
+  std::string nodeInternalAddress(
       const std::function<std::string()>& defaultIp = nullptr) const;
 
   std::string nodeLocation() const;

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -9,8 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(presto_common_test CommonTest.cpp SystemConfigTest.cpp
-        BaseVeloxQueryConfigTest.cpp)
+add_executable(presto_common_test CommonTest.cpp ConfigTest.cpp
+                                  BaseVeloxQueryConfigTest.cpp)
 
 add_test(presto_common_test presto_common_test)
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -21,7 +21,7 @@ namespace facebook::presto::test {
 
 using namespace velox;
 
-class SystemConfigTest : public testing::Test {
+class ConfigTest : public testing::Test {
  protected:
   void setUpConfigFile(bool isMutable) {
     velox::filesystems::registerLocalFileSystem();
@@ -48,7 +48,7 @@ class SystemConfigTest : public testing::Test {
   }
 
   void init(
-      SystemConfig& config,
+      ConfigBase& config,
       std::unordered_map<std::string, std::string> properties) {
     config.initialize(std::make_unique<core::MemConfig>(std::move(properties)));
   }
@@ -58,7 +58,7 @@ class SystemConfigTest : public testing::Test {
   const std::string prestoVersion2{"SystemConfigTest2"};
 };
 
-TEST_F(SystemConfigTest, defaultConfig) {
+TEST_F(ConfigTest, defaultSystemConfig) {
   setUpConfigFile(false);
   auto systemConfig = SystemConfig::instance();
   systemConfig->initialize(configFilePath);
@@ -72,7 +72,7 @@ TEST_F(SystemConfigTest, defaultConfig) {
       VeloxException);
 }
 
-TEST_F(SystemConfigTest, mutableConfig) {
+TEST_F(ConfigTest, mutableSystemConfig) {
   setUpConfigFile(true);
   auto systemConfig = SystemConfig::instance();
   systemConfig->initialize(configFilePath);
@@ -95,7 +95,7 @@ TEST_F(SystemConfigTest, mutableConfig) {
       systemConfig->setValue("unregisteredProp1", "x"), VeloxException);
 }
 
-TEST_F(SystemConfigTest, requiredConfigs) {
+TEST_F(ConfigTest, requiredSystemConfigs) {
   SystemConfig config;
   init(config, {});
 
@@ -111,7 +111,7 @@ TEST_F(SystemConfigTest, requiredConfigs) {
   ASSERT_EQ(config.httpServerHttpPort(), 8080);
 }
 
-TEST_F(SystemConfigTest, optionalConfigs) {
+TEST_F(ConfigTest, optionalSystemConfigs) {
   SystemConfig config;
   init(config, {});
   ASSERT_EQ(folly::none, config.discoveryUri());
@@ -120,7 +120,30 @@ TEST_F(SystemConfigTest, optionalConfigs) {
   ASSERT_EQ(config.discoveryUri(), "my uri");
 }
 
-TEST_F(SystemConfigTest, optionalWithDefault) {
+TEST_F(ConfigTest, optionalNodeConfigs) {
+  NodeConfig config;
+  init(config, {});
+  ASSERT_EQ(config.nodeInternalAddress([]() { return "0.0.0.0"; }), "0.0.0.0");
+
+  init(config, {{std::string(NodeConfig::kNodeInternalAddress), "localhost"}});
+  ASSERT_EQ(
+      config.nodeInternalAddress([]() { return "0.0.0.0"; }), "localhost");
+
+  // "node.internal-address" is the new config replacing legacy config "node.ip"
+  init(
+      config,
+      {{std::string(NodeConfig::kNodeInternalAddress), "localhost"},
+       {std::string(NodeConfig::kNodeIp), "127.0.0.1"}});
+  ASSERT_EQ(
+      config.nodeInternalAddress([]() { return "0.0.0.0"; }), "localhost");
+
+  // make sure "node.ip" works too
+  init(config, {{std::string(NodeConfig::kNodeIp), "127.0.0.1"}});
+  ASSERT_EQ(
+      config.nodeInternalAddress([]() { return "0.0.0.0"; }), "127.0.0.1");
+}
+
+TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   SystemConfig config;
   init(config, {});
   ASSERT_EQ(config.maxDriversPerTask(), 16);
@@ -128,7 +151,7 @@ TEST_F(SystemConfigTest, optionalWithDefault) {
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }
 
-TEST_F(SystemConfigTest, remoteFunctionServer) {
+TEST_F(ConfigTest, remoteFunctionServer) {
   SystemConfig config;
   init(config, {});
   ASSERT_EQ(folly::none, config.remoteFunctionServerLocation());

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -532,7 +532,7 @@ class TaskManagerTest : public testing::Test {
     auto nodeConfigFile = fileSystem->openFileForWrite(nodeConfigFilePath);
     nodeConfigFile->append(fmt::format(
         "{}={}\n{}={}",
-        NodeConfig::kNodeIp,
+        NodeConfig::kNodeInternalAddress,
         "192.16.7.66",
         NodeConfig::kNodeId,
         "12"));


### PR DESCRIPTION
## Description
Add node.internal-address to support hostname and FQDN.
This aligns with Presto Java config. 


## Motivation and Context
We can only provide IP address now currently in `node.ip` config. When we use secure TLS communication 
between internal nodes, if the certificate provided doesn't have the IP address in the Subject Alternative Names,
then native worker cannot establish communication with the coordinator. Hence, the need to support
 hostname/FQDN too and the need to change the config name also to `node.internal-address` which 
also matches the Presto Java config property name.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No public API changes. `node.ip` is supported as legacy config and it will continue to work. 
No performance impacting changes.

## Test Plan
Added a test in SystemConfigTest.cpp to test the new config.

```
== RELEASE NOTES ==

General Changes
* Node config property `node.ip` is now a legacy config. It is replaced with `node.internal-address` to support hostname/FQDN too.
```