### PR TITLE
Add plan node hash to Query complete event

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -13,12 +13,15 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,6 +41,7 @@ public class QueryCompletedEvent
     private final List<OperatorStatistics> operatorStatistics;
     private final List<PlanStatisticsWithSourceInfo> planStatisticsRead;
     private final List<PlanStatisticsWithSourceInfo> planStatisticsWritten;
+    private final Map<PlanNodeId, Map<PlanCanonicalizationStrategy, String>> planNodeHash;
 
     private final Instant createTime;
     private final Instant executionStartTime;
@@ -65,6 +69,7 @@ public class QueryCompletedEvent
             List<OperatorStatistics> operatorStatistics,
             List<PlanStatisticsWithSourceInfo> planStatisticsRead,
             List<PlanStatisticsWithSourceInfo> planStatisticsWritten,
+            Map<PlanNodeId, Map<PlanCanonicalizationStrategy, String>> planNodeHash,
             Optional<String> expandedQuery,
             List<PlanOptimizerInformation> optimizerInformation,
             List<CTEInformation> cteInformationList,
@@ -86,6 +91,7 @@ public class QueryCompletedEvent
         this.stageStatistics = requireNonNull(stageStatistics, "stageStatistics is null");
         this.operatorStatistics = requireNonNull(operatorStatistics, "operatorStatistics is null");
         this.planStatisticsRead = requireNonNull(planStatisticsRead, "planStatisticsRead is null");
+        this.planNodeHash = requireNonNull(planNodeHash, "planNodeHash is null");
         this.planStatisticsWritten = requireNonNull(planStatisticsWritten, "planStatisticsWritten is null");
         this.expandedQuery = requireNonNull(expandedQuery, "expandedQuery is null");
         this.optimizerInformation = requireNonNull(optimizerInformation, "optimizerInformation is null");
@@ -168,6 +174,11 @@ public class QueryCompletedEvent
     public List<PlanStatisticsWithSourceInfo> getPlanStatisticsWritten()
     {
         return planStatisticsWritten;
+    }
+
+    public Map<PlanNodeId, Map<PlanCanonicalizationStrategy, String>> getPlanNodeHash()
+    {
+        return planNodeHash;
     }
 
     public Optional<String> getExpandedQuery()


### PR DESCRIPTION
## Description
Add plan node hash to query complete event, so that it can be logged after query finish

Depended by https://github.com/facebookexternal/presto-facebook/pull/2456

## Motivation and Context
HBO will canonicalize and hash query plan node, this hash will be used to fetch history statistics. When no matched hash is found, it will fall back to CBO.

This change will enable logging hash when it fall back to CBO, so as to help in debugging the mismatch.

## Impact
Easier debugging.

## Test Plan
Tested in https://github.com/facebookexternal/presto-facebook/pull/2456

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

