### PR TITLE
Use JDK 11 to build Java source code

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -40,9 +40,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2
@@ -89,9 +90,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -38,9 +38,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -24,9 +24,10 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -44,9 +44,10 @@ jobs:
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -44,9 +44,10 @@ jobs:
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2
@@ -92,9 +93,10 @@ jobs:
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -39,9 +39,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -39,9 +39,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,10 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         if: needs.changes.outputs.codechange == 'true'
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         if: needs.changes.outputs.codechange == 'true'
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache local Maven repository
         if: needs.changes.outputs.codechange == 'true'
         id: cache-maven

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [User Manual](https://prestodb.github.io/docs/current/) for deployment i
 ## Requirements
 
 * Mac OS X or Linux
-* Java 8 Update 151 or higher (8u151+), 64-bit. Both Oracle JDK and OpenJDK are supported.
+* Java 11, 64-bit. Both Oracle JDK and OpenJDK are supported.
 * Maven 3.3.9+ (for building)
 * Python 2.4+ (for running with the launcher script)
 
@@ -42,13 +42,13 @@ After building Presto for the first time, you can load the project into your IDE
 After opening the project in IntelliJ, double check that the Java SDK is properly configured for the project:
 
 * Open the File menu and select Project Structure
-* In the SDKs section, ensure that a 1.8 JDK is selected (create one if none exist)
+* In the SDKs section, ensure that a JDK 11 is selected (create one if none exist)
 * In the Project section, ensure the Project language level is set to 8.0 as Presto makes use of several Java 8 language features
 
 Presto comes with sample configuration that should work out-of-the-box for development. Use the following options to create a run configuration:
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
-* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
+* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties -Djdk.attach.allowAttachSelf=true`
 * Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends your version of IntelliJ)
 * Use classpath of module: `presto-main`
 

--- a/jenkins/agent-dind.yaml
+++ b/jenkins/agent-dind.yaml
@@ -10,7 +10,7 @@ spec:
     serviceAccountName: oss-agent
     containers:
     - name: dind
-      image: docker:20.10.16-dind-alpine3.15
+      image: docker:24.0.5-dind-alpine3.18
       securityContext:
         privileged: true
       tty: true

--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -10,7 +10,7 @@ spec:
     serviceAccountName: oss-agent
     containers:
     - name: maven
-      image: maven:3.8.6-openjdk-8-slim
+      image: maven:3.8.6-openjdk-11-slim
       env:
       - name: MAVEN_OPTS
         value: "-Xmx8000m -Xms8000m"

--- a/pom.xml
+++ b/pom.xml
@@ -2520,5 +2520,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java-8-api</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Description
Meta has moved to use JDK 11 to build.

```
== NO RELEASE NOTE ==
```

