### PR TITLE
Skip access check for is null arguments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -607,7 +607,8 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitIsNullPredicate(IsNullPredicate node, StackableAstVisitorContext<Context> context)
         {
-            process(node.getValue(), context);
+            Context newContext = context.getContext().withUnusedExpressionsForAccessControl(ImmutableSet.of(NodeRef.of(node.getValue())));
+            process(node.getValue(), new StackableAstVisitorContext<>(newContext));
 
             return setExpressionType(node, BOOLEAN);
         }
@@ -615,7 +616,8 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitIsNotNullPredicate(IsNotNullPredicate node, StackableAstVisitorContext<Context> context)
         {
-            process(node.getValue(), context);
+            Context newContext = context.getContext().withUnusedExpressionsForAccessControl(ImmutableSet.of(NodeRef.of(node.getValue())));
+            process(node.getValue(), new StackableAstVisitorContext<>(newContext));
 
             return setExpressionType(node, BOOLEAN);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
@@ -50,6 +50,28 @@ public class TestColumnAndSubfieldAnalyzer
                 ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t11"), ImmutableSet.of()));
     }
 
+    public void testIsNull()
+    {
+        assertTableColumns(
+                "SELECT a IS NULL FROM tpch.s1.t11",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t11"), ImmutableSet.of()));
+
+        assertTableColumns(
+                "SELECT transform(b.x, yo -> yo IS NULL) FROM tpch.s1.t11",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t11"), ImmutableSet.of()));
+    }
+
+    public void testIsNotNull()
+    {
+        assertTableColumns(
+                "SELECT a IS NOT NULL FROM tpch.s1.t11",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t11"), ImmutableSet.of()));
+
+        assertTableColumns(
+                "SELECT transform(b.x, yo -> yo IS NOT NULL) FROM tpch.s1.t11",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t11"), ImmutableSet.of()));
+    }
+
     @Test
     public void testTransform()
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -162,6 +162,28 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT cardinality(x.f3) from test_subfield",
                 privilege("x.f3", SELECT_COLUMN));
 
+        assertAccessAllowed(session,
+                "SELECT x.f3 IS NULL from test_subfield",
+                privilege("x.f3", SELECT_COLUMN));
+
+        assertAccessAllowed(session,
+                "SELECT x.f3 IS NOT NULL from test_subfield",
+                privilege("x.f3", SELECT_COLUMN));
+
+        assertAccessAllowed(session,
+                "SELECT x.f3 IS NULL from test_subfield",
+                privilege("x", SELECT_COLUMN));
+        assertAccessAllowed(session,
+                "SELECT x.f3 IS NOT NULL from test_subfield",
+                privilege("x", SELECT_COLUMN));
+
+        assertAccessAllowed(session,
+                "SELECT x IS NULL from test_subfield",
+                privilege("x", SELECT_COLUMN));
+        assertAccessAllowed(session,
+                "SELECT x IS NOT NULL from test_subfield",
+                privilege("x", SELECT_COLUMN));
+
         assertUpdate("DROP TABLE test_subfield");
     }
 


### PR DESCRIPTION
This gives IS NULL and IS NOT NULL the same behavior as cardinality() functions
https://github.com/prestodb/presto/commit/e90dd3b84f342d8c8257ba5c6541765ae17726ed.

## Description
Remove access control checks for IS NULL and IS NOT NULL since they aren't really looking into the data. This brings those functions in line with how we handle cardinality()

## Motivation and Context
Motivation is to remove user pain when someone writes a query `SELECT x.y IS NULL`, but gets denied because they don't have permissions on x.y.subfield1 even though they do have permissions on other subfields of x.y

## Impact
Removing access control checks for the arguments to IS NULL or IS NOT NULL functions

## Test Plan
New unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Skip access control checks for IS NULL and IS NOT NULL

```

