### PR TITLE
[Iceberg] Add support for TRUNCATE

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -479,6 +479,30 @@ Alter table operations are supported in the connector::
 
      ALTER TABLE iceberg.web.page_views DROP COLUMN location;
 
+TRUNCATE
+^^^^^^^^
+
+The iceberg connector can delete all of the data from tables without
+dropping the table from the metadata catalog using ``TRUNCATE TABLE``.
+
+.. code-block:: sql
+
+    TRUNCATE TABLE nation;
+
+.. code-block:: text
+
+    TRUNCATE TABLE;
+
+.. code-block:: sql
+
+    SELECT * FROM nation;
+
+.. code-block:: text
+
+     nationkey | name | regionkey | comment
+    -----------+------+-----------+---------
+    (0 rows)
+
 DROP TABLE
 ^^^^^^^^^^^
 
@@ -674,6 +698,5 @@ exists as we've rolled back to the previous state.
 Iceberg Connector Limitations
 -----------------------------
 
-* :doc:`/sql/delete` is only supported if the ``WHERE`` clause matches entire partitions.
 * The ``SELECT`` operations on Iceberg Tables with format version 2 do not read the delete files
   and remove the deleted rows as of now (:issue:`20492`).


### PR DESCRIPTION
## Description

This commit adds support for deleting records from iceberg tables using the query `TRUNCATE TABLE <table>;`

## Motivation and Context

This allows removing data from Iceberg tables without having to drop the table from the catalog.

## Impact

Additional syntax support.

## Test Plan

Test cases:
- `TRUNCATE TABLE x` with a table that has no rows
- `TRUNCATE TABLE x` on a table with records
- Truncate and insert on the same table multiple times back to back


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* The Iceberg connector now supports `TRUNCATE TABLE <table>` statements
```

