### PR TITLE
Enable outer join null salt by cost model

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -258,6 +258,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_MULTIPLE_APPROX_PERCENTILE_ON_SAME_FIELD = "optimize_multiple_approx_percentile_on_same_field";
     public static final String RANDOMIZE_OUTER_JOIN_NULL_KEY = "randomize_outer_join_null_key";
     public static final String RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY = "randomize_outer_join_null_key_strategy";
+    public static final String RANDOMIZE_OUTER_JOIN_NULL_KEY_NULL_RATIO_THRESHOLD = "randomize_outer_join_null_key_null_ratio_threshold";
     public static final String IN_PREDICATES_AS_INNER_JOINS_ENABLED = "in_predicates_as_inner_joins_enabled";
     public static final String PUSH_AGGREGATION_BELOW_JOIN_BYTE_REDUCTION_THRESHOLD = "push_aggregation_below_join_byte_reduction_threshold";
     public static final String KEY_BASED_SAMPLING_ENABLED = "key_based_sampling_enabled";
@@ -1540,6 +1541,11 @@ public final class SystemSessionProperties
                         false,
                         value -> RandomizeOuterJoinNullKeyStrategy.valueOf(((String) value).toUpperCase()),
                         RandomizeOuterJoinNullKeyStrategy::name),
+                doubleProperty(
+                        RANDOMIZE_OUTER_JOIN_NULL_KEY_NULL_RATIO_THRESHOLD,
+                        "Enable randomizing null join key for outer join when ratio of null join keys exceed the threshold",
+                        0.02,
+                        false),
                 booleanProperty(
                         OPTIMIZE_CONDITIONAL_AGGREGATION_ENABLED,
                         "Enable rewriting IF(condition, AGG(x)) to AGG(x) with condition included in mask",
@@ -2704,6 +2710,11 @@ public final class SystemSessionProperties
             return RandomizeOuterJoinNullKeyStrategy.ALWAYS;
         }
         return session.getSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY, RandomizeOuterJoinNullKeyStrategy.class);
+    }
+
+    public static double getRandomizeOuterJoinNullKeyNullRatioThreshold(Session session)
+    {
+        return session.getSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY_NULL_RATIO_THRESHOLD, Double.class);
     }
 
     public static boolean isOptimizeConditionalAggregationEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -365,6 +365,7 @@ public class FeaturesConfig
     {
         DISABLED,
         KEY_FROM_OUTER_JOIN, // Enabled only when join keys are from output of outer joins
+        COST_BASED,
         ALWAYS
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -715,7 +715,7 @@ public class PlanOptimizers
                             // Must run before AddExchanges and after ReplicateSemiJoinInDelete
                             // to avoid temporarily having an invalid plan
                             new DetermineSemiJoinDistributionType(costComparator, taskCountEstimator))));
-            builder.add(new RandomizeNullKeyInOuterJoin(metadata.getFunctionAndTypeManager()),
+            builder.add(new RandomizeNullKeyInOuterJoin(metadata.getFunctionAndTypeManager(), statsCalculator),
                     new PruneUnreferencedOutputs(),
                     new IterativeOptimizer(
                             metadata,


### PR DESCRIPTION
## Description
Enable randomize null key for outer join optimization with HBO. Enable it by setting `randomize_outer_join_null_key_strategy` to be 'COST_BASED', and the trigger condition can be set by session properties `randomize_outer_join_null_key_null_count_threshold` and `randomize_outer_join_null_key_null_ratio_threshold`.

## Motivation and Context
Part of https://github.com/prestodb/presto/issues/20355
Randomize null key for outer join was added to mitigate null value skew in outer joins. It's default to be disabled. With change in https://github.com/prestodb/presto/pull/20337, we have data about number of keys in join build side and the number of keys which are null in HBO. With these information we can enable the randomize null key for outer join with cost model.

## Impact
Will have randomize null key for outer join optimization enabled with cost based model.

## Test Plan
Tested end to end ([link](https://www.internalfb.com/intern/presto/query/?query_id=20230905_230840_00009_5th46#plan))

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an option to make `RandomizeNullKeyInOuterJoin` cost based. It can be enabled by setting `randomize_outer_join_null_key_strategy` to be `cost_based`. The trigger condition can be set by session properties `randomize_outer_join_null_key_null_count_threshold` and `randomize_outer_join_null_key_null_ratio_threshold`.

```

