### PR TITLE
[native] Fix announcment retry.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -85,8 +85,7 @@ void PeriodicServiceInventoryManager::sendRequest() {
       .via(eventBaseThread_.getEventBase())
       .thenValue([this](auto response) {
         auto message = response->headers();
-        if (message->getStatusCode() != http::kHttpAccepted ||
-            message->getStatusCode() != http::kHttpNoContent) {
+        if (message->getStatusCode() != http::kHttpAccepted) {
           ++failedAttempts_;
           LOG(WARNING) << id_ << " failed: HTTP " << message->getStatusCode()
                        << " - " << response->dumpBodyChain();


### PR DESCRIPTION
We only consider http status xxx as success, and http status kHttpNoContent should be considered as a failure. This is a regression introduced by recent [change PR](https://github.com/prestodb/presto/pull/20627). We are reverting it here.