### PR TITLE
Upgrade PostgreSQL JDBC driver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1173,7 +1173,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.3.3</version>
+                <version>42.6.0</version>
             </dependency>
 
             <dependency>
@@ -1895,7 +1895,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.20.0</version>
+                <version>3.37.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
The PR upgrades PostgreSQL JDBC driver version to address known CVEs.

## Motivation and Context
Dependency [org.postgresql:postgresql:42.3.3](https://mvnrepository.com/artifact/org.postgresql/postgresql/42.3.3) has at least two direct vulnerabilities:
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31197
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41946

The following PRs should be closed after merge:
 - https://github.com/prestodb/presto/pull/17303
 - https://github.com/prestodb/presto/pull/18387
 - https://github.com/prestodb/presto/pull/18477

## Impact
None

## Test Plan
Existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

PostgreSQL Connector Changes
* Upgrade JDBC driver version to 42.6.0
```

