### PR TITLE
[WIP] Improve like performance

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/likematcher/DFA.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/DFA.java
@@ -1,0 +1,161 @@
+package com.facebook.presto.likematcher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class DFA
+{
+    private final State start;
+    private final State failed;
+    private List<State> states;
+    private Map<Integer, List<Transition>> transitions;
+
+    public DFA(State start, State failed, List<State> states, Map<Integer, List<Transition>> transitions)
+    {
+        this.start = Objects.requireNonNull(start, "start is null");
+        this.failed = Objects.requireNonNull(failed, "failed is null");
+        this.states = ImmutableList.copyOf(states);
+        this.transitions = ImmutableMap.copyOf(transitions);
+    }
+
+    public State getStart()
+    {
+        return start;
+    }
+
+    public State getFailed()
+    {
+        return failed;
+    }
+
+    public List<State> getStates()
+    {
+        return states;
+    }
+
+    public Map<Integer, List<Transition>> getTransitions()
+    {
+        return transitions;
+    }
+
+    public List<Transition> transitions(State state)
+    {
+        return transitions.get(state.getId());
+    }
+
+    public static class State
+    {
+        private final int id;
+        private final String label;
+        private final boolean accept;
+
+        public State(int id, String label, boolean accept)
+        {
+            this.id = id;
+            this.label = label;
+            this.accept = accept;
+        }
+
+        public int getId()
+        {
+            return id;
+        }
+
+        public String getLabel()
+        {
+            return label;
+        }
+
+        public boolean isAccept()
+        {
+            return accept;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%d:%s%s", id, accept ? "*" : "", label);
+        }
+    }
+
+    public static class Transition
+    {
+        private final int value;
+        private final State target;
+
+        public Transition(int value, State target)
+        {
+            this.value = value;
+            this.target = target;
+        }
+
+        public int getValue()
+        {
+            return value;
+        }
+
+        public State getTarget()
+        {
+            return target;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("-[%s]-> %s", value, target);
+        }
+    }
+
+    public static class Builder
+    {
+        private int nextId;
+        private State start;
+        private State failed;
+        private final List<State> states = new ArrayList<>();
+        private final Map<Integer, List<Transition>> transitions = new HashMap<>();
+
+        public State addState(String label, boolean accept)
+        {
+            State state = new State(nextId++, label, accept);
+            states.add(state);
+            return state;
+        }
+
+        public State addStartState(String label, boolean accept)
+        {
+            if (start != null) {
+                throw new IllegalStateException("Start state already set");
+            }
+            State state = addState(label, accept);
+            start = state;
+            return state;
+        }
+
+        public State addFailState()
+        {
+            if (failed != null) {
+                throw new IllegalStateException("Fail state already set");
+            }
+            State state = addState("fail", false);
+            failed = state;
+            return state;
+        }
+
+        public void addTransition(State from, int value, State to)
+        {
+            transitions.computeIfAbsent(from.getId(), key -> new ArrayList<>())
+                    .add(new Transition(value, to));
+        }
+
+        public DFA build()
+        {
+            return new DFA(start, failed, states, transitions);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/DenseDfaMatcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/DenseDfaMatcher.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+class DenseDfaMatcher
+{
+    // The DFA is encoded as a sequence of transitions for each possible byte value for each state.
+    // I.e., 256 transitions per state.
+    // The content of the transitions array is the base offset into
+    // the next state to follow. I.e., the desired state * 256
+    private final int[] transitions;
+
+    // The starting state
+    private final int start;
+
+    // For each state, whether it's an accepting state
+    private final boolean[] accept;
+
+    // Artificial state to sink all invalid matches
+    private final int fail;
+
+    private final boolean exact;
+
+    /**
+     * @param exact whether to match to the end of the input
+     */
+    public static DenseDfaMatcher newInstance(DFA dfa, boolean exact)
+    {
+        int[] transitions = new int[dfa.getStates().size() * 256];
+        boolean[] accept = new boolean[dfa.getStates().size()];
+
+        for (DFA.State state : dfa.getStates()) {
+            for (DFA.Transition transition : dfa.transitions(state)) {
+                transitions[state.getId() * 256 + transition.getValue()] = transition.getTarget().getId() * 256;
+            }
+
+            if (state.isAccept()) {
+                accept[state.getId()] = true;
+            }
+        }
+
+        return new DenseDfaMatcher(transitions, dfa.getStart().getId(), accept, 0, exact);
+    }
+
+    private DenseDfaMatcher(int[] transitions, int start, boolean[] accept, int fail, boolean exact)
+    {
+        this.transitions = transitions;
+        this.start = start;
+        this.accept = accept;
+        this.fail = fail;
+        this.exact = exact;
+    }
+
+    public boolean match(byte[] input, int offset, int length)
+    {
+        if (exact) {
+            return exactMatch(input, offset, length);
+        }
+
+        return prefixMatch(input, offset, length);
+    }
+
+    /**
+     * Returns a positive match when the final state after all input has been consumed is an accepting state
+     */
+    private boolean exactMatch(byte[] input, int offset, int length)
+    {
+        int state = start << 8;
+        for (int i = offset; i < offset + length; i++) {
+            byte inputByte = input[i];
+            state = transitions[state | (inputByte & 0xFF)];
+
+            if (state == fail) {
+                return false;
+            }
+        }
+
+        return accept[state >>> 8];
+    }
+
+    /**
+     * Returns a positive match as soon as the DFA reaches an accepting state, regardless of whether
+     * the whole input has been consumed
+     */
+    private boolean prefixMatch(byte[] input, int offset, int length)
+    {
+        int state = start << 8;
+        for (int i = offset; i < offset + length; i++) {
+            byte inputByte = input[i];
+            state = transitions[state | (inputByte & 0xFF)];
+
+            if (state == fail) {
+                return false;
+            }
+
+            if (accept[state >>> 8]) {
+                return true;
+            }
+        }
+
+        return accept[state >>> 8];
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/LikeMatcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/LikeMatcher.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class LikeMatcher
@@ -30,7 +29,7 @@ public class LikeMatcher
     private final OptionalInt maxSize;
     private final byte[] prefix;
     private final byte[] suffix;
-    private final Optional<DenseDfaMatcher> matcher;
+    private final Optional<Matcher> matcher;
 
     private LikeMatcher(
             String pattern,
@@ -39,7 +38,7 @@ public class LikeMatcher
             OptionalInt maxSize,
             byte[] prefix,
             byte[] suffix,
-            Optional<DenseDfaMatcher> matcher)
+            Optional<Matcher> matcher)
     {
         this.pattern = pattern;
         this.escape = escape;
@@ -62,13 +61,17 @@ public class LikeMatcher
 
     public static LikeMatcher compile(String pattern)
     {
-        return compile(pattern, Optional.empty());
+        return compile(pattern, Optional.empty(), true);
     }
 
     public static LikeMatcher compile(String pattern, Optional<Character> escape)
     {
+        return compile(pattern, escape, true);
+    }
+
+    public static LikeMatcher compile(String pattern, Optional<Character> escape, boolean optimize)
+    {
         List<Pattern> parsed = parse(pattern, escape);
-        List<Pattern> optimized = optimize(parsed);
 
         // Calculate minimum and maximum size for candidate strings
         // This is used for short-circuiting the match if the size of
@@ -76,20 +79,21 @@ public class LikeMatcher
         int minSize = 0;
         int maxSize = 0;
         boolean unbounded = false;
-        for (Pattern expression : optimized) {
+        for (Pattern expression : parsed) {
             if (expression instanceof Pattern.Literal) {
                 Pattern.Literal literal = (Pattern.Literal) expression;
                 int length = literal.getValue().getBytes(UTF_8).length;
                 minSize += length;
                 maxSize += length;
             }
+            else if (expression instanceof Pattern.ZeroOrMore) {
+                unbounded = true;
+            }
             else if (expression instanceof Pattern.Any) {
                 Pattern.Any any = (Pattern.Any) expression;
-                int length = any.getMin();
+                int length = any.getLength();
                 minSize += length;
                 maxSize += length * 4; // at most 4 bytes for a single UTF-8 codepoint
-
-                unbounded = unbounded || any.isUnbounded();
             }
             else {
                 throw new UnsupportedOperationException("Not supported: " + expression.getClass().getName());
@@ -101,26 +105,19 @@ public class LikeMatcher
         // exact match to short-circuit DFA evaluation
         byte[] prefix = new byte[0];
         byte[] suffix = new byte[0];
-        List<Pattern> middle = new ArrayList<>();
-        for (int i = 0; i < optimized.size(); i++) {
-            Pattern expression = optimized.get(i);
 
-            if (i == 0) {
-                if (expression instanceof Pattern.Literal) {
-                    Pattern.Literal literal = (Pattern.Literal) expression;
-                    prefix = literal.getValue().getBytes(UTF_8);
-                    continue;
-                }
-            }
-            else if (i == optimized.size() - 1) {
-                if (expression instanceof Pattern.Literal) {
-                    Pattern.Literal literal = (Pattern.Literal) expression;
-                    suffix = literal.getValue().getBytes(UTF_8);
-                    continue;
-                }
-            }
+        int patternStart = 0;
+        int patternEnd = parsed.size() - 1;
+        if (parsed.size() > 0 && parsed.get(0) instanceof Pattern.Literal) {
+            Pattern.Literal literal = (Pattern.Literal) parsed.get(0);
+            prefix = literal.getValue().getBytes(UTF_8);
+            patternStart++;
+        }
 
-            middle.add(expression);
+        if (parsed.size() > 1 && parsed.get(parsed.size() - 1) instanceof Pattern.Literal) {
+            Pattern.Literal literal = (Pattern.Literal) parsed.get(parsed.size() - 1);
+            suffix = literal.getValue().getBytes(UTF_8);
+            patternEnd--;
         }
 
         // If the pattern (after excluding constant prefix/suffixes) ends with an unbounded match (i.e., %)
@@ -128,26 +125,20 @@ public class LikeMatcher
         // is no need to consume the remaining input
         // This section determines whether the pattern is a candidate for non-exact match.
         boolean exact = true; // whether to match to the end of the input
-        if (!middle.isEmpty()) {
-            // guaranteed to be Any because any Literal would've been turned into a suffix above
-            Pattern.Any last = (Pattern.Any) middle.get(middle.size() - 1);
-            if (last.isUnbounded()) {
-                exact = false;
-
-                // Since the matcher will stop early, no need for an unbounded matcher (it produces a simpler DFA)
-                if (last.getMin() == 0) {
-                    // We'd end up with an empty string match at the end, so just remove it
-                    middle.remove(middle.size() - 1);
-                }
-                else {
-                    middle.set(middle.size() - 1, new Pattern.Any(last.getMin(), false));
-                }
-            }
+        if (patternStart <= patternEnd && parsed.get(patternEnd) instanceof Pattern.ZeroOrMore) {
+            // guaranteed to be Any or ZeroOrMore because any Literal would've been turned into a suffix above
+            exact = false;
+            patternEnd--;
         }
 
-        Optional<DenseDfaMatcher> matcher = Optional.empty();
-        if (!middle.isEmpty()) {
-            matcher = Optional.of(DenseDfaMatcher.newInstance(makeNfa(middle).toDfa(), exact));
+        Optional<Matcher> matcher = Optional.empty();
+        if (patternStart <= patternEnd) {
+            if (optimize) {
+                matcher = Optional.of(new DenseDfaMatcher(parsed, patternStart, patternEnd, exact));
+            }
+            else {
+                matcher = Optional.of(new NfaMatcher(parsed, patternStart, patternEnd, exact));
+            }
         }
 
         return new LikeMatcher(
@@ -201,11 +192,13 @@ public class LikeMatcher
         return true;
     }
 
-    private static List<Pattern> parse(String pattern, Optional<Character> escape)
+    static List<Pattern> parse(String pattern, Optional<Character> escape)
     {
         List<Pattern> result = new ArrayList<>();
 
         StringBuilder literal = new StringBuilder();
+        int anyCount = 0;
+        boolean anyUnbounded = false;
         boolean inEscape = false;
         for (int i = 0; i < pattern.length(); i++) {
             char character = pattern.charAt(i);
@@ -214,26 +207,47 @@ public class LikeMatcher
                 if (character != '%' && character != '_' && character != escape.get()) {
                     throw new IllegalArgumentException("Escape character must be followed by '%', '_' or the escape character itself");
                 }
+
                 literal.append(character);
                 inEscape = false;
             }
             else if (escape.isPresent() && character == escape.get()) {
                 inEscape = true;
+
+                if (anyCount != 0) {
+                    result.add(new Pattern.Any(anyCount));
+                    anyCount = 0;
+                }
+
+                if (anyUnbounded) {
+                    result.add(new Pattern.ZeroOrMore());
+                    anyUnbounded = false;
+                }
             }
             else if (character == '%' || character == '_') {
                 if (literal.length() != 0) {
                     result.add(new Pattern.Literal(literal.toString()));
-                    literal = new StringBuilder();
+                    literal.setLength(0);
                 }
 
                 if (character == '%') {
-                    result.add(new Pattern.Any(0, true));
+                    anyUnbounded = true;
                 }
                 else {
-                    result.add(new Pattern.Any(1, false));
+                    anyCount++;
                 }
             }
             else {
+                if (anyCount != 0) {
+                    result.add(new Pattern.Any(anyCount));
+                    anyCount = 0;
+                }
+
+                if (anyUnbounded) {
+                    result.add(new Pattern.ZeroOrMore());
+                    anyUnbounded = false;
+                }
+
                 literal.append(character);
             }
         }
@@ -245,146 +259,16 @@ public class LikeMatcher
         if (literal.length() != 0) {
             result.add(new Pattern.Literal(literal.toString()));
         }
-
-        return result;
-    }
-
-    private static List<Pattern> optimize(List<Pattern> pattern)
-    {
-        if (pattern.isEmpty()) {
-            return pattern;
-        }
-
-        List<Pattern> result = new ArrayList<>();
-
-        int anyPatternStart = -1;
-        for (int i = 0; i < pattern.size(); i++) {
-            Pattern current = pattern.get(i);
-
-            if (anyPatternStart == -1 && current instanceof Pattern.Any) {
-                anyPatternStart = i;
+        else {
+            if (anyCount != 0) {
+                result.add(new Pattern.Any(anyCount));
             }
-            else if (current instanceof Pattern.Literal) {
-                if (anyPatternStart != -1) {
-                    result.add(collapse(pattern, anyPatternStart, i));
-                }
 
-                result.add(current);
-                anyPatternStart = -1;
+            if (anyUnbounded) {
+                result.add(new Pattern.ZeroOrMore());
             }
-        }
-
-        if (anyPatternStart != -1) {
-            result.add(collapse(pattern, anyPatternStart, pattern.size()));
         }
 
         return result;
-    }
-
-    /**
-     * Collapses a sequence of consecutive Any items
-     */
-    private static Pattern.Any collapse(List<Pattern> pattern, int start, int end)
-    {
-        int min = 0;
-        boolean unbounded = false;
-
-        for (int i = start; i < end; i++) {
-            Pattern.Any any = (Pattern.Any) pattern.get(i);
-
-            min += any.getMin();
-            unbounded = unbounded || any.isUnbounded();
-        }
-
-        return new Pattern.Any(min, unbounded);
-    }
-
-    private static NFA makeNfa(List<Pattern> pattern)
-    {
-        checkArgument(!pattern.isEmpty(), "pattern is empty");
-
-        NFA.Builder builder = new NFA.Builder();
-
-        NFA.State state = builder.addStartState();
-
-        for (Pattern item : pattern) {
-            if (item instanceof Pattern.Literal) {
-                Pattern.Literal literal = (Pattern.Literal) item;
-                for (byte current : literal.getValue().getBytes(UTF_8)) {
-                    state = matchByte(builder, state, current);
-                }
-            }
-
-            else if (item instanceof Pattern.Any) {
-                Pattern.Any any = (Pattern.Any) item;
-                NFA.State previous;
-                int i = 0;
-                do {
-                    previous = state;
-                    state = matchSingleUtf8(builder, state);
-                    i++;
-                }
-                while (i < any.getMin());
-
-                if (any.getMin() == 0) {
-                    builder.addTransition(previous, new NFA.Epsilon(), state);
-                }
-
-                if (any.isUnbounded()) {
-                    builder.addTransition(state, new NFA.Epsilon(), previous);
-                }
-            }
-            else {
-                throw new UnsupportedOperationException("Not supported: " + item.getClass().getName());
-            }
-        }
-
-        builder.setAccept(state);
-
-        return builder.build();
-    }
-
-    private static NFA.State matchByte(NFA.Builder builder, NFA.State state, byte value)
-    {
-        NFA.State next = builder.addState();
-        builder.addTransition(state, new NFA.Value(value), next);
-        return next;
-    }
-
-    private static NFA.State matchSingleUtf8(NFA.Builder builder, NFA.State start)
-    {
-        /*
-            Implements a state machine to recognize UTF-8 characters.
-
-                  11110xxx       10xxxxxx       10xxxxxx       10xxxxxx
-              O ───────────► O ───────────► O ───────────► O ───────────► O
-              │                             ▲              ▲              ▲
-              ├─────────────────────────────┘              │              │
-              │          1110xxxx                          │              │
-              │                                            │              │
-              ├────────────────────────────────────────────┘              │
-              │                   110xxxxx                                │
-              │                                                           │
-              └───────────────────────────────────────────────────────────┘
-                                        0xxxxxxx
-        */
-
-        NFA.State next = builder.addState();
-
-        builder.addTransition(start, new NFA.Prefix(0, 1), next);
-
-        NFA.State state1 = builder.addState();
-        NFA.State state2 = builder.addState();
-        NFA.State state3 = builder.addState();
-
-        builder.addTransition(start, new NFA.Prefix(0b11110, 5), state1);
-        builder.addTransition(start, new NFA.Prefix(0b1110, 4), state2);
-        builder.addTransition(start, new NFA.Prefix(0b110, 3), state3);
-
-        builder.addTransition(state1, new NFA.Prefix(0b10, 2), state2);
-        builder.addTransition(state2, new NFA.Prefix(0b10, 2), state3);
-        builder.addTransition(state3, new NFA.Prefix(0b10, 2), next);
-
-        return next;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/LikeMatcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/LikeMatcher.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class LikeMatcher
+{
+    private final String pattern;
+    private final Optional<Character> escape;
+
+    private final int minSize;
+    private final OptionalInt maxSize;
+    private final byte[] prefix;
+    private final byte[] suffix;
+    private final Optional<DenseDfaMatcher> matcher;
+
+    private LikeMatcher(
+            String pattern,
+            Optional<Character> escape,
+            int minSize,
+            OptionalInt maxSize,
+            byte[] prefix,
+            byte[] suffix,
+            Optional<DenseDfaMatcher> matcher)
+    {
+        this.pattern = pattern;
+        this.escape = escape;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.matcher = matcher;
+    }
+
+    public String getPattern()
+    {
+        return pattern;
+    }
+
+    public Optional<Character> getEscape()
+    {
+        return escape;
+    }
+
+    public static LikeMatcher compile(String pattern)
+    {
+        return compile(pattern, Optional.empty());
+    }
+
+    public static LikeMatcher compile(String pattern, Optional<Character> escape)
+    {
+        List<Pattern> parsed = parse(pattern, escape);
+        List<Pattern> optimized = optimize(parsed);
+
+        // Calculate minimum and maximum size for candidate strings
+        // This is used for short-circuiting the match if the size of
+        // the input is outside those bounds
+        int minSize = 0;
+        int maxSize = 0;
+        boolean unbounded = false;
+        for (Pattern expression : optimized) {
+            if (expression instanceof Pattern.Literal) {
+                Pattern.Literal literal = (Pattern.Literal) expression;
+                int length = literal.getValue().getBytes(UTF_8).length;
+                minSize += length;
+                maxSize += length;
+            }
+            else if (expression instanceof Pattern.Any) {
+                Pattern.Any any = (Pattern.Any) expression;
+                int length = any.getMin();
+                minSize += length;
+                maxSize += length * 4; // at most 4 bytes for a single UTF-8 codepoint
+
+                unbounded = unbounded || any.isUnbounded();
+            }
+            else {
+                throw new UnsupportedOperationException("Not supported: " + expression.getClass().getName());
+            }
+        }
+
+        // Calculate exact match prefix and suffix
+        // If the pattern starts and ends with a literal, we can perform a quick
+        // exact match to short-circuit DFA evaluation
+        byte[] prefix = new byte[0];
+        byte[] suffix = new byte[0];
+        List<Pattern> middle = new ArrayList<>();
+        for (int i = 0; i < optimized.size(); i++) {
+            Pattern expression = optimized.get(i);
+
+            if (i == 0) {
+                if (expression instanceof Pattern.Literal) {
+                    Pattern.Literal literal = (Pattern.Literal) expression;
+                    prefix = literal.getValue().getBytes(UTF_8);
+                    continue;
+                }
+            }
+            else if (i == optimized.size() - 1) {
+                if (expression instanceof Pattern.Literal) {
+                    Pattern.Literal literal = (Pattern.Literal) expression;
+                    suffix = literal.getValue().getBytes(UTF_8);
+                    continue;
+                }
+            }
+
+            middle.add(expression);
+        }
+
+        // If the pattern (after excluding constant prefix/suffixes) ends with an unbounded match (i.e., %)
+        // we can perform a non-exact match and end as soon as the DFA reaches an accept state -- there
+        // is no need to consume the remaining input
+        // This section determines whether the pattern is a candidate for non-exact match.
+        boolean exact = true; // whether to match to the end of the input
+        if (!middle.isEmpty()) {
+            // guaranteed to be Any because any Literal would've been turned into a suffix above
+            Pattern.Any last = (Pattern.Any) middle.get(middle.size() - 1);
+            if (last.isUnbounded()) {
+                exact = false;
+
+                // Since the matcher will stop early, no need for an unbounded matcher (it produces a simpler DFA)
+                if (last.getMin() == 0) {
+                    // We'd end up with an empty string match at the end, so just remove it
+                    middle.remove(middle.size() - 1);
+                }
+                else {
+                    middle.set(middle.size() - 1, new Pattern.Any(last.getMin(), false));
+                }
+            }
+        }
+
+        Optional<DenseDfaMatcher> matcher = Optional.empty();
+        if (!middle.isEmpty()) {
+            matcher = Optional.of(DenseDfaMatcher.newInstance(makeNfa(middle).toDfa(), exact));
+        }
+
+        return new LikeMatcher(
+                pattern,
+                escape,
+                minSize,
+                unbounded ? OptionalInt.empty() : OptionalInt.of(maxSize),
+                prefix,
+                suffix,
+                matcher);
+    }
+
+    public boolean match(byte[] input)
+    {
+        return match(input, 0, input.length);
+    }
+
+    public boolean match(byte[] input, int offset, int length)
+    {
+        if (length < minSize) {
+            return false;
+        }
+
+        if (maxSize.isPresent() && length > maxSize.getAsInt()) {
+            return false;
+        }
+
+        if (!startsWith(prefix, input, offset)) {
+            return false;
+        }
+
+        if (!startsWith(suffix, input, offset + length - suffix.length)) {
+            return false;
+        }
+
+        if (matcher.isPresent()) {
+            return matcher.get().match(input, offset + prefix.length, length - suffix.length - prefix.length);
+        }
+
+        return true;
+    }
+
+    private boolean startsWith(byte[] pattern, byte[] input, int offset)
+    {
+        for (int i = 0; i < pattern.length; i++) {
+            if (pattern[i] != input[offset + i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static List<Pattern> parse(String pattern, Optional<Character> escape)
+    {
+        List<Pattern> result = new ArrayList<>();
+
+        StringBuilder literal = new StringBuilder();
+        boolean inEscape = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char character = pattern.charAt(i);
+
+            if (inEscape) {
+                if (character != '%' && character != '_' && character != escape.get()) {
+                    throw new IllegalArgumentException("Escape character must be followed by '%', '_' or the escape character itself");
+                }
+                literal.append(character);
+                inEscape = false;
+            }
+            else if (escape.isPresent() && character == escape.get()) {
+                inEscape = true;
+            }
+            else if (character == '%' || character == '_') {
+                if (literal.length() != 0) {
+                    result.add(new Pattern.Literal(literal.toString()));
+                    literal = new StringBuilder();
+                }
+
+                if (character == '%') {
+                    result.add(new Pattern.Any(0, true));
+                }
+                else {
+                    result.add(new Pattern.Any(1, false));
+                }
+            }
+            else {
+                literal.append(character);
+            }
+        }
+
+        if (inEscape) {
+            throw new IllegalArgumentException("Escape character must be followed by '%', '_' or the escape character itself");
+        }
+
+        if (literal.length() != 0) {
+            result.add(new Pattern.Literal(literal.toString()));
+        }
+
+        return result;
+    }
+
+    private static List<Pattern> optimize(List<Pattern> pattern)
+    {
+        if (pattern.isEmpty()) {
+            return pattern;
+        }
+
+        List<Pattern> result = new ArrayList<>();
+
+        int anyPatternStart = -1;
+        for (int i = 0; i < pattern.size(); i++) {
+            Pattern current = pattern.get(i);
+
+            if (anyPatternStart == -1 && current instanceof Pattern.Any) {
+                anyPatternStart = i;
+            }
+            else if (current instanceof Pattern.Literal) {
+                if (anyPatternStart != -1) {
+                    result.add(collapse(pattern, anyPatternStart, i));
+                }
+
+                result.add(current);
+                anyPatternStart = -1;
+            }
+        }
+
+        if (anyPatternStart != -1) {
+            result.add(collapse(pattern, anyPatternStart, pattern.size()));
+        }
+
+        return result;
+    }
+
+    /**
+     * Collapses a sequence of consecutive Any items
+     */
+    private static Pattern.Any collapse(List<Pattern> pattern, int start, int end)
+    {
+        int min = 0;
+        boolean unbounded = false;
+
+        for (int i = start; i < end; i++) {
+            Pattern.Any any = (Pattern.Any) pattern.get(i);
+
+            min += any.getMin();
+            unbounded = unbounded || any.isUnbounded();
+        }
+
+        return new Pattern.Any(min, unbounded);
+    }
+
+    private static NFA makeNfa(List<Pattern> pattern)
+    {
+        checkArgument(!pattern.isEmpty(), "pattern is empty");
+
+        NFA.Builder builder = new NFA.Builder();
+
+        NFA.State state = builder.addStartState();
+
+        for (Pattern item : pattern) {
+            if (item instanceof Pattern.Literal) {
+                Pattern.Literal literal = (Pattern.Literal) item;
+                for (byte current : literal.getValue().getBytes(UTF_8)) {
+                    state = matchByte(builder, state, current);
+                }
+            }
+
+            else if (item instanceof Pattern.Any) {
+                Pattern.Any any = (Pattern.Any) item;
+                NFA.State previous;
+                int i = 0;
+                do {
+                    previous = state;
+                    state = matchSingleUtf8(builder, state);
+                    i++;
+                }
+                while (i < any.getMin());
+
+                if (any.getMin() == 0) {
+                    builder.addTransition(previous, new NFA.Epsilon(), state);
+                }
+
+                if (any.isUnbounded()) {
+                    builder.addTransition(state, new NFA.Epsilon(), previous);
+                }
+            }
+            else {
+                throw new UnsupportedOperationException("Not supported: " + item.getClass().getName());
+            }
+        }
+
+        builder.setAccept(state);
+
+        return builder.build();
+    }
+
+    private static NFA.State matchByte(NFA.Builder builder, NFA.State state, byte value)
+    {
+        NFA.State next = builder.addState();
+        builder.addTransition(state, new NFA.Value(value), next);
+        return next;
+    }
+
+    private static NFA.State matchSingleUtf8(NFA.Builder builder, NFA.State start)
+    {
+        /*
+            Implements a state machine to recognize UTF-8 characters.
+
+                  11110xxx       10xxxxxx       10xxxxxx       10xxxxxx
+              O ───────────► O ───────────► O ───────────► O ───────────► O
+              │                             ▲              ▲              ▲
+              ├─────────────────────────────┘              │              │
+              │          1110xxxx                          │              │
+              │                                            │              │
+              ├────────────────────────────────────────────┘              │
+              │                   110xxxxx                                │
+              │                                                           │
+              └───────────────────────────────────────────────────────────┘
+                                        0xxxxxxx
+        */
+
+        NFA.State next = builder.addState();
+
+        builder.addTransition(start, new NFA.Prefix(0, 1), next);
+
+        NFA.State state1 = builder.addState();
+        NFA.State state2 = builder.addState();
+        NFA.State state3 = builder.addState();
+
+        builder.addTransition(start, new NFA.Prefix(0b11110, 5), state1);
+        builder.addTransition(start, new NFA.Prefix(0b1110, 4), state2);
+        builder.addTransition(start, new NFA.Prefix(0b110, 3), state3);
+
+        builder.addTransition(state1, new NFA.Prefix(0b10, 2), state2);
+        builder.addTransition(state2, new NFA.Prefix(0b10, 2), state3);
+        builder.addTransition(state3, new NFA.Prefix(0b10, 2), next);
+
+        return next;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/Matcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/Matcher.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+public interface Matcher
+{
+    boolean match(byte[] input, int offset, int length);
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/NFA.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/NFA.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.internal.guava.base.Preconditions.checkState;
+
+public class NFA
+{
+    private final State start;
+    private final State accept;
+    private List<State> states;
+    private Map<Integer, List<Transition>> transitions;
+
+    public NFA(State start, State accept, List<State> states, Map<Integer, List<Transition>> transitions)
+    {
+        this.start = requireNonNull(start, "start is null");
+        this.accept = requireNonNull(accept, "accept is null");
+        this.states = ImmutableList.copyOf(states);
+        this.transitions = ImmutableMap.copyOf(transitions);
+    }
+
+    public DFA toDfa()
+    {
+        Map<Set<NFA.State>, DFA.State> activeStates = new HashMap<>();
+
+        DFA.Builder builder = new DFA.Builder();
+        DFA.State failed = builder.addFailState();
+        for (int i = 0; i < 256; i++) {
+            builder.addTransition(failed, i, failed);
+        }
+
+        Set<NFA.State> initial = transitiveClosure(Collections.singleton((this.start)));
+        Queue<Set<State>> queue = new ArrayDeque<>();
+        queue.add(initial);
+
+        DFA.State dfaStartState = builder.addStartState(makeLabel(initial), initial.contains(accept));
+        activeStates.put(initial, dfaStartState);
+
+        Set<Set<NFA.State>> visited = new HashSet<>();
+        while (!queue.isEmpty()) {
+            Set<NFA.State> current = queue.poll();
+
+            if (!visited.add(current)) {
+                continue;
+            }
+
+            // For each possible byte value...
+            for (int byteValue = 0; byteValue < 256; byteValue++) {
+                Set<NFA.State> next = new HashSet<>();
+                for (NFA.State nfaState : current) {
+                    for (Transition transition : transitions(nfaState)) {
+                        Condition condition = transition.getCondition();
+                        State target = states.get(transition.getTarget());
+
+                        if (condition instanceof Value) {
+                            Value valueTransition = (Value) condition;
+                            if (valueTransition.getValue() == (byte) byteValue) {
+                                next.add(target);
+                            }
+                        }
+                        else if (condition instanceof Prefix) {
+                            Prefix prefixTransition = (Prefix) condition;
+                            if (byteValue >>> (8 - prefixTransition.getBits()) == prefixTransition.getPrefix()) {
+                                next.add(target);
+                            }
+                        }
+                    }
+                }
+
+                DFA.State from = activeStates.get(current);
+                DFA.State to = failed;
+                if (!next.isEmpty()) {
+                    Set<NFA.State> closure = transitiveClosure(next);
+                    to = activeStates.computeIfAbsent(closure, nfaStates -> builder.addState(makeLabel(nfaStates), nfaStates.contains(accept)));
+                    queue.add(closure);
+                }
+                builder.addTransition(from, byteValue, to);
+            }
+        }
+
+        return builder.build();
+    }
+
+    private List<Transition> transitions(State state)
+    {
+        return transitions.getOrDefault(state.id, ImmutableList.of());
+    }
+
+    /**
+     * Traverse epsilon transitions to compute the reachable set of states
+     */
+    private Set<State> transitiveClosure(Set<State> states)
+    {
+        Set<State> result = new HashSet<>();
+
+        Queue<State> queue = new ArrayDeque<>(states);
+        while (!queue.isEmpty()) {
+            State state = queue.poll();
+
+            if (result.contains(state)) {
+                continue;
+            }
+
+            transitions(state).stream()
+                    .filter(transition -> transition.getCondition() instanceof Epsilon)
+                    .forEach(transition -> {
+                        State target = this.states.get(transition.getTarget());
+                        result.add(target);
+                        queue.add(target);
+                    });
+        }
+
+        result.addAll(states);
+
+        return result;
+    }
+
+    private String makeLabel(Set<State> states)
+    {
+        return "{" + states.stream()
+                .map(NFA.State::getId)
+                .map(Object::toString)
+                .sorted()
+                .collect(Collectors.joining(",")) + "}";
+    }
+
+    public static class Builder
+    {
+        private int nextId;
+        private State start;
+        private State accept;
+        private final List<State> states = new ArrayList<>();
+        private final Map<Integer, List<Transition>> transitions = new HashMap<>();
+
+        public State addState()
+        {
+            State state = new State(nextId++);
+            states.add(state);
+            return state;
+        }
+
+        public State addStartState()
+        {
+            checkState(start == null, "Start state is already set");
+            start = addState();
+            return start;
+        }
+
+        public void setAccept(State state)
+        {
+            checkState(accept == null, "Accept state is already set");
+            accept = state;
+        }
+
+        public void addTransition(State from, Condition condition, State to)
+        {
+            transitions.computeIfAbsent(from.getId(), key -> new ArrayList<>())
+                    .add(new Transition(to.getId(), condition));
+        }
+
+        public NFA build()
+        {
+            return new NFA(start, accept, states, transitions);
+        }
+    }
+
+    public static class State
+    {
+        private final int id;
+
+        public State(int id)
+        {
+            this.id = id;
+        }
+
+        public int getId()
+        {
+            return id;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "(" + id + ")";
+        }
+    }
+
+    public static class Transition
+    {
+        private final int target;
+        private final Condition condition;
+
+        public Transition(int target, Condition condition)
+        {
+            this.target = target;
+            this.condition = condition;
+        }
+
+        public int getTarget()
+        {
+            return target;
+        }
+
+        public Condition getCondition()
+        {
+            return condition;
+        }
+    }
+
+    public interface Condition
+    {
+    }
+
+    public static class Epsilon
+            implements Condition
+    {
+    }
+
+    public static class Value
+            implements Condition
+    {
+        private final byte value;
+
+        public Value(byte value)
+        {
+            this.value = value;
+        }
+
+        public byte getValue()
+        {
+            return value;
+        }
+    }
+
+    public static class Prefix
+            implements Condition
+    {
+        private final int prefix;
+        private final int bits;
+
+        public Prefix(int prefix, int bits)
+        {
+            this.prefix = prefix;
+            this.bits = bits;
+        }
+
+        public int getPrefix()
+        {
+            return prefix;
+        }
+
+        public int getBits()
+        {
+            return bits;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/NFA.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/NFA.java
@@ -13,58 +13,50 @@
  */
 package com.facebook.presto.likematcher;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.ints.IntArraySet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.internal.guava.base.Preconditions.checkState;
 
-public class NFA
+final class NFA
 {
-    private final State start;
-    private final State accept;
-    private List<State> states;
-    private Map<Integer, List<Transition>> transitions;
+    private final int start;
+    private final int accept;
+    private final List<List<Transition>> transitions;
 
-    public NFA(State start, State accept, List<State> states, Map<Integer, List<Transition>> transitions)
+    private NFA(int start, int accept, List<List<Transition>> transitions)
     {
-        this.start = requireNonNull(start, "start is null");
-        this.accept = requireNonNull(accept, "accept is null");
-        this.states = ImmutableList.copyOf(states);
-        this.transitions = ImmutableMap.copyOf(transitions);
+        this.start = start;
+        this.accept = accept;
+        this.transitions = requireNonNull(transitions, "transitions is null");
     }
 
     public DFA toDfa()
     {
-        Map<Set<NFA.State>, DFA.State> activeStates = new HashMap<>();
+        Map<IntSet, Integer> activeStates = new HashMap<>();
 
         DFA.Builder builder = new DFA.Builder();
-        DFA.State failed = builder.addFailState();
-        for (int i = 0; i < 256; i++) {
-            builder.addTransition(failed, i, failed);
-        }
 
-        Set<NFA.State> initial = transitiveClosure(Collections.singleton((this.start)));
-        Queue<Set<State>> queue = new ArrayDeque<>();
+        IntSet initial = new IntArraySet();
+        initial.add(start);
+        Queue<IntSet> queue = new ArrayDeque<>();
         queue.add(initial);
 
-        DFA.State dfaStartState = builder.addStartState(makeLabel(initial), initial.contains(accept));
+        int dfaStartState = builder.addStartState(initial.contains(accept));
         activeStates.put(initial, dfaStartState);
 
-        Set<Set<NFA.State>> visited = new HashSet<>();
+        Set<IntSet> visited = new HashSet<>();
         while (!queue.isEmpty()) {
-            Set<NFA.State> current = queue.poll();
+            IntSet current = queue.poll();
 
             if (!visited.add(current)) {
                 continue;
@@ -72,17 +64,14 @@ public class NFA
 
             // For each possible byte value...
             for (int byteValue = 0; byteValue < 256; byteValue++) {
-                Set<NFA.State> next = new HashSet<>();
-                for (NFA.State nfaState : current) {
+                IntSet next = new IntArraySet();
+                for (int nfaState : current) {
                     for (Transition transition : transitions(nfaState)) {
                         Condition condition = transition.getCondition();
-                        State target = states.get(transition.getTarget());
+                        int target = transition.getTarget();
 
-                        if (condition instanceof Value) {
-                            Value valueTransition = (Value) condition;
-                            if (valueTransition.getValue() == (byte) byteValue) {
-                                next.add(target);
-                            }
+                        if (condition instanceof Value && ((Value) condition).getValue() == (byte) byteValue) {
+                            next.add(target);
                         }
                         else if (condition instanceof Prefix) {
                             Prefix prefixTransition = (Prefix) condition;
@@ -93,121 +82,56 @@ public class NFA
                     }
                 }
 
-                DFA.State from = activeStates.get(current);
-                DFA.State to = failed;
                 if (!next.isEmpty()) {
-                    Set<NFA.State> closure = transitiveClosure(next);
-                    to = activeStates.computeIfAbsent(closure, nfaStates -> builder.addState(makeLabel(nfaStates), nfaStates.contains(accept)));
-                    queue.add(closure);
+                    int from = activeStates.get(current);
+                    int to = activeStates.computeIfAbsent(next, nfaStates -> builder.addState(nfaStates.contains(accept)));
+                    builder.addTransition(from, byteValue, to);
+
+                    queue.add(next);
                 }
-                builder.addTransition(from, byteValue, to);
             }
         }
 
         return builder.build();
     }
 
-    private List<Transition> transitions(State state)
+    private List<Transition> transitions(int state)
     {
-        return transitions.getOrDefault(state.id, ImmutableList.of());
-    }
-
-    /**
-     * Traverse epsilon transitions to compute the reachable set of states
-     */
-    private Set<State> transitiveClosure(Set<State> states)
-    {
-        Set<State> result = new HashSet<>();
-
-        Queue<State> queue = new ArrayDeque<>(states);
-        while (!queue.isEmpty()) {
-            State state = queue.poll();
-
-            if (result.contains(state)) {
-                continue;
-            }
-
-            transitions(state).stream()
-                    .filter(transition -> transition.getCondition() instanceof Epsilon)
-                    .forEach(transition -> {
-                        State target = this.states.get(transition.getTarget());
-                        result.add(target);
-                        queue.add(target);
-                    });
-        }
-
-        result.addAll(states);
-
-        return result;
-    }
-
-    private String makeLabel(Set<State> states)
-    {
-        return "{" + states.stream()
-                .map(NFA.State::getId)
-                .map(Object::toString)
-                .sorted()
-                .collect(Collectors.joining(",")) + "}";
+        return transitions.get(state);
     }
 
     public static class Builder
     {
         private int nextId;
-        private State start;
-        private State accept;
-        private final List<State> states = new ArrayList<>();
-        private final Map<Integer, List<Transition>> transitions = new HashMap<>();
+        private int start;
+        private int accept;
+        private final List<List<Transition>> transitions = new ArrayList<>();
 
-        public State addState()
+        public int addState()
         {
-            State state = new State(nextId++);
-            states.add(state);
-            return state;
+            transitions.add(new ArrayList<>());
+            return nextId++;
         }
 
-        public State addStartState()
+        public int addStartState()
         {
-            checkState(start == null, "Start state is already set");
             start = addState();
             return start;
         }
 
-        public void setAccept(State state)
+        public void setAccept(int state)
         {
-            checkState(accept == null, "Accept state is already set");
             accept = state;
         }
 
-        public void addTransition(State from, Condition condition, State to)
+        public void addTransition(int from, Condition condition, int to)
         {
-            transitions.computeIfAbsent(from.getId(), key -> new ArrayList<>())
-                    .add(new Transition(to.getId(), condition));
+            transitions.get(from).add(new Transition(to, condition));
         }
 
         public NFA build()
         {
-            return new NFA(start, accept, states, transitions);
-        }
-    }
-
-    public static class State
-    {
-        private final int id;
-
-        public State(int id)
-        {
-            this.id = id;
-        }
-
-        public int getId()
-        {
-            return id;
-        }
-
-        @Override
-        public String toString()
-        {
-            return "(" + id + ")";
+            return new NFA(start, accept, transitions);
         }
     }
 
@@ -231,15 +155,14 @@ public class NFA
         {
             return condition;
         }
+
+        // Implement equals(), hashCode(), and toString() as needed
+        // ...
     }
 
     public interface Condition
     {
-    }
-
-    public static class Epsilon
-            implements Condition
-    {
+        // methods, if any
     }
 
     public static class Value
@@ -256,6 +179,9 @@ public class NFA
         {
             return value;
         }
+
+        // Implement equals(), hashCode(), and toString() as needed
+        // ...
     }
 
     public static class Prefix
@@ -279,5 +205,8 @@ public class NFA
         {
             return bits;
         }
+
+        // Implement equals(), hashCode(), and toString() as needed
+        // ...
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/NfaMatcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/NfaMatcher.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+import java.util.Arrays;
+import java.util.List;
+
+final class NfaMatcher
+        implements Matcher
+{
+    private static final int ANY = -1;
+    private static final int NONE = -2;
+    private static final int INVALID_CODEPOINT = -1;
+
+    private final boolean exact;
+
+    private final boolean[] loopback;
+    private final int[] match;
+    private final int acceptState;
+    private final int stateCount;
+
+    public NfaMatcher(List<Pattern> pattern, int start, int end, boolean exact)
+    {
+        this.exact = exact;
+
+        stateCount = calculateStateCount(pattern, start, end);
+
+        loopback = new boolean[stateCount];
+        match = new int[stateCount];
+        Arrays.fill(match, NONE);
+        acceptState = stateCount - 1;
+
+        int state = 0;
+        for (int j = start; j <= end; j++) {
+            Pattern element = pattern.get(j);
+            if (element instanceof Pattern.Literal) {
+                Pattern.Literal literal = (Pattern.Literal) element;
+                for (int i = 0; i < literal.getValue().length(); i++) {
+                    match[state++] = literal.getValue().charAt(i);
+                }
+            }
+            else if (element instanceof Pattern.Any) {
+                Pattern.Any any = (Pattern.Any) element;
+                for (int i = 0; i < any.getLength(); i++) {
+                    match[state++] = ANY;
+                }
+            }
+            else if (element instanceof Pattern.ZeroOrMore) {
+                loopback[state] = true;
+            }
+        }
+    }
+
+    private static int calculateStateCount(List<Pattern> pattern, int start, int end)
+    {
+        int states = 1;
+        for (int i = start; i <= end; i++) {
+            Pattern element = pattern.get(i);
+            if (element instanceof Pattern.Literal) {
+                Pattern.Literal literal = (Pattern.Literal) element;
+                states += literal.getValue().length();
+            }
+            else if (element instanceof Pattern.Any) {
+                Pattern.Any any = (Pattern.Any) element;
+                states += any.getLength();
+            }
+        }
+        return states;
+    }
+
+    @Override
+    public boolean match(byte[] input, int offset, int length)
+    {
+        boolean[] seen = new boolean[stateCount + 1];
+        int[] currentStates = new int[stateCount];
+        int[] nextStates = new int[stateCount];
+        int currentStatesIndex = 0;
+        int nextStatesIndex;
+
+        currentStates[currentStatesIndex++] = 0;
+
+        int limit = offset + length;
+        int current = offset;
+        boolean accept = false;
+        while (current < limit) {
+            int codepoint = INVALID_CODEPOINT;
+
+            // decode the next UTF-8 codepoint
+            int header = input[current] & 0xFF;
+            if (header < 0x80) {
+                // normal ASCII
+                // 0xxx_xxxx
+                codepoint = header;
+                current++;
+            }
+            else if ((header & 0b1110_0000) == 0b1100_0000) {
+                // 110x_xxxx 10xx_xxxx
+                if (current + 1 < limit) {
+                    codepoint = ((header & 0b0001_1111) << 6) | (input[current + 1] & 0b0011_1111);
+                    current += 2;
+                }
+            }
+            else if ((header & 0b1111_0000) == 0b1110_0000) {
+                // 1110_xxxx 10xx_xxxx 10xx_xxxx
+                if (current + 2 < limit) {
+                    codepoint = ((header & 0b0000_1111) << 12) | ((input[current + 1] & 0b0011_1111) << 6) | (input[current + 2] & 0b0011_1111);
+                    current += 3;
+                }
+            }
+            else if ((header & 0b1111_1000) == 0b1111_0000) {
+                // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
+                if (current + 3 < limit) {
+                    codepoint = ((header & 0b0000_0111) << 18) | ((input[current + 1] & 0b0011_1111) << 12) | ((input[current + 2] & 0b0011_1111) << 6) | (input[current + 3] & 0b0011_1111);
+                    current += 4;
+                }
+            }
+
+            if (codepoint == INVALID_CODEPOINT) {
+                return false;
+            }
+
+            accept = false;
+            nextStatesIndex = 0;
+            Arrays.fill(seen, false);
+            for (int i = 0; i < currentStatesIndex; i++) {
+                int state = currentStates[i];
+                if (!seen[state] && loopback[state]) {
+                    nextStates[nextStatesIndex++] = state;
+                    accept |= state == acceptState;
+                    seen[state] = true;
+                }
+                int next = state + 1;
+                if (!seen[next] && (match[state] == ANY || match[state] == codepoint)) {
+                    nextStates[nextStatesIndex++] = next;
+                    accept |= next == acceptState;
+                    seen[next] = true;
+                }
+            }
+
+            if (nextStatesIndex == 0) {
+                return false;
+            }
+
+            if (!exact && accept) {
+                return true;
+            }
+
+            int[] tmp = currentStates;
+            currentStates = nextStates;
+            nextStates = tmp;
+            currentStatesIndex = nextStatesIndex;
+        }
+
+        return accept;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/Pattern.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/Pattern.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.likematcher;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public interface Pattern
+{
+
+    class Literal
+            implements Pattern
+    {
+        private final String value;
+
+        public Literal(String value)
+        {
+            this.value = value;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return value;
+        }
+
+        // You can add equals, hashCode, and other utility methods if required
+    }
+
+    class Any
+            implements Pattern
+    {
+        private final int min;
+        private final boolean unbounded;
+
+        public Any(int min, boolean unbounded)
+        {
+            checkArgument(min > 0 || unbounded, "Any must be unbounded or require at least 1 character");
+            this.min = min;
+            this.unbounded = unbounded;
+        }
+
+        public int getMin()
+        {
+            return min;
+        }
+
+        public boolean isUnbounded()
+        {
+            return unbounded;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("{%s%s}", min, unbounded ? "+" : "");
+        }
+
+        // You can add equals, hashCode, and other utility methods if required
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/likematcher/Pattern.java
+++ b/presto-main/src/main/java/com/facebook/presto/likematcher/Pattern.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.likematcher;
 
+import com.google.common.base.Strings;
+
+import java.util.Objects;
+
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 
 public interface Pattern
 {
-
     class Literal
             implements Pattern
     {
@@ -43,33 +45,56 @@ public interface Pattern
         // You can add equals, hashCode, and other utility methods if required
     }
 
+    public class ZeroOrMore
+            implements Pattern
+    {
+        @Override
+        public String toString()
+        {
+            return "%";
+        }
+
+        // Equals and hashCode methods might be required based on usage,
+        // the record provided them by default
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(); // No fields to hash in this case
+        }
+    }
+
     class Any
             implements Pattern
     {
-        private final int min;
-        private final boolean unbounded;
+        private final int length;
 
-        public Any(int min, boolean unbounded)
+        public Any(int length)
         {
-            checkArgument(min > 0 || unbounded, "Any must be unbounded or require at least 1 character");
-            this.min = min;
-            this.unbounded = unbounded;
+            checkArgument(length > 0, "Length must be > 0");
+            this.length = length;
         }
 
-        public int getMin()
+        public int getLength()
         {
-            return min;
-        }
-
-        public boolean isUnbounded()
-        {
-            return unbounded;
+            return length;
         }
 
         @Override
         public String toString()
         {
-            return format("{%s%s}", min, unbounded ? "+" : "");
+            return Strings.repeat("_", length);
         }
 
         // You can add equals, hashCode, and other utility methods if required

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Interpreters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Interpreters.java
@@ -17,9 +17,9 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.likematcher.LikeMatcher;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.type.LikeFunctions;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 
 import java.util.Map;
@@ -58,14 +58,14 @@ public class Interpreters
         throw new UnsupportedOperationException("Dereference a unsupported primitive type: " + javaType.getName());
     }
 
-    static boolean interpretLikePredicate(Type valueType, Slice value, Regex regex)
+    static boolean interpretLikePredicate(Type valueType, Slice value, LikeMatcher matcher)
     {
         if (valueType instanceof VarcharType) {
-            return LikeFunctions.likeVarchar(value, regex);
+            return LikeFunctions.likeVarchar(value, matcher);
         }
 
         checkState(valueType instanceof CharType, "LIKE value is neither VARCHAR or CHAR");
-        return LikeFunctions.likeChar((long) ((CharType) valueType).getLength(), value, regex);
+        return LikeFunctions.likeChar((long) ((CharType) valueType).getLength(), value, matcher);
     }
 
     public static class LambdaVariableResolver

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.likematcher.LikeMatcher;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ConnectorSession;
@@ -47,7 +48,6 @@ import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.util.Failures;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
@@ -904,8 +904,8 @@ public class RowExpressionInterpreter
 
             if (!hasUnresolvedValue(value) && !hasUnresolvedValue(nonCompiledPattern) && (!hasEscape || !hasUnresolvedValue(escape))) {
                 // fast path when we know the pattern and escape are constants
-                if (possibleCompiledPattern instanceof Regex) {
-                    return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (Regex) possibleCompiledPattern));
+                if (possibleCompiledPattern instanceof LikeMatcher) {
+                    return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (LikeMatcher) possibleCompiledPattern));
                 }
                 if (possibleCompiledPattern == null) {
                     return changed(null);
@@ -922,8 +922,8 @@ public class RowExpressionInterpreter
                     possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session.getSqlFunctionProperties(), nonCompiledPattern);
                 }
 
-                checkState(possibleCompiledPattern instanceof Regex, "unexpected like pattern type " + possibleCompiledPattern.getClass());
-                return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (Regex) possibleCompiledPattern));
+                checkState(possibleCompiledPattern instanceof LikeMatcher, "unexpected like pattern type " + possibleCompiledPattern.getClass());
+                return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (LikeMatcher) possibleCompiledPattern));
             }
 
             // if pattern is a constant without % or _ replace with a comparison

--- a/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
@@ -33,7 +33,6 @@ import static com.facebook.presto.util.Failures.checkCondition;
 
 public final class LikeFunctions
 {
-
     private LikeFunctions() {}
 
     @ScalarFunction(value = "like", visibility = HIDDEN)
@@ -76,7 +75,7 @@ public final class LikeFunctions
 
     public static LikeMatcher likePattern(Slice pattern)
     {
-        return LikeMatcher.compile(pattern.toStringUtf8(), Optional.empty());
+        return LikeMatcher.compile(pattern.toStringUtf8(), Optional.empty(), false);
     }
 
     @ScalarFunction(visibility = HIDDEN)
@@ -85,7 +84,7 @@ public final class LikeFunctions
     public static LikeMatcher likePattern(@SqlType("varchar(x)") Slice pattern, @SqlType("varchar(y)") Slice escape)
     {
         try {
-            return LikeMatcher.compile(pattern.toStringUtf8(), getEscapeChar(escape));
+            return LikeMatcher.compile(pattern.toStringUtf8(), getEscapeChar(escape), false);
         }
         catch (RuntimeException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);

--- a/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
@@ -19,8 +19,8 @@ import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.likematcher.LikeMatcher;
 import com.facebook.presto.spi.PrestoException;
-import io.airlift.joni.Regex;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
@@ -32,7 +32,7 @@ public class LikePatternType
 
     public LikePatternType()
     {
-        super(new TypeSignature(NAME), Regex.class);
+        super(new TypeSignature(NAME), LikeMatcher.class);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/BenchmarkLike.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/BenchmarkLike.java
@@ -1,16 +1,17 @@
-///*
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //package com.facebook.presto.sql;
 //
 //import com.facebook.presto.likematcher.LikeMatcher;

--- a/presto-main/src/test/java/com/facebook/presto/sql/BenchmarkLike.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/BenchmarkLike.java
@@ -1,0 +1,204 @@
+///*
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package com.facebook.presto.sql;
+//
+//import com.facebook.presto.likematcher.LikeMatcher;
+//import io.airlift.jcodings.specific.NonStrictUTF8Encoding;
+//import io.airlift.joni.Matcher;
+//import io.airlift.joni.Option;
+//import io.airlift.joni.Regex;
+//import io.airlift.joni.Syntax;
+//import io.airlift.slice.Slice;
+//import io.airlift.slice.Slices;
+//import io.trino.likematcher.LikeMatcher;
+//import io.trino.type.JoniRegexp;
+//import org.openjdk.jmh.annotations.Benchmark;
+//import org.openjdk.jmh.annotations.BenchmarkMode;
+//import org.openjdk.jmh.annotations.Fork;
+//import org.openjdk.jmh.annotations.Measurement;
+//import org.openjdk.jmh.annotations.OutputTimeUnit;
+//import org.openjdk.jmh.annotations.Param;
+//import org.openjdk.jmh.annotations.Setup;
+//import org.openjdk.jmh.annotations.State;
+//import org.openjdk.jmh.annotations.Warmup;
+//import org.openjdk.jmh.results.format.ResultFormatType;
+//import org.openjdk.jmh.runner.Runner;
+//import org.openjdk.jmh.runner.RunnerException;
+//import org.openjdk.jmh.runner.options.Options;
+//import org.openjdk.jmh.runner.options.OptionsBuilder;
+//import org.openjdk.jmh.runner.options.VerboseMode;
+//
+//import java.util.Optional;
+//
+//import static io.airlift.joni.constants.MetaChar.INEFFECTIVE_META_CHAR;
+//import static io.airlift.joni.constants.SyntaxProperties.OP_ASTERISK_ZERO_INF;
+//import static io.airlift.joni.constants.SyntaxProperties.OP_DOT_ANYCHAR;
+//import static io.airlift.joni.constants.SyntaxProperties.OP_LINE_ANCHOR;
+//import static java.nio.charset.StandardCharsets.UTF_8;
+//import static java.util.concurrent.TimeUnit.MILLISECONDS;
+//import static java.util.concurrent.TimeUnit.NANOSECONDS;
+//import static org.openjdk.jmh.annotations.Mode.AverageTime;
+//import static org.openjdk.jmh.annotations.Scope.Thread;
+//
+//@State(Thread)
+//@OutputTimeUnit(NANOSECONDS)
+//@BenchmarkMode(AverageTime)
+//@Fork(3)
+//@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+//@Measurement(iterations = 30, time = 500, timeUnit = MILLISECONDS)
+//public class BenchmarkLike
+//{
+//    private static final Syntax SYNTAX = new Syntax(
+//            OP_DOT_ANYCHAR | OP_ASTERISK_ZERO_INF | OP_LINE_ANCHOR,
+//            0,
+//            0,
+//            Option.NONE,
+//            new Syntax.MetaCharTable(
+//                    '\\',                           /* esc */
+//                    INEFFECTIVE_META_CHAR,          /* anychar '.' */
+//                    INEFFECTIVE_META_CHAR,          /* anytime '*' */
+//                    INEFFECTIVE_META_CHAR,          /* zero or one time '?' */
+//                    INEFFECTIVE_META_CHAR,          /* one or more time '+' */
+//                    INEFFECTIVE_META_CHAR));        /* anychar anytime */
+//
+//    @State(Thread)
+//    public static class Data
+//    {
+//        @Param({
+//                "%",
+//                "_%",
+//                "%_",
+//                "abc%",
+//                "%abc",
+//                "_____",
+//                "abc%def%ghi",
+//                "%abc%def%",
+//        })
+//        private String pattern;
+//
+//        private Slice data;
+//        private byte[] bytes;
+//        private Regex regex;
+//        private LikeMatcher matcher;
+//
+//        @Setup
+//        public void setup()
+//        {
+//            data = Slices.utf8Slice(
+//                    switch (pattern) {
+//                        case "%" -> "qeroighqeorhgqerhb2eriuyerqiubgierubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet";
+//                        case "_%", "%_" -> "qeroighqeorhgqerhb2eriuyerqiubgierubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet";
+//                        case "abc%" -> "abcqeroighqeorhgqerhb2eriuyerqiubgierubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet";
+//                        case "%abc" -> "qeroighqeorhgqerhb2eriuyerqiubgierubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhetabc";
+//                        case "_____" -> "abcde";
+//                        case "abc%def%ghi" -> "abc qeroighqeorhgqerhb2eriuyerqiubgier def ubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet ghi";
+//                        case "%abc%def%" -> "fdnbqerbfklerqbgqjerbgkr abc qeroighqeorhgqerhb2eriuyerqiubgier def ubgleuqrbgilquebriuqebryqebrhqerhqsnajkbcowuhet";
+//                        default -> throw new IllegalArgumentException("Unknown pattern: " + pattern);
+//                    });
+//
+//            matcher = LikeMatcher.compile(pattern, Optional.empty());
+//            joniPattern = compileJoni(Slices.utf8Slice(pattern).toStringUtf8(), '0', false);
+//
+//            bytes = data.getBytes();
+//        }
+//    }
+//
+//    @Benchmark
+//    public boolean benchmarkJoni(Data data)
+//    {
+//        return likeVarchar(data.data, data.joniPattern);
+//    }
+//
+//    @Benchmark
+//    public boolean benchmarkCurrent(Data data)
+//    {
+//        return data.matcher.match(data.bytes, 0, data.bytes.length);
+//    }
+//
+//    public static boolean likeVarchar(Slice value, JoniRegexp pattern)
+//    {
+//        Matcher matcher;
+//        int offset;
+//        if (value.hasByteArray()) {
+//            offset = value.byteArrayOffset();
+//            matcher = pattern.regex().matcher(value.byteArray(), offset, offset + value.length());
+//        }
+//        else {
+//            offset = 0;
+//            matcher = pattern.matcher(value.getBytes());
+//        }
+//        return matcher.match(offset, offset + value.length(), Option.NONE) != -1;
+//    }
+//
+//    private static JoniRegexp compileJoni(String patternString, char escapeChar, boolean shouldEscape)
+//    {
+//        byte[] bytes = likeToRegex(patternString, escapeChar, shouldEscape).getBytes(UTF_8);
+//        Regex joniRegex = new Regex(bytes, 0, bytes.length, Option.MULTILINE, NonStrictUTF8Encoding.INSTANCE, SYNTAX);
+//        return new JoniRegexp(Slices.wrappedBuffer(bytes), joniRegex);
+//    }
+//
+//    private static String likeToRegex(String patternString, char escapeChar, boolean shouldEscape)
+//    {
+//        StringBuilder regex = new StringBuilder(patternString.length() * 2);
+//
+//        regex.append('^');
+//        boolean escaped = false;
+//        for (char currentChar : patternString.toCharArray()) {
+//            checkEscape(!escaped || currentChar == '%' || currentChar == '_' || currentChar == escapeChar);
+//            if (shouldEscape && !escaped && (currentChar == escapeChar)) {
+//                escaped = true;
+//            }
+//            else {
+//                switch (currentChar) {
+//                    case '%' -> {
+//                        regex.append(escaped ? "%" : ".*");
+//                        escaped = false;
+//                    }
+//                    case '_' -> {
+//                        regex.append(escaped ? "_" : ".");
+//                        escaped = false;
+//                    }
+//                    default -> {
+//                        // escape special regex characters
+//                        switch (currentChar) {
+//                            case '\\', '^', '$', '.', '*' -> regex.append('\\');
+//                        }
+//                        regex.append(currentChar);
+//                        escaped = false;
+//                    }
+//                }
+//            }
+//        }
+//        checkEscape(!escaped);
+//        regex.append('$');
+//        return regex.toString();
+//    }
+//
+//    private static void checkEscape(boolean condition)
+//    {
+//        checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
+//    }
+//
+//    public static void main(String[] args)
+//            throws RunnerException
+//    {
+//        Options options = new OptionsBuilder()
+//                .verbosity(VerboseMode.NORMAL)
+//                .include(".*" + BenchmarkLike.class.getSimpleName() + ".*")
+//                .resultFormat(ResultFormatType.JSON)
+//                .build();
+//
+//        new Runner(options).run();
+//    }
+//}

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestLikeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestLikeMatcher.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.likematcher.LikeMatcher;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class TestLikeMatcher
+{
+    @Test
+    public void test()
+    {
+        // min length short-circuit
+        assertFalse(match("__", "a"));
+
+        // max length short-circuit
+        assertFalse(match("__", "abcdefghi"));
+
+        // prefix short-circuit
+        assertFalse(match("a%", "xyz"));
+
+        // prefix match
+        assertTrue(match("a%", "a"));
+        assertTrue(match("a%", "ab"));
+        assertTrue(match("a_", "ab"));
+
+        // suffix short-circuit
+        assertFalse(match("%a", "xyz"));
+
+        // suffix match
+        assertTrue(match("%z", "z"));
+        assertTrue(match("%z", "yz"));
+        assertTrue(match("_z", "yz"));
+
+        // match literal
+        assertTrue(match("abcd", "abcd"));
+
+        // match one
+        assertFalse(match("_", ""));
+        assertTrue(match("_", "a"));
+        assertFalse(match("_", "ab"));
+
+        // match zero or more
+        assertTrue(match("%", ""));
+        assertTrue(match("%", "a"));
+        assertTrue(match("%", "ab"));
+
+        // non-strict matching
+        assertTrue(match("_%", "abcdefg"));
+        assertFalse(match("_a%", "abcdefg"));
+
+        // strict matching
+        assertTrue(match("_ab_", "xabc"));
+        assertFalse(match("_ab_", "xyxw"));
+        assertTrue(match("_a%b_", "xaxxxbx"));
+
+        // optimization of consecutive _ and %
+        assertTrue(match("_%_%_%_%", "abcdefghij"));
+
+        // utf-8
+        LikeMatcher single = LikeMatcher.compile("_");
+        LikeMatcher multiple = LikeMatcher.compile("_a%b_"); // prefix and suffix with _a and b_ to avoid optimizations
+        for (int i = 0; i < Character.MAX_CODE_POINT; i++) {
+            assertTrue(single.match(Character.toString(i).getBytes(StandardCharsets.UTF_8)));
+
+            String value = "aa" + (char) i + "bb";
+            assertTrue(multiple.match(value.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    @Test
+    public void testEscape()
+    {
+        assertTrue(match("-%", "%", '-'));
+        assertTrue(match("-_", "_", '-'));
+        assertTrue(match("--", "-", '-'));
+    }
+
+    private static boolean match(String pattern, String value)
+    {
+        return match(pattern, value, Optional.empty());
+    }
+
+    private static boolean match(String pattern, String value, char escape)
+    {
+        return match(pattern, value, Optional.of(escape));
+    }
+
+    private static boolean match(String pattern, String value, Optional<Character> escape)
+    {
+        String padding = "++++";
+        String padded = padding + value + padding;
+        byte[] bytes = padded.getBytes(StandardCharsets.UTF_8);
+
+        boolean withoutPadding = LikeMatcher.compile(pattern, escape).match(value.getBytes(StandardCharsets.UTF_8));
+        boolean withPadding = LikeMatcher.compile(pattern, escape).match(bytes, padding.length(), bytes.length - padding.length() * 2);  // exclude padding
+
+        assertEquals(withoutPadding, withPadding);
+        return withPadding;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.likematcher.LikeMatcher;
 import com.facebook.presto.operator.scalar.BitwiseFunctions;
 import com.facebook.presto.operator.scalar.DateTimeFunctions;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
@@ -41,7 +42,6 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.Duration;
@@ -1553,7 +1553,7 @@ public class TestExpressionCompiler
             for (String pattern : stringLefts) {
                 Boolean expected = null;
                 if (value != null && pattern != null) {
-                    Regex regex = LikeFunctions.likePattern(utf8Slice(pattern), utf8Slice("\\"));
+                    LikeMatcher regex = LikeFunctions.likePattern(utf8Slice(pattern), utf8Slice("\\"));
                     expected = LikeFunctions.likeVarchar(utf8Slice(value), regex);
                 }
                 assertExecute(generateExpression("%s like %s", value, pattern), BOOLEAN, expected);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Cherry-picked changes [change1](https://github.com/trinodb/trino/pull/13479) , [change2](https://github.com/trinodb/trino/pull/15999) Microbenchmark was good, but did not show any production benefit. Some operations like Array.fill() etc were slower in NFA matching,  suggesting that the micro benchmark was not accurate.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

