### PR TITLE
[native] Skip redundant Ip object to string conversion.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -83,7 +83,7 @@ PrestoExchangeSource::PrestoExchangeSource(
       clientCertAndKeyPath_(clientCertAndKeyPath),
       ciphers_(ciphers),
       exchangeExecutor_(executor) {
-  folly::SocketAddress address(folly::IPAddress(host_).str(), port_);
+  folly::SocketAddress address(folly::IPAddress(host_), port_);
   auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(
       SystemConfig::instance()->exchangeRequestTimeout());
   VELOX_CHECK_NOT_NULL(exchangeExecutor_.get());


### PR DESCRIPTION
SocketAddress constructor can take IPAddress object. Current
code converts a IP address string to IPAddress object and then
converts it back to string. Skipping the redundant conersion here.