### PR TITLE
[native] Fix presto_on_spark_cpp contbuild

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol-json-hpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol-json-hpp.mustache
@@ -32,7 +32,7 @@
 #include <folly/Format.h>
 #include <utility>
 #include "velox/common/encode/Base64.h"
-#include "presto_cpp/external/json/json.hpp"
+#include "presto_cpp/external/json/nlohmann/json.hpp"
 #include "presto_cpp/presto_protocol/DataSize.h"
 #include "presto_cpp/presto_protocol/Duration.h"
 


### PR DESCRIPTION
Summary: This fixes the presto_on_spark_cpp build after changes in json.hpp location introduced in the following PR  https://github.com/prestodb/presto/pull/20619

Differential Revision: D48985300


