### PR TITLE
[native] Print velox user error log upon failure during start up.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -175,8 +175,7 @@ void PrestoServer::run() {
     }
     nodeLocation_ = nodeConfig->nodeLocation();
   } catch (const VeloxUserError& e) {
-    // VeloxUserError is always logged as an error.
-    // Avoid logging again.
+    PRESTO_STARTUP_LOG(ERROR) << "Failed to start server due to " << e.what();
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
If presto start up fails due to a user error (e.g. config file is missing), the exception is not printed and server exits without any trace of what happened. When this code was written, throwing VeloxUserError was printing the error. However, later this behavior is altered (https://github.com/facebookincubator/velox/pull/5610). Hence the error needs to be logged for better debugging of incidents where config files are missing.