### PR TITLE
Fix #20447: Wait for queries to start running and add retry on failure

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/Retry.java
+++ b/presto-tests/src/test/java/com/facebook/presto/Retry.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class Retry
+        implements IRetryAnalyzer
+{
+    private static final int maxTry = 5;
+    private int count;
+
+    @Override
+    public boolean retry(ITestResult iTestResult)
+    {
+        if (!iTestResult.isSuccess()) {
+            if (count < maxTry) {
+                count++;
+                System.out.println("Retry #" + count + " for test: " + iTestResult.getMethod().getMethodName());
+                iTestResult.setStatus(ITestResult.FAILURE);
+                return true;
+            }
+            else {
+                iTestResult.setStatus(ITestResult.FAILURE);
+            }
+        }
+        else {
+            iTestResult.setStatus(ITestResult.SUCCESS);
+        }
+        return false;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tests;
 
+import com.facebook.presto.Retry;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
@@ -237,8 +238,7 @@ public class TestQueryManager
         }
     }
 
-    // Flaky test: https://github.com/prestodb/presto/issues/20447
-    @Test(enabled = false)
+    @Test(retryAnalyzer = Retry.class)
     public void testQueryCountMetrics()
             throws Exception
     {
@@ -246,6 +246,11 @@ public class TestQueryManager
         // Create a total of 10 queries to test concurrency limit and
         // ensure that some queries are queued as concurrency limit is 3
         createQueries(dispatchManager, 10);
+
+        //Wait for the queries to be in running state
+        while (dispatchManager.getStats().getRunningQueries() != 3) {
+            Thread.sleep(1000);
+        }
 
         List<BasicQueryInfo> queries = dispatchManager.getQueries();
         long queuedQueryCount = dispatchManager.getStats().getQueuedQueries();

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -238,7 +238,7 @@ public class TestQueryManager
         }
     }
 
-    @Test(retryAnalyzer = Retry.class)
+    @Test(invocationCount = 5, retryAnalyzer = Retry.class)
     public void testQueryCountMetrics()
             throws Exception
     {


### PR DESCRIPTION
## Description
Fix Flakiness in com.facebook.presto.tests.TestQueryManager#testQueryCountMetrics  
Also, introduce retry mechanism to the above test

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fix #20447

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

