### PR TITLE
[native] Add support for background CPU time stats in Shuffle operators

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -510,8 +510,11 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
           opOut.getOutputCalls,
           opOut.getOutputWall,
           opOut.getOutputCpu);
+      CpuWallTiming finishAndBackgroundTiming;
+      finishAndBackgroundTiming.add(op.finishTiming);
+      finishAndBackgroundTiming.add(op.backgroundTiming);
       setTiming(
-          op.finishTiming,
+          finishAndBackgroundTiming,
           opOut.finishCalls,
           opOut.finishWall,
           opOut.finishCpu);


### PR DESCRIPTION
Folds per operator background CPU into OperatorStats.finishTiming
before sending the metrics to the Presto Coordinator. Moreover, enables
collecting of background CPU time in ShuffleWrite operator.

