### PR TITLE
[Native] Fix e2e testing for normal_cdf

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
@@ -87,7 +87,7 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
     public void testNormalCDF()
     {
         assertQuery("SELECT normal_cdf(nationKey, 7.3, 10.5) FROM nation");
-        assertQuery("SELECT normal_cdf(9.15, nationKey, 5.3) FROM nation");
+        assertQuery("SELECT normal_cdf(9.15, nationKey, 5.3) FROM nation WHERE nationKey != 0");
         assertQuery("SELECT normal_cdf(2.3, 11.2, nationKey) FROM nation");
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the e2e testing for normal_cdf. (Delivered via https://github.com/prestodb/presto/pull/20644)

Current Error
```
java.lang.AssertionError: Execution of 'actual' query failed: SELECT normal_cdf(9.15, nationKey, 5.3) FROM nation

Caused by: java.lang.RuntimeException: sd > 0 (0 vs. 0) standardDeviation must be > 0 presto.default.normal_cdf(9.15:DOUBLE, cast((nationkey) as DOUBLE), 5.3:DOUBLE)
```

```
== NO RELEASE NOTE ==
```

