### PR TITLE
[native] Move testDereference to a general native test

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1339,6 +1339,13 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("select cardinality(merge(empty_approx_set(0.1))) from orders");
     }
 
+    @Test
+    public void testDereference()
+    {
+        assertQuery("SELECT transform(array[row(orderkey, comment)], x -> x[2]) FROM orders");
+        assertQuery("SELECT transform(array[row(orderkey, orderkey * 10)], x -> x[2]) FROM orders");
+    }
+
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -102,13 +102,6 @@ public class TestPrestoSparkNativeSimpleQueries
     }
 
     @Test
-    public void testDereference()
-    {
-        assertQuery("SELECT transform(array[row(orderkey, comment)], x -> x[2]) FROM orders");
-        assertQuery("SELECT transform(array[row(orderkey, orderkey * 10)], x -> x[2]) FROM orders");
-    }
-
-    @Test
     public void testFailures()
     {
         assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");


### PR DESCRIPTION
testDereference was added as a Sapphire-specific test, but it's testing general native behavior, so it would be better placed in a class shared by Sapphire and Prestissimo.