### PR TITLE
Enlarge timeout value of testQueryOutputSizeExceeded test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -223,7 +223,7 @@ public class TestQueryManager
         }
     }
 
-    @Test(timeOut = 60_000L)
+    @Test(timeOut = 120_000L)
     public void testQueryOutputSizeExceeded()
             throws Exception
     {


### PR DESCRIPTION
## Description
Increase the timeout value for testQueryOutputSizeExceeded test

## Motivation and Context
I've seen this test timeout consistently in my last few PRs, and have to rerun for this one. Briefly checked the test and I guess it's fine to increase the timeout limit.

## Impact
Less pain to rerun the test

## Test Plan
Let me see if it can finish without rerun
The test [test (:presto-tests -P presto-tests-general)](https://github.com/prestodb/presto/actions/runs/6042795796/job/16398646149?pr=20734#logs) completed without timeout failure!

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

