### PR TITLE
Add plan node id to query plan output

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/NodeRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/NodeRepresentation.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +41,7 @@ public class NodeRepresentation
     private final Optional<PlanNodeStats> stats;
     private final List<PlanNodeStatsEstimate> estimatedStats;
     private final List<PlanCostEstimate> estimatedCost;
+    private final List<PlanNodeId> planNodeIds;
 
     private final StringBuilder details = new StringBuilder();
 
@@ -54,7 +56,8 @@ public class NodeRepresentation
             List<PlanNodeStatsEstimate> estimatedStats,
             List<PlanCostEstimate> estimatedCost,
             List<PlanNodeId> children,
-            List<PlanFragmentId> remoteSources)
+            List<PlanFragmentId> remoteSources,
+            List<PlanNodeId> planNodeIds)
     {
         this.sourceLocation = sourceLocation;
         this.id = requireNonNull(id, "id is null");
@@ -67,6 +70,7 @@ public class NodeRepresentation
         this.estimatedCost = requireNonNull(estimatedCost, "estimatedCost is null");
         this.children = requireNonNull(children, "children is null");
         this.remoteSources = requireNonNull(remoteSources, "remoteSources is null");
+        this.planNodeIds = ImmutableList.copyOf(requireNonNull(planNodeIds, "planNodeIds is null"));
 
         checkArgument(estimatedCost.size() == estimatedStats.size(), "size of cost and stats list does not match");
     }
@@ -145,5 +149,10 @@ public class NodeRepresentation
     public List<PlanCostEstimate> getEstimatedCost()
     {
         return estimatedCost;
+    }
+
+    public List<PlanNodeId> getPlanNodeIds()
+    {
+        return planNodeIds;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1345,7 +1345,8 @@ public class PlanPrinter
                     estimatedStats,
                     estimatedCosts,
                     childrenIds,
-                    remoteSources);
+                    remoteSources,
+                    allNodes);
 
             representation.addNode(nodeOutput);
             return nodeOutput;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.sql.planner.optimizations.OptimizerResult;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
@@ -72,6 +73,7 @@ public class TextRenderer
         output.append(indentString(level))
                 .append("- ")
                 .append(node.getName())
+                .append(node.getPlanNodeIds().isEmpty() ? "" : format("[PlanNodeId %s]", Joiner.on(",").join(node.getPlanNodeIds())))
                 .append(node.getSourceLocation().isPresent() ? "(" + node.getSourceLocation().get().toString() + ")" : "")
                 .append(node.getIdentifier())
                 .append(" => [")

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
@@ -106,6 +106,7 @@ public class TestJsonRenderer
                 ImmutableList.of(),
                 ImmutableList.of(),
                 planNodeIds,
+                ImmutableList.of(),
                 ImmutableList.of());
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1311,6 +1311,6 @@ public abstract class AbstractTestDistributedQueries
 
     private String sanitizePlan(String explain)
     {
-        return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX").replaceAll("Values => .*\n", "\n");
+        return explain.replaceAll("hashvalue_[0-9][0-9][0-9]", "hashvalueXXX").replaceAll("\\[PlanNodeId (\\d+(?:,\\d+)*)\\]", "").replaceAll("Values => .*\n", "\n");
     }
 }


### PR DESCRIPTION
## Description
Add plan node id to the printed query plan.

## Motivation and Context
This information can be helpful when debugging queries.

## Impact
Make debug easier.

## Test Plan
A `[PlanNodeId]` field added after node name.
Before change:
```
presto:tpch> explain (type distributed) select orderpriority, sum(quantity) from orders o join lineitem l on o.orderkey=l.orderkey group by 1;
                                                                                                                                                         Query Plan                                                                   >
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                                                  >
     Output layout: [orderpriority, sum]                                                                                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                                                                                                   >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                                    >
     - Output[orderpriority, _col1] => [orderpriority:varchar(15), sum:double]                                                                                                                                                        >
             _col1 := sum (1:50)                                                                                                                                                                                                      >
         - RemoteSource[1] => [orderpriority:varchar(15), sum:double]                                                                                                                                                                 >
                                                                                                                                                                                                                                      >
 Fragment 1 [HASH]                                                                                                                                                                                                                    >
     Output layout: [orderpriority, sum]                                                                                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                                                                                                   >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                                    >
     - Project[projectLocality = LOCAL] => [orderpriority:varchar(15), sum:double]                                                                                                                                                    >
         - Aggregate(FINAL)[orderpriority][$hashvalue] => [orderpriority:varchar(15), $hashvalue:bigint, sum:double]                                                                                                                  >
                 sum := "presto.default.sum"((sum_16)) (1:50)                                                                                                                                                                         >
             - LocalExchange[HASH][$hashvalue] (orderpriority) => [orderpriority:varchar(15), sum_16:double, $hashvalue:bigint]                                                                                                       >
                 - RemoteSource[2] => [orderpriority:varchar(15), sum_16:double, $hashvalue_17:bigint]                                                                                                                                >
                                                                                                                                                                                                                                      >
 Fragment 2 [HASH]                                                                                                                                                                                                                    >
     Output layout: [orderpriority, sum_16, $hashvalue_23]                                                                                                                                                                            >
     Output partitioning: HASH [orderpriority][$hashvalue_23]                                                                                                                                                                         >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                                    >
     - Aggregate(PARTIAL)[orderpriority][$hashvalue_23] => [orderpriority:varchar(15), $hashvalue_23:bigint, sum_16:double]                                                                                                           >
             sum_16 := "presto.default.sum"((quantity)) (1:50)                                                                                                                                                                        >
         - Project[projectLocality = LOCAL] => [quantity:double, orderpriority:varchar(15), $hashvalue_23:bigint]                                                                                                                     >
                 Estimates: {source: CostBasedSourceInfo, rows: 58490 (1.75MB), cpu: 11326518.68, memory: 471188.00, network: 2095913.00}                                                                                             >
                 $hashvalue_23 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderpriority), BIGINT'0')) (1:35)                                                                                                             >
             - InnerJoin[("orderkey_0" = "orderkey")][$hashvalue_18, $hashvalue_20] => [quantity:double, orderpriority:varchar(15)]                                                                                                   >
                     Estimates: {source: CostBasedSourceInfo, rows: 58490 (1.75MB), cpu: 9489184.71, memory: 471188.00, network: 2095913.00}                                                                                          >
                     Distribution: PARTITIONED                                                                                                                                                                                        >
                 - RemoteSource[3] => [orderkey_0:bigint, quantity:double, $hashvalue_18:bigint]                                                                                                                                      >
                 - LocalExchange[HASH][$hashvalue_20] (orderkey) => [orderkey:bigint, orderpriority:varchar(15), $hashvalue_20:bigint]                                                                                                >
                         Estimates: {source: CostBasedSourceInfo, rows: 15000 (460.14kB), cpu: 1749752.00, memory: 0.00, network: 471188.00}                                                                                          >
                     - RemoteSource[4] => [orderkey:bigint, orderpriority:varchar(15), $hashvalue_21:bigint]                                                                                                                          >
                                                                                                                                                                                                                                      >
 Fragment 3 [SOURCE]                                                                                                                                                                                                                  >
     Output layout: [orderkey_0, quantity, $hashvalue_19]                                                                                                                                                                             >
     Output partitioning: HASH [orderkey_0][$hashvalue_19]                                                                                                                                                                            >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                                    >
     - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{}]'}, grouped = false, proje>
             Estimates: {source: CostBasedSourceInfo, rows: 60175 (1.55MB), cpu: 1083150.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 60175 (1.55MB), cpu: 2707875.00, memory: 0.00, network: 0.00}           >
             $hashvalue_19 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey_0), BIGINT'0')) (1:83)                                                                                                                    >
             LAYOUT: tpch.lineitem{}                                                                                                                                                                                                  >
             orderkey_0 := orderkey:bigint:0:REGULAR (1:83)                                                                                                                                                                           >
             quantity := quantity:double:4:REGULAR (1:83)                                                                                                                                                                             >
                                                                                                                                                                                                                                      >
 Fragment 4 [SOURCE]                                                                                                                                                                                                                  >
     Output layout: [orderkey, orderpriority, $hashvalue_22]                                                                                                                                                                          >
     Output partitioning: HASH [orderkey][$hashvalue_22]                                                                                                                                                                              >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                                    >
     - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.orders{}]'}, grouped = false, projectLo>
             Estimates: {source: CostBasedSourceInfo, rows: 15000 (460.14kB), cpu: 336188.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 15000 (460.14kB), cpu: 807376.00, memory: 0.00, network: 0.00}         >
             $hashvalue_22 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey), BIGINT'0')) (1:69)                                                                                                                      >
             LAYOUT: tpch.orders{}                                                                                                                                                                                                    >
             orderpriority := orderpriority:varchar(15):5:REGULAR (1:69)                                                                                                                                                              >
             orderkey := orderkey:bigint:0:REGULAR (1:69)                                                                                                                                                                             >
                                                                                                                                                                                                                                      >
                                                                                                                                                                                                                                      >
(1 row)
```

After change:
```
presto:tpch> explain (type distributed) select orderpriority, sum(quantity) from orders o join lineitem l on o.orderkey=l.orderkey group by 1;
                                                                                                                                                                 >
----------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                             >
     Output layout: [orderpriority, sum]                                                                                                                         >
     Output partitioning: SINGLE []                                                                                                                              >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                               >
     - Output[PlanNodeId 12][orderpriority, _col1] => [orderpriority:varchar(15), sum:double]                                                                    >
             _col1 := sum (1:50)                                                                                                                                 >
         - RemoteSource[1] => [orderpriority:varchar(15), sum:double]                                                                                            >
                                                                                                                                                                 >
 Fragment 1 [HASH]                                                                                                                                               >
     Output layout: [orderpriority, sum]                                                                                                                         >
     Output partitioning: SINGLE []                                                                                                                              >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                               >
     - Project[PlanNodeId 398][projectLocality = LOCAL] => [orderpriority:varchar(15), sum:double]                                                               >
         - Aggregate(FINAL)[orderpriority][$hashvalue][PlanNodeId 7] => [orderpriority:varchar(15), $hashvalue:bigint, sum:double]                               >
                 sum := "presto.default.sum"((sum_16)) (1:50)                                                                                                    >
             - LocalExchange[PlanNodeId 348][HASH][$hashvalue] (orderpriority) => [orderpriority:varchar(15), sum_16:double, $hashvalue:bigint]                  >
                 - RemoteSource[2] => [orderpriority:varchar(15), sum_16:double, $hashvalue_17:bigint]                                                           >
                                                                                                                                                                 >
 Fragment 2 [HASH]                                                                                                                                               >
     Output layout: [orderpriority, sum_16, $hashvalue_23]                                                                                                       >
     Output partitioning: HASH [orderpriority][$hashvalue_23]                                                                                                    >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                               >
     - Aggregate(PARTIAL)[orderpriority][$hashvalue_23][PlanNodeId 352] => [orderpriority:varchar(15), $hashvalue_23:bigint, sum_16:double]                      >
             sum_16 := "presto.default.sum"((quantity)) (1:50)                                                                                                   >
         - Project[PlanNodeId 397][projectLocality = LOCAL] => [quantity:double, orderpriority:varchar(15), $hashvalue_23:bigint]                                >
                 Estimates: {source: CostBasedSourceInfo, rows: 58490 (1.75MB), cpu: 11326518.68, memory: 471188.00, network: 2095913.00}                        >
                 $hashvalue_23 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderpriority), BIGINT'0')) (1:35)                                        >
             - InnerJoin[PlanNodeId 264][("orderkey_0" = "orderkey")][$hashvalue_18, $hashvalue_20] => [quantity:double, orderpriority:varchar(15)]              >
                     Estimates: {source: CostBasedSourceInfo, rows: 58490 (1.75MB), cpu: 9489184.71, memory: 471188.00, network: 2095913.00}                     >
                     Distribution: PARTITIONED                                                                                                                   >
                 - RemoteSource[3] => [orderkey_0:bigint, quantity:double, $hashvalue_18:bigint]                                                                 >
                 - LocalExchange[PlanNodeId 331][HASH][$hashvalue_20] (orderkey) => [orderkey:bigint, orderpriority:varchar(15), $hashvalue_20:bigint]           >
                         Estimates: {source: CostBasedSourceInfo, rows: 15000 (460.14kB), cpu: 1749752.00, memory: 0.00, network: 471188.00}                     >
                     - RemoteSource[4] => [orderkey:bigint, orderpriority:varchar(15), $hashvalue_21:bigint]                                                     >
                                                                                                                                                                 >
 Fragment 3 [SOURCE]                                                                                                                                             >
     Output layout: [orderkey_0, quantity, $hashvalue_19]                                                                                                        >
     Output partitioning: HASH [orderkey_0][$hashvalue_19]                                                                                                       >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                               >
     - ScanProject[PlanNodeId 1,395][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartit>
             Estimates: {source: CostBasedSourceInfo, rows: 60175 (1.55MB), cpu: 1083150.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 601>
             $hashvalue_19 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey_0), BIGINT'0')) (1:83)                                               >
             LAYOUT: tpch.lineitem{}                                                                                                                             >
             orderkey_0 := orderkey:bigint:0:REGULAR (1:83)                                                                                                      >
             quantity := quantity:double:4:REGULAR (1:83)                                                                                                        >
                                                                                                                                                                 >
 Fragment 4 [SOURCE]                                                                                                                                             >
     Output layout: [orderkey, orderpriority, $hashvalue_22]                                                                                                     >
     Output partitioning: HASH [orderkey][$hashvalue_22]                                                                                                         >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                               >
     - ScanProject[PlanNodeId 0,396][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitio>
             Estimates: {source: CostBasedSourceInfo, rows: 15000 (460.14kB), cpu: 336188.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 15>
             $hashvalue_22 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey), BIGINT'0')) (1:69)                                                 >
             LAYOUT: tpch.orders{}                                                                                                                               >
             orderpriority := orderpriority:varchar(15):5:REGULAR (1:69)                                                                                         >
             orderkey := orderkey:bigint:0:REGULAR (1:69)                                                                                                        >
                                                                                                                                                                 >
                                                                                                                                                                 >
(1 row)
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

