### PR TITLE
[native] Fix spilling counter comments and remove unnecessary includes.

### DIFF
--- a/presto-native-execution/presto_cpp/main/CoordinatorDiscoverer.cpp
+++ b/presto-native-execution/presto_cpp/main/CoordinatorDiscoverer.cpp
@@ -14,7 +14,6 @@
 
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include <folly/Uri.h>
-#include <mutex>
 #include "presto_cpp/main/common/Configs.h"
 
 namespace facebook::presto {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -47,7 +47,6 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/connectors/Connector.h"
-#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/Config.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -16,7 +16,6 @@
 #include <folly/Synchronized.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
-#include <list>
 #include <memory>
 #include <unordered_map>
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -139,15 +139,15 @@ constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
 
 /// The number of times that spilling runs on a velox operator.
 constexpr folly::StringPiece kCounterSpillRuns{"presto_cpp.spill_run_count"};
-/// The number of bytes spilled to disks.
-///
-/// NOTE: if compression is enabled, this counts the compressed bytes.
+/// The number of spilled files.
 constexpr folly::StringPiece kCounterSpilledFiles{
     "presto_cpp.spilled_file_count"};
 /// The number of spilled rows.
 constexpr folly::StringPiece kCounterSpilledRows{
     "presto_cpp.spilled_row_count"};
-/// The number of spilled files.
+/// The number of bytes spilled to disks.
+///
+/// NOTE: if compression is enabled, this counts the compressed bytes.
 constexpr folly::StringPiece kCounterSpilledBytes{"presto_cpp.spilled_bytes"};
 /// The time spent on filling rows for spilling.
 constexpr folly::StringPiece kCounterSpillFillTimeUs{


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

