### PR TITLE
Remove overload version for hash_counts of Return type varchar

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.type.setdigest;
 
-import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
@@ -22,12 +21,8 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
-import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -36,8 +31,6 @@ import static com.facebook.presto.type.setdigest.SetDigest.exactIntersectionCard
 
 public final class SetDigestFunctions
 {
-    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
-
     private SetDigestFunctions()
     {
     }
@@ -99,19 +92,5 @@ public final class SetDigestFunctions
         blockBuilder.closeEntry();
 
         return (Block) mapType.getObject(blockBuilder, 0);
-    }
-
-    @ScalarFunction
-    @SqlType(StandardTypes.VARCHAR)
-    public static Slice hashCounts(@SqlType(SetDigestType.NAME) Slice slice)
-    {
-        SetDigest digest = SetDigest.newInstance(slice);
-
-        try {
-            return Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(digest.getHashCounts()));
-        }
-        catch (JsonProcessingException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSetDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSetDigestFunctions.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestSetDigestFunctions
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testCardinality()
+    {
+        assertions.assertQuery(
+                "SELECT cardinality(make_set_digest(value)) " +
+                        "FROM (VALUES 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5) T(value)", "VALUES CAST(5 AS BIGINT)");
+    }
+
+    @Test
+    public void testExactIntersectionCardinality()
+    {
+        assertions.assertQuery(
+                "SELECT intersection_cardinality(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (1, 1), (NULL, 2), (2, 3), (3, 4)) T(v1, v2)", "VALUES CAST(3 AS BIGINT)");
+    }
+
+    @Test
+    public void testJaccardIndex()
+    {
+        assertions.assertQuery(
+                "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2)", "VALUES CAST(0.5 AS DOUBLE)");
+    }
+
+    @Test
+    public void hashCounts()
+    {
+        assertions.assertQuery(
+                "SELECT hash_counts(make_set_digest(value)) " +
+                        "FROM (VALUES 1, 1, 1, 2, 2) T(value)", "VALUES map(cast(ARRAY[19144387141682250, -2447670524089286488] AS array(bigint)), cast(ARRAY[3, 2] AS array(smallint)))");
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/setdigest/TestSetDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/setdigest/TestSetDigest.java
@@ -14,20 +14,27 @@
 
 package com.facebook.presto.type.setdigest;
 
-import com.facebook.airlift.json.JsonObjectMapperProvider;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.SingleMapBlock;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.MapType;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import static com.facebook.presto.common.block.MethodHandleUtil.compose;
+import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static com.facebook.presto.type.setdigest.SetDigest.DEFAULT_MAX_HASHES;
 import static com.facebook.presto.type.setdigest.SetDigest.NUMBER_OF_BUCKETS;
 import static com.facebook.presto.type.setdigest.SetDigestFunctions.hashCounts;
@@ -38,6 +45,11 @@ import static org.testng.Assert.assertTrue;
 
 public class TestSetDigest
 {
+    private static final MethodHandle KEY_NATIVE_EQUALS = getOperatorMethodHandle(OperatorType.EQUAL, BIGINT, BIGINT);
+    private static final MethodHandle KEY_BLOCK_EQUALS = compose(KEY_NATIVE_EQUALS, nativeValueGetter(BIGINT), nativeValueGetter(BIGINT));
+    private static final MethodHandle KEY_NATIVE_HASH_CODE = getOperatorMethodHandle(OperatorType.HASH_CODE, BIGINT);
+    private static final MethodHandle KEY_BLOCK_HASH_CODE = compose(KEY_NATIVE_HASH_CODE, nativeValueGetter(BIGINT));
+
     @Test
     public void testIntersectionCardinality()
             throws Exception
@@ -92,7 +104,6 @@ public class TestSetDigest
 
     @Test
     public void testHashCounts()
-            throws Exception
     {
         SetDigest digest1 = new SetDigest();
         digest1.add(0);
@@ -105,18 +116,26 @@ public class TestSetDigest
         digest2.add(2);
         digest2.add(2);
 
-        ObjectMapper mapper = new JsonObjectMapperProvider().get();
+        MapType mapType = new MapType(BIGINT, SMALLINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE);
+        Block block = hashCounts(mapType, digest1.serialize());
+        assertTrue(block instanceof SingleMapBlock);
+        Set<Short> blockValues = new HashSet<>();
+        for (int i = 1; i < block.getPositionCount(); i += 2) {
+            blockValues.add(block.getShort(i));
+        }
 
-        Slice slice = hashCounts(digest1.serialize());
-        Map<Long, Short> counts = mapper.readValue(slice.toStringUtf8(), new TypeReference<Map<Long, Short>>() {});
         Set<Short> expected = ImmutableSet.of((short) 1, (short) 2);
-        assertEquals(counts.values(), expected);
+        assertEquals(blockValues, expected);
 
         digest1.mergeWith(digest2);
-        slice = hashCounts(digest1.serialize());
-        counts = mapper.readValue(slice.toStringUtf8(), new TypeReference<Map<Long, Short>>() {});
+        block = hashCounts(mapType, digest1.serialize());
+        assertTrue(block instanceof SingleMapBlock);
         expected = ImmutableSet.of((short) 1, (short) 2, (short) 4);
-        assertEquals(ImmutableSet.copyOf(counts.values()), expected);
+        blockValues = new HashSet<>();
+        for (int i = 1; i < block.getPositionCount(); i += 2) {
+            blockValues.add(block.getShort(i));
+        }
+        assertEquals(blockValues, expected);
     }
 
     @Test


### PR DESCRIPTION
SELECT hash_counts(make_set_digest(value))
-> FROM (VALUES 1, 1, 1, 2, 2) T(value);
Query 20230825_135635_00045_6rvfh failed: line 1:8: Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
* presto.default.hash_counts(SetDigest):map(bigint,smallint)
* presto.default.hash_counts(SetDigest):varchar

Prefer using hash_counts(setdigest):map(bigint,smallint) over hash_counts(setdigest):varchar.

Along the way also a test showcasing the usage of setdigest functions has been added.
