### PR TITLE
Enforce JWT authentication without bearer token

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
@@ -41,7 +41,7 @@ public class InternalAuthenticationManager
 {
     private static final Logger log = Logger.get(InternalAuthenticationManager.class);
 
-    private static final String PRESTO_INTERNAL_BEARER = "X-Presto-Internal-Bearer";
+    public static final String PRESTO_INTERNAL_BEARER = "X-Presto-Internal-Bearer";
 
     private final boolean internalJwtEnabled;
     private final byte[] hmac;

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
@@ -48,12 +48,19 @@ public class MockHttpServletRequest
     private final ListMultimap<String, String> headers;
     private final String remoteAddress;
     private final Map<String, Object> attributes;
+    private final boolean isSecure;
 
     public MockHttpServletRequest(ListMultimap<String, String> headers, String remoteAddress, Map<String, Object> attributes)
+    {
+        this(headers, remoteAddress, attributes, false);
+    }
+
+    public MockHttpServletRequest(ListMultimap<String, String> headers, String remoteAddress, Map<String, Object> attributes, boolean isSecure)
     {
         this.headers = ImmutableListMultimap.copyOf(requireNonNull(headers, "headers is null"));
         this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress is null");
         this.attributes = ImmutableMap.copyOf(requireNonNull(attributes, "attributes is null"));
+        this.isSecure = isSecure;
     }
 
     @Override
@@ -395,7 +402,7 @@ public class MockHttpServletRequest
     @Override
     public boolean isSecure()
     {
-        throw new UnsupportedOperationException();
+        return isSecure;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletResponse.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletResponse.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class MockHttpServletResponse
+        implements HttpServletResponse
+{
+    private OptionalInt errorCode = OptionalInt.empty();
+    private Optional<String> errorMessage = Optional.empty();
+
+    public boolean hasErrorCode()
+    {
+        return errorCode.isPresent();
+    }
+
+    public int getErrorCode()
+    {
+        return errorCode.getAsInt();
+    }
+
+    public boolean hasErrorMessage()
+    {
+        return errorMessage.isPresent();
+    }
+
+    public String getErrorMessage()
+    {
+        return errorMessage.get();
+    }
+
+    @Override
+    public void sendError(int sc, String msg)
+            throws IOException
+    {
+        errorCode = OptionalInt.of(sc);
+        errorMessage = Optional.of(msg);
+    }
+
+    @Override
+    public void sendError(int sc)
+            throws IOException
+    {
+        errorCode = OptionalInt.of(sc);
+    }
+
+    @Override
+    public void addCookie(Cookie cookie)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsHeader(String name)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeURL(String url)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectURL(String url)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeUrl(String url)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendRedirect(String location)
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDateHeader(String name, long date)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addDateHeader(String name, long date)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setHeader(String name, String value)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addHeader(String name, String value)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setIntHeader(String name, int value)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addIntHeader(String name, int value)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(int sc)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(int sc, String sm)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getStatus()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream()
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PrintWriter getWriter()
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLength(int len)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLengthLong(long len)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentType(String type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBufferSize(int size)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBufferSize()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushBuffer()
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetBuffer()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCommitted()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reset()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLocale(Locale loc)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestAuthenticationFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestAuthenticationFilter.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security;
+
+import com.facebook.presto.server.InternalAuthenticationManager;
+import com.facebook.presto.server.InternalCommunicationConfig;
+import com.facebook.presto.server.MockHttpServletRequest;
+import com.facebook.presto.server.MockHttpServletResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.testng.annotations.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static com.facebook.presto.server.InternalAuthenticationManager.PRESTO_INTERNAL_BEARER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestAuthenticationFilter
+{
+    @Test
+    public void testJwtAuthenticationRejectsWithNoBearerTokenJwtEnabled()
+            throws Exception
+    {
+        String sharedSecret = "secret";
+        boolean internalJwtEnabled = true;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(
+                ImmutableList.of(),
+                internalAuthenticationManager,
+                new InternalCommunicationConfig().setInternalJwtEnabled(internalJwtEnabled),
+                (request) -> {});
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of(), "localhost", ImmutableMap.of(), true);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        TestingFilterChain filterChain = new TestingFilterChain();
+
+        authenticationFilter.doFilter(request, response, filterChain);
+        assertFalse(filterChain.isFilterApplied(), "Request unexpectedly passed authentication");
+        assertTrue(response.hasErrorCode());
+        assertEquals(SC_UNAUTHORIZED, response.getErrorCode());
+        assertTrue(response.hasErrorMessage());
+        assertEquals("Unauthorized", response.getErrorMessage());
+    }
+
+    @Test
+    public void testJwtAuthenticationPassesWithNoBearerTokenJwtDisabledNoAuthenticators()
+            throws Exception
+    {
+        String sharedSecret = "secret";
+        boolean internalJwtEnabled = false;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(
+                ImmutableList.of(),
+                internalAuthenticationManager,
+                new InternalCommunicationConfig().setInternalJwtEnabled(internalJwtEnabled),
+                (request) -> {});
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of(), "localhost", ImmutableMap.of(), true);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        TestingFilterChain filterChain = new TestingFilterChain();
+
+        authenticationFilter.doFilter(request, response, filterChain);
+        assertTrue(filterChain.isFilterApplied(), "Request unexpectedly failed authentication");
+        assertFalse(filterChain.getPrincipal().isPresent());
+        assertFalse(response.hasErrorCode());
+        assertFalse(response.hasErrorMessage());
+    }
+    @Test
+    public void testJwtAuthenticationPassesWithBearerTokenJwtEnabled()
+            throws Exception
+    {
+        String sharedSecret = "secret";
+        String principalString = "456";
+        boolean internalJwtEnabled = true;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(
+                ImmutableList.of(),
+                internalAuthenticationManager,
+                new InternalCommunicationConfig().setInternalJwtEnabled(internalJwtEnabled),
+                (request) -> {});
+
+        String jwtToken = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .setSubject(principalString)
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken), "localhost", ImmutableMap.of(), true);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        TestingFilterChain filterChain = new TestingFilterChain();
+
+        authenticationFilter.doFilter(request, response, filterChain);
+        assertTrue(filterChain.isFilterApplied(), "Request unexpectedly failed authentication");
+        assertTrue(filterChain.getPrincipal().isPresent());
+        assertEquals(filterChain.getPrincipal().get().toString(), principalString);
+        assertFalse(response.hasErrorCode());
+        assertFalse(response.hasErrorMessage());
+    }
+    @Test
+    public void testJwtAuthenticationRejectsWithBearerTokenJwtDisabled()
+            throws Exception
+    {
+        String sharedSecret = "secret";
+        String principalString = "456";
+        boolean internalJwtEnabled = false;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(
+                ImmutableList.of(),
+                internalAuthenticationManager,
+                new InternalCommunicationConfig().setInternalJwtEnabled(internalJwtEnabled),
+                (request) -> {});
+
+        String jwtToken = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .setSubject(principalString)
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken), "localhost", ImmutableMap.of(), true);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        TestingFilterChain filterChain = new TestingFilterChain();
+
+        authenticationFilter.doFilter(request, response, filterChain);
+        assertFalse(filterChain.isFilterApplied(), "Request unexpectedly passed authentication");
+        assertTrue(response.hasErrorCode());
+        assertEquals(SC_UNAUTHORIZED, response.getErrorCode());
+        assertFalse(response.hasErrorMessage());
+    }
+
+    private static class TestingFilterChain
+            implements FilterChain
+    {
+        private boolean filterApplied;
+        private Optional<Principal> principal = Optional.empty();
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response)
+                throws IOException, ServletException
+        {
+            filterApplied = true;
+            principal = Optional.ofNullable(((HttpServletRequest) request).getUserPrincipal());
+        }
+
+        public boolean isFilterApplied()
+        {
+            return filterApplied;
+        }
+
+        public Optional<Principal> getPrincipal()
+        {
+            return principal;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This fixes a flaw in the JWT authentication for internal communication.

## Motivation and Context
Secure communication.

## Impact
This fixes a problem with secure internal communication with JWT--without it, it's possible to authenticate successfully by simply sending no bearer token when no other authenticators are configured.

## Test Plan
Unit tests were added. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a security gap in the JWT authentication for internal communication.

```

