### PR TITLE
[native]Avoid potential deadlock by moving presto task deletion out o…

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -652,10 +652,13 @@ size_t TaskManager::cleanOldTasks() {
 
   const auto elapsedMs = (getCurrentTimeMs() - startTimeMs);
   if (not taskIdsToClean.empty()) {
+    std::vector<std::shared_ptr<PrestoTask>> tasksToDelete;
+    tasksToDelete.reserve(taskIdsToClean.size());
     {
       // Remove tasks from the task map. We briefly lock for write here.
       auto writableTaskMap = taskMap_.wlock();
       for (const auto& taskId : taskIdsToClean) {
+        tasksToDelete.push_back(std::move(writableTaskMap->at(taskId)));
         writableTaskMap->erase(taskId);
       }
     }


### PR DESCRIPTION
Current old task cleanup code might trigger Presto Task (velox task) destruction
inside the taskMap_ writer lock. This is not good practice which might cause the
potential deadlock if Presto task dtor tries to grab taskMap_ lock or forms a circular
lock chain that leads to deadlock which have seen in Meta Prestissimo internal
testing

```
== NO RELEASE NOTE ==
```

