### PR TITLE
[native] Add memory arbitrator metrics

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -102,12 +102,16 @@ class PeriodicTaskManager {
   void addHttpEndpointLatencyStatsTask();
   void printHttpEndpointLatencyStats();
 
+  void addArbitratorStatsTask();
+  void updateArbitratorStatsTask();
+
   folly::FunctionScheduler scheduler_;
   folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
   folly::IOThreadPoolExecutor* const httpExecutor_;
   TaskManager* const taskManager_;
   const velox::memory::MemoryAllocator* const memoryAllocator_;
   const velox::cache::AsyncDataCache* const asyncDataCache_;
+  const velox::memory::MemoryArbitrator* const arbitrator_;
   const std::unordered_map<
       std::string,
       std::shared_ptr<velox::connector::Connector>>& connectors_;
@@ -129,6 +133,7 @@ class PeriodicTaskManager {
   int64_t lastVoluntaryContextSwitches_{0};
   int64_t lastForcedContextSwitches_{0};
   velox::exec::SpillStats lastSpillStats_;
+  velox::memory::MemoryArbitrator::Stats lastArbitratorStats_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -216,6 +216,23 @@ void registerPrestoCppCounters() {
       kCounterSpillFlushTimeUs, facebook::velox::StatType::SUM);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSpillWriteTimeUs, facebook::velox::StatType::SUM);
+  // Memory arbitrator stats.
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorNumRequests, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorNumAborted, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorNumFailures, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorQueueTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorArbitrationTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorNumShrunkBytes, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorNumReclaimedBytes, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterArbitratorFreeCapacityBytes, facebook::velox::StatType::AVG);
 
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -135,6 +135,34 @@ constexpr folly::StringPiece kCounterMmapRawAllocBytesSmall{
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
 
+/// ================== Memory Arbitrator Counters =================
+
+/// The number of arbitration requests.
+constexpr folly::StringPiece kCounterArbitratorNumRequests{
+    "presto_cpp.arbitrator_num_requests"};
+/// The number of aborted arbitration requests.
+constexpr folly::StringPiece kCounterArbitratorNumAborted{
+    "presto_cpp.arbitrator_num_aborted"};
+/// The number of arbitration request failures.
+constexpr folly::StringPiece kCounterArbitratorNumFailures{
+    "presto_cpp.arbitrator_num_failures"};
+/// The sum of all the arbitration request queue times in microseconds.
+constexpr folly::StringPiece kCounterArbitratorQueueTimeUs{
+    "presto_cpp.arbitrator_queue_time_us"};
+/// The sum of all the arbitration run times in microseconds.
+constexpr folly::StringPiece kCounterArbitratorArbitrationTimeUs{
+    "presto_cpp.arbitrator_arbitration_time_us"};
+/// The amount of memory bytes freed by reducing the memory pool's capacity
+/// without actually freeing memory.
+constexpr folly::StringPiece kCounterArbitratorNumShrunkBytes{
+    "presto_cpp.arbitrator_num_shrunk_bytes"};
+/// The amount of memory bytes freed by memory reclamation.
+constexpr folly::StringPiece kCounterArbitratorNumReclaimedBytes{
+    "presto_cpp.arbitrator_num_reclaimed_bytes"};
+/// The free memory capacity in bytes.
+constexpr folly::StringPiece kCounterArbitratorFreeCapacityBytes{
+    "presto_cpp.arbitrator_free_capacity_bytes"};
+
 /// ================== Disk Spilling Counters =================
 
 /// The number of times that spilling runs on a velox operator.


### PR DESCRIPTION
Adds memory arbitrator related metrics to be exported and printed. The printed metrics will be used by Spark native.
```
== NO RELEASE NOTE ==
```

