### PR TITLE
Add raw size to ORC column stats in simple column writers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -122,8 +122,11 @@ public class BooleanColumnWriter
                 statisticsBuilder.addValue(value);
             }
         }
+
         // For boolean columns, null and values has the same size (1 byte)
-        return block.getPositionCount() * NULL_SIZE;
+        long rawSize = block.getPositionCount() * NULL_SIZE;
+        statisticsBuilder.incrementRawSize(rawSize);
+        return rawSize;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -64,6 +64,7 @@ public class ByteColumnWriter
     private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
+    private long rawSize;
 
     private boolean closed;
 
@@ -115,7 +116,9 @@ public class ByteColumnWriter
             }
         }
         // For byte columns, null and values has the same size (1 byte)
-        return block.getPositionCount() * NULL_SIZE;
+        long rawSize = block.getPositionCount() * NULL_SIZE;
+        this.rawSize += rawSize;
+        return rawSize;
     }
 
     @Override
@@ -126,6 +129,7 @@ public class ByteColumnWriter
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
+        rawSize = 0;
         return ImmutableMap.of(column, statistics);
     }
 
@@ -188,5 +192,6 @@ public class ByteColumnWriter
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
+        rawSize = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -119,7 +119,10 @@ public class DoubleColumnWriter
                 nonNullValueCount++;
             }
         }
-        return nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+
+        long rawSize = nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+        statisticsBuilder.incrementRawSize(rawSize);
+        return rawSize;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -121,7 +121,10 @@ public class FloatColumnWriter
                 nonNullValueCount++;
             }
         }
-        return nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+
+        long rawSize = nonNullValueCount * TYPE_SIZE + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+        statisticsBuilder.incrementRawSize(rawSize);
+        return rawSize;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -68,6 +68,7 @@ public class ListColumnWriter
     private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
+    private long rawSize;
 
     private boolean closed;
 
@@ -150,7 +151,9 @@ public class ListColumnWriter
             childRawSize += elementWriter.writeBlock(elementsBlock);
         }
         nonNullValueCount += blockNonNullValueCount;
-        return (columnarArray.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        long rawSize = (columnarArray.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        this.rawSize += rawSize;
+        return rawSize;
     }
 
     @Override
@@ -162,6 +165,7 @@ public class ListColumnWriter
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
+        rawSize = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
         columnStatistics.put(column, statistics);
@@ -238,5 +242,6 @@ public class ListColumnWriter
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
+        rawSize = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -158,7 +158,10 @@ public class LongColumnWriter
                 nonNullValueCount++;
             }
         }
-        return nonNullValueCount * typeSize + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+
+        long rawSize = nonNullValueCount * typeSize + (block.getPositionCount() - nonNullValueCount) * NULL_SIZE;
+        statisticsBuilder.incrementRawSize(rawSize);
+        return rawSize;
     }
 
     void writeValue(long value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -69,6 +69,7 @@ public class MapColumnWriter
     private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
+    private long rawSize;
 
     private boolean closed;
 
@@ -158,7 +159,9 @@ public class MapColumnWriter
             childRawSize += valueWriter.writeBlock(columnarMap.getValuesBlock());
         }
         nonNullValueCount += blockNonNullValueCount;
-        return (columnarMap.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        long rawSize = (columnarMap.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        this.rawSize += rawSize;
+        return rawSize;
     }
 
     @Override
@@ -170,6 +173,7 @@ public class MapColumnWriter
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
+        rawSize = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
         columnStatistics.put(column, statistics);
@@ -252,5 +256,6 @@ public class MapColumnWriter
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
+        rawSize = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -150,7 +150,10 @@ public class SliceDirectColumnWriter
                 nonNullValueCount++;
             }
         }
-        return (block.getPositionCount() - nonNullValueCount) * NULL_SIZE + elementSize;
+
+        long rawSize = (block.getPositionCount() - nonNullValueCount) * NULL_SIZE + elementSize;
+        statisticsBuilder.incrementRawSize(rawSize);
+        return rawSize;
     }
 
     void writePresentValue(boolean value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -63,6 +63,7 @@ public class StructColumnWriter
     private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
+    private long rawSize;
 
     private boolean closed;
 
@@ -148,7 +149,9 @@ public class StructColumnWriter
             }
         }
         nonNullValueCount += blockNonNullValueCount;
-        return (columnarRow.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        long rawSize = (columnarRow.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+        this.rawSize += rawSize;
+        return rawSize;
     }
 
     @Override
@@ -159,6 +162,7 @@ public class StructColumnWriter
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
+        rawSize = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
         columnStatistics.put(column, statistics);
@@ -249,5 +253,6 @@ public class StructColumnWriter
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
+        rawSize = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -86,6 +86,7 @@ public class TimestampColumnWriter
     private final int trailingZeros;
 
     private int nonNullValueCount;
+    private long rawSize;
 
     private boolean closed;
 
@@ -197,7 +198,9 @@ public class TimestampColumnWriter
         }
 
         nonNullValueCount += blockNonNullValueCount;
-        return (block.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + blockNonNullValueCount * TIMESTAMP_RAW_SIZE;
+        long rawSize = (block.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + blockNonNullValueCount * TIMESTAMP_RAW_SIZE;
+        this.rawSize += rawSize;
+        return rawSize;
     }
 
     @Override
@@ -208,6 +211,7 @@ public class TimestampColumnWriter
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
+        rawSize = 0;
         return ImmutableMap.of(column, statistics);
     }
 
@@ -273,5 +277,6 @@ public class TimestampColumnWriter
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
+        rawSize = 0;
     }
 }


### PR DESCRIPTION
## Description
This change adds tracking of raw size in most of column writers except complex flat map 
and dictionary column writers.

I will be making this change in the following order to reduce the scope of changes per PR:
- [x] Add size and raw size to stats builders
-  Make column writers write raw sizes
- [ ] Propagate size and raw size to the ColumnStat objects created by stats builders
- [ ] Update DWRF protobuf if needed
- [ ] Make DWRF metadata writer / reader translate stats from DWRF to ColumnStat
- [ ] Populate size and rawSize in column stats during the Metastore commit


## Motivation and Context
Close this feature gap between Velox/BBIO and Presto written files. It has been
requested multiple times for data quality and column size monitoring purposes.
See T161955910 for more context.

## Impact
Some column writers will slightly increased memory consumption by 8 bytes per 
column writer because of the new rawSize:long field.

## Test Plan
Existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

