### PR TITLE
Enforce copy-on-write mode for Iceberg Tables V2 or higher

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -213,6 +213,11 @@ Property Name                                      Description                  
                                                    performance on tables with small files. A higher value may
                                                    improve performance for queries with highly skewed
                                                    aggregations or joins.
+
+``iceberg.enable-merge-on-read-mode``              Enable reading base tables that use merge-on-read for          ``false``
+                                                   updates. The Iceberg connector currently does not read
+                                                   delete lists, which means any updates will not be
+                                                   reflected in the table.
 ================================================== ============================================================= ============
 
 Table Properties

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -42,6 +42,7 @@ public class IcebergConfig
     private List<String> hadoopConfigResources = ImmutableList.of();
     private double minimumAssignedSplitWeight = 0.05;
     private boolean parquetDereferencePushdownEnabled = true;
+    private boolean mergeOnReadModeEnabled;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -165,5 +166,18 @@ public class IcebergConfig
     public boolean isParquetDereferencePushdownEnabled()
     {
         return parquetDereferencePushdownEnabled;
+    }
+
+    @Config("iceberg.enable-merge-on-read-mode")
+    @ConfigDescription("enable merge-on-read mode")
+    public IcebergConfig setMergeOnReadModeEnabled(boolean mergeOnReadModeEnabled)
+    {
+        this.mergeOnReadModeEnabled = mergeOnReadModeEnabled;
+        return this;
+    }
+
+    public boolean isMergeOnReadModeEnabled()
+    {
+        return mergeOnReadModeEnabled;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -67,6 +67,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.TableType.DATA;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
@@ -128,6 +129,8 @@ public class IcebergHiveMetadata
 
         org.apache.iceberg.Table table = getHiveIcebergTable(metastore, hdfsEnvironment, session, tableName);
         Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
+
+        validateTableMode(session, table);
 
         return new IcebergTableHandle(
                 tableName.getSchemaName(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
+import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.TableType.DATA;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
@@ -120,6 +121,8 @@ public class IcebergNativeMetadata
             // return null to throw
             return null;
         }
+
+        validateTableMode(session, table);
 
         return new IcebergTableHandle(
                 tableName.getSchemaName(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -78,6 +78,7 @@ public final class IcebergSessionProperties
     private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
+    public static final String MERGE_ON_READ_MODE_ENABLED = "merge_on_read_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -273,6 +274,11 @@ public final class IcebergSessionProperties
                         PARQUET_DEREFERENCE_PUSHDOWN_ENABLED,
                         "Is dereference pushdown expression pushdown into Parquet reader enabled?",
                         icebergConfig.isParquetDereferencePushdownEnabled(),
+                        false),
+                booleanProperty(
+                        MERGE_ON_READ_MODE_ENABLED,
+                        "Reads enabled for merge-on-read Iceberg tables",
+                        icebergConfig.isMergeOnReadModeEnabled(),
                         false));
     }
 
@@ -444,5 +450,10 @@ public final class IcebergSessionProperties
     public static boolean isParquetDereferencePushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_DEREFERENCE_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isMergeOnReadModeEnabled(ConnectorSession session)
+    {
+        return session.getProperty(MERGE_ON_READ_MODE_ENABLED, Boolean.class);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -36,6 +36,8 @@ public final class IcebergQueryRunner
     private static final Logger log = Logger.get(IcebergQueryRunner.class);
 
     public static final String ICEBERG_CATALOG = "iceberg";
+    public static final String TEST_DATA_DIRECTORY = "iceberg_data";
+    public static final String TEST_CATALOG_DIRECTORY = "catalog";
 
     private IcebergQueryRunner() {}
 
@@ -98,8 +100,8 @@ public final class IcebergQueryRunner
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");
 
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-        Path catalogDirectory = dataDirectory.getParent().resolve("catalog");
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY);
+        Path catalogDirectory = dataDirectory.getParent().resolve(TEST_CATALOG_DIRECTORY);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -42,7 +42,8 @@ public class TestIcebergConfig
                 .setHadoopConfigResources(null)
                 .setMaxPartitionsPerWriter(100)
                 .setMinimumAssignedSplitWeight(0.05)
-                .setParquetDereferencePushdownEnabled(true));
+                .setParquetDereferencePushdownEnabled(true)
+                .setMergeOnReadModeEnabled(false));
     }
 
     @Test
@@ -58,6 +59,7 @@ public class TestIcebergConfig
                 .put("iceberg.max-partitions-per-writer", "222")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .put("iceberg.enable-parquet-dereference-pushdown", "false")
+                .put("iceberg.enable-merge-on-read-mode", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -69,7 +71,8 @@ public class TestIcebergConfig
                 .setHadoopConfigResources("/etc/hadoop/conf/core-site.xml")
                 .setMaxPartitionsPerWriter(222)
                 .setMinimumAssignedSplitWeight(0.01)
-                .setParquetDereferencePushdownEnabled(false);
+                .setParquetDereferencePushdownEnabled(false)
+                .setMergeOnReadModeEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -14,8 +14,22 @@
 package com.facebook.presto.iceberg.hive;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.Table;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -28,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.hive.metastore.CachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static java.lang.String.format;
 import static org.testng.Assert.fail;
@@ -90,5 +105,32 @@ public class TestIcebergSmokeHive
     {
         File tempLocation = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().toFile();
         return format("%scatalog/%s/%s", tempLocation.toURI(), schema, table);
+    }
+
+    protected static HdfsEnvironment getHdfsEnvironment()
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig),
+                ImmutableSet.of(),
+                hiveClientConfig);
+        return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
+    }
+
+    protected ExtendedHiveMetastore getFileHiveMetastore()
+    {
+        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+                getCatalogDirectory().toFile().getPath(),
+                "test");
+        return memoizeMetastore(fileHiveMetastore, false, 1000, 0);
+    }
+
+    @Override
+    protected Table getIcebergTable(ConnectorSession session, String schema, String tableName)
+    {
+        return IcebergUtil.getHiveIcebergTable(getFileHiveMetastore(),
+                getHdfsEnvironment(),
+                session,
+                SchemaTableName.valueOf(schema + "." + tableName));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -13,12 +13,21 @@
  */
 package com.facebook.presto.iceberg.nessie;
 
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.IcebergResourceFactory;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.Table;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -28,6 +37,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -81,5 +91,24 @@ public class TestIcebergSmokeNessie
             throws Exception
     {
         return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+    }
+
+    @Override
+    protected Table getIcebergTable(ConnectorSession session, String schema, String tableName)
+    {
+        IcebergConfig icebergConfig = new IcebergConfig();
+        icebergConfig.setCatalogType(NESSIE);
+        icebergConfig.setCatalogWarehouse(getCatalogDirectory().toFile().getPath());
+
+        NessieConfig nessieConfig = new NessieConfig().setServerUri(nessieContainer.getRestApiUri());
+
+        IcebergResourceFactory resourceFactory = new IcebergResourceFactory(icebergConfig,
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                nessieConfig,
+                new PrestoS3ConfigurationUpdater(new HiveS3Config()));
+
+        return IcebergUtil.getNativeIcebergTable(resourceFactory,
+                session,
+                SchemaTableName.valueOf(schema + "." + tableName));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -499,6 +499,13 @@ public abstract class AbstractTestQueryFramework
         return queryRunner;
     }
 
+    protected DistributedQueryRunner getDistributedQueryRunner()
+    {
+        checkState(queryRunner != null, "queryRunner not set");
+        checkState(queryRunner instanceof DistributedQueryRunner, "queryRunner is not an instance of DistributedQueryRunner");
+        return (DistributedQueryRunner) queryRunner;
+    }
+
     protected ExpectedQueryRunner getExpectedQueryRunner()
     {
         checkState(expectedQueryRunner != null, "expectedQueryRunner not set");


### PR DESCRIPTION
## Description
Fail if Iceberg table's delete, merge, or update modes are set to merge-on-read until https://github.com/prestodb/presto/issues/20492 is complete. Otherwise Presto would read deleted data for format versions >= 2. 

## GitHub issue
https://github.com/prestodb/presto/issues/20493

## Impact
An error will be returned if a user tries running queries on Iceberg table V2 format with merge-on-read set for delete, merge, and update modes.

## Test Plan
- [x] Added tests for configuration changes and merge-on-read mode.
- [x] Manual tests for V2 table with merge-on-read with default configuration:
```
presto:test> select * from "test_table $properties";
        key        |     value     
-------------------+---------------
 owner             | user           
 write.merge.mode  | merge-on-read 
 write.update.mode | merge-on-read 
 write.delete.mode | copy-on-write 
(4 rows)

presto:test> insert into test_table values(2, 2);
Query 20230907_185027_00004_kcmk9 failed: merge-on-read table mode not supported yet

presto:test> select * from test_table;
Query 20230907_185032_00005_kcmk9 failed: merge-on-read table mode not supported yet
```
- [x] Manual tests for V2 table with merge-on-read with ``iceberg.enable-merge-on-read-mode`` configuration property set to true:
```
presto:test> select * from test_table;
 c1 | c2 
----+----
  1 |  1 
(1 row)

presto:test> insert into test_table values(2, 2);
INSERT: 1 row

Query 20230908_153550_00001_mhekq, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:10, server-side: 0:10] [0 rows, 0B] [0 rows/s, 0B/s]

presto:test> select * from test_table;
 c1 | c2 
----+----
  1 |  1 
  2 |  2 
(2 rows)
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Enforce copy-on-write mode for Iceberg tables. 
This can disabled with the ``merge_on_read_enabled`` session property or the ``iceberg.enable-merge-on-read-mode``configuration property.
```

