### PR TITLE
Add raw and storage sizes to DWRF ColumnStatistics

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -754,7 +754,7 @@ public class OrcWriteValidation
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
             // if there are no rows, there will be no stats
             if (rowCount > 0) {
-                statisticsBuilders.add(new ColumnStatistics(rowCount, null));
+                statisticsBuilders.add(new ColumnStatistics(rowCount, null, null, null));
                 columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             }
             return statisticsBuilders.build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -486,6 +486,8 @@ public class DwrfMetadataReader
     {
         return createColumnStatistics(
                 statistics.getNumberOfValues(),
+                statistics.hasRawSize() ? statistics.getRawSize() : null,
+                statistics.hasSize() ? statistics.getSize() : null,
                 statistics.hasBucketStatistics() ? toBooleanStatistics(statistics.getBucketStatistics()) : null,
                 statistics.hasIntStatistics() ? toIntegerStatistics(statistics.getIntStatistics()) : null,
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -269,6 +269,8 @@ public class OrcMetadataReader
     {
         return createColumnStatistics(
                 statistics.getNumberOfValues(),
+                null,
+                null,
                 statistics.hasBucketStatistics() ? toBooleanStatistics(statistics.getBucketStatistics()) : null,
                 statistics.hasIntStatistics() ? toIntegerStatistics(statistics.getIntStatistics()) : null,
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
@@ -62,7 +62,7 @@ public class TestStripeReader
         long numRowsInGroup = MILLION;
         IntegerStatistics integerStatistics = new IntegerStatistics(0L, 0L, 0L);
         ColumnStatistics intColumnStatistics = new IntegerColumnStatistics(numRowsInGroup, null, integerStatistics);
-        ColumnStatistics mapColumnStatistics = new ColumnStatistics(numRowsInGroup, null);
+        ColumnStatistics mapColumnStatistics = new ColumnStatistics(numRowsInGroup, null, null, null);
         ColumnStatistics mapKeyColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, integerStatistics);
         ColumnStatistics mapValueColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, integerStatistics);
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -95,7 +95,7 @@ public class TestTupleDomainOrcPredicate
             booleanStatistics = new BooleanStatistics(trueValueCount);
             return new BooleanColumnStatistics(numberOfValues, null, booleanStatistics);
         }
-        return new ColumnStatistics(numberOfValues, null);
+        return new ColumnStatistics(numberOfValues, null, null, null);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
@@ -352,6 +352,13 @@ public class TestDwrfMetadataReader
     @DataProvider
     public Object[][] columnStatisticsSupplier()
     {
+        ColumnStatistics columnStatistics1 = new ColumnStatistics(7L, null, null, null);
+        ColumnStatistics columnStatistics2 = new ColumnStatistics(7L, null, 3L, 5L);
+        ColumnStatistics columnStatistics3 = new ColumnStatistics(7L, null, 3L, null);
+        ColumnStatistics columnStatistics4 = new ColumnStatistics(7L, null, null, 5L);
+        // DWRF metadata writer does not support writing rawSize and storageSize yet
+        ColumnStatistics columnStatisticsWithoutSize = new ColumnStatistics(7L, null, null, null);
+
         ColumnStatistics integerColumnStatistics1 = new IntegerColumnStatistics(7L, null, new IntegerStatistics(25L, 95L, 100L));
         ColumnStatistics integerColumnStatistics2 = new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L));
 
@@ -367,7 +374,7 @@ public class TestDwrfMetadataReader
         mapStatsStringKeyBuilder.increaseValueCount(23L);
         ColumnStatistics mapColumnStatisticsStringKey = mapStatsStringKeyBuilder.buildColumnStatistics();
 
-        ColumnStatistics expectedDisabledMapStats = new ColumnStatistics(23L, null);
+        ColumnStatistics expectedDisabledMapStats = new ColumnStatistics(23L, null, null, null);
 
         OrcReaderOptions orcReaderOptionsDisabledMapStats = OrcReaderOptions.builder()
                 .withMaxMergeDistance(new DataSize(1, MEGABYTE))
@@ -378,6 +385,10 @@ public class TestDwrfMetadataReader
         DwrfMetadataReader dwrfMetadataReaderDisabledMapStats = new DwrfMetadataReader(new RuntimeStats(), orcReaderOptionsDisabledMapStats);
 
         return new Object[][] {
+                {columnStatistics1, columnStatisticsWithoutSize, dwrfMetadataReader},
+                {columnStatistics2, columnStatisticsWithoutSize, dwrfMetadataReader},
+                {columnStatistics3, columnStatisticsWithoutSize, dwrfMetadataReader},
+                {columnStatistics4, columnStatisticsWithoutSize, dwrfMetadataReader},
                 {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReader},
                 {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReaderDisabledMapStats},
                 {mapColumnStatisticsIntKey, mapColumnStatisticsIntKey, dwrfMetadataReader},


### PR DESCRIPTION
## Description
Add fields for raw and storage sizes to the base ColumnStatistics class, move majority of
places using the old 1-2 argument constructor to the new 4 argument constructor, 
add unit tests. 

I'll update type specific ColumnStatistics classes in the next PR to keep the scope of
changes manageable.

I will be making this change in the following order to reduce the scope of changes per PR:
- [x] Add size and raw size to stats builders
 - Add size and raw size to ColumnStatistics classes
- [ ] Propagate size and raw size to the ColumnStatistics objects created by stats builders
- [ ] Make column writers write raw sizes
- [ ] Make DWRF metadata writer / reader translate stats from DWRF to ColumnStatistics

## Motivation and Context
Close this feature gap between Velox/BBIO and Presto written files. It has been
requested multiple times for data quality and column size monitoring purposes.
See T161955910 for more context. 


## Test Plan
Existing tests, new tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


