### PR TITLE
Add storage size and raw size to ORC stats builders

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -25,6 +25,8 @@ public class BinaryStatisticsBuilder
         implements SliceColumnStatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private long sum;
 
     @Override
@@ -60,6 +62,18 @@ public class BinaryStatisticsBuilder
             return new BinaryColumnStatistics(nonNullValueCount, null, binaryStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<BinaryStatistics> mergeBinaryStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -25,6 +25,8 @@ public class BooleanStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private long trueValueCount;
 
     @Override
@@ -69,6 +71,18 @@ public class BooleanStatisticsBuilder
             return new BooleanColumnStatistics(nonNullValueCount, null, booleanStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<BooleanStatistics> mergeBooleanStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
@@ -20,6 +20,8 @@ public class CountStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
 
     @Override
     public void addBlock(Type type, Block block)
@@ -48,5 +50,17 @@ public class CountStatisticsBuilder
     public ColumnStatistics buildColumnStatistics()
     {
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -23,6 +23,8 @@ public class DateStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private int minimum = Integer.MAX_VALUE;
     private int maximum = Integer.MIN_VALUE;
 
@@ -63,6 +65,18 @@ public class DateStatisticsBuilder
             return new DateColumnStatistics(nonNullValueCount, null, dateStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<DateStatistics> mergeDateStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -26,6 +26,8 @@ public class DoubleStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private boolean hasNan;
     private double minimum = Double.POSITIVE_INFINITY;
     private double maximum = Double.NEGATIVE_INFINITY;
@@ -85,6 +87,18 @@ public class DoubleStatisticsBuilder
             return new DoubleColumnStatistics(nonNullValueCount, null, doubleStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<DoubleStatistics> mergeDoubleStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -23,6 +23,8 @@ public class IntegerStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private long minimum = Long.MAX_VALUE;
     private long maximum = Long.MIN_VALUE;
     private long sum;
@@ -91,6 +93,18 @@ public class IntegerStatisticsBuilder
             return new IntegerColumnStatistics(nonNullValueCount, null, integerStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<IntegerStatistics> mergeIntegerStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -33,6 +33,8 @@ public class LongDecimalStatisticsBuilder
     public static final long LONG_DECIMAL_VALUE_BYTES = 16L;
 
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private BigDecimal minimum;
     private BigDecimal maximum;
 
@@ -98,6 +100,18 @@ public class LongDecimalStatisticsBuilder
             return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<DecimalStatistics> mergeDecimalStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
@@ -35,6 +35,8 @@ public class MapColumnStatisticsBuilder
     private final boolean collectKeyStats;
 
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private boolean hasEntries;
 
     /**
@@ -86,6 +88,18 @@ public class MapColumnStatisticsBuilder
             return new MapColumnStatistics(nonNullValueCount, null, mapStatistics);
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<MapStatistics> mergeMapStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -25,6 +25,8 @@ public class ShortDecimalStatisticsBuilder
     private final int scale;
 
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private long minimum = Long.MAX_VALUE;
     private long maximum = Long.MIN_VALUE;
 
@@ -61,5 +63,17 @@ public class ShortDecimalStatisticsBuilder
             return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilder.java
@@ -26,4 +26,14 @@ public interface StatisticsBuilder
     }
 
     ColumnStatistics buildColumnStatistics();
+
+    /**
+     * Increment the storage (after compression) size for a given column.
+     */
+    void incrementSize(long size);
+
+    /**
+     * Increment the raw data size of a column data before compression.
+     */
+    void incrementRawSize(long rawSize);
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -32,6 +32,8 @@ public class StringStatisticsBuilder
     private final int stringStatisticsLimitInBytes;
 
     private long nonNullValueCount;
+    private long size;
+    private long rawSize;
     private Slice minimum;
     private Slice maximum;
     private long sum;
@@ -129,6 +131,18 @@ public class StringStatisticsBuilder
             return new StringColumnStatistics(nonNullValueCount, null, stringStatistics.get());
         }
         return new ColumnStatistics(nonNullValueCount, null);
+    }
+
+    @Override
+    public void incrementRawSize(long rawSize)
+    {
+        this.rawSize += rawSize;
+    }
+
+    @Override
+    public void incrementSize(long size)
+    {
+        this.size += size;
     }
 
     public static Optional<StringStatistics> mergeStringStatistics(List<ColumnStatistics> stats)


### PR DESCRIPTION
## Description
This change adds size and raw size to ORC column statistic builders. The new 
values and methods are not used anywhere yet.

I will be making this change in the following order to reduce the scope of changes per PR:
[x] Add size and row size to stats builders
[] Make column writers write raw sizes
[] Propagate size and raw size to the ColumnStat objects created by stats builders
[] Update DWRF protobuf if needed
[] Make DWRF metadata writer / reader translate stats from DWRF to ColumnStat
[] Populate size and rawSize in column stats during the Metastore commit 

## Motivation and Context
Close this feature gap between Velox/BBIO and Presto written files. It has been
requested multiple times for data quality and column size monitoring purposes.
See T161955910 for more context. 

## Impact
Adding size and raw size to column stats will slightly increase memory consumption
by 16 bytes per column per written stripe.

## Test Plan
Existing tests. Full test coverage will be added step 3 when new columns will be added to
the column stats and builders start populating this value.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

