### PR TITLE
[native] Remove spill console logging in periodic task manager.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -567,7 +567,6 @@ void PeriodicTaskManager::updateSpillStatsTask() {
       kCounterSpillFlushTimeUs, deltaSpillStats.spillFlushTimeUs);
   REPORT_IF_NOT_ZERO(
       kCounterSpillWriteTimeUs, deltaSpillStats.spillWriteTimeUs);
-  LOG(INFO) << "Spill Stats:\n" << deltaSpillStats.toString() << "\n";
   lastSpillStats_ = updatedSpillStats;
 }
 


### PR DESCRIPTION
Counters are exported for spilling, no need to log stats in
console periodically as the periodic task is very chatty and
many times server has empty stats. Keeping the logs clean by
removing redundant spill status printing.