### PR TITLE
Add NOISY_COUNT_GAUSSIAN aggregation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -333,6 +333,33 @@ Approximate Aggregate Functions
     :func:`numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
     In this case, the total weight in the returned map is the count of items in the bin.
 
+.. function:: noisy_count_gaussian(x, noise_scale) -> bigint
+
+    Counts the non-null values and then adds a random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale`` to the true count.
+    The noisy count is post-processed to be non-negative and rounded to bigint.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Noise is from a secure random. ::
+
+        SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; -- (0 row)
+
+.. function:: noisy_count_gaussian(x, noise_scale, random_seed) -> bigint
+
+    Counts the non-null values and then adds a random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale`` to the true count.
+    The noisy count is post-processed to be non-negative and rounded to bigint.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Random seed is used to seed the random generator.
+    This method does not use a secure random. ::
+
+        SELECT noisy_count_gaussian(orderkey, 20.0, 321) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_count_gaussian(orderkey, 20.0, 321) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; --  (0 row)
+
 
 Statistical Aggregate Functions
 -------------------------------

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -344,6 +344,8 @@ import static com.facebook.presto.operator.aggregation.minmaxby.MaxByAggregation
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByNAggregationFunction.MAX_BY_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.minmaxby.MinByAggregationFunction.MIN_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.MinByNAggregationFunction.MIN_BY_N_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnAggregation.NOISY_COUNT_GAUSSIAN_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnRandomSeedAggregation.NOISY_COUNT_GAUSSIAN_RANDOM_SEED_AGGREGATION;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
 import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLATTEN_FUNCTION;
@@ -874,6 +876,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)
                 .function(COUNT_COLUMN)
+                .function(NOISY_COUNT_GAUSSIAN_AGGREGATION)
+                .function(NOISY_COUNT_GAUSSIAN_RANDOM_SEED_AGGREGATION)
                 .functions(ROW_HASH_CODE, ROW_TO_JSON, JSON_TO_ROW, JSON_STRING_TO_ROW, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_GREATER_THAN, ROW_GREATER_THAN_OR_EQUAL, ROW_LESS_THAN, ROW_LESS_THAN_OR_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST, ROW_INDETERMINATE)
                 .functions(VARCHAR_CONCAT, VARBINARY_CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/CountScaleRandomSeedState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/CountScaleRandomSeedState.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+
+public interface CountScaleRandomSeedState
+        extends AccumulatorState
+{
+    long getCount();
+
+    void setCount(long value);
+
+    double getNoiseScale();
+
+    void setNoiseScale(double value);
+
+    long getRandomSeed();
+
+    void setRandomSeed(long value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/CountScaleState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/CountScaleState.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+
+public interface CountScaleState
+        extends AccumulatorState
+{
+    double getNoiseScale();
+
+    void setNoiseScale(double value);
+
+    long getCount();
+
+    void setCount(long value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnAggregation.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Random;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnAggregationUtils.computeNoisyCount;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.Signature.typeVariable;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * Add a random Gaussian noise to true count with a given value of standard deviation of the noise.
+ * If one needs to replace COUNT(*), NOISY_COUNT_GAUSSIAN(1, noiseScale) should be used.
+ * <p>
+ * This function behaves similarly to COUNT.
+ * So, in the case of empty input, this function returns 0 if there is no grouping,
+ * and returns NULL if there is grouping
+ * <p>
+ * Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes.
+ * If randomSeed is omitted or 0, SecureRandom is used. If randomSeed > 0 is provided, Random is used.
+ * <p>
+ * Function signature is NOISY_COUNT_GAUSSIAN(x, noiseScale[, randomSeed])
+ * - x: input column/value
+ * - noiseScale: standard deviation of noise
+ * - randomSeed: (optional) random seed
+ */
+public class NoisyCountGaussianColumnAggregation
+        extends SqlAggregationFunction
+{
+    public static final NoisyCountGaussianColumnAggregation NOISY_COUNT_GAUSSIAN_AGGREGATION = new NoisyCountGaussianColumnAggregation();
+    private static final String NAME = "noisy_count_gaussian";
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(NoisyCountGaussianColumnAggregation.class, "input", CountScaleState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisyCountGaussianColumnAggregation.class, "combine", CountScaleState.class, CountScaleState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisyCountGaussianColumnAggregation.class, "output", CountScaleState.class, BlockBuilder.class);
+
+    public NoisyCountGaussianColumnAggregation()
+    {
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature("T"), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Counts the non-null values and then add Gaussian noise to the true count. The noisy count is post-processed to be non-negative and rounded to bigint. Noise is from a secure random.";
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return generateAggregation(type);
+    }
+
+    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(NoisyCountGaussianColumnAggregation.class.getClassLoader());
+
+        AccumulatorStateSerializer<CountScaleState> stateSerializer = StateCompiler.generateStateSerializer(CountScaleState.class, classLoader);
+        AccumulatorStateFactory<CountScaleState> stateFactory = StateCompiler.generateStateFactory(CountScaleState.class, classLoader);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        List<Type> inputTypes = ImmutableList.of(type, DOUBLE);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, BIGINT.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(type),
+                INPUT_FUNCTION,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        CountScaleState.class,
+                        stateSerializer,
+                        stateFactory)),
+                BIGINT);
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), BIGINT,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type type)
+    {
+        return ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, type),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(CountScaleState state, Block valueBlock, Block noiseScaleBlock, int index)
+    {
+        double noiseScale = DOUBLE.getDouble(noiseScaleBlock, index);
+        if (noiseScale < 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Noise scale must be >= 0");
+        }
+        // Update count and retain scale and random seed
+        state.setCount(state.getCount() + 1);
+        state.setNoiseScale(noiseScale);
+    }
+
+    public static void combine(CountScaleState state, CountScaleState otherState)
+    {
+        state.setCount(state.getCount() + otherState.getCount());
+        state.setNoiseScale(state.getNoiseScale() > 0 ? state.getNoiseScale() : otherState.getNoiseScale()); // noise scale should be > 0
+    }
+
+    public static void output(CountScaleState state, BlockBuilder out)
+    {
+        if (state.getCount() == 0) {
+            out.appendNull();
+            return;
+        }
+
+        Random random = new SecureRandom();
+        long noisyCountFixedSignAndType = computeNoisyCount(state.getCount(), state.getNoiseScale(), random);
+        BIGINT.writeLong(out, noisyCountFixedSignAndType);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnAggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnAggregationUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import java.util.Random;
+
+public class NoisyCountGaussianColumnAggregationUtils
+{
+    private NoisyCountGaussianColumnAggregationUtils()
+    {
+    }
+
+    public static long computeNoisyCount(long trueCount, double noiseScale, Random random)
+    {
+        double noise = random.nextGaussian() * noiseScale;
+        double noisyCount = trueCount + noise;
+        double noisyCountFixedSign = Math.max(noisyCount, 0);  // count should always be >= 0
+        return Math.round(noisyCountFixedSign);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnRandomSeedAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountGaussianColumnRandomSeedAggregation.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Random;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnAggregationUtils.computeNoisyCount;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.Signature.typeVariable;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class NoisyCountGaussianColumnRandomSeedAggregation
+        extends SqlAggregationFunction
+{
+    public static final NoisyCountGaussianColumnRandomSeedAggregation NOISY_COUNT_GAUSSIAN_RANDOM_SEED_AGGREGATION = new NoisyCountGaussianColumnRandomSeedAggregation();
+    private static final String NAME = "noisy_count_gaussian";
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(NoisyCountGaussianColumnRandomSeedAggregation.class, "input", CountScaleRandomSeedState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisyCountGaussianColumnRandomSeedAggregation.class, "combine", CountScaleRandomSeedState.class, CountScaleRandomSeedState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisyCountGaussianColumnRandomSeedAggregation.class, "output", CountScaleRandomSeedState.class, BlockBuilder.class);
+
+    public NoisyCountGaussianColumnRandomSeedAggregation()
+    {
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature("T"), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature()));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Counts the non-null values and then add Gaussian noise to the true count. The noisy count is post-processed to be non-negative and rounded to bigint. Random seed is used to seed random generator. This method does not use a secure random.";
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return generateAggregation(type);
+    }
+
+    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(NoisyCountGaussianColumnRandomSeedAggregation.class.getClassLoader());
+
+        AccumulatorStateSerializer<CountScaleRandomSeedState> stateSerializer = StateCompiler.generateStateSerializer(CountScaleRandomSeedState.class, classLoader);
+        AccumulatorStateFactory<CountScaleRandomSeedState> stateFactory = StateCompiler.generateStateFactory(CountScaleRandomSeedState.class, classLoader);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        List<Type> inputTypes = ImmutableList.of(type, DOUBLE, BIGINT);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, BIGINT.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(type),
+                INPUT_FUNCTION,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        CountScaleRandomSeedState.class,
+                        stateSerializer,
+                        stateFactory)),
+                BIGINT);
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), BIGINT,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type type)
+    {
+        return ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, type),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, BIGINT),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(CountScaleRandomSeedState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int index)
+    {
+        double noiseScale = DOUBLE.getDouble(noiseScaleBlock, index);
+        if (noiseScale < 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Noise scale must be >= 0");
+        }
+        // Update count and retain scale and random seed
+        state.setCount(state.getCount() + 1);
+        state.setNoiseScale(noiseScale);
+        state.setRandomSeed(BIGINT.getLong(randomSeedBlock, index));
+    }
+
+    public static void combine(CountScaleRandomSeedState state, CountScaleRandomSeedState otherState)
+    {
+        state.setCount(state.getCount() + otherState.getCount());
+        state.setNoiseScale(state.getNoiseScale() > 0 ? state.getNoiseScale() : otherState.getNoiseScale()); // noise scale should be > 0
+        state.setRandomSeed(otherState.getRandomSeed());
+    }
+
+    public static void output(CountScaleRandomSeedState state, BlockBuilder out)
+    {
+        if (state.getCount() == 0) {
+            out.appendNull();
+            return;
+        }
+
+        Random random = new Random(state.getRandomSeed());
+        long noisyCountFixedSignAndType = computeNoisyCount(state.getCount(), state.getNoiseScale(), random);
+        BIGINT.writeLong(out, noisyCountFixedSignAndType);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianAggregation.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.NamedType;
+import com.facebook.presto.common.type.RowFieldName;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeParameter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.QuantileDigestParametricType.QDIGEST;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyCountGaussianAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyCountGaussianAggregationUtils.buildData;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.type.ArrayParametricType.ARRAY;
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static com.facebook.presto.type.IpAddressType.IPADDRESS;
+import static com.facebook.presto.type.IpPrefixType.IPPREFIX;
+import static com.facebook.presto.type.MapParametricType.MAP;
+import static com.facebook.presto.type.RowParametricType.ROW;
+import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyCountGaussianAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_count_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    private static final double DEFAULT_TEST_STANDARD_DEVIATION = 1;
+    private static final BiFunction<Object, Object, Boolean> equalAssertion = (actual, expected) -> new Long(actual.toString()).equals(new Long(expected.toString()));
+
+    @Test
+    public void testNoisyCountGaussianDefinitions()
+    {
+        // Function is available for all standard data types
+        getFunction(TINYINT, DOUBLE);
+        getFunction(SMALLINT, DOUBLE);
+        getFunction(INTEGER, DOUBLE);
+        getFunction(BIGINT, DOUBLE);
+        getFunction(REAL, DOUBLE);
+        getFunction(DOUBLE, DOUBLE);
+        getFunction(createDecimalType(38, 0), DOUBLE);
+        getFunction(createDecimalType(18, 0), DOUBLE);
+        getFunction(VARCHAR, DOUBLE);
+        getFunction(createCharType(1), DOUBLE);
+        getFunction(VARBINARY, DOUBLE);
+        getFunction(JSON, DOUBLE);
+        getFunction(DATE, DOUBLE);
+        getFunction(TIME, DOUBLE);
+        getFunction(TIME_WITH_TIME_ZONE, DOUBLE);
+        getFunction(TIMESTAMP, DOUBLE);
+        getFunction(TIMESTAMP_WITH_TIME_ZONE, DOUBLE);
+        getFunction(INTERVAL_DAY_TIME, DOUBLE);
+        getFunction(INTERVAL_YEAR_MONTH, DOUBLE);
+        getFunction(ARRAY.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE);
+        getFunction(MAP.createType(FunctionAndTypeManager.createTestFunctionAndTypeManager(), ImmutableList.of(TypeParameter.of(BIGINT), TypeParameter.of(DOUBLE))), DOUBLE);
+        getFunction(ROW.createType(ImmutableList.of(TypeParameter.of(new NamedType(Optional.of(new RowFieldName("x", false)), DOUBLE)))), DOUBLE);
+        getFunction(IPADDRESS, DOUBLE);
+        getFunction(IPPREFIX, DOUBLE);
+        getFunction(UUID, DOUBLE);
+        getFunction(HYPER_LOG_LOG, DOUBLE);
+        getFunction(P4_HYPER_LOG_LOG, DOUBLE);
+        getFunction(K_HYPER_LOG_LOG, DOUBLE);
+        getFunction(QDIGEST.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE);
+        getFunction(TDIGEST.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE);
+    }
+
+    @Test
+    public void testNoisyCountGaussianStarZeroNoiseScaleNoRandomSeed()
+    {
+        // Test COUNT(1)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE);
+
+        int numRows = 1000;
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale) with noiseScale=0 which means no noise",
+                new Page(
+                        createRLEBlock(1, numRows),
+                        createRLEBlock(0.0, numRows)),
+                numRows);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Noise scale must be >= 0")
+    public void testNoisyCountGaussianLongInvalidNoiseScale()
+    {
+        // Test COUNT(col, -123, 10)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE);
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale, randomSeed) with noiseScale < 0 which we expect an error",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(-123.0, numRows)),
+                numRows);
+    }
+
+    @Test
+    public void testNoisyCountGaussianLongZeroNoiseScaleWithNull()
+    {
+        // Test COUNT(col, 0) with 1 NULL row
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE);
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, true);
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale, randomSeed) with null",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(0, numRows)),
+                numRows - 1); // null does not count
+    }
+
+    @Test
+    public void testNoisyCountGaussianLongRandomNoiseWithinSomeStd()
+    {
+        // Test COUNT(col, 100)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE);
+
+        BiFunction<Object, Object, Boolean> withinSomeStdAssertion = (actual, expected) -> {
+            long actualValue = Long.parseLong(actual.toString());
+            long expectedValue = Long.parseLong(expected.toString());
+            return expectedValue - 50 * DEFAULT_TEST_STANDARD_DEVIATION <= actualValue && actualValue <= expectedValue + 50 * DEFAULT_TEST_STANDARD_DEVIATION;
+        };
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_count_gaussian(long, noiseScale) with noiseScale=DEFAULT_TEST_STANDARD_DEVIATION and expect result is within some std from mean",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                numRows); // expected mean
+    }
+
+    @Test
+    public void testNoisyCountGaussianStarZeroNoiseScaleVsNormalCountStar()
+    {
+        int numRows = 1000;
+        String data = buildData(numRows, false);
+        String query1 = "SELECT COUNT(*) FROM " + data;
+        String query2 = "SELECT " + FUNCTION_NAME + "(1, 0) FROM " + data;
+        runQueryTestWith2Results(query1, query2);
+    }
+
+    @Test
+    public void testNoisyCountGaussianStarZeroNoiseScaleVsNormalCountStarWithNull()
+    {
+        int numRows = 1000;
+        String data = buildData(numRows, true);
+        String query1 = "SELECT COUNT(*) FROM " + data;
+        String query2 = "SELECT " + FUNCTION_NAME + "(1, 0) FROM " + data;
+        runQueryTestWith2Results(query1, query2);
+    }
+
+    @Test
+    public void testNoisyCountGaussianLongZeroNoiseScaleVsNormalCount()
+    {
+        int numRows = 1000;
+        String data = buildData(numRows, false);
+        String query1 = "SELECT COUNT(index) FROM " + data;
+        String query2 = "SELECT " + FUNCTION_NAME + "(index, 0) FROM " + data;
+        runQueryTestWith2Results(query1, query2);
+    }
+
+    @Test
+    public void testNoisyCountGaussianLongZeroNoiseScaleVsNormalCountWithNull()
+    {
+        int numRows = 1000;
+        String data = buildData(numRows, true);
+        String query1 = "SELECT COUNT(index) FROM " + data;
+        String query2 = "SELECT " + FUNCTION_NAME + "(index, 0) FROM " + data;
+        runQueryTestWith2Results(query1, query2);
+    }
+
+    @Test
+    public void testNoisyCountGaussianBigIntStarZeroNoiseScaleVsNormalCountStarWithNull()
+    {
+        // With 1 NULL row, COUNT(*) still count that row, but COUNT(col) does not count that row.
+        // That is why noisy_count_gaussian(index, 0) + 1 = count(*)
+        int numRows = 100;
+        String data = buildData(numRows, true);
+        String query1 = "SELECT COUNT(*) FROM " + data;
+        String columnName = buildColumnName(StandardTypes.BIGINT);
+        String query2 = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data;
+        runQueryTestWith2Results(query1, query2);
+    }
+
+    @Test
+    public void testNoisyCountGaussianNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true);
+        String columnName = buildColumnName(StandardTypes.BIGINT);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyCountGaussianNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true);
+        String columnName = buildColumnName(StandardTypes.BIGINT);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    /**
+     * Running 2 queries and expect their values should be similar.
+     * Both queries expect to return only 1 value.
+     */
+    private void runQueryTestWith2Results(String query1, String query2)
+    {
+        List<MaterializedRow> actualRows = runQuery(query1);
+        assertEquals(actualRows.size(), 1);
+        long result1 = Long.parseLong(actualRows.get(0).getField(0).toString());
+
+        actualRows = runQuery(query2);
+        assertEquals(actualRows.size(), 1);
+        long result2 = Long.parseLong(actualRows.get(0).getField(0).toString());
+
+        assertEquals(result1, result2);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianAggregationUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianAggregationUtils.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.type.StandardTypes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestNoisyCountGaussianAggregationUtils
+{
+    private TestNoisyCountGaussianAggregationUtils()
+    {
+    }
+    public static List<Long> createTestValues(int numRows, boolean includeNull)
+    {
+        ArrayList<Long> values = new ArrayList<>();
+        for (int i = 0; i < numRows; i++) {
+            values.add((long) i);
+        }
+        if (includeNull) {
+            values.remove(0);
+            values.add(null);
+        }
+
+        return values;
+    }
+
+    /**
+     * Build a dataset that can be selected from. This is in the form of:
+     * (SELECT
+     * CAST(index AS bigint) AS index,
+     * CAST(col_bigint AS bigint) as col_bigint,
+     * CAST(col_varchar AS varchar) as col_varchar
+     * FROM (
+     * VALUES
+     * (1, 1, '{}'),
+     * (NULL, NULL, NULL)
+     * ) AS t (index, col_bigint, col_varchar))
+     * <p>
+     * CASTs is to make sure data type is explicitly provided, not inferred
+     */
+    public static String buildData(int numRows, boolean includeNullValue)
+    {
+        int finalNumRows = numRows;
+        if (includeNullValue) {
+            finalNumRows = numRows - 1;
+        }
+        List<String> types = Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.VARCHAR);
+        // Build CASTs to make sure data type is explicitly provided, not inferred
+        StringBuilder sb = new StringBuilder();
+        sb.append("(SELECT ");
+        sb.append("CAST(index AS bigint) AS index, ");
+        for (int i = 0; i < types.size(); i++) {
+            String type = types.get(i);
+            String column = buildColumnName(type);
+            sb.append("CAST(").append(column).append(" AS ").append(type).append(") AS ").append(column);
+            if (i < types.size() - 1) {
+                sb.append(",");
+            }
+            sb.append(" ");
+        }
+        sb.append("FROM (VALUES ");
+        for (int i = 0; i < finalNumRows; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            buildRow(sb, i, types, false);
+        }
+        if (includeNullValue) {
+            sb.append(",");
+            buildRow(sb, finalNumRows, types, true);
+        }
+        sb.append(") AS t (").append("index");
+        // build column names
+        for (String type : types) {
+            sb.append(", ").append(buildColumnName(type));
+        }
+        sb.append("))");
+        return sb.toString();
+    }
+
+    public static String buildColumnName(String type)
+    {
+        return "col_" + type;
+    }
+
+    public static void buildRow(StringBuilder sb, int index, List<String> types, boolean isNullRow)
+    {
+        // index column
+        sb.append("(").append(isNullRow ? "NULL" : index);
+
+        // value column(s)
+        for (String type : types) {
+            sb.append(", ");
+            if (isNullRow) {
+                sb.append("NULL");
+            }
+            else {
+                if (type.equals(StandardTypes.TINYINT) || type.equals(StandardTypes.SMALLINT) || type.equals(StandardTypes.INTEGER) || type.equals(StandardTypes.BIGINT)
+                        || type.equals(StandardTypes.REAL) || type.equals(StandardTypes.DOUBLE)) {
+                    sb.append(index);
+                }
+                if (type.equals(StandardTypes.REAL) || type.equals(StandardTypes.DOUBLE) || type.equals(StandardTypes.DECIMAL)) {
+                    sb.append(index).append(".0");
+                }
+                else if (type.equals(StandardTypes.VARCHAR) || type.equals(StandardTypes.CHAR) || type.equals(StandardTypes.VARBINARY) || type.equals(StandardTypes.JSON)) {
+                    sb.append("'{}'");
+                }
+            }
+        }
+        sb.append(")");
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianRandomSeedAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyCountGaussianRandomSeedAggregation.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.NamedType;
+import com.facebook.presto.common.type.RowFieldName;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeParameter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.QuantileDigestParametricType.QDIGEST;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyCountGaussianAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyCountGaussianAggregationUtils.buildData;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.type.ArrayParametricType.ARRAY;
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static com.facebook.presto.type.IpAddressType.IPADDRESS;
+import static com.facebook.presto.type.IpPrefixType.IPPREFIX;
+import static com.facebook.presto.type.MapParametricType.MAP;
+import static com.facebook.presto.type.RowParametricType.ROW;
+import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyCountGaussianRandomSeedAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_count_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    private static final double DEFAULT_TEST_STANDARD_DEVIATION = 1;
+    private static final BiFunction<Object, Object, Boolean> equalAssertion = (actual, expected) -> new Long(actual.toString()).equals(new Long(expected.toString()));
+
+    @Test
+    public void testNoisyCountGaussianDefinitions()
+    {
+        // Function is available for all standard data types
+        getFunction(TINYINT, DOUBLE, BIGINT);
+        getFunction(SMALLINT, DOUBLE, BIGINT);
+        getFunction(INTEGER, DOUBLE, BIGINT);
+        getFunction(BIGINT, DOUBLE, BIGINT);
+        getFunction(REAL, DOUBLE, BIGINT);
+        getFunction(DOUBLE, DOUBLE, BIGINT);
+        getFunction(createDecimalType(38, 0), DOUBLE, BIGINT);
+        getFunction(createDecimalType(18, 0), DOUBLE, BIGINT);
+        getFunction(VARCHAR, DOUBLE, BIGINT);
+        getFunction(createCharType(1), DOUBLE, BIGINT);
+        getFunction(VARBINARY, DOUBLE, BIGINT);
+        getFunction(JSON, DOUBLE, BIGINT);
+        getFunction(DATE, DOUBLE, BIGINT);
+        getFunction(TIME, DOUBLE, BIGINT);
+        getFunction(TIME_WITH_TIME_ZONE, DOUBLE, BIGINT);
+        getFunction(TIMESTAMP, DOUBLE, BIGINT);
+        getFunction(TIMESTAMP_WITH_TIME_ZONE, DOUBLE, BIGINT);
+        getFunction(INTERVAL_DAY_TIME, DOUBLE, BIGINT);
+        getFunction(INTERVAL_YEAR_MONTH, DOUBLE, BIGINT);
+        getFunction(ARRAY.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE, BIGINT);
+        getFunction(MAP.createType(FunctionAndTypeManager.createTestFunctionAndTypeManager(), ImmutableList.of(TypeParameter.of(BIGINT), TypeParameter.of(DOUBLE))), DOUBLE, BIGINT);
+        getFunction(ROW.createType(ImmutableList.of(TypeParameter.of(new NamedType(Optional.of(new RowFieldName("x", false)), DOUBLE)))), DOUBLE, BIGINT);
+        getFunction(IPADDRESS, DOUBLE, BIGINT);
+        getFunction(IPPREFIX, DOUBLE, BIGINT);
+        getFunction(UUID, DOUBLE, BIGINT);
+        getFunction(HYPER_LOG_LOG, DOUBLE, BIGINT);
+        getFunction(P4_HYPER_LOG_LOG, DOUBLE, BIGINT);
+        getFunction(K_HYPER_LOG_LOG, DOUBLE, BIGINT);
+        getFunction(QDIGEST.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE, BIGINT);
+        getFunction(TDIGEST.createType(ImmutableList.of(TypeParameter.of(DOUBLE))), DOUBLE, BIGINT);
+    }
+
+    @Test
+    public void testNoisyCountGaussianRandomSeedLongZeroNoiseScaleZeroRandomSeed()
+    {
+        // Test COUNT(col, 0, 0)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE, BIGINT);
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(0, numRows)),
+                numRows);
+    }
+
+    @Test
+    public void testNoisyCountGaussianRandomSeedLongSomeNoiseScaleFixedRandomSeed()
+    {
+        // Test COUNT(col, 12, 10)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE, BIGINT);
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale, randomSeed) with noiseScale=12 which there is some noise, and a fixed random seed",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(10, numRows)),
+                1010); // 1010 is when numRows=1000, noiseScale=12 and randomSeed=10
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Noise scale must be >= 0")
+    public void testNoisyCountGaussianRandomSeedLongInvalidNoiseScale()
+    {
+        // Test COUNT(col, -123, 10)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE, BIGINT);
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                equalAssertion,
+                "Test noisy_count_gaussian(long, noiseScale, randomSeed) with noiseScale < 0 which we expect an error",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(-123.0, numRows),
+                        createRLEBlock(10, numRows)),
+                numRows);
+    }
+
+    @Test
+    public void testNoisyCountGaussianRandomSeedLongRandomNoiseWithinSomeStd()
+    {
+        // Test COUNT(col, 100)
+        JavaAggregationFunctionImplementation noisyCountGaussian = getFunction(BIGINT, DOUBLE, BIGINT);
+
+        BiFunction<Object, Object, Boolean> withinSomeStdAssertion = (actual, expected) -> {
+            long actualValue = Long.parseLong(actual.toString());
+            long expectedValue = Long.parseLong(expected.toString());
+            return expectedValue - 50 * DEFAULT_TEST_STANDARD_DEVIATION <= actualValue && actualValue <= expectedValue + 50 * DEFAULT_TEST_STANDARD_DEVIATION;
+        };
+
+        int numRows = 1000;
+        List<Long> values = TestNoisyCountGaussianAggregationUtils.createTestValues(numRows, false);
+        assertAggregation(
+                noisyCountGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_count_gaussian(long, noiseScale) with noiseScale=DEFAULT_TEST_STANDARD_DEVIATION and expect result is within some std from mean",
+                new Page(
+                        createLongsBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(10, numRows)),
+                numRows); // expected mean
+    }
+
+    @Test
+    public void testNoisyCountGaussianRandomSeedNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true);
+        String columnName = buildColumnName(StandardTypes.BIGINT);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0, 1) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyCountGaussianRandomSeedNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true);
+        String columnName = buildColumnName(StandardTypes.BIGINT);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0, 1) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestNoisyAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestNoisyAggregations.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.Test;
+
+public class TestNoisyAggregations
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder().build();
+    }
+
+    @Test
+    public void testNoisyCountGaussianZeroNoiseScaleVsNormalCount()
+    {
+        assertQuery("SELECT noisy_count_gaussian(1, 0) FROM lineitem", "SELECT count(*) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(linenumber, 0) FROM lineitem", "SELECT count(linenumber) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(orderkey, 0) FROM lineitem", "SELECT count(orderkey) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(quantity, 0) FROM lineitem", "SELECT count(quantity) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(linestatus, 0) FROM lineitem", "SELECT count(linestatus) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(shipdate, 0) FROM lineitem", "SELECT count(shipdate) FROM lineitem");
+    }
+
+    @Test
+    public void testNoisyCountGaussianZeroNoiseScaleRandomSeedVsNormalCount()
+    {
+        assertQuery("SELECT noisy_count_gaussian(1, 0, 10) FROM lineitem", "SELECT count(*) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(linenumber, 0, 10) FROM lineitem", "SELECT count(linenumber) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(orderkey, 0, 10) FROM lineitem", "SELECT count(orderkey) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(quantity, 0, 10) FROM lineitem", "SELECT count(quantity) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(linestatus, 0, 10) FROM lineitem", "SELECT count(linestatus) FROM lineitem");
+        assertQuery("SELECT noisy_count_gaussian(shipdate, 0, 10) FROM lineitem", "SELECT count(shipdate) FROM lineitem");
+    }
+}


### PR DESCRIPTION
## Description
This commit adds `NOISY_COUNT_GAUSSIAN` aggregation. This is to replace `COUNT(*)` and `COUNT(col)` with `NOISY_COUNT_GAUSSIAN(col, noiseScale[, randomSeed])`. `COUNT(*)` should be considered as `COUNT(1)` and can be replaced with `NOISY_COUNT_GAUSSIAN(1, noiseScale[, randomSeed])`.

Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes. If randomSeed is omitted, SecureRandom is used; otherwise, Random is used.

## Motivation and Context
The purpose is to help build systems/tools/framework that provide differential privacy guarantees. Differential privacy has been used by multiple teams within Meta to develop privacy-preserving systems. Current implementation involves complicated SQL operation even for simplest aggregations, increasing development time, complexity, maintenance and sharing cost, and sometimes completely blocking development of new features.

This is one of aggregations in our effort to add Presto UDF for noisy aggregations, used as building block for differential privacy in Presto.

While these functions on their own do not guarantee 100% differential privacy, they are the building blocks for other systems. That is also why we do not call these functions “differentially private aggregations” but only “noisy aggregations” to avoid a wrong impression of achieving differential privacy solely by using these functions.

## Impact
This adds a new aggregation `NOISY_COUNT_GAUSSIAN(col, noiseScale[, randomSeed])` that can be used to replace `COUNT(*)` and `COUNT(col)` if Gaussian noise is needed.

## Test Plan
Unittest:
- Both `NOISY_COUNT_GAUSSIAN(col, noiseScale)` and `NOISY_COUNT_GAUSSIAN(col, noiseScale, randomSeed)`:
  - Both are available for all standard data types
  - Both are tested with noiseScale = 0, noiseScale = fixed value, invalid noiseScale, and with some noiseScale the output is within 5 x noiseScale
- `NOISY_COUNT_GAUSSIAN(col, noiseScale)` we also tested with NULL rows, and run local queries to test its output compared to `COUNT(*)` and `COUNT(col)` 
- Both are test with 0 input rows

## Contributor checklist

- [ x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Adds NOISY_COUNT_GAUSSIAN aggregation that counts the non-null values and then add Gaussian noise to the true count. 
  The noisy count is post-processed to be non-negative and rounded to bigint. Noise is from a secure random.
  When there are no input rows, this function returns ``NULL``.
  Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes. 
  If randomSeed is omitted, SecureRandom is used; otherwise, Random is used.


