### PR TITLE
Fix exception when array is NULL for array contains to In expression rewrite rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1660,8 +1660,8 @@ public final class SystemSessionProperties
                         false),
                 booleanProperty(
                         REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION,
-                        "Rewrite contant array contains to IN expression",
-                        true,
+                        "Rewrite contsant array contains to IN expression",
+                        featuresConfig.isRewriteConstantArrayContainsToInEnabled(),
                         false),
                 booleanProperty(
                         INFER_INEQUALITY_PREDICATES,

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -274,6 +274,7 @@ public class FeaturesConfig
     private boolean addPartialNodeForRowNumberWithLimit = true;
     private boolean inferInequalityPredicates;
     private boolean pullUpExpressionFromLambda;
+    private boolean rewriteConstantArrayContainsToIn;
 
     private boolean preProcessMetadataCalls;
 
@@ -2721,6 +2722,19 @@ public class FeaturesConfig
     public FeaturesConfig setInferInequalityPredicates(boolean inferInequalityPredicates)
     {
         this.inferInequalityPredicates = inferInequalityPredicates;
+        return this;
+    }
+
+    public boolean isRewriteConstantArrayContainsToInEnabled()
+    {
+        return this.rewriteConstantArrayContainsToIn;
+    }
+
+    @Config("optimizer.rewrite-constant-array-contains-to-in")
+    @ConfigDescription("Rewrite constant array contains function to IN expression")
+    public FeaturesConfig setRewriteConstantArrayContainsToInEnabled(boolean rewriteConstantArrayContainsToIn)
+    {
+        this.rewriteConstantArrayContainsToIn = rewriteConstantArrayContainsToIn;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteConstantArrayContainsToInExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteConstantArrayContainsToInExpression.java
@@ -100,7 +100,7 @@ public class RewriteConstantArrayContainsToInExpression
         @Override
         public RowExpression rewriteCall(CallExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
         {
-            if (functionResolution.isArrayContainsFunction(node.getFunctionHandle()) && node.getArguments().get(0) instanceof ConstantExpression) {
+            if (functionResolution.isArrayContainsFunction(node.getFunctionHandle()) && node.getArguments().get(0) instanceof ConstantExpression && !((ConstantExpression) node.getArguments().get(0)).isNull()) {
                 checkState(((ConstantExpression) node.getArguments().get(0)).getValue() instanceof Block && node.getArguments().get(0).getType() instanceof ArrayType);
                 Block arrayValue = (Block) ((ConstantExpression) node.getArguments().get(0)).getValue();
                 if (arrayValue.getPositionCount() == 0) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -241,7 +241,8 @@ public class TestFeaturesConfig
                 .setBroadcastJoinWithSmallBuildUnknownProbe(false)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(true)
                 .setInferInequalityPredicates(false)
-                .setPullUpExpressionFromLambdaEnabled(false));
+                .setPullUpExpressionFromLambdaEnabled(false)
+                .setRewriteConstantArrayContainsToInEnabled(false));
     }
 
     @Test
@@ -431,6 +432,7 @@ public class TestFeaturesConfig
                 .put("optimizer.add-partial-node-for-row-number-with-limit", "false")
                 .put("optimizer.infer-inequality-predicates", "true")
                 .put("optimizer.pull-up-expression-from-lambda", "true")
+                .put("optimizer.rewrite-constant-array-contains-to-in", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -617,7 +619,8 @@ public class TestFeaturesConfig
                 .setBroadcastJoinWithSmallBuildUnknownProbe(true)
                 .setAddPartialNodeForRowNumberWithLimitEnabled(false)
                 .setInferInequalityPredicates(true)
-                .setPullUpExpressionFromLambdaEnabled(true);
+                .setPullUpExpressionFromLambdaEnabled(true)
+                .setRewriteConstantArrayContainsToInEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_E
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CASE_TO_MAP_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_ARRAY_CONTAINS_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CROSS_JOIN_OR_TO_INNER_JOIN;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_LEFT_JOIN_NULL_FILTER_TO_SEMI_JOIN;
@@ -7099,10 +7100,14 @@ public abstract class AbstractTestQueries
     @Test
     public void testRewriteContainsToIn()
     {
-        assertQuery("select k from (values 1, 2, 3, 4, 5) t(k) where contains(array[1, 3, 4], k)", "values 1, 3, 4");
-        assertQuery("select filter(arr, x -> contains(array[1,5], x)) from (values array[1, 2, 3, 4], array[1,3,5,7]) t(arr)", "values array[1], array[1, 5]");
-        assertQuery("select x, contains(array[null], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, null), (2, null), (3, null), (4, null), (null, null)");
-        assertQuery("select x, contains(array[null, 1], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, true), (2, null), (3, null), (4, null), (null, null)");
-        assertQuery("select x, contains(array[], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, false), (2, false), (3, false), (4, false), (null, null)");
+        Session session = Session.builder(getSession())
+                .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
+                .build();
+        assertQuery(session, "select k from (values 1, 2, 3, 4, 5) t(k) where contains(array[1, 3, 4], k)", "values 1, 3, 4");
+        assertQuery(session, "select filter(arr, x -> contains(array[1,5], x)) from (values array[1, 2, 3, 4], array[1,3,5,7]) t(arr)", "values array[1], array[1, 5]");
+        assertQuery(session, "select x, contains(array[null], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, null), (2, null), (3, null), (4, null), (null, null)");
+        assertQuery(session, "select x, contains(array[null, 1], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, true), (2, null), (3, null), (4, null), (null, null)");
+        assertQuery(session, "select x, contains(array[], x) from (values 1, 2, 3, 4, null) t(x)", "values (1, false), (2, false), (3, false), (4, false), (null, null)");
+        assertQuery(session, "select x, contains(cast(null as array<bigint>), x) from (values 1, 2, 3, 4, null) t(x)", "values (1, null), (2, null), (3, null), (4, null), (null, null)");
     }
 }


### PR DESCRIPTION
## Description
Fix a bug in the optimizer rule for queries like `select contains(null, col) from t` where array is NULL. In this case it will throw exception by the checkState in the rule. Here this PR will skip the optimization.

## Motivation and Context
Fix bug

## Impact
Fix bug

## Test Plan
Add test for this case.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix bug in array contains to In expression rewrite rule. It will throw exception for expression `contains(null, col)`, now it will be skipped and not throwing exceptions.
```


