### PR TITLE
[native] Treat http 204 as announcement success

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -85,7 +85,9 @@ void PeriodicServiceInventoryManager::sendRequest() {
       .via(eventBaseThread_.getEventBase())
       .thenValue([this](auto response) {
         auto message = response->headers();
-        if (message->getStatusCode() != http::kHttpAccepted) {
+        // Treat both 202 and 204 as success.
+        if (message->getStatusCode() != http::kHttpAccepted &&
+            message->getStatusCode() != http::kHttpNoContent) {
           ++failedAttempts_;
           LOG(WARNING) << id_ << " failed: HTTP " << message->getStatusCode()
                        << " - " << response->dumpBodyChain();


### PR DESCRIPTION
Followup of https://github.com/prestodb/presto/pull/20754

Previously we used OR instead of AND, which made all successful announcements be logged as failed. 
```
== NO RELEASE NOTE ==
```

