### PR TITLE
[native] Enable cache TTL and export stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -134,6 +134,7 @@ class PeriodicTaskManager {
   int64_t lastMemoryCacheEvictionChecks_{0};
   int64_t lastMemoryCacheStalls_{0};
   int64_t lastMemoryCacheAllocClocks_{0};
+  int64_t lastMemoryCacheAgedOuts_{0};
 
   // Operating system related stats.
   int64_t lastUserCpuTimeUs_{0};

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -214,6 +214,9 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kUseLegacyArrayAgg, false),
           STR_PROP(kSinkMaxBufferSize, "32MB"),
           STR_PROP(kDriverMaxPagePartitioningBufferSize, "32MB"),
+          BOOL_PROP(kCacheVeloxTtlEnabled, false),
+          STR_PROP(kCacheVeloxTtlThreshold, "2d"),
+          STR_PROP(kCacheVeloxTtlCheckInterval, "1h"),
       };
 }
 
@@ -571,6 +574,20 @@ int32_t SystemConfig::internalCommunicationJwtExpirationSeconds() const {
 
 bool SystemConfig::useLegacyArrayAgg() const {
   return optionalProperty<bool>(kUseLegacyArrayAgg).value();
+}
+
+bool SystemConfig::cacheVeloxTtlEnabled() const {
+  return optionalProperty<bool>(kCacheVeloxTtlEnabled).value();
+}
+
+std::chrono::duration<double> SystemConfig::cacheVeloxTtlThreshold() const {
+  return velox::core::toDuration(
+      optionalProperty(kCacheVeloxTtlThreshold).value());
+}
+
+std::chrono::duration<double> SystemConfig::cacheVeloxTtlCheckInterval() const {
+  return velox::core::toDuration(
+      optionalProperty(kCacheVeloxTtlCheckInterval).value());
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -282,6 +282,18 @@ class SystemConfig : public ConfigBase {
       "async-cache-ssd-disable-file-cow"};
   static constexpr std::string_view kEnableSerializedPageChecksum{
       "enable-serialized-page-checksum"};
+
+  /// Enable TTL for AsyncDataCache and SSD cache.
+  static constexpr std::string_view kCacheVeloxTtlEnabled{
+      "cache.velox.ttl-enabled"};
+  /// TTL duration for AsyncDataCache and SSD cache entries.
+  static constexpr std::string_view kCacheVeloxTtlThreshold{
+      "cache.velox.ttl-threshold"};
+  /// The periodic duration to apply cache TTL and evict AsyncDataCache and SSD
+  /// cache entries.
+  static constexpr std::string_view kCacheVeloxTtlCheckInterval{
+      "cache.velox.ttl-check-interval"};
+
   static constexpr std::string_view kUseMmapArena{"use-mmap-arena"};
   static constexpr std::string_view kMmapArenaCapacityRatio{
       "mmap-arena-capacity-ratio"};
@@ -623,6 +635,12 @@ class SystemConfig : public ConfigBase {
   int32_t internalCommunicationJwtExpirationSeconds() const;
 
   bool useLegacyArrayAgg() const;
+
+  bool cacheVeloxTtlEnabled() const;
+
+  std::chrono::duration<double> cacheVeloxTtlThreshold() const;
+
+  std::chrono::duration<double> cacheVeloxTtlCheckInterval() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -86,6 +86,11 @@ void registerPrestoMetrics() {
       0,
       62l * 1024 * 1024 * 1024, // max bucket value: 62GB
       100);
+
+  /// ================== AsyncDataCache Counters ==================
+
+  DEFINE_METRIC(kCounterCacheMaxAgeSecs, facebook::velox::StatType::AVG);
+
   DEFINE_METRIC(kCounterMemoryCacheNumEntries, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterMemoryCacheNumEmptyEntries, facebook::velox::StatType::AVG);
@@ -138,6 +143,17 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(
       kCounterMemoryCacheNumAllocClocks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
+      kCounterMemoryCacheNumCumulativeAgedOutEntries,
+      facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterMemoryCacheNumAgedOutEntries, facebook::velox::StatType::AVG);
+
+  /// ================== SsdCache Counters ==================
+
+  DEFINE_METRIC(kCounterSsdCacheCachedEntries, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterSsdCacheCachedRegions, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterSsdCacheCachedBytes, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
       kCounterSsdCacheCumulativeReadEntries, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterSsdCacheCumulativeReadBytes, facebook::velox::StatType::AVG);
@@ -146,9 +162,9 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(
       kCounterSsdCacheCumulativeWrittenBytes, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
-      kCounterSsdCacheCumulativeCachedEntries, facebook::velox::StatType::AVG);
+      kCounterSsdCacheCumulativeAgedOutEntries, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
-      kCounterSsdCacheCumulativeCachedBytes, facebook::velox::StatType::AVG);
+      kCounterSsdCacheCumulativeAgedOutRegions, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterSsdCacheCumulativeOpenSsdErrors, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
@@ -171,7 +187,9 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(
       kCounterSsdCacheCumulativeReadCheckpointErrors,
       facebook::velox::StatType::AVG);
-  // Disk spilling stats.
+
+  /// ================== Disk Spilling Counters =================
+
   DEFINE_METRIC(kCounterSpillRuns, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterSpilledFiles, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterSpilledRows, facebook::velox::StatType::SUM);
@@ -191,7 +209,9 @@ void registerPrestoMetrics() {
       20l * 1024 * 1024 * 1024, // max bucket value: 20GB
       100);
   DEFINE_METRIC(kCounterSpillMaxLevelExceeded, facebook::velox::StatType::SUM);
-  // Memory arbitrator stats.
+
+  /// ================== Memory Arbitrator Counters =================
+
   DEFINE_METRIC(kCounterArbitratorNumRequests, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterArbitratorNumAborted, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterArbitratorNumFailures, facebook::velox::StatType::SUM);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -212,7 +212,12 @@ constexpr folly::StringPiece kCounterSpillMemoryBytes{
 constexpr folly::StringPiece kCounterSpillPeakMemoryBytes{
     "presto_cpp.spill_peak_memory_bytes"};
 
-/// ================== Cache Counters ==================
+/// ================== AsyncDataCache Counters ==================
+
+/// Max possible age of AsyncDataCache and SsdCache entries since the raw file
+/// was opened to load the cache.
+constexpr folly::StringPiece kCounterCacheMaxAgeSecs{
+    "presto_cpp.cache_max_age_secs"};
 
 /// Total number of cache entries.
 constexpr folly::StringPiece kCounterMemoryCacheNumEntries{
@@ -251,7 +256,7 @@ constexpr folly::StringPiece kCounterMemoryCacheTotalPrefetchBytes{
 /// for entries in cache.
 constexpr folly::StringPiece kCounterMemoryCacheSumEvictScore{
     "presto_cpp.memory_cache_sum_evict_score"};
-/// Cumulated number of hits (saved IO). The first hit to a prefetched entry
+/// Cumulative number of hits (saved IO). The first hit to a prefetched entry
 /// does not count.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeHit{
     "presto_cpp.memory_cache_num_cumulative_hit"};
@@ -259,7 +264,7 @@ constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeHit{
 /// prefetched entry does not count.
 constexpr folly::StringPiece kCounterMemoryCacheNumHit{
     "presto_cpp.memory_cache_num_hit"};
-/// Cumulated amount of hit bytes (saved IO). The first hit to a prefetched
+/// Cumulative amount of hit bytes (saved IO). The first hit to a prefetched
 /// entry does not count.
 constexpr folly::StringPiece kCounterMemoryCacheCumulativeHitBytes{
     "presto_cpp.memory_cache_cumulative_hit_bytes"};
@@ -267,26 +272,26 @@ constexpr folly::StringPiece kCounterMemoryCacheCumulativeHitBytes{
 /// to a prefetched entry does not count.
 constexpr folly::StringPiece kCounterMemoryCacheHitBytes{
     "presto_cpp.memory_cache_hit_bytes"};
-/// Cumulated number of new entries created.
+/// Cumulative number of new entries created.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeNew{
     "presto_cpp.memory_cache_num_cumulative_new"};
 /// Number of new entries created since last counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumNew{
     "presto_cpp.memory_cache_num_new"};
-/// Cumulated number of times a valid entry was removed in order to make space.
+/// Cumulative number of times a valid entry was removed in order to make space.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvict{
     "presto_cpp.memory_cache_num_cumulative_evict"};
 /// Number of times a valid entry was removed in order to make space, since last
 /// counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumEvict{
     "presto_cpp.memory_cache_num_evict"};
-/// Cumulated number of entries considered for evicting.
+/// Cumulative number of entries considered for evicting.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeEvictChecks{
     "presto_cpp.memory_cache_num_cumulative_evict_checks"};
 /// Number of entries considered for evicting, since last counter retrieval.
 constexpr folly::StringPiece kCounterMemoryCacheNumEvictChecks{
     "presto_cpp.memory_cache_num_evict_checks"};
-/// Cumulated number of times a user waited for an entry to transit from
+/// Cumulative number of times a user waited for an entry to transit from
 /// exclusive to shared mode.
 constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeWaitExclusive{
     "presto_cpp.memory_cache_num_cumulative_wait_exclusive"};
@@ -302,6 +307,26 @@ constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAllocClocks{
 /// since last counter retrieval
 constexpr folly::StringPiece kCounterMemoryCacheNumAllocClocks{
     "presto_cpp.memory_cache_num_alloc_clocks"};
+/// Cumulative number of AsyncDataCache entries that are aged out and evicted
+/// given configured TTL.
+constexpr folly::StringPiece kCounterMemoryCacheNumCumulativeAgedOutEntries{
+    "presto_cpp.memory_cache_num_cumulative_aged_out_entries"};
+/// Number of AsyncDataCache entries that are aged out and evicted
+/// given configured TTL.
+constexpr folly::StringPiece kCounterMemoryCacheNumAgedOutEntries{
+    "presto_cpp.memory_cache_num_aged_out_entries"};
+
+/// ================== SsdCache Counters ==================
+
+/// Number of regions currently cached by SSD.
+constexpr folly::StringPiece kCounterSsdCacheCachedRegions{
+    "presto_cpp.ssd_cache_cached_regions"};
+/// Number of entries currently cached by SSD.
+constexpr folly::StringPiece kCounterSsdCacheCachedEntries{
+    "presto_cpp.ssd_cache_cached_entries"};
+/// Total bytes currently cached by SSD.
+constexpr folly::StringPiece kCounterSsdCacheCachedBytes{
+    "presto_cpp.ssd_cache_cached_bytes"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadEntries{
     "presto_cpp.ssd_cache_cumulative_read_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeReadBytes{
@@ -310,10 +335,15 @@ constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenEntries{
     "presto_cpp.ssd_cache_cumulative_written_entries"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeWrittenBytes{
     "presto_cpp.ssd_cache_cumulative_written_bytes"};
-constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedEntries{
-    "presto_cpp.ssd_cache_cumulative_cached_entries"};
-constexpr folly::StringPiece kCounterSsdCacheCumulativeCachedBytes{
-    "presto_cpp.ssd_cache_cumulative_cached_bytes"};
+/// Cumulative number of SsdCache entries that are aged out and evicted given
+/// configured TTL.
+constexpr folly::StringPiece kCounterSsdCacheCumulativeAgedOutEntries{
+    "presto_cpp.ssd_cache_cumulative_aged_out_entries"};
+/// Cumulative number of SsdCache regions that are aged out and evicted given
+/// configured TTL.
+constexpr folly::StringPiece kCounterSsdCacheCumulativeAgedOutRegions{
+    "presto_cpp.ssd_cache_cumulative_aged_out_regions"};
+
 constexpr folly::StringPiece kCounterSsdCacheCumulativeOpenSsdErrors{
     "presto_cpp.ssd_cache_cumulative_open_ssd_errors"};
 constexpr folly::StringPiece kCounterSsdCacheCumulativeOpenCheckpointErrors{


### PR DESCRIPTION
Enable TTL for AsyncDataCache and SsdCache, if AsyncDataCache is
enabled. It will call CacheTTLControl::applyTTL(ttlSecs).

Introduce three configs for TTL,
cache.velox.ttl-enabled
cache.velox.ttl-threshold
cache.velox.ttl-check-interval

Expose the following age counters for AsyncDataCache and SsdCache
presto_cpp.cache_max_age_secs
presto_cpp.memory_cache_num_cumulative_aged_out_entries
presto_cpp.ssd_cache_cumulative_aged_out_entries
presto_cpp.ssd_cache_cumulative_aged_out_regions

as well as
presto_cpp.ssd_cache_cached_regions
presto_cpp.ssd_cache_cached_entries
presto_cpp.ssd_cache_cached_bytes

```
== NO RELEASE NOTE ==
```

