### PR TITLE
Fix Redis Hbo Provider docs

### DIFF
--- a/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
+++ b/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
@@ -16,29 +16,31 @@ Configuration properties
 
 The following configuration properties are available:
 
-====================================== =====================================================================
-Property Name                          Description
-====================================== =====================================================================
-``coordinator``                        Boolean property whether Presto server is a coordinator
+
+============================================ =====================================================================
+Property Name                                Description
+============================================ =====================================================================
+``coordinator``                              Boolean property whether Presto server is a coordinator
 ``hbo.redis-provider.server_uri``            Redis Server URI
 ``hbo.redis-provider.total-fetch-timeoutms`` Maximum timeout in ms for Redis fetch requests
 ``hbo.redis-provider.total-set-timeoutms``   Maximum timeout in ms for Redis set requests
 ``hbo.redis-provider.default-ttl-seconds``   TTL in seconds of the Redis data to be stored
 ``hbo.redis-provider.enabled``               Boolean property whether this plugin is enabled in production
-``credentials-path``                   Path for Redis credentials
+``credentials-path``                         Path for Redis credentials
 ``hbo.redis-provider.cluster-mode-enabled``  Boolean property whether cluster mode is enabled
-====================================== =====================================================================
+============================================ =====================================================================
 
 Credentials
 -----------
 
-The plugin requires the Redis Server URI property ``hbo.redis-provider.server_uri`` in order to access Redis
-Based on your custom Redis deployment you may need to add additional credentials
+The plugin requires the Redis Server URI property ``hbo.redis-provider.server_uri`` in order to access Redis.
+Based on your custom Redis deployment you may need to add additional credentials.
 
 Local Test setup
 ------------------------
 
-Set up local Redis Cluster with the guideline of `Redis <https://github.com/lettuce-io/lettuce-core>`_
+Set up local Redis Cluster with the guideline of `Redis <https://github.com/lettuce-io/lettuce-core>`_.
+
 Add ``../redis-hbo-provider/pom.xml,\`` to ``presto-main/etc/config.properties``.
 
 Add the following config file in ``presto-main/etc/hbo-provider.properties``
@@ -55,9 +57,12 @@ Add the following config file in ``presto-main/etc/hbo-provider.properties``
 
 Production Setup
 ------------------------
-You should place the JAR file into the plugins directory, insert the required configuration where needed, and it will then be loaded dynamically during runtime.
 
-Steps
+1. You can place the plugin JARs in the production's plugins directory.
+
+2. Alternatively, follow this method to ensure that the plugin is loaded during the Presto build.
+Steps to register the plugin in production
+
 1. Add the following to register the plugin in <fileSets> in presto-server/src/main/assembly/presto.xml
 
 .. code-block:: text
@@ -67,14 +72,15 @@ Steps
        <outputDirectory>plugin/redis-hbo-provider</outputDirectory>
     </fileSet>
 
-2. Add META-INF.services file in ``presto-hbo-provider/src/main/resources`` with the Plugin entry class com.facebook.presto.statistic.RedisProviderPlugin
+2. Add META-INF.services file in ``redis-hbo-provider/src/main/resources`` with the Plugin entry class com.facebook.presto.statistic.RedisProviderPlugin
+
 3. Add dependency on the module in ``presto-server/pom.xml``
 
 .. code-block:: text
 
     <dependency>
         <groupId>com.facebook.presto</groupId>
-        <artifactId>presto-hbo-provider</artifactId>
+        <artifactId>redis-hbo-provider</artifactId>
         <version>${project.version}</version>
         <type>zip</type>
         <scope>provided</scope>


### PR DESCRIPTION
## Description
Fixes Redis Hbo Provider docs.
1. Fixes a rendering issue where a table was not properly displayed
2. Fixes nomenclature to use the redis-hbo-provider plugin name instead of the presto-hbo-provider

== NO RELEASE NOTE ==

