### PR TITLE
[native] Fix exchange client to use IP or hostname for destination

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -83,7 +83,13 @@ PrestoExchangeSource::PrestoExchangeSource(
       clientCertAndKeyPath_(clientCertAndKeyPath),
       ciphers_(ciphers),
       exchangeExecutor_(executor) {
-  folly::SocketAddress address(folly::IPAddress(host_), port_);
+  folly::SocketAddress address;
+  // If host_ is an IP address, set address from it, else resolve host_
+  if (folly::IPAddress::validate(host_)) {
+    address.setFromIpPort(host_, port_);
+  } else {
+    address.setFromHostPort(host_, port_);
+  }
   auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(
       SystemConfig::instance()->exchangeRequestTimeout());
   VELOX_CHECK_NOT_NULL(exchangeExecutor_.get());


### PR DESCRIPTION
## Description
When creating PrestoExchangeSource client, currently only IP address is expected to be present in the destination URI. Fixing it to use hostname too.

## Motivation and Context
Native worker's PrestoExchangeSource expects only IP address in the destination URI and fails if a hostname is present. Certificate based authentication generally has hostnames as Subject Alternative Names. When we use this, in Presto and native worker, we use `node.internal-address` config to set the hostname. When we set the hostname in this config, the PrestoExchangeSource fails since it won't be able to resolve hostname. 

## Impact
No public facing changes and performance impact

## Test Plan
Tested manually that with both hostname and IPAddress, the client creation works successfully.

```
== NO RELEASE NOTE ==
```

