### PR TITLE
fix(sec): upgrade io.netty:netty-handler to 4.1.94.final

### DIFF
--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <lettuce.version>6.2.4.RELEASE</lettuce.version>
-        <netty.version>4.1.91.Final</netty.version>
+        <netty.version>4.1.94.final</netty.version>
     </properties>
 
     <artifactId>redis-hbo-provider</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-handler 4.1.91.Final
- [MPS-2022-12067](https://www.oscs1024.com/hd/MPS-2022-12067)


### What did I do？
Upgrade io.netty:netty-handler from 4.1.91.Final to 4.1.94.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS