### PR TITLE
[native] Pass serde parameters to Velox split

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
@@ -70,6 +70,11 @@ velox::exec::Split toVeloxSplit(
       extraFileInfo = std::make_shared<std::string>(
           velox::encoding::Base64::decode(*hiveSplit->fileSplit.extraFileInfo));
     }
+    std::unordered_map<std::string, std::string> serdeParameters;
+    serdeParameters.reserve(hiveSplit->storage.serdeParameters.size());
+    for (const auto& [key, value] : hiveSplit->storage.serdeParameters) {
+      serdeParameters[key] = value;
+    }
     return velox::exec::Split(
         std::make_shared<connector::hive::HiveConnectorSplit>(
             scheduledSplit.split.connectorId,
@@ -82,7 +87,8 @@ velox::exec::Split toVeloxSplit(
                 ? std::optional<int>(*hiveSplit->tableBucketNumber)
                 : std::nullopt,
             customSplitInfo,
-            extraFileInfo),
+            extraFileInfo,
+            serdeParameters),
         splitGroupId);
   }
   if (auto remoteSplit = std::dynamic_pointer_cast<const protocol::RemoteSplit>(

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxSplitTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxSplitTest.cpp
@@ -93,3 +93,34 @@ TEST(PrestoToVeloxSplitTest, extraFileInfo) {
   ASSERT_TRUE(veloxHiveSplit->extraFileInfo);
   ASSERT_EQ(*veloxHiveSplit->extraFileInfo, "quux");
 }
+
+TEST(PrestoToVeloxSplitTest, serdeParameters) {
+  auto scheduledSplit = makeHiveScheduledSplit();
+  auto& hiveSplit =
+      dynamic_cast<protocol::HiveSplit&>(*scheduledSplit.split.connectorSplit);
+  hiveSplit.storage.serdeParameters[dwio::common::SerDeOptions::kFieldDelim] =
+      "\t";
+  hiveSplit.storage
+      .serdeParameters[dwio::common::SerDeOptions::kCollectionDelim] = ",";
+  hiveSplit.storage.serdeParameters[dwio::common::SerDeOptions::kMapKeyDelim] =
+      "|";
+
+  auto veloxSplit = toVeloxSplit(scheduledSplit);
+  auto* veloxHiveSplit =
+      dynamic_cast<const connector::hive::HiveConnectorSplit*>(
+          veloxSplit.connectorSplit.get());
+  ASSERT_TRUE(veloxHiveSplit);
+  ASSERT_EQ(veloxHiveSplit->serdeParameters.size(), 3);
+  ASSERT_EQ(
+      veloxHiveSplit->serdeParameters.at(
+          dwio::common::SerDeOptions::kFieldDelim),
+      "\t");
+  ASSERT_EQ(
+      veloxHiveSplit->serdeParameters.at(
+          dwio::common::SerDeOptions::kCollectionDelim),
+      ",");
+  ASSERT_EQ(
+      veloxHiveSplit->serdeParameters.at(
+          dwio::common::SerDeOptions::kMapKeyDelim),
+      "|");
+}


### PR DESCRIPTION
Currently, serde parameters such as delimiters are not passed to Velox split during conversion, which is needed to read TEXTFILE.

```
== NO RELEASE NOTE ==
```

