### PR TITLE
Fix missing equals and hashCode in ORC BinaryStatistics

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
@@ -16,6 +16,8 @@ package com.facebook.presto.orc.metadata.statistics;
 import com.facebook.presto.orc.metadata.statistics.StatisticsHasher.Hashable;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Objects;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class BinaryStatistics
@@ -55,5 +57,24 @@ public class BinaryStatistics
     public void addHash(StatisticsHasher hasher)
     {
         hasher.putLong(sum);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BinaryStatistics that = (BinaryStatistics) o;
+        return sum == that.sum;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sum);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
@@ -28,6 +28,7 @@ import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.merge
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 
 public class TestBinaryStatisticsBuilder
@@ -121,7 +122,7 @@ public class TestBinaryStatisticsBuilder
 
         addValue(statisticsBuilder, SECOND_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
-        assertMergedBinaryStatistics(statisticsList, 6, FIRST_VALUE.length() * 2 + SECOND_VALUE.length());
+        assertMergedBinaryStatistics(statisticsList, 6, FIRST_VALUE.length() * 2L + SECOND_VALUE.length());
     }
 
     @Test
@@ -131,6 +132,22 @@ public class TestBinaryStatisticsBuilder
         assertTotalValueBytes(BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(EMPTY_SLICE));
         assertTotalValueBytes(FIRST_VALUE.length() + BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(FIRST_VALUE));
         assertTotalValueBytes((FIRST_VALUE.length() + SECOND_VALUE.length()) + 2 * BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(FIRST_VALUE, SECOND_VALUE));
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        BinaryStatisticsBuilder statisticsBuilder = new BinaryStatisticsBuilder();
+        addValue(statisticsBuilder, FIRST_VALUE);
+        ColumnStatistics statA1 = statisticsBuilder.buildColumnStatistics();
+        ColumnStatistics statA2 = statisticsBuilder.buildColumnStatistics();
+        assertEquals(statA1, statA2);
+        assertEquals(statA1.hashCode(), statA2.hashCode());
+
+        addValue(statisticsBuilder, SECOND_VALUE);
+        ColumnStatistics statB1 = statisticsBuilder.buildColumnStatistics();
+        assertNotEquals(statA1, statB1);
+        assertNotEquals(statA1.hashCode(), statB1.hashCode());
     }
 
     private void assertMergedBinaryStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, long expectedSum)


### PR DESCRIPTION
## Description
Add missing equals and hashCode in ORC BinaryStatistics. Because of the 
missing equals and hashCode in the BinaryStatistics the BinaryColumnStatistics
did not work quite right.

## Test Plan
Existing and new unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

