### PR TITLE
[pos] Fix invalid argument exception in PhysicalResourceCalculator

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkPhysicalResourceCalculator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkPhysicalResourceCalculator.java
@@ -71,7 +71,6 @@ public class PrestoSparkPhysicalResourceCalculator
         }
 
         double inputDataInBytes = prestoSparkSourceStatsCollector.collectSourceStats(plan);
-        DataSize inputSize = new DataSize(inputDataInBytes, BYTE);
         if (inputDataInBytes < 0) {
             log.warn(String.format("Input data statistics missing, inputDataInBytes=%.2f skipping automatic resource tuning. Executing query %s with %s",
                     inputDataInBytes, session.getQueryId(), defaultResourceSettings));
@@ -82,6 +81,8 @@ public class PrestoSparkPhysicalResourceCalculator
                     inputDataInBytes, session.getQueryId(), defaultResourceSettings));
             return defaultResourceSettings;
         }
+        DataSize inputSize = new DataSize(inputDataInBytes, BYTE);
+
         // update hashPartitionCount only if resource allocation or hash partition allocation is enabled
         if (isSparkResourceAllocationStrategyEnabled(session) || isSparkHashPartitionCountAllocationStrategyEnabled(session)) {
             hashPartitionCount = calculateHashPartitionCount(session, inputSize);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkPhysicalResourceAllocationStrategy.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkPhysicalResourceAllocationStrategy.java
@@ -56,15 +56,22 @@ import static org.testng.Assert.assertFalse;
 
 public class TestPrestoSparkPhysicalResourceAllocationStrategy
 {
-    // mocked metadata with table statistics generating random estimate count for the purpose of testing
-    // no other method is stubbed so will likely throw UnsupportedOperationException
+    // Mocked metadata with table statistics generating estimate count for the purpose of testing.
+    // No other method is stubbed so will likely throw UnsupportedOperationException.
     private static class MockedMetadata
             extends AbstractMockMetadata
     {
+        private final Estimate tableSizeEstimate;
+
+        public MockedMetadata(Estimate mockedTableSizeEstimate)
+        {
+            this.tableSizeEstimate = mockedTableSizeEstimate;
+        }
+
         @Override
         public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
         {
-            return TableStatistics.builder().setRowCount(Estimate.of(100)).setTotalSize(Estimate.of(1000)).build();
+            return TableStatistics.builder().setRowCount(Estimate.of(100)).setTotalSize(tableSizeEstimate).build();
         }
     }
 
@@ -90,7 +97,8 @@ public class TestPrestoSparkPhysicalResourceAllocationStrategy
                     PropertyMetadata.booleanProperty(SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED, "SPARK_HASH_PARTITION_COUNT_ALLOCATION_STRATEGY_ENABLED", false, false),
                     PropertyMetadata.booleanProperty(SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED, "SPARK_EXECUTOR_ALLOCATION_STRATEGY_ENABLED", false, false)
             ).build())).build();
-    private static final Metadata mockedMetadata = new MockedMetadata();
+    private static final Metadata mockedMetadata = new MockedMetadata(Estimate.of(1000));
+    private static final Metadata mockedUnknownMetadata = new MockedMetadata(Estimate.unknown());
 
     /**
      * Return any plan node, the node does not even need to be "correct",
@@ -108,26 +116,34 @@ public class TestPrestoSparkPhysicalResourceAllocationStrategy
         return planBuilder.join(JoinNode.Type.LEFT, a, b);
     }
 
+    private PhysicalResourceSettings getSettingsHolder(Session session, Metadata metadata)
+    {
+        PrestoSparkSourceStatsCollector prestoSparkSourceStatsCollector = new PrestoSparkSourceStatsCollector(metadata, session);
+        PlanNode nodeToTest = getPlanToTest(session, metadata);
+
+        return new PrestoSparkPhysicalResourceCalculator().calculate(nodeToTest, prestoSparkSourceStatsCollector, session);
+    }
+
     @Test
     public void testHashPartitionCountAllocationStrategy()
     {
-        PrestoSparkSourceStatsCollector prestoSparkSourceStatsCollector = new PrestoSparkSourceStatsCollector(mockedMetadata, testSessionWithAllocation);
-        PlanNode nodeToTest = getPlanToTest(testSessionWithAllocation, mockedMetadata);
-
-        PhysicalResourceSettings settingsHolder = new PrestoSparkPhysicalResourceCalculator()
-                .calculate(nodeToTest, prestoSparkSourceStatsCollector, testSessionWithAllocation);
+        PhysicalResourceSettings settingsHolder = getSettingsHolder(testSessionWithAllocation, mockedMetadata);
         assertEquals(settingsHolder.getHashPartitionCount(), 20);
         assertEquals(settingsHolder.getMaxExecutorCount().getAsInt(), 10);
     }
 
     @Test
+    public void testStrategyWithUnknownEstimate()
+    {
+        PhysicalResourceSettings settingsHolder = getSettingsHolder(testSessionWithAllocation, mockedUnknownMetadata);
+        assertEquals(settingsHolder.getHashPartitionCount(), 150);
+        assertFalse(settingsHolder.getMaxExecutorCount().isPresent());
+    }
+
+    @Test
     public void testHashPartitionCountWithoutAllocationStrategy()
     {
-        PrestoSparkSourceStatsCollector prestoSparkSourceStatsCollector = new PrestoSparkSourceStatsCollector(mockedMetadata, testSessionWithoutAllocation);
-        PlanNode nodeToTest = getPlanToTest(testSessionWithoutAllocation, mockedMetadata);
-
-        PhysicalResourceSettings settingsHolder = new PrestoSparkPhysicalResourceCalculator()
-                .calculate(nodeToTest, prestoSparkSourceStatsCollector, testSessionWithoutAllocation);
+        PhysicalResourceSettings settingsHolder = getSettingsHolder(testSessionWithoutAllocation, mockedMetadata);
         assertEquals(settingsHolder.getHashPartitionCount(), 150);
         assertFalse(settingsHolder.getMaxExecutorCount().isPresent());
     }


### PR DESCRIPTION
## Description
Fix bug in PhysicalResourceCalculator when estimates are unknown.

## Motivation and Context
When estimates are unknown prestoSparkSourceStatsCollector returns NaN. Check for valid return type before creating DataSize object from the estimate.

## Impact
Fix Invalid argument exception when datasize is unknown.

## Test Plan
Added unit test to replicate and fix the behaviour.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

