### PR TITLE
[Iceberg] Implement ANALYZE when Hive is configured

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStatisticsUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStatisticsUtil.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTimeZone;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.hive.metastore.Statistics.fromComputedStatistics;
+import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
+import static com.google.common.base.Verify.verify;
+
+public class HiveStatisticsUtil
+{
+    private HiveStatisticsUtil()
+    {
+    }
+
+    public static PartitionStatistics createPartitionStatistics(
+            ConnectorSession session,
+            HiveBasicStatistics basicStatistics,
+            Map<String, Type> columnTypes,
+            Map<ColumnStatisticMetadata, Block> computedColumnStatistics,
+            DateTimeZone timeZone)
+    {
+        long rowCount = basicStatistics.getRowCount().orElseThrow(() -> new IllegalArgumentException("rowCount not present"));
+        Map<String, HiveColumnStatistics> columnStatistics = fromComputedStatistics(
+                session,
+                timeZone,
+                computedColumnStatistics,
+                columnTypes,
+                rowCount);
+        return new PartitionStatistics(basicStatistics, columnStatistics);
+    }
+
+    public static PartitionStatistics createPartitionStatistics(
+            ConnectorSession session,
+            Map<String, Type> columnTypes,
+            ComputedStatistics computedStatistics,
+            DateTimeZone timeZone)
+    {
+        Map<ColumnStatisticMetadata, Block> computedColumnStatistics = computedStatistics.getColumnStatistics();
+
+        Block rowCountBlock = Optional.ofNullable(computedStatistics.getTableStatistics().get(ROW_COUNT))
+                .orElseThrow(() -> new VerifyException("rowCount not present"));
+        verify(!rowCountBlock.isNull(0), "rowCount must never be null");
+        long rowCount = BIGINT.getLong(rowCountBlock, 0);
+        HiveBasicStatistics rowCountOnlyBasicStatistics = new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(rowCount), OptionalLong.empty(), OptionalLong.empty());
+        return createPartitionStatistics(session, rowCountOnlyBasicStatistics, columnTypes, computedColumnStatistics, timeZone);
+    }
+
+    public static Map<ColumnStatisticMetadata, Block> getColumnStatistics(Map<List<String>, ComputedStatistics> statistics, List<String> partitionValues)
+    {
+        return Optional.ofNullable(statistics.get(partitionValues))
+                .map(ComputedStatistics::getColumnStatistics)
+                .orElse(ImmutableMap.of());
+    }
+
+    // TODO: Collect file count, on-disk size and in-memory size during ANALYZE
+    /**
+     *  This method updates old {@link PartitionStatistics} with new statistics, only if the new
+     *  partition stats are not empty. This method always overwrites each of the
+     *  {@link HiveColumnStatistics} contained in the new partition statistics.
+     *
+     * @param oldPartitionStats old version of partition statistics
+     * @param newPartitionStats new version of partition statistics
+     * @return updated partition statistics
+     */
+    public static PartitionStatistics updatePartitionStatistics(PartitionStatistics oldPartitionStats, PartitionStatistics newPartitionStats)
+    {
+        HiveBasicStatistics oldBasicStatistics = oldPartitionStats.getBasicStatistics();
+        HiveBasicStatistics newBasicStatistics = newPartitionStats.getBasicStatistics();
+        HiveBasicStatistics updatedBasicStatistics = new HiveBasicStatistics(
+                firstPresent(newBasicStatistics.getFileCount(), oldBasicStatistics.getFileCount()),
+                firstPresent(newBasicStatistics.getRowCount(), oldBasicStatistics.getRowCount()),
+                firstPresent(newBasicStatistics.getInMemoryDataSizeInBytes(), oldBasicStatistics.getInMemoryDataSizeInBytes()),
+                firstPresent(newBasicStatistics.getOnDiskDataSizeInBytes(), oldBasicStatistics.getOnDiskDataSizeInBytes()));
+        return new PartitionStatistics(updatedBasicStatistics, newPartitionStats.getColumnStatistics());
+    }
+
+    private static OptionalLong firstPresent(OptionalLong first, OptionalLong second)
+    {
+        return first.isPresent() ? first : second;
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStatisticsUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStatisticsUtil.java
@@ -34,7 +34,7 @@ import static com.facebook.presto.hive.metastore.Statistics.fromComputedStatisti
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.google.common.base.Verify.verify;
 
-public class HiveStatisticsUtil
+public final class HiveStatisticsUtil
 {
     private HiveStatisticsUtil()
     {

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -94,6 +94,11 @@
         </dependency>
 
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory-context</artifactId>
         </dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -68,6 +68,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
@@ -392,7 +393,7 @@ public abstract class IcebergAbstractMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
-        return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
+        return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable, columnHandles.stream().map(IcebergColumnHandle.class::cast).collect(Collectors.toList()));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.hive.HiveCompressionCodec;
+import com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.FileFormat;
@@ -43,6 +44,8 @@ public class IcebergConfig
     private double minimumAssignedSplitWeight = 0.05;
     private boolean parquetDereferencePushdownEnabled = true;
     private boolean mergeOnReadModeEnabled;
+
+    private HiveStatisticsMergeStrategy hiveStatisticsMergeStrategy = HiveStatisticsMergeStrategy.NONE;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -179,5 +182,18 @@ public class IcebergConfig
     public boolean isMergeOnReadModeEnabled()
     {
         return mergeOnReadModeEnabled;
+    }
+
+    @Config("iceberg.hive-statistics-merge-strategy")
+    @ConfigDescription("determines how to merge statistics that are stored in the Hive Metastore")
+    public IcebergConfig setHiveStatisticsMergeStrategy(HiveStatisticsMergeStrategy mergeStrategy)
+    {
+        this.hiveStatisticsMergeStrategy = mergeStrategy;
+        return this;
+    }
+
+    public HiveStatisticsMergeStrategy getHiveStatisticsMergeStrategy()
+    {
+        return hiveStatisticsMergeStrategy;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -14,16 +14,20 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HiveTypeTranslator;
 import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.hive.ViewAlreadyExistsException;
+import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -39,8 +43,13 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticType;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -49,15 +58,23 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
 
+import static com.facebook.presto.hive.HiveStatisticsUtil.createPartitionStatistics;
+import static com.facebook.presto.hive.HiveStatisticsUtil.updatePartitionStatistics;
 import static com.facebook.presto.hive.HiveUtil.decodeViewData;
 import static com.facebook.presto.hive.HiveUtil.encodeViewData;
+import static com.facebook.presto.hive.HiveUtil.hiveColumnHandles;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.TABLE_COMMENT;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.checkIfNullView;
@@ -66,6 +83,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeade
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isPrestoView;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isUserDefinedTypeEncodingEnabled;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyAndPopulateViews;
+import static com.facebook.presto.hive.metastore.Statistics.createComputedStatisticsToPartitionMap;
 import static com.facebook.presto.iceberg.IcebergSchemaProperties.getSchemaLocation;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
@@ -81,7 +99,10 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
+import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
@@ -97,6 +118,7 @@ public class IcebergHiveMetadata
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final String prestoVersion;
+    private final DateTimeZone timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID())));
 
     public IcebergHiveMetadata(
             ExtendedHiveMetastore metastore,
@@ -135,14 +157,13 @@ public class IcebergHiveMetadata
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
-        return metastore.getAllDatabases(metastoreContext);
+        return metastore.getAllDatabases(getMetastoreContext(session));
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        MetastoreContext metastoreContext = getMetastoreContext(session);
         // If schema name is not present, list tables from all schemas
         List<String> schemaNames = schemaName
                 .map(ImmutableList::of)
@@ -176,7 +197,7 @@ public class IcebergHiveMetadata
                 .setOwnerName(session.getUser())
                 .build();
 
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        MetastoreContext metastoreContext = getMetastoreContext(session);
         metastore.createDatabase(metastoreContext, database);
     }
 
@@ -188,14 +209,14 @@ public class IcebergHiveMetadata
                 !listViews(session, Optional.of(schemaName)).isEmpty()) {
             throw new PrestoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + schemaName);
         }
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        MetastoreContext metastoreContext = getMetastoreContext(session);
         metastore.dropDatabase(metastoreContext, schemaName);
     }
 
     @Override
     public void renameSchema(ConnectorSession session, String source, String target)
     {
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        MetastoreContext metastoreContext = getMetastoreContext(session);
         metastore.renameDatabase(metastoreContext, source, target);
     }
 
@@ -210,7 +231,7 @@ public class IcebergHiveMetadata
 
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
 
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        MetastoreContext metastoreContext = getMetastoreContext(session);
         Database database = metastore.getDatabase(metastoreContext, schemaName)
                 .orElseThrow(() -> new SchemaNotFoundException(schemaName));
 
@@ -229,7 +250,7 @@ public class IcebergHiveMetadata
 
         TableOperations operations = new HiveTableOperations(
                 metastore,
-                new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER),
+                getMetastoreContext(session),
                 hdfsEnvironment,
                 hdfsContext,
                 schemaName,
@@ -279,23 +300,20 @@ public class IcebergHiveMetadata
                 table.properties().containsKey(WRITE_DATA_LOCATION)) {
             throw new PrestoException(NOT_SUPPORTED, "Table " + handle.getSchemaTableName() + " contains Iceberg path override properties and cannot be dropped from Presto");
         }
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
-        metastore.dropTable(metastoreContext, handle.getSchemaName(), handle.getTableName(), true);
+        metastore.dropTable(getMetastoreContext(session), handle.getSchemaName(), handle.getTableName(), true);
     }
 
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
-        metastore.renameTable(metastoreContext, handle.getSchemaName(), handle.getTableName(), newTable.getSchemaName(), newTable.getTableName());
+        metastore.renameTable(getMetastoreContext(session), handle.getSchemaName(), handle.getTableName(), newTable.getSchemaName(), newTable.getTableName());
     }
 
     @Override
     protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
     {
-        MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
-        if (!metastore.getTable(metastoreContext, table.getSchemaName(), table.getTableName()).isPresent()) {
+        if (!metastore.getTable(getMetastoreContext(session), table.getSchemaName(), table.getTableName()).isPresent()) {
             throw new TableNotFoundException(table);
         }
 
@@ -405,5 +423,56 @@ public class IcebergHiveMetadata
             return listSchemaNames(session);
         }
         return ImmutableList.of(schemaNameOrNull);
+    }
+    public IcebergTableHandle getTableHandleForStatisticsCollection(ConnectorSession session, SchemaTableName tableName, Map<String, Object> analyzeProperties)
+    {
+        return getTableHandle(session, tableName);
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        Set<ColumnStatisticMetadata> columnStatistics = tableMetadata.getColumns().stream()
+                .filter(column -> !column.isHidden())
+                .flatMap(meta -> metastore.getSupportedColumnStatistics(getMetastoreContext(session), meta.getType())
+                        .stream()
+                        .map(statType -> new ColumnStatisticMetadata(meta.getName(), statType)))
+                .collect(toImmutableSet());
+
+        Set<TableStatisticType> tableStatistics = ImmutableSet.of(ROW_COUNT);
+        return new TableStatisticsMetadata(columnStatistics, tableStatistics, Collections.emptyList());
+    }
+
+    @Override
+    public ConnectorTableHandle beginStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return tableHandle;
+    }
+
+    @Override
+    public void finishStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
+        MetastoreContext metastoreContext = getMetastoreContext(session);
+        Table table = metastore.getTable(metastoreContext, icebergTableHandle.getSchemaTableName().getSchemaName(), icebergTableHandle.getSchemaTableName().getTableName())
+                .orElseThrow(() -> new TableNotFoundException(icebergTableHandle.getSchemaTableName()));
+
+        List<Column> partitionColumns = table.getPartitionColumns();
+        List<String> partitionColumnNames = partitionColumns.stream()
+                .map(Column::getName)
+                .collect(toImmutableList());
+        List<HiveColumnHandle> hiveColumnHandles = hiveColumnHandles(table);
+        Map<String, Type> columnTypes = hiveColumnHandles.stream()
+                .filter(columnHandle -> !columnHandle.isHidden())
+                .collect(toImmutableMap(HiveColumnHandle::getName, column -> column.getHiveType().getType(typeManager)));
+
+        Map<List<String>, ComputedStatistics> computedStatisticsMap = createComputedStatisticsToPartitionMap(computedStatistics, partitionColumnNames, columnTypes);
+
+        // commit analyze to unpartitioned table
+        PartitionStatistics tableStatistics = createPartitionStatistics(session, columnTypes, computedStatisticsMap.get(ImmutableList.<String>of()), timeZone);
+        metastore.updateTableStatistics(metastoreContext,
+                table.getDatabaseName(),
+                table.getTableName(),
+                oldStats -> updatePartitionStatistics(oldStats, tableStatistics));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -19,6 +19,8 @@ import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
+import com.facebook.presto.spi.relation.RowExpressionService;
 
 import javax.inject.Inject;
 
@@ -32,6 +34,8 @@ public class IcebergHiveMetadataFactory
     final TypeManager typeManager;
     final JsonCodec<CommitTaskData> commitTaskCodec;
     final String prestoVersion;
+    final FilterStatsCalculatorService filterStatsCalculatorService;
+    final RowExpressionService rowExpressionService;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -40,7 +44,9 @@ public class IcebergHiveMetadataFactory
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
-            NodeVersion nodeVersion)
+            NodeVersion nodeVersion,
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            RowExpressionService rowExpressionService)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -48,11 +54,13 @@ public class IcebergHiveMetadataFactory
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         requireNonNull(nodeVersion, "nodeVersion is null");
         this.prestoVersion = nodeVersion.toString();
+        this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         requireNonNull(config, "config is null");
     }
 
     public ConnectorMetadata create()
     {
-        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec, prestoVersion);
+        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec, prestoVersion, filterStatsCalculatorService, rowExpressionService);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPag
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.common.collect.ImmutableSet;
@@ -89,6 +90,7 @@ public final class InternalIcebergConnectorFactory
                         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
                         binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                        binder.bind(FilterStatsCalculatorService.class).toInstance(context.getFilterStatsCalculatorService());
                     });
 
             Injector injector = app

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/HiveStatisticsMergeStrategy.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/HiveStatisticsMergeStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.util;
+
+/**
+ * strategies that define how to merge hive column statistics into Iceberg column statistics.
+ */
+public enum HiveStatisticsMergeStrategy
+{
+    /**
+     * Do not merge statistics from Hive
+     */
+    NONE,
+    /**
+     * Only merge NDV statistics from hive
+     */
+    USE_NDV,
+    /**
+     * Only merge null fractions from hive
+     */
+    USE_NULLS_FRACTIONS,
+    /**
+     * Merge both null fractions and NDVs from Hive
+     */
+    USE_NULLS_FRACTION_AND_NDV,
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.util;
+
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import org.apache.iceberg.PartitionSpec;
+
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.NONE;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NDV;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NULLS_FRACTIONS;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NULLS_FRACTION_AND_NDV;
+
+public final class StatisticsUtil
+{
+    private StatisticsUtil()
+    {
+    }
+
+    public static TableStatistics mergeHiveStatistics(TableStatistics icebergStatistics, PartitionStatistics hiveStatistics, HiveStatisticsMergeStrategy mergeStrategy, PartitionSpec spec)
+    {
+        if (mergeStrategy.equals(NONE) || spec.isPartitioned()) {
+            return icebergStatistics;
+        }
+        // We really only need to merge in NDVs and null fractions from the column statistics in hive's stats
+        //
+        // take iceberg data and column size, and row count statistics over hive's as they're more likely
+        // to be up to date since they are computed on the fly
+        Map<String, HiveColumnStatistics> columnStats = hiveStatistics.getColumnStatistics();
+        TableStatistics.Builder statsBuilder = TableStatistics.builder();
+        statsBuilder.setTotalSize(icebergStatistics.getTotalSize());
+        statsBuilder.setRowCount(icebergStatistics.getRowCount());
+        icebergStatistics.getColumnStatistics().forEach((columnHandle, icebergColumnStats) -> {
+            HiveColumnStatistics hiveColumnStats = columnStats.get(((IcebergColumnHandle) columnHandle).getName());
+            ColumnStatistics.Builder mergedStats = ColumnStatistics.builder()
+                    .setDataSize(icebergColumnStats.getDataSize())
+                    .setDistinctValuesCount(icebergColumnStats.getDistinctValuesCount())
+                    .setRange(icebergColumnStats.getRange())
+                    .setNullsFraction(icebergColumnStats.getNullsFraction())
+                    .setDistinctValuesCount(icebergColumnStats.getDistinctValuesCount())
+                    .setRange(icebergColumnStats.getRange());
+            if (hiveColumnStats != null) {
+                if (mergeStrategy.equals(USE_NDV) || mergeStrategy.equals(USE_NULLS_FRACTION_AND_NDV)) {
+                    hiveColumnStats.getDistinctValuesCount().ifPresent(ndvs -> mergedStats.setDistinctValuesCount(Estimate.of(ndvs)));
+                }
+                if (mergeStrategy.equals(USE_NULLS_FRACTIONS) || mergeStrategy.equals(USE_NULLS_FRACTION_AND_NDV)) {
+                    hiveColumnStats.getNullsCount().ifPresent(nullCount -> {
+                        Estimate nullsFraction;
+                        if (!hiveStatistics.getBasicStatistics().getRowCount().isPresent()) {
+                            if (icebergStatistics.getRowCount().isUnknown()) {
+                                nullsFraction = Estimate.unknown();
+                            }
+                            else {
+                                nullsFraction = Estimate.of((double) nullCount / icebergStatistics.getRowCount().getValue());
+                            }
+                        }
+                        else {
+                            nullsFraction = Estimate.of((double) nullCount / hiveStatistics.getBasicStatistics().getRowCount().getAsLong());
+                        }
+                        mergedStats.setNullsFraction(nullsFraction);
+                    });
+                }
+            }
+            statsBuilder.setColumnStatistics(columnHandle, mergedStats.build());
+        });
+        return statsBuilder.build();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -27,6 +28,7 @@ import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergFileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergFileFormat.PARQUET;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NDV;
 
 public class TestIcebergConfig
 {
@@ -40,6 +42,7 @@ public class TestIcebergConfig
                 .setCatalogWarehouse(null)
                 .setCatalogCacheSize(10)
                 .setHadoopConfigResources(null)
+                .setHiveStatisticsMergeStrategy(HiveStatisticsMergeStrategy.NONE)
                 .setMaxPartitionsPerWriter(100)
                 .setMinimumAssignedSplitWeight(0.05)
                 .setParquetDereferencePushdownEnabled(true)
@@ -60,6 +63,7 @@ public class TestIcebergConfig
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .put("iceberg.enable-parquet-dereference-pushdown", "false")
                 .put("iceberg.enable-merge-on-read-mode", "true")
+                .put("iceberg.hive-statistics-merge-strategy", "USE_NDV")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -72,7 +76,8 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(222)
                 .setMinimumAssignedSplitWeight(0.01)
                 .setParquetDereferencePushdownEnabled(false)
-                .setMergeOnReadModeEnabled(true);
+                .setMergeOnReadModeEnabled(true)
+                .setHiveStatisticsMergeStrategy(USE_NDV);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestStatisticsUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestStatisticsUtil.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveBasicStatistics;
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
+import com.facebook.presto.iceberg.ColumnIdentity.TypeCategory;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.DoubleRange;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.NONE;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NDV;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NULLS_FRACTIONS;
+import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NULLS_FRACTION_AND_NDV;
+import static com.facebook.presto.iceberg.util.StatisticsUtil.mergeHiveStatistics;
+import static org.testng.Assert.assertEquals;
+
+public class TestStatisticsUtil
+{
+    @Test
+    public void testMergeStrategyNone()
+    {
+        TableStatistics merged = mergeHiveStatistics(generateSingleColumnIcebergStats(), generateSingleColumnHiveStatistics(), NONE, PartitionSpec.unpartitioned());
+        assertEquals(Estimate.of(1), merged.getRowCount());
+        assertEquals(Estimate.unknown(), merged.getTotalSize());
+        assertEquals(1, merged.getColumnStatistics().size());
+        ColumnStatistics stats = merged.getColumnStatistics().values().stream().findFirst().get();
+        assertEquals(Estimate.of(8), stats.getDataSize());
+        assertEquals(Estimate.of(1), stats.getDistinctValuesCount());
+        assertEquals(Estimate.of(0.1), stats.getNullsFraction());
+        assertEquals(new DoubleRange(0.0, 1.0), stats.getRange().get());
+    }
+
+    @Test
+    public void testMergeStrategyWithPartitioned()
+    {
+        TableStatistics merged = mergeHiveStatistics(generateSingleColumnIcebergStats(), generateSingleColumnHiveStatistics(), USE_NULLS_FRACTION_AND_NDV,
+                PartitionSpec.builderFor(new Schema(Types.NestedField.required(0, "test", Types.IntegerType.get()))).bucket("test", 100).build());
+        assertEquals(Estimate.of(1), merged.getRowCount());
+        assertEquals(Estimate.unknown(), merged.getTotalSize());
+        assertEquals(1, merged.getColumnStatistics().size());
+        ColumnStatistics stats = merged.getColumnStatistics().values().stream().findFirst().get();
+        assertEquals(Estimate.of(8), stats.getDataSize());
+        assertEquals(Estimate.of(1), stats.getDistinctValuesCount());
+        assertEquals(Estimate.of(0.1), stats.getNullsFraction());
+        assertEquals(new DoubleRange(0.0, 1.0), stats.getRange().get());
+    }
+
+    @Test
+    public void testMergeStrategyNDVs()
+    {
+        TableStatistics merged = mergeHiveStatistics(generateSingleColumnIcebergStats(), generateSingleColumnHiveStatistics(), USE_NDV, PartitionSpec.unpartitioned());
+        assertEquals(Estimate.of(1), merged.getRowCount());
+        assertEquals(Estimate.unknown(), merged.getTotalSize());
+        assertEquals(1, merged.getColumnStatistics().size());
+        ColumnStatistics stats = merged.getColumnStatistics().values().stream().findFirst().get();
+        assertEquals(Estimate.of(8), stats.getDataSize());
+        assertEquals(Estimate.of(2), stats.getDistinctValuesCount());
+        assertEquals(Estimate.of(0.1), stats.getNullsFraction());
+        assertEquals(new DoubleRange(0.0, 1.0), stats.getRange().get());
+    }
+
+    @Test
+    public void testMergeStrategyNulls()
+    {
+        TableStatistics merged = mergeHiveStatistics(generateSingleColumnIcebergStats(), generateSingleColumnHiveStatistics(), USE_NULLS_FRACTIONS, PartitionSpec.unpartitioned());
+        assertEquals(Estimate.of(1), merged.getRowCount());
+        assertEquals(Estimate.unknown(), merged.getTotalSize());
+        assertEquals(1, merged.getColumnStatistics().size());
+        ColumnStatistics stats = merged.getColumnStatistics().values().stream().findFirst().get();
+        assertEquals(Estimate.of(8), stats.getDataSize());
+        assertEquals(Estimate.of(1), stats.getDistinctValuesCount());
+        assertEquals(Estimate.of(1.0), stats.getNullsFraction());
+        assertEquals(new DoubleRange(0.0, 1.0), stats.getRange().get());
+    }
+
+    @Test
+    public void testMergeStrategyNDVsAndNulls()
+    {
+        TableStatistics merged = mergeHiveStatistics(generateSingleColumnIcebergStats(), generateSingleColumnHiveStatistics(), USE_NULLS_FRACTION_AND_NDV, PartitionSpec.unpartitioned());
+        assertEquals(Estimate.of(1), merged.getRowCount());
+        assertEquals(Estimate.unknown(), merged.getTotalSize());
+        assertEquals(1, merged.getColumnStatistics().size());
+        ColumnStatistics stats = merged.getColumnStatistics().values().stream().findFirst().get();
+        assertEquals(Estimate.of(8), stats.getDataSize());
+        assertEquals(Estimate.of(2), stats.getDistinctValuesCount());
+        assertEquals(Estimate.of(1.0), stats.getNullsFraction());
+        assertEquals(new DoubleRange(0.0, 1.0), stats.getRange().get());
+    }
+
+    private static TableStatistics generateSingleColumnIcebergStats()
+    {
+        return TableStatistics.builder()
+                .setRowCount(Estimate.of(1))
+                .setTotalSize(Estimate.unknown())
+                .setColumnStatistics(new IcebergColumnHandle(
+                                new ColumnIdentity(1, "test", TypeCategory.PRIMITIVE, Collections.emptyList()),
+                                INTEGER,
+                                Optional.empty()),
+                        ColumnStatistics.builder()
+                                .setNullsFraction(Estimate.of(0.1))
+                                .setRange(new DoubleRange(0.0, 1.0))
+                                .setDataSize(Estimate.of(8))
+                                .setDistinctValuesCount(Estimate.of(1))
+                                .build())
+                .build();
+    }
+
+    private static PartitionStatistics generateSingleColumnHiveStatistics()
+    {
+        return new PartitionStatistics(
+                new HiveBasicStatistics(1, 2, 16, 16),
+                ImmutableMap.of("test",
+                        HiveColumnStatistics.createIntegerColumnStatistics(
+                                OptionalLong.of(1),
+                                OptionalLong.of(2),
+                                OptionalLong.of(2),
+                                OptionalLong.of(2))));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * This class tests the ability for the Hive implementation of the IcebergMetadata to store and read
+ * table statistics
+ */
+public class TestIcebergHiveStatistics
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of("iceberg.hive-statistics-merge-strategy", "USE_NDV"));
+    }
+
+    private static final Set<String> NUMERIC_ORDERS_COLUMNS = ImmutableSet.<String>builder()
+            .add("orderkey")
+            .add("custkey")
+            .add("totalprice")
+            .add("orderdate")
+            .add("shippriority")
+            .build();
+
+    private static final Set<String> NON_NUMERIC_ORDERS_COLUMNS = ImmutableSet.<String>builder()
+            .add("orderstatus")
+            .add("orderpriority")
+            .add("clerk")
+            .add("comment")
+            .build();
+    private static final Set<String> ALL_ORDERS_COLUMNS = Arrays.stream(StatsSchema.values()).map(StatsSchema::getColumnName).collect(Collectors.toSet());
+
+    enum StatsSchema
+    {
+        COLUMN_NAME("column_name"),
+        DATA_SIZE("data_size"),
+        DISTINCT_VALUES_COUNT("distinct_values_count"),
+        NULLS_FRACTION("nulls_fraction"),
+        ROW_COUNT("row_count"),
+        LOW_VALUE("low_value"),
+        HIGH_VALUE("high_value");
+        private final String name;
+
+        StatsSchema(String name)
+        {
+            this.name = name;
+        }
+
+        public String getColumnName()
+        {
+            return name;
+        }
+    }
+
+    /**
+     * ensures that the stats not provided by {@link com.facebook.presto.iceberg.TableStatisticsMaker} are
+     * populated and served from the metadata after running an ANALYZE query
+     */
+    @Test
+    public void testSimpleAnalyze()
+    {
+        assertQuerySucceeds("CREATE TABLE simpleAnalyze as SELECT * FROM orders");
+        MaterializedResult stats = getQueryRunner().execute("SHOW STATS FOR simpleAnalyze");
+        assertStatValueAbsent(StatsSchema.DISTINCT_VALUES_COUNT, stats, NUMERIC_ORDERS_COLUMNS);
+        assertQuerySucceeds("ANALYZE simpleAnalyze");
+        stats = getQueryRunner().execute("SHOW STATS FOR simpleAnalyze");
+        assertStatValuePresent(StatsSchema.DISTINCT_VALUES_COUNT, stats, NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.NULLS_FRACTION, stats, NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.NULLS_FRACTION, stats, NON_NUMERIC_ORDERS_COLUMNS);
+    }
+
+    /**
+     * Tests the TableStatisticsMaker is used, even when ANALYZE has not been run yet
+     */
+    @Test
+    public void testStatsBeforeAnalyze()
+    {
+        assertQuerySucceeds("CREATE TABLE statsBeforeAnalyze as SELECT * FROM orders");
+        MaterializedResult stats = getQueryRunner().execute("SHOW STATS FOR statsBeforeAnalyze");
+        assertStatValueAbsent(StatsSchema.DISTINCT_VALUES_COUNT, stats, NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.DATA_SIZE, stats, ALL_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.LOW_VALUE, stats, NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.HIGH_VALUE, stats, ALL_ORDERS_COLUMNS);
+    }
+
+    @Test
+    public void testStatsWithPartitionedTableAnalyzed()
+    {
+        assertQuerySucceeds("CREATE TABLE statsNoPartitionAnalyze as SELECT * FROM orders LIMIT 100");
+        assertQuerySucceeds("CREATE TABLE statsWithPartitionAnalyze WITH (partitioning = ARRAY['orderdate']) as SELECT * FROM statsNoPartitionAnalyze");
+        assertQuerySucceeds("ANALYZE statsNoPartitionAnalyze");
+        assertQuerySucceeds("ANALYZE statsWithPartitionAnalyze");
+        Metadata meta = getQueryRunner().getMetadata();
+        TransactionId txid = getQueryRunner().getTransactionManager().beginTransaction(false);
+        Session session = getSession().beginTransactionId(txid, getQueryRunner().getTransactionManager(), new AllowAllAccessControl());
+        Map<String, ColumnHandle> noPartColumns = getColumnHandles("statsnopartitionanalyze", session);
+        Map<String, ColumnHandle> partColumns = getColumnHandles("statswithpartitionanalyze", session);
+        List<ColumnHandle> noPartColumnHandles = new ArrayList<>(noPartColumns.values());
+        List<ColumnHandle> partColumnHandles = new ArrayList<>(partColumns.values());
+        // Test that with all columns and no constraints that stats are equivalent
+        TableStatistics statsNoPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsNoPartitionAnalyze", session), noPartColumnHandles, Constraint.alwaysTrue());
+        TableStatistics statsWithPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsWithPartitionAnalyze", session), partColumnHandles, Constraint.alwaysTrue());
+        assertNDVsPresent(statsNoPartition);
+        assertNDVsNotPresent(statsWithPartition);
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+
+        // Test that with one column and no constraints that stats are equivalent
+        statsNoPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsNoPartitionAnalyze", session), Collections.singletonList(noPartColumns.get("totalprice")), Constraint.alwaysTrue());
+        statsWithPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsWithPartitionAnalyze", session), Collections.singletonList(partColumns.get("totalprice")), Constraint.alwaysTrue());
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("totalprice")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("totalprice")));
+        assertNDVsPresent(statsNoPartition);
+        assertNDVsNotPresent(statsWithPartition);
+
+        // Test that with all columns and a Tuple constraint that stats are equivalent
+        statsNoPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsNoPartitionAnalyze", session), noPartColumnHandles, Constraint.alwaysTrue());
+        statsWithPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsWithPartitionAnalyze", session), partColumnHandles, Constraint.alwaysTrue());
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+        assertEquals(statsNoPartition.getColumnStatistics().size(), noPartColumnHandles.size());
+        assertEquals(statsWithPartition.getColumnStatistics().size(), partColumnHandles.size());
+        assertNDVsPresent(statsNoPartition);
+        assertNDVsNotPresent(statsWithPartition);
+
+        // Test that with one column and a constraint on that column that the partitioned stats return less values
+        Constraint<ColumnHandle> noPartConstraint = constraintWithMinValue(noPartColumns.get("totalprice"), 100000.0);
+        Constraint<ColumnHandle> partConstraint = constraintWithMinValue(partColumns.get("totalprice"), 100000.0);
+        statsNoPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsNoPartitionAnalyze", session), Collections.singletonList(noPartColumns.get("totalprice")), noPartConstraint);
+        statsWithPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsWithPartitionAnalyze", session), Collections.singletonList(partColumns.get("totalprice")), partConstraint);
+        // ensure partitioned table actually returns less rows
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("totalprice")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("totalprice")));
+        assertNDVsPresent(statsNoPartition);
+        assertNDVsNotPresent(statsWithPartition);
+        // partitioned table should have stats partially filtered since data should span > 1 file
+        assertTrue(statsWithPartition.getRowCount().getValue() < statsNoPartition.getRowCount().getValue());
+
+        // Test that with one column and a constraint on a different column that stats are equivalent.
+        noPartConstraint = constraintWithMinValue(noPartColumns.get("totalprice"), 100000.0);
+        partConstraint = constraintWithMinValue(partColumns.get("totalprice"), 100000.0);
+        statsNoPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsNoPartitionAnalyze", session), Collections.singletonList(noPartColumns.get("orderkey")), noPartConstraint);
+        statsWithPartition = meta.getTableStatistics(session, getAnalyzeTableHandle("statsWithPartitionAnalyze", session), Collections.singletonList(partColumns.get("orderkey")), partConstraint);
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("orderkey")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("orderkey")));
+        assertNDVsPresent(statsNoPartition);
+        assertNDVsNotPresent(statsWithPartition);
+        // partitioned table should have stats partially filtered since data should span > 1 file
+        assertTrue(statsWithPartition.getRowCount().getValue() < statsNoPartition.getRowCount().getValue());
+
+        assertQuerySucceeds("DROP TABLE statsNoPartitionAnalyze");
+        assertQuerySucceeds("DROP TABLE statsWithPartitionAnalyze");
+    }
+
+    @Test
+    public void testStatsWithPartitionedTablesNoAnalyze()
+    {
+        assertQuerySucceeds("CREATE TABLE statsNoPartition as SELECT * FROM orders LIMIT 100");
+        assertQuerySucceeds("CREATE TABLE statsWithPartition WITH (partitioning = ARRAY['orderdate']) as SELECT * FROM statsNoPartition");
+        Metadata meta = getQueryRunner().getMetadata();
+        TransactionId txid = getQueryRunner().getTransactionManager().beginTransaction(false);
+        Session s = getSession().beginTransactionId(txid, getQueryRunner().getTransactionManager(), new AllowAllAccessControl());
+        Map<String, ColumnHandle> noPartColumns = getColumnHandles("statsnopartition", s);
+        Map<String, ColumnHandle> partColumns = getColumnHandles("statswithpartition", s);
+        List<ColumnHandle> noPartColumnHandles = new ArrayList<>(noPartColumns.values());
+        List<ColumnHandle> partColumnHandles = new ArrayList<>(partColumns.values());
+        // Test that with all columns and no constraints that stats are equivalent
+        TableStatistics statsNoPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsNoPartition", s), noPartColumnHandles, Constraint.alwaysTrue());
+        TableStatistics statsWithPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsWithPartition", s), partColumnHandles, Constraint.alwaysTrue());
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+        columnStatsEqual(statsNoPartition.getColumnStatistics(), statsWithPartition.getColumnStatistics());
+
+        // Test that with one column and no constraints that stats are equivalent
+        statsNoPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsNoPartition", s), Collections.singletonList(noPartColumns.get("totalprice")), Constraint.alwaysTrue());
+        statsWithPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsWithPartition", s), Collections.singletonList(partColumns.get("totalprice")), Constraint.alwaysTrue());
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("totalprice")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("totalprice")));
+        columnStatsEqual(statsNoPartition.getColumnStatistics(), statsWithPartition.getColumnStatistics());
+
+        // Test that with all columns and a Tuple constraint that stats are equivalent
+        statsNoPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsNoPartition", s), noPartColumnHandles, Constraint.alwaysTrue());
+        statsWithPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsWithPartition", s), partColumnHandles, Constraint.alwaysTrue());
+        assertEquals(statsNoPartition.getRowCount(), statsWithPartition.getRowCount());
+        assertEquals(statsNoPartition.getColumnStatistics().size(), noPartColumnHandles.size());
+        assertEquals(statsWithPartition.getColumnStatistics().size(), partColumnHandles.size());
+        columnStatsEqual(statsNoPartition.getColumnStatistics(), statsWithPartition.getColumnStatistics());
+
+        // Test that with one column and a constraint on that column that the partitioned stats return less values
+        Constraint<ColumnHandle> noPartConstraint = constraintWithMinValue(noPartColumns.get("totalprice"), 100000.0);
+        Constraint<ColumnHandle> partConstraint = constraintWithMinValue(partColumns.get("totalprice"), 100000.0);
+        statsNoPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsNoPartition", s), Collections.singletonList(noPartColumns.get("totalprice")), noPartConstraint);
+        statsWithPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsWithPartition", s), Collections.singletonList(partColumns.get("totalprice")), partConstraint);
+        // ensure partitioned table actually returns less rows
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("totalprice")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("totalprice")));
+        // partitioned table should have stats partially filtered since data should span > 1 file
+        assertTrue(statsWithPartition.getRowCount().getValue() < statsNoPartition.getRowCount().getValue());
+
+        // Test that with one column and a constraint on a different column that stats are equivalent.
+        noPartConstraint = constraintWithMinValue(noPartColumns.get("totalprice"), 100000.0);
+        partConstraint = constraintWithMinValue(partColumns.get("totalprice"), 100000.0);
+        statsNoPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsNoPartition", s), Collections.singletonList(noPartColumns.get("orderkey")), noPartConstraint);
+        statsWithPartition = meta.getTableStatistics(s, getAnalyzeTableHandle("statsWithPartition", s), Collections.singletonList(partColumns.get("orderkey")), partConstraint);
+        assertEquals(statsNoPartition.getColumnStatistics().size(), 1);
+        assertEquals(statsWithPartition.getColumnStatistics().size(), 1);
+        assertNotNull(statsWithPartition.getColumnStatistics().get(partColumns.get("orderkey")));
+        assertNotNull(statsNoPartition.getColumnStatistics().get(noPartColumns.get("orderkey")));
+        // partitioned table should have stats partially filtered since data should span > 1 file
+        assertTrue(statsWithPartition.getRowCount().getValue() < statsNoPartition.getRowCount().getValue());
+        assertQuerySucceeds("DROP TABLE statsNoPartition");
+        assertQuerySucceeds("DROP TABLE statsWithPartition");
+    }
+
+    private void columnStatsEqual(Map<ColumnHandle, ColumnStatistics> actualStats, Map<ColumnHandle, ColumnStatistics> expectedStats)
+    {
+        for (ColumnHandle handle : actualStats.keySet()) {
+            ColumnStatistics actual = actualStats.get(handle);
+            ColumnStatistics expected = expectedStats.get(handle);
+            assertEquals(actual.getRange(), expected.getRange(), "range for col: " + handle);
+            assertEquals(actual.getNullsFraction(), expected.getNullsFraction(), "nulls fraction for col: " + handle);
+            assertEquals(actual.getDistinctValuesCount(), expected.getDistinctValuesCount(), "NDVs for col: " + handle);
+        }
+    }
+
+    private static Constraint<ColumnHandle> constraintWithMinValue(ColumnHandle col, Double min)
+    {
+        return new Constraint<>(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(col, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, min)), true))));
+    }
+
+    private TableHandle getAnalyzeTableHandle(String tableName, Session session)
+    {
+        Metadata meta = getQueryRunner().getMetadata();
+        return meta.getTableHandleForStatisticsCollection(
+                session,
+                new QualifiedObjectName("iceberg", "tpch", tableName.toLowerCase(Locale.US)),
+                Collections.emptyMap()).get();
+    }
+
+    private TableHandle getTableHandle(String tableName, Session session)
+    {
+        MetadataResolver resolver = getQueryRunner().getMetadata().getMetadataResolver(session);
+        return resolver.getTableHandle(new QualifiedObjectName("iceberg", "tpch", tableName.toLowerCase(Locale.US))).get();
+    }
+
+    private Map<String, ColumnHandle> getColumnHandles(String tableName, Session session)
+    {
+        return getQueryRunner().getMetadata().getColumnHandles(session, getTableHandle(tableName, session));
+    }
+
+    static void assertStatValuePresent(StatsSchema column, MaterializedResult result, Set<String> columnNames)
+    {
+        assertStatValue(column, result, columnNames, null, true);
+    }
+
+    static void assertStatValueAbsent(StatsSchema column, MaterializedResult result, Set<String> columnNames)
+    {
+        assertStatValue(column, result, columnNames, null, false);
+    }
+
+    static void assertStatValue(StatsSchema column, MaterializedResult result, Set<String> columnNames, Object value, boolean assertNot)
+    {
+        result.getMaterializedRows().forEach(row -> {
+            if (columnNames.contains((String) row.getField(StatsSchema.COLUMN_NAME.ordinal()))) {
+                Object resultValue = row.getField(column.ordinal());
+                if (assertNot) {
+                    assertNotEquals(resultValue, value);
+                }
+                else {
+                    assertEquals(resultValue, value);
+                }
+            }
+        });
+    }
+
+    static void assertNDVsPresent(TableStatistics stats)
+    {
+        for (Map.Entry<ColumnHandle, ColumnStatistics> entry : stats.getColumnStatistics().entrySet()) {
+            assertFalse(entry.getValue().getDistinctValuesCount().isUnknown(), entry.getKey() + " NDVs are unknown");
+        }
+    }
+
+    static void assertNDVsNotPresent(TableStatistics stats)
+    {
+        for (Map.Entry<ColumnHandle, ColumnStatistics> entry : stats.getColumnStatistics().entrySet()) {
+            assertTrue(entry.getValue().getDistinctValuesCount().isUnknown(), entry.getKey() + " NDVs are not unknown");
+        }
+    }
+}


### PR DESCRIPTION
## Description

This commit adds support in the IcebergHiveMetadata implementation to store and retrieve statistics from the Hive metastore when the optimizer asks for statistics.

Iceberg already provides a subset of statistics through its TableStatisticsMaker utility which scans the table metadata to determine the min, max, data size, and row count. The missing stats are the NDVs. Those stats can be collected and stored in the Hive metastore. This change improves the IcebergHiveMetadata implementation by allowing us to store the column aggregations from ANALYZE into the Hive metastore.

When retrieving stats, only the values from the NDVs are used from the HMS. Those values are merged with the info from the TableStatisticsMaker, since the parquet file information is more likely to be up-to-date than the HMS.


## Motivation and Context

See issue #20614. This PR closes #20614.

## Impact

Iceberg tables will now support `ANALYZE` when the HMS is the configured catalog.

## Test Plan

Basic tests are included to ensure statistics are stored and retrieved properly after executing an `ANALYZE` query.


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Iceberg connector now supports ANALYZE when configured with a Hive catalog and the table is unpartitioned
```


