### PR TITLE
Fix bug in pull up expression in lambda rule

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -163,6 +163,12 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuery(queryRunner, getSession(), actual, queryRunner, expected, false, false);
     }
 
+    protected void assertQueryWithSameQueryRunner(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        checkArgument(!actual.equals(expected));
+        QueryAssertions.assertQuery(queryRunner, session, actual, queryRunner, expected, false, false);
+    }
+
     protected void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, expectedQueryRunner, expected, false, false);


### PR DESCRIPTION
## Description
Fix bug in pull expression from lambda rule, it will not pull up WHEN expression and skip conditional expression.

## Motivation and Context
We see two bugs in this rule: 1) WHEN expression is pulled up, however WHEN expression should always stay in the SWITCH expression 2) conditional expression is evaluated and throw array out of bound access error. This PR fix the two bugs.

## Impact
Fix bugs in optimizer.

## Test Plan
Add unit and sql tests, [verifier suite](https://www.internalfb.com/intern/presto/verifier/results/?test_id=137810)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix bugs in PullUpExpressionInLambdaRules. 
   The bugs may cause compile exception with message "Can not compile special form: WHEN" and lead to runtime exception of array out of bound access.
```


