### PR TITLE
Turn off PullUpExpressionInLambdaRules

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -272,8 +272,8 @@ public class FeaturesConfig
     private boolean leftJoinNullFilterToSemiJoin = true;
     private boolean broadcastJoinWithSmallBuildUnknownProbe;
     private boolean addPartialNodeForRowNumberWithLimit = true;
-    private boolean pullUpExpressionFromLambda = true;
     private boolean inferInequalityPredicates;
+    private boolean pullUpExpressionFromLambda;
 
     private boolean preProcessMetadataCalls;
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -240,8 +240,8 @@ public class TestFeaturesConfig
                 .setLeftJoinNullFilterToSemiJoin(true)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(false)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(true)
-                .setPullUpExpressionFromLambdaEnabled(true)
-                .setInferInequalityPredicates(false));
+                .setInferInequalityPredicates(false)
+                .setPullUpExpressionFromLambdaEnabled(false));
     }
 
     @Test
@@ -429,8 +429,8 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-left-join-with-null-filter-to-semi-join", "false")
                 .put("experimental.optimizer.broadcast-join-with-small-build-unknown-probe", "true")
                 .put("optimizer.add-partial-node-for-row-number-with-limit", "false")
-                .put("optimizer.pull-up-expression-from-lambda", "false")
                 .put("optimizer.infer-inequality-predicates", "true")
+                .put("optimizer.pull-up-expression-from-lambda", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -616,8 +616,8 @@ public class TestFeaturesConfig
                 .setLeftJoinNullFilterToSemiJoin(false)
                 .setBroadcastJoinWithSmallBuildUnknownProbe(true)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(false)
-                .setPullUpExpressionFromLambdaEnabled(false)
-                .setInferInequalityPredicates(true);
+                .setInferInequalityPredicates(true)
+                .setPullUpExpressionFromLambdaEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullUpExpressionInLambdaRules.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullUpExpressionInLambdaRules.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
 
+import static com.facebook.presto.SystemSessionProperties.PULL_EXPRESSION_FROM_LAMBDA_ENABLED;
 import static com.facebook.presto.common.block.MethodHandleUtil.compose;
 import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -45,6 +46,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testProjection()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -63,6 +65,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testFilter()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -83,6 +86,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testNonDeterministicProjection()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -96,6 +100,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testNonDeterministicFilter()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -109,6 +114,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testNoValidProjection()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -123,6 +129,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testNoValidFilter()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).filterNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("idmap", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
@@ -136,6 +143,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testNestedLambdaInProjection()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("expr", new ArrayType(new ArrayType(BIGINT)));
@@ -158,6 +166,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testInvalidNestedLambdaInProjection()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("expr", new ArrayType(new ArrayType(BIGINT)));
@@ -173,6 +182,7 @@ public class TestPullUpExpressionInLambdaRules
     public void testSkipTryFunction()
     {
         tester().assertThat(new PullUpExpressionInLambdaRules(getFunctionManager()).projectNodeRule())
+                .setSystemProperty(PULL_EXPRESSION_FROM_LAMBDA_ENABLED, "true")
                 .on(p ->
                 {
                     p.variable("x");


### PR DESCRIPTION
## Description
The optimization will cause bug when a WHEN expression is in lambda and not referring to the lambda argument.
For example, for query `select transform(col1, x -> concat(case when col2 is null then '*' when contains(col2, x) then '+' else ' ' end, x)) from (values (array['1'], array['1'])) t(col1, col2);` it will throw error `Can not compile special form: WHEN`.

## Motivation and Context
Fix bug

## Impact
Fix bug

## Test Plan
exisit

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* Disable the optimizer PullUpExpressionInLambdaRules which can lead to query failures.
   The failure happens when a "CASE" expression is in a lambda expression and not using the lambda arguments. The error message will be "Can not compile special form: WHEN"

```

