### PR TITLE
[native] Map Presto DereferenceExpr to Velox DereferenceTypedExpr 

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -619,17 +619,8 @@ TypedExprPtr convertDereferenceExpr(
   auto childIndex = childIndexExpr->value().value<int32_t>();
 
   VELOX_USER_CHECK_LT(childIndex, inputType.size());
-  auto childName = inputType.names()[childIndex];
 
-  VELOX_USER_CHECK_EQ(
-      childIndex,
-      inputType.getChildIdx(childName),
-      "Cannot map field index to name in dereference expression: {}. "
-      "Input struct may have duplicate or empty field names: {}.",
-      childIndex,
-      inputType.toString())
-
-  return std::make_shared<FieldAccessTypedExpr>(returnType, input, childName);
+  return std::make_shared<DereferenceTypedExpr>(returnType, input, childIndex);
 }
 } // namespace
 

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -922,7 +922,7 @@ TEST_F(RowExpressionTest, dereference) {
   auto expr = converter_->toVeloxExpr(p);
 
   auto fieldAccess =
-      std::dynamic_pointer_cast<const FieldAccessTypedExpr>(expr);
+      std::dynamic_pointer_cast<const DereferenceTypedExpr>(expr);
   ASSERT_NE(fieldAccess, nullptr);
 
   ASSERT_EQ(fieldAccess->name(), "partkey");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -102,12 +102,16 @@ public class TestPrestoSparkNativeSimpleQueries
     }
 
     @Test
+    public void testDereference()
+    {
+        assertQuery("SELECT transform(array[row(orderkey, comment)], x -> x[2]) FROM orders");
+        assertQuery("SELECT transform(array[row(orderkey, orderkey * 10)], x -> x[2]) FROM orders");
+    }
+
+    @Test
     public void testFailures()
     {
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
-
-        assertQueryFails("SELECT transform(array[row(orderkey, comment)], x -> x[2]) FROM orders", ".*Cannot map field index to name in dereference expression: 1.*");
-        assertQueryFails("SELECT transform(array[row(orderkey, orderkey * 10)], x -> x[2]) FROM orders", ".*Cannot map field index to name in dereference expression: 1.*");
     }
 
     /**


### PR DESCRIPTION
Velox added a new DereferenceTypedExpr that takes a field index in place of a field name, aligning with the implementation 
in Presto.  This fixes an existing issue where non-unique field names may cause queries to fail or produce incorrect results.

See https://github.com/facebookincubator/velox/issues/5536 and https://github.com/prestodb/presto/pull/20058