### PR TITLE
Set Digest Functions Hash_counts Issue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
@@ -110,6 +110,11 @@ public final class FunctionSignatureMatcher
             return Optional.of(getOnlyElement(applicableFunctions).getBoundSignature());
         }
 
+        //Hash_counts
+        if (applicableFunctions.size() == 2 && applicableFunctions.get(1).getBoundSignature().getName().getObjectName().equals("hash_counts")) {
+            return Optional.of(applicableFunctions.get(1).getBoundSignature());
+        }
+
         StringBuilder errorMessageBuilder = new StringBuilder();
         errorMessageBuilder.append("Could not choose a best candidate operator. Explicit type casts must be added.\n");
         errorMessageBuilder.append("Candidates are:\n");


### PR DESCRIPTION

function:: hash_counts(x) -> map(bigint, smallint)

    Returns a map containing the `Murmur3Hash128 <https://wikipedia.org/wiki/MurmurHash#MurmurHash3>`_
    hashed values and the count of their occurences within
    the internal ``MinHash`` structure belonging to ``x``.

    ``x`` must be of type  ``setdigest``.






SELECT hash_counts(make_set_digest(value))
             -> FROM (VALUES 1, 1, 1, 2, 2) T(value);
Query 20230825_135635_00045_6rvfh failed: line 1:8: Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
         * presto.default.hash_counts(SetDigest):map(bigint,smallint)
         * presto.default.hash_counts(SetDigest):varchar



**After Fix :**
        SELECT hash_counts(make_set_digest(value))
        FROM (VALUES 1, 1, 1, 2, 2) T(value);
        -- {19144387141682250=3, -2447670524089286488=2}
