### PR TITLE
Iceberg split changes for execution with Velox

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.hive.HivePartitionKey;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.PrestoException;
 import io.airlift.slice.Slice;
@@ -65,7 +66,7 @@ public class IcebergPageSource
 
     public IcebergPageSource(
             List<IcebergColumnHandle> columns,
-            Map<Integer, String> partitionKeys,
+            Map<Integer, HivePartitionKey> partitionKeys,
             ConnectorPageSource delegate,
             TimeZoneKey timeZoneKey)
     {
@@ -80,9 +81,9 @@ public class IcebergPageSource
         int delegateIndex = 0;
         for (IcebergColumnHandle column : columns) {
             if (partitionKeys.containsKey(column.getId())) {
-                String partitionValue = partitionKeys.get(column.getId());
+                HivePartitionKey icebergPartition = partitionKeys.get(column.getId());
                 Type type = column.getType();
-                Object prefilledValue = deserializePartitionValue(type, partitionValue, column.getName(), timeZoneKey);
+                Object prefilledValue = deserializePartitionValue(type, icebergPartition.getValue().orElse(null), column.getName(), timeZoneKey);
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(type, prefilledValue);
                 delegateIndexes[outputIndex] = -1;
             }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -29,6 +29,7 @@ import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HiveDwrfEncryptionProvider;
 import com.facebook.presto.hive.HiveFileContext;
 import com.facebook.presto.hive.HiveOrcAggregatedMemoryContext;
+import com.facebook.presto.hive.HivePartitionKey;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.hive.orc.HdfsOrcDataSource;
 import com.facebook.presto.hive.orc.OrcBatchPageSource;
@@ -658,7 +659,7 @@ public class IcebergPageSourceProvider
                 .map(IcebergColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        Map<Integer, String> partitionKeys = split.getPartitionKeys();
+        Map<Integer, HivePartitionKey> partitionKeys = split.getPartitionKeys();
 
         List<IcebergColumnHandle> regularColumns = columns.stream()
                 .map(IcebergColumnHandle.class::cast)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.hive.HivePartitionKey;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
@@ -40,7 +41,7 @@ public class IcebergSplit
     private final long length;
     private final FileFormat fileFormat;
     private final List<HostAddress> addresses;
-    private final Map<Integer, String> partitionKeys;
+    private final Map<Integer, HivePartitionKey> partitionKeys;
     private final NodeSelectionStrategy nodeSelectionStrategy;
     private final SplitWeight splitWeight;
 
@@ -51,7 +52,7 @@ public class IcebergSplit
             @JsonProperty("length") long length,
             @JsonProperty("fileFormat") FileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("partitionKeys") Map<Integer, String> partitionKeys,
+            @JsonProperty("partitionKeys") Map<Integer, HivePartitionKey> partitionKeys,
             @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy,
             @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
@@ -97,7 +98,7 @@ public class IcebergSplit
     }
 
     @JsonProperty
-    public Map<Integer, String> getPartitionKeys()
+    public Map<Integer, HivePartitionKey> getPartitionKeys()
     {
         return partitionKeys;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
@@ -44,7 +45,7 @@ public class IcebergSplit
     private final Map<Integer, HivePartitionKey> partitionKeys;
     private final NodeSelectionStrategy nodeSelectionStrategy;
     private final SplitWeight splitWeight;
-
+    private final List<DeleteFile> deletes;
     @JsonCreator
     public IcebergSplit(
             @JsonProperty("path") String path,
@@ -54,7 +55,8 @@ public class IcebergSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionKeys") Map<Integer, HivePartitionKey> partitionKeys,
             @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy,
-            @JsonProperty("splitWeight") SplitWeight splitWeight)
+            @JsonProperty("splitWeight") SplitWeight splitWeight,
+            @JsonProperty("deletes") List<DeleteFile> deletes)
     {
         requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
         this.path = requireNonNull(path, "path is null");
@@ -65,6 +67,7 @@ public class IcebergSplit
         this.partitionKeys = Collections.unmodifiableMap(requireNonNull(partitionKeys, "partitionKeys is null"));
         this.nodeSelectionStrategy = nodeSelectionStrategy;
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
+        this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
     }
 
     @JsonProperty
@@ -123,6 +126,12 @@ public class IcebergSplit
     public SplitWeight getSplitWeight()
     {
         return splitWeight;
+    }
+
+    @JsonProperty
+    public List<DeleteFile> getDeletes()
+    {
+        return deletes;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -44,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNodeSelectionStrategy;
 import static com.facebook.presto.iceberg.IcebergUtil.getIdentityPartitions;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.limit;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -122,7 +124,8 @@ public class IcebergSplitSource
                 ImmutableList.of(),
                 getPartitionKeys(task),
                 getNodeSelectionStrategy(session),
-                SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / tableScan.targetSplitSize(), minimumAssignedSplitWeight), 1.0)));
+                SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / tableScan.targetSplitSize(), minimumAssignedSplitWeight), 1.0)),
+                task.deletes().stream().map(DeleteFile::fromIceberg).collect(toImmutableList()));
     }
 
     private static Map<Integer, HivePartitionKey> getPartitionKeys(FileScanTask scanTask)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeleteFile
+{
+    private final FileContent content;
+    private final String path;
+    private final FileFormat format;
+    private final long recordCount;
+    private final long fileSizeInBytes;
+    private final List<Integer> equalityFieldIds;
+    private final Map<Integer, ByteBuffer> lowerBounds;
+    private final Map<Integer, ByteBuffer> upperBounds;
+
+    public static DeleteFile fromIceberg(org.apache.iceberg.DeleteFile deleteFile)
+    {
+        return new DeleteFile(
+                deleteFile.content(),
+                deleteFile.path().toString(),
+                deleteFile.format(),
+                deleteFile.recordCount(),
+                deleteFile.fileSizeInBytes(),
+                Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
+                deleteFile.lowerBounds(),
+                deleteFile.upperBounds());
+    }
+
+    @JsonCreator
+    public DeleteFile(
+            FileContent content,
+            String path,
+            FileFormat format,
+            long recordCount,
+            long fileSizeInBytes,
+            List<Integer> equalityFieldIds,
+            Map<Integer, ByteBuffer> lowerBounds,
+            Map<Integer, ByteBuffer> upperBounds)
+    {
+        this.content = requireNonNull(content, "content is null");
+        this.path = requireNonNull(path, "path is null");
+        this.format = requireNonNull(format, "format is null");
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
+        this.lowerBounds = requireNonNull(lowerBounds, "lowerBounds is null");
+        this.upperBounds = requireNonNull(upperBounds, "upperBounds is null");
+    }
+
+    @JsonProperty
+    public FileContent content()
+    {
+        return content;
+    }
+
+    @JsonProperty
+    public String path()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public FileFormat format()
+    {
+        return format;
+    }
+
+    @JsonProperty
+    public long recordCount()
+    {
+        return recordCount;
+    }
+
+    @JsonProperty
+    public long fileSizeInBytes()
+    {
+        return fileSizeInBytes;
+    }
+
+    @JsonProperty
+    public List<Integer> equalityFieldIds()
+    {
+        return equalityFieldIds;
+    }
+
+    @JsonProperty
+    public Map<Integer, ByteBuffer> getLowerBounds()
+    {
+        return lowerBounds;
+    }
+
+    @JsonProperty
+    public Map<Integer, ByteBuffer> getUpperBounds()
+    {
+        return upperBounds;
+    }
+}


### PR DESCRIPTION
Co-authors: @agrawalreetika and @imjalpreet 

## Description
This PR introduces the below addition to Iceberg Connector Split in an ongoing effort to make it compatible with execution on Velox:
- Passing more partition details like partition name along with the value and id in IcebergSplit
- Adding DeleteFile information as part of Split to support Delete filter in queries

This PR is a continuation of existing PR - https://github.com/prestodb/presto/pull/20501 

## Motivation and Context
To support Iceberg Table Query Execution with Velox on Presto

## Impact
No impact on the existing Iceberg connector 

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
== NO RELEASE NOTE ==


