### PR TITLE
[native] Tighten decimal signature check in TypeSignatureTest.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/TypeSignatureTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/TypeSignatureTest.cpp
@@ -400,14 +400,8 @@ TEST_F(TestTypeSignature, functionType) {
 }
 
 TEST_F(TestTypeSignature, decimalType) {
-  // https://github.com/facebookincubator/velox/pull/6295 changes the output of
-  // DecimalType::toString() in Velox to add a space after comma. To avoid
-  // breakages, temporarily, allow both formats.
-  auto signature1 = parseTypeSignature("decimal(10, 5)")->toString();
-  ASSERT_TRUE(signature1 == "DECIMAL(10, 5)" || signature1 == "DECIMAL(10,5)");
-  auto signature2 = parseTypeSignature("decimal(20,10)")->toString();
-  ASSERT_TRUE(
-      signature2 == "DECIMAL(20, 10)" || signature2 == "DECIMAL(20,10)");
+  assertSignature("decimal(10, 5)", "DECIMAL(10, 5)");
+  assertSignature("decimal(20,10)", "DECIMAL(20, 10)");
   ASSERT_THROWS_CONTAINS_MESSAGE(
       parseTypeSignature("decimal");
       , VeloxUserError, "Failed to parse type [decimal]");


### PR DESCRIPTION
Update TypeSignatureTest.cpp to align with Velox.
The format is being modified in https://github.com/facebookincubator/velox/pull/6295.
Resolves temporarily https://github.com/prestodb/presto/pull/20710

```
== NO RELEASE NOTE ==
```

