### PR TITLE
Disallow alter add column with not null constraint in iceberg

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -334,6 +334,9 @@ public class IcebergHiveMetadata
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
+        if (!column.isNullable()) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support add column with non null");
+        }
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         org.apache.iceberg.Table icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -283,6 +283,9 @@ public class IcebergNativeMetadata
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
+        if (!column.isNullable()) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support add column with non null");
+        }
         TableIdentifier tableIdentifier = toIcebergTableIdentifier(((IcebergTableHandle) tableHandle).getSchemaTableName());
         Table icebergTable = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -199,12 +199,25 @@ public class TestIcebergSystemTables
         assertQuery("SELECT sum(record_count) FROM test_schema.\"test_table_drop_column$files\"", "VALUES 6");
     }
 
+    @Test
+    public void testAlterTableColumnNotNull()
+    {
+        String tableName = "test_schema.test_table_add_column";
+        assertUpdate("CREATE TABLE " + tableName + " (c1 INTEGER, c2 INTEGER)");
+        assertQueryFails("ALTER TABLE " + tableName + " ADD COLUMN c3 INTEGER NOT NULL",
+                "This connector does not support add column with non null");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1,1)", 1);
+        assertQueryFails("ALTER TABLE " + tableName + " ADD COLUMN c3 INTEGER NOT NULL",
+                "This connector does not support add column with non null");
+    }
+
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_multilevel_partitions");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_drop_column");
+        assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_add_column");
         assertUpdate("DROP SCHEMA IF EXISTS test_schema");
     }
 }


### PR DESCRIPTION
Presto issue - https://github.com/prestodb/presto/issues/20618

Return an error for presto iceberg connector for adding non-null column in alter table.
    
Cherry-pick of https://github.com/trinodb/trino/pull/13673 (https://github.com/trinodb/trino/pull/13673)

Co-authored-by: ebyhr <ebyhry@gmail.com>

## Description
Disallow alter add column with not null constraint. Iceberg V3 spec supports default values, at which point presto should support "alter table add column not null" with the default value using the 'initial-default' setting in the schema (see the iceberg table spec for how that should work)

`ALTER TABLE A ADD COLUMN C2 INT NOT NULL;`

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
- Add a new test in presto-iceberg

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==


Iceberg Changes
* Disallow specifying `NOT NULL` constraint when adding a new column in `ALTER TABLE` statement.

```


