### PR TITLE
[native] ReAdd protobuf dependency

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -160,6 +160,9 @@ endif()
 include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 # Include third party header files
+
+find_package(Protobuf REQUIRED)
+
 find_path(OPT_OPENSSL_DIR NAMES opt/openssl@1.1)
 set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl@1.1")
 find_package(OpenSSL REQUIRED)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ add_executable(
   ServerOperationTest.cpp
   TaskManagerTest.cpp)
 
+include_directories(${Protobuf_INCLUDE_DIR})
+
 add_test(
   NAME presto_server_test
   COMMAND presto_server_test


### PR DESCRIPTION
## Description
This change re-add's protobuf dependency since Velox leaks some protobuf headers via SeekableInputStream.h #20649. 

## Motivation and Context
Builds break on clean systems without this change. 

## Test Plan
Tested on local machines. 

```
== NO RELEASE NOTE ==
```

