### PR TITLE
Remote function profile

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -120,6 +120,7 @@ jobs:
           root: presto-native-execution
           paths:
             - _build/debug/presto_cpp/main/presto_server
+            - _build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main
 
   linux-presto-e2e-tests:
     executor: build
@@ -136,6 +137,7 @@ jobs:
           name: 'Run presto-native e2e tests'
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+            export REMOTE_FUNCTION_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main"
             export TEMP_PATH="/tmp"
             TESTFILES=$(circleci tests glob "presto-native-execution/src/test/**/TestPrestoNative*.java" | circleci tests split --split-by=timings)
             # Convert file paths to comma separated class names
@@ -148,7 +150,15 @@ jobs:
             done
             export TESTCLASSES=${TESTCLASSES#,}
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Dtest="com.facebook.presto.nativeworker.TestPrestoNativeRemoteFunctions" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DREMOTE_FUNCTION_SERVER=${REMOTE_FUNCTION_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-spark-e2e-tests:
@@ -177,7 +187,14 @@ jobs:
             done
             export TESTCLASSES=${TESTCLASSES#,}
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Dtest="${TESTCLASSES}" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-build-all:

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -192,6 +192,7 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <excludedGroups>remote-function</excludedGroups>
                     <systemPropertyVariables>
                         <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
                         <DATA_DIR>/tmp/velox</DATA_DIR>
@@ -199,5 +200,28 @@
                 </configuration>
             </plugin>
         </plugins>
+
     </build>
+    <profiles>
+        <profile>
+            <id>presto-native-execution-remote-functions</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups combine.self="override" />
+                            <groups>remote-function</groups>
+                            <systemPropertyVariables>
+                                <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
+                                <DATA_DIR>/tmp/velox</DATA_DIR>
+                                <REMOTE_FUNCTION_SERVER>/path/to/remote/function</REMOTE_FUNCTION_SERVER>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_CATALOG_NAME;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_JSON_SIGNATURES;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.setupJsonFunctionNamespaceManager;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.startRemoteFunctionServer;
+
+public abstract class AbstractTestNativeRemoteFunctions
+        extends AbstractTestQueryFramework
+{
+    // The unix domain socket (UDS) path to communicate with the remote fuction server.
+    protected String remoteFunctionServerUds;
+
+    // The path to the compiled remote function server binary.
+    private String remoteFunctionServerBinaryPath;
+
+    @Override
+    protected void preInitQueryRunners()
+    {
+        // Initialize the remote function thrift server process.
+        remoteFunctionServerBinaryPath = System.getProperty("REMOTE_FUNCTION_SERVER");
+        if (remoteFunctionServerBinaryPath != null) {
+            remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
+        }
+    }
+
+    @Override
+    protected void postInitQueryRunners()
+    {
+        // Install json function registration namespace manager.
+        setupJsonFunctionNamespaceManager(getQueryRunner(), REMOTE_FUNCTION_JSON_SIGNATURES, REMOTE_FUNCTION_CATALOG_NAME);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        // Create some tpch tables.
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+    }
+
+    @Test
+    public void testRemoteFunction()
+    {
+        if (remoteFunctionServerBinaryPath == null) {
+            throw new SkipException("Skipping remote functions tests since REMOTE_FUNCTION_SERVER was not provided.");
+        }
+
+        assertQuery("SELECT remote.schema.ceil(linenumber) FROM lineitem", "SELECT ceil(linenumber) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount) FROM lineitem", "SELECT ceil(discount) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount * 7) FROM lineitem", "SELECT ceil(discount * 7) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(ceil(discount)) FROM lineitem", "SELECT ceil(ceil(discount * 7)) FROM lineitem");
+
+        assertQuery("SELECT remote.schema.concat(returnflag, linestatus) FROM lineitem", "SELECT concat(returnflag, linestatus) FROM lineitem");
+        assertQuery("SELECT remote.schema.concat('asd', linestatus) FROM lineitem", "SELECT concat('asd', linestatus) FROM lineitem");
+
+        // TODO: `throwOnError` needs to be implemented in the server so we can have remote functions as function parameters.
+        // https://github.com/facebookincubator/velox/issues/5288
+        //
+        // "(?s)" enables DOTALL mode so that "." can match newlines.
+        assertQueryFails("SELECT remote.schema.ceil(remote.schema.ceil(discount)) FROM lineitem", "(?s).*Error.*");
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
@@ -23,7 +23,9 @@ import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMO
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_JSON_SIGNATURES;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.setupJsonFunctionNamespaceManager;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.startRemoteFunctionServer;
+import static java.util.Objects.requireNonNull;
 
+@Test(groups = "remote-function")
 public abstract class AbstractTestNativeRemoteFunctions
         extends AbstractTestQueryFramework
 {
@@ -37,10 +39,8 @@ public abstract class AbstractTestNativeRemoteFunctions
     protected void preInitQueryRunners()
     {
         // Initialize the remote function thrift server process.
-        remoteFunctionServerBinaryPath = System.getProperty("REMOTE_FUNCTION_SERVER");
-        if (remoteFunctionServerBinaryPath != null) {
-            remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
-        }
+        requireNonNull(System.getProperty("REMOTE_FUNCTION_SERVER"));
+        remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -39,7 +39,15 @@ import static org.testng.Assert.assertNotNull;
 
 public class PrestoNativeQueryRunnerUtils
 {
+    private static final Logger log = Logger.get(PrestoNativeQueryRunnerUtils.class);
+
     private static final String DEFAULT_STORAGE_FORMAT = "DWRF";
+
+    // The unix domain socket (UDS) used to communicate with the remote function server.
+    public static final String REMOTE_FUNCTION_UDS = "remote_function_server.socket";
+    public static final String REMOTE_FUNCTION_JSON_SIGNATURES = "remote_function_server.json";
+    public static final String REMOTE_FUNCTION_CATALOG_NAME = "remote";
+
     private PrestoNativeQueryRunnerUtils() {}
 
     public static QueryRunner createQueryRunner()
@@ -81,7 +89,7 @@ public class PrestoNativeQueryRunnerUtils
 
         defaultQueryRunner.close();
 
-        return createNativeQueryRunner(dataDirectory.get().toString(), prestoServerPath.get(), workerCount, cacheMaxSize, true, storageFormat);
+        return createNativeQueryRunner(dataDirectory.get().toString(), prestoServerPath.get(), workerCount, cacheMaxSize, true, Optional.empty(), storageFormat);
     }
 
     public static QueryRunner createJavaQueryRunner() throws Exception
@@ -133,6 +141,7 @@ public class PrestoNativeQueryRunnerUtils
             Optional<Integer> workerCount,
             int cacheMaxSize,
             boolean useThrift,
+            Optional<String> remoteFunctionServerUds,
             String storageFormat)
             throws Exception
     {
@@ -154,18 +163,25 @@ public class PrestoNativeQueryRunnerUtils
                 Optional.of((workerIndex, discoveryUri) -> {
                     try {
                         Path tempDirectoryPath = Files.createTempDirectory(PrestoNativeQueryRunnerUtils.class.getSimpleName());
-                        Logger log = Logger.get(PrestoNativeQueryRunnerUtils.class);
                         log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
                         int port = 1234 + workerIndex;
 
                         // Write config files
                         Files.write(tempDirectoryPath.resolve("velox.properties"), "".getBytes());
-                        Files.write(tempDirectoryPath.resolve("config.properties"),
-                                format("discovery.uri=%s%n" +
-                                        "presto.version=testversion%n" +
-                                        "http_exec_threads=8%n" +
-                                        "system-memory-gb=4%n" +
-                                        "http-server.http.port=%d", discoveryUri, port).getBytes());
+                        String configProperties = format("discovery.uri=%s%n" +
+                                "presto.version=testversion%n" +
+                                "http_exec_threads=8%n" +
+                                "system-memory-gb=4%n" +
+                                "http-server.http.port=%d", discoveryUri, port);
+
+                        if (remoteFunctionServerUds.isPresent()) {
+                            String jsonSignaturesPath = Resources.getResource(REMOTE_FUNCTION_JSON_SIGNATURES).getFile();
+                            configProperties = format("%s%n" +
+                                    "remote-function-server.catalog-name=%s%n" +
+                                    "remote-function-server.thrift.uds-path=%s%n" +
+                                    "remote-function-server.signature.files.directory.path=%s%n", configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
+                        }
+                        Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
                         Files.write(tempDirectoryPath.resolve("node.properties"),
                                 format("node.id=%s%n" +
                                         "node.ip=127.0.0.1%n" +
@@ -208,6 +224,12 @@ public class PrestoNativeQueryRunnerUtils
                 }));
     }
 
+    public static QueryRunner createNativeQueryRunner(String remoteFunctionServerUds)
+            throws Exception
+    {
+        return createNativeQueryRunner(false, DEFAULT_STORAGE_FORMAT, Optional.ofNullable(remoteFunctionServerUds));
+    }
+
     public static QueryRunner createNativeQueryRunner(boolean useThrift)
             throws Exception
     {
@@ -215,6 +237,12 @@ public class PrestoNativeQueryRunnerUtils
     }
 
     public static QueryRunner createNativeQueryRunner(boolean useThrift, String storageFormat)
+            throws Exception
+    {
+        return createNativeQueryRunner(useThrift, storageFormat, Optional.empty());
+    }
+
+    public static QueryRunner createNativeQueryRunner(boolean useThrift, String storageFormat, Optional<String> remoteFunctionServerUds)
             throws Exception
     {
         String prestoServerPath = System.getProperty("PRESTO_SERVER");
@@ -225,7 +253,28 @@ public class PrestoNativeQueryRunnerUtils
         assertNotNull(prestoServerPath, "Native worker binary path is missing. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.");
         assertNotNull(dataDirectory, "Data directory path is missing. Add -DDATA_DIR=<path/to/data> to your JVM arguments.");
 
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(dataDirectory, prestoServerPath, Optional.ofNullable(workerCount).map(Integer::parseInt), cacheMaxSize, useThrift, storageFormat);
+        return createNativeQueryRunner(dataDirectory, prestoServerPath, Optional.ofNullable(workerCount).map(Integer::parseInt), cacheMaxSize, useThrift, remoteFunctionServerUds, storageFormat);
+    }
+
+    // Start the remote function server. Return the UDS path used to communicate with it.
+    public static String startRemoteFunctionServer(String remoteFunctionServerBinaryPath)
+    {
+        try {
+            Path tempDirectoryPath = Files.createTempDirectory("RemoteFunctionServer");
+            Path remoteFunctionServerUdsPath = tempDirectoryPath.resolve(REMOTE_FUNCTION_UDS);
+            log.info("Temp directory for Remote Function Server: %s", tempDirectoryPath.toString());
+
+            Process p = new ProcessBuilder(remoteFunctionServerBinaryPath, "--uds_path", remoteFunctionServerUdsPath.toString(), "--function_prefix", REMOTE_FUNCTION_CATALOG_NAME + ".schema.")
+                                .directory(tempDirectoryPath.toFile())
+                                .redirectErrorStream(true)
+                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("thrift_server.out").toFile()))
+                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("thrift_server.err").toFile()))
+                                .start();
+            return remoteFunctionServerUdsPath.toString();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public static void setupJsonFunctionNamespaceManager(QueryRunner queryRunner, String jsonFileName, String catalogName)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoNativeRemoteFunctions
+        extends AbstractTestNativeRemoteFunctions
+{
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(remoteFunctionServerUds);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+}

--- a/presto-native-execution/src/test/resources/remote_function_server.json
+++ b/presto-native-execution/src/test/resources/remote_function_server.json
@@ -1,0 +1,51 @@
+{
+  "udfSignatureMap": {
+    "ceil":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "INTEGER",
+        "paramTypes": [
+          "INTEGER"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "DOUBLE",
+        "paramTypes": [
+          "DOUBLE"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "concat":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "VARCHAR",
+        "paramTypes": [
+          "VARCHAR",
+          "VARCHAR"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -80,11 +80,17 @@ public abstract class AbstractTestQueryFramework
     public void init()
             throws Exception
     {
+        preInitQueryRunners();
         queryRunner = createQueryRunner();
         expectedQueryRunner = createExpectedQueryRunner();
+        postInitQueryRunners();
         sqlParser = new SqlParser();
         createTables();
     }
+
+    protected void preInitQueryRunners() {}
+
+    protected void postInitQueryRunners() {}
 
     protected void createTables() {}
 


### PR DESCRIPTION
For running remote-function tests
```
$ cd presto-native-execution
# This will run only the tests which have been annotated with @Test(groups = "remote-function")
$ ../mvnw test -Ppresto-native-execution-remote-functions
[INFO] Running com.facebook.presto.nativeworker.TestPrestoNativeScaledWriter
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.266 s - in com.facebook.presto.nativeworker.TestPrestoNativeScaledWriter
Picked up JAVA_TOOL_OPTIONS:
[INFO] Running com.facebook.presto.nativeworker.TestPrestoNativeWindowQueries
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.24 s - in com.facebook.presto.nativeworker.TestPrestoNativeWindowQueries
Picked up JAVA_TOOL_OPTIONS:
[INFO] Running com.facebook.presto.nativeworker.TestPrestoNativeRemoteFunctions
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.284 s - in com.facebook.presto.nativeworker.TestPrestoNativeRemoteFunctions
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1

```


With `../mvnw test -Ppresto-native-execution-remote-functions` the only problem is that non-remote-functions tests loaded onto the class loader and not executed. Loading theses classes increases the test duration by ~30 seconds. An even better solution would be to add exclusion filters in pom.xml to not even load certain classes by path. But this requires all the remote function tests to be under predefined folder.



For running all tests BUT remote-functions
```
$ cd presto-native-execution
$ ../mvnw test
```

You may pass environment variable via `$ ../mvnw test -DPRESTO_SERVER=xyz -DREMOTE_FUNCTION_SERVER=abc`