### PR TITLE
[native] Support host or Ip in exchange client.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -83,7 +83,12 @@ PrestoExchangeSource::PrestoExchangeSource(
       clientCertAndKeyPath_(clientCertAndKeyPath),
       ciphers_(ciphers),
       exchangeExecutor_(executor) {
-  folly::SocketAddress address(folly::IPAddress(host_), port_);
+  folly::SocketAddress address;
+  if (folly::IPAddress::validate(host_)) {
+    address = folly::SocketAddress(folly::IPAddress(host_), port_);
+  } else {
+    address = folly::SocketAddress(host_, port_, true);
+  }
   auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(
       SystemConfig::instance()->exchangeRequestTimeout());
   VELOX_CHECK_NOT_NULL(exchangeExecutor_.get());


### PR DESCRIPTION
Adding support to use host name or IP address in exchange client creation. We keep the fast path where IP address object is directly passed to Socket creation, thus completely removing look up procedure. In other case, where host name is provided, look up is enabled to get IP address from host. Generally, using IP address to look up is fine, however based on host and network configuration, it may fail. Hence, its reliable (and also performant) to directly use IP address (if provided), otherwise regular host based look up is used.