### PR TITLE
Fix CTEInformation resolution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -139,6 +139,28 @@ public final class MetadataUtil
         return new CatalogSchemaName(catalogName, schemaName);
     }
 
+    public static boolean hasQualifiedObjectName(Session session, QualifiedName name)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(name, "name is null");
+
+        int partsLength = name.getParts().size();
+        if (partsLength > 3) {
+            throw new PrestoException(SYNTAX_ERROR, format("Too many dots in table name: %s", name));
+        }
+
+        switch (partsLength) {
+            case 0:
+                return false;
+            case 1:
+                return session.getCatalog().isPresent() && session.getSchema().isPresent();
+            case 2:
+                return session.getSchema().isPresent();
+            default:
+                return true;
+        }
+    }
+
     public static QualifiedObjectName createQualifiedObjectName(Session session, Node node, QualifiedName name)
     {
         requireNonNull(session, "session is null");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
-import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.MapType;
@@ -109,6 +108,7 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.SystemSessionProperties.getQueryAnalyzerTimeout;
 import static com.facebook.presto.common.type.TypeUtils.isEnumType;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
+import static com.facebook.presto.metadata.MetadataUtil.hasQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_PLANNING_TIMEOUT;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
@@ -176,8 +176,8 @@ class RelationPlanner
         Scope scope = analysis.getScope(node);
 
         if (namedQuery != null) {
-            QualifiedObjectName name = createQualifiedObjectName(session, node, node.getName());
-            session.getCteInformationCollector().addCTEReference(node.getName(), analysis.isView(name));
+            boolean isView = hasQualifiedObjectName(session, node.getName()) && analysis.isView(createQualifiedObjectName(session, node, node.getName()));
+            session.getCteInformationCollector().addCTEReference(node.getName(), isView);
             RelationPlan subPlan = process(namedQuery, context);
 
             // Add implicit coercions if view query produces types that don't match the declared output types


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/20622 introduced CTE resolution changes that break when the session catalog and schema are not set. See repro - 
```
~/W/o/presto (master|✔) $ presto-cli --server localhost:8086 --debug
presto> set session verbose_optimizer_info_enabled=true;
SET SESSION
presto> explain with t1 as (select 1) select 1 from tpch.sf1.supplier, t1;
Query 20230831_052332_00003_5am95 failed: line 1:64: Schema must be specified when session schema is not set
com.facebook.presto.sql.analyzer.SemanticException: line 1:64: Schema must be specified when session schema is not set
        at com.facebook.presto.metadata.MetadataUtil.lambda$createQualifiedObjectName$2(MetadataUtil.java:153)
        at java.util.Optional.orElseThrow(Optional.java:290)
        at com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName(MetadataUtil.java:152)
        at com.facebook.presto.sql.planner.RelationPlanner.visitTable(RelationPlanner.java:179)
        at com.facebook.presto.sql.planner.RelationPlanner.visitTable(RelationPlanner.java:133)
        at com.facebook.presto.sql.tree.Table.accept(Table.java:53)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
        at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:169)
        at com.facebook.presto.sql.planner.RelationPlanner.visitJoin(RelationPlanner.java:274)
        at com.facebook.presto.sql.planner.RelationPlanner.visitJoin(RelationPlanner.java:133)
        at com.facebook.presto.sql.tree.Join.accept(Join.java:90)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
        at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:169)
        at com.facebook.presto.sql.planner.QueryPlanner.planFrom(QueryPlanner.java:315)
        at com.facebook.presto.sql.planner.QueryPlanner.plan(QueryPlanner.java:197)
        at com.facebook.presto.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:756)
        at com.facebook.presto.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:133)
        at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:138)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
        at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:169)
        at com.facebook.presto.sql.planner.QueryPlanner.planQueryBody(QueryPlanner.java:304)
        at com.facebook.presto.sql.planner.QueryPlanner.plan(QueryPlanner.java:180)
        at com.facebook.presto.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:749)
        at com.facebook.presto.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:133)
        at com.facebook.presto.sql.tree.Query.accept(Query.java:105)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
        at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:169)
        at com.facebook.presto.sql.planner.LogicalPlanner.createRelationPlan(LogicalPlanner.java:503)
        at com.facebook.presto.sql.planner.LogicalPlanner.planStatementWithoutOutput(LogicalPlanner.java:173)
        at com.facebook.presto.sql.planner.LogicalPlanner.planStatement(LogicalPlanner.java:151)
        at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:135)
        at com.facebook.presto.sql.analyzer.QueryExplainer.lambda$getLogicalPlan$0(QueryExplainer.java:215)
        at com.facebook.presto.common.RuntimeStats.profileNanos(RuntimeStats.java:136)
        at com.facebook.presto.sql.analyzer.QueryExplainer.getLogicalPlan(QueryExplainer.java:213)
        at com.facebook.presto.sql.analyzer.QueryExplainer.getLogicalPlan(QueryExplainer.java:197)
        at com.facebook.presto.sql.analyzer.QueryExplainer.getPlan(QueryExplainer.java:136)
        at com.facebook.presto.sql.rewrite.ExplainRewrite$Visitor.getQueryPlan(ExplainRewrite.java:140)
        at com.facebook.presto.sql.rewrite.ExplainRewrite$Visitor.visitExplain(ExplainRewrite.java:123)
        at com.facebook.presto.sql.rewrite.ExplainRewrite$Visitor.visitExplain(ExplainRewrite.java:68)
        at com.facebook.presto.sql.tree.Explain.accept(Explain.java:80)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
        at com.facebook.presto.sql.rewrite.ExplainRewrite.rewrite(ExplainRewrite.java:65)
        at com.facebook.presto.sql.rewrite.StatementRewrite.rewrite(StatementRewrite.java:58)
        at com.facebook.presto.sql.analyzer.Analyzer.analyzeSemantic(Analyzer.java:112)
        at com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer.analyze(BuiltInQueryAnalyzer.java:93)
        at com.facebook.presto.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:205)
        at com.facebook.presto.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:109)
        at com.facebook.presto.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:961)
        at com.facebook.presto.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:167)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
explain with t1 as (select 1) select 1 from tpch.sf1.supplier, t1
```

## After fix
```
presto> create or replace view local_hms.tpch_sf1_parquet.t1 as select orderkey from tpch.sf1.orders;
CREATE VIEW
presto> explain with t1 as (select 1) select 1 from tpch.sf1.supplier, t1, local_hms.tpch_sf1_parquet.t1;
                                                                                                                                                                                                                                        >
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[_col0] => [expr_11:integer]                                                                                                                                                                                                   >
         Estimates: {source: CostBasedSourceInfo, rows: 15000000000 (69.85GB), cpu: 75000000000.00, memory: 0.00, network: 75000000000.00}                                                                                              >
         _col0 := expr_11 (1:38)                                                                                                                                                                                                        >
     - RemoteStreamingExchange[GATHER] => [expr_11:integer]                                                                                                                                                                             >
             Estimates: {source: CostBasedSourceInfo, rows: 15000000000 (69.85GB), cpu: 75000000000.00, memory: 0.00, network: 75000000000.00}                                                                                          >
         - Project[projectLocality = LOCAL] => [expr_11:integer]                                                                                                                                                                        >
                 Estimates: {source: CostBasedSourceInfo, rows: 15000000000 (69.85GB), cpu: 75000000000.00, memory: 0.00, network: 0.00}                                                                                                >
                 expr_11 := INTEGER'1'                                                                                                                                                                                                  >
             - CrossJoin => []                                                                                                                                                                                                          >
                     Estimates: {source: CostBasedSourceInfo, rows: 15000000000 (69.85GB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                      >
                     Distribution: REPLICATED                                                                                                                                                                                           >
                 - CrossJoin => []                                                                                                                                                                                                      >
                         Estimates: {source: CostBasedSourceInfo, rows: 10000 (48.83kB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                        >
                         Distribution: REPLICATED                                                                                                                                                                                       >
                     - TableScan[TableHandle {connectorId='tpch', connectorHandle='supplier:sf1.0', layout='Optional[supplier:sf1.0]'}] => []                                                                                           >
                             Estimates: {source: CostBasedSourceInfo, rows: 10000 (48.83kB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                    >
                     - LocalExchange[SINGLE] () => []                                                                                                                                                                                   >
                             Estimates: {source: CostBasedSourceInfo, rows: 1 (5B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                             >
                         - RemoteStreamingExchange[REPLICATE] => []                                                                                                                                                                     >
                                 Estimates: {source: CostBasedSourceInfo, rows: 1 (5B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                         >
                             - Values => []                                                                                                                                                                                             >
                                     Estimates: {source: CostBasedSourceInfo, rows: 1 (5B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                     >
                                     ()                                                                                                                                                                                                 >
                 - LocalExchange[SINGLE] () => []                                                                                                                                                                                       >
                         Estimates: {source: CostBasedSourceInfo, rows: 1500000 (7.15MB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                       >
                     - RemoteStreamingExchange[REPLICATE] => []                                                                                                                                                                         >
                             Estimates: {source: CostBasedSourceInfo, rows: 1500000 (7.15MB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                                   >
                         - TableScan[TableHandle {connectorId='tpch', connectorHandle='orders:sf1.0', layout='Optional[orders:sf1.0]'}] => []                                                                                           >
                                 Estimates: {source: CostBasedSourceInfo, rows: 1500000 (7.15MB), cpu: 0.00, memory: 0.00, network: 0.00}                                                                                               >
                                 tpch:orderstatus                                                                                                                                                                                       >
                                     :: [["F"], ["O"], ["P"]]                                                                                                                                                                           >
 Triggered optimizers: [PruneCrossJoinColumns, RemoveRedundantIdentityProjections, PruneTableScanColumns, PruneProjectColumns, UnaliasSymbolReferences, RemoveRedundantIdentityProjections, PruneUnreferencedOutputs, PickTableLayoutWit>
 Applicable optimizers: [RandomizeNullKeyInOuterJoin, MergePartialAggregationsWithFilter]                                                                                                                                               >
 CTEInfo: [local_hms.tpch_sf1_parquet.t1: 1 (is_view: true), t1: 1 (is_view: false)]                                                                                                                                                    >
                                                                                                                                                                                                                                        >
(1 row)

Query 20230831_130121_00008_k5srz, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:02] [0 rows, 0B] [0 rows/s, 0B/s]
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.


## Release Notes

```
== NO RELEASE NOTE ==
```

