### PR TITLE
SetDigest jaccard_index implementation Issue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
@@ -183,6 +183,34 @@ public class SetDigest
         return intersection / (double) sizeOfSmallerSet;
     }
 
+    public static double jaccardIndex_new(SetDigest a, SetDigest b)
+    {
+        SetDigest smaller;
+        SetDigest larger;
+        if (a.minhash.size() < b.minhash.size()) {
+            smaller = a;
+            larger = b;
+        }
+        else {
+            smaller = b;
+            larger = a;
+        }
+
+        LongSortedSet smallerSet = new LongRBTreeSet(smaller.minhash.keySet());
+        LongSortedSet largerSet = new LongRBTreeSet(larger.minhash.keySet());
+
+        int intersection = 0;
+        for (long key : smallerSet) {
+            if (largerSet.contains(key)) {
+                intersection++;
+            }
+        }
+        LongSortedSet union = new LongRBTreeSet(largerSet);
+        union.addAll(smallerSet);
+
+        return intersection / (double) union.size();
+    }
+
     public void add(long value)
     {
         addHash(Murmur3Hash128.hash64(value));

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSetDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSetDigestFunctions.java
@@ -55,7 +55,20 @@ public class TestSetDigestFunctions
     {
         assertions.assertQuery(
                 "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
-                        "FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2)", "VALUES CAST(0.5 AS DOUBLE)");
+                        "FROM (VALUES (2, NULL), (3, 4)) T(v1, v2)", "VALUES CAST(0.0 AS DOUBLE)");
+
+        assertions.assertQuery(
+                "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (NULL, NULL), (2, 4)) T(v1, v2)", "VALUES CAST(0.0 AS DOUBLE)", false);
+        assertions.assertQuery(
+                "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (1, NULL), (1, 4)) T(v1, v2)", "VALUES CAST(0.0 AS DOUBLE)", false);
+        assertions.assertQuery(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM " +
+                        "(VALUES (1, 2), (2, 1)) T(value,value1)", "VALUES CAST(1.0 AS DOUBLE)", false);
+        assertions.assertQuery(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) " +
+                        "FROM (VALUES (2, 2), (3, 3)) T(value,value1)", "VALUES CAST(1.0 AS DOUBLE)", false);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/setdigest/TestSetDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/setdigest/TestSetDigest.java
@@ -38,7 +38,7 @@ import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHa
 import static com.facebook.presto.type.setdigest.SetDigest.DEFAULT_MAX_HASHES;
 import static com.facebook.presto.type.setdigest.SetDigest.NUMBER_OF_BUCKETS;
 import static com.facebook.presto.type.setdigest.SetDigestFunctions.hashCounts;
-import static com.facebook.presto.type.setdigest.SetDigestFunctions.intersectionCardinality;
+import static com.facebook.presto.type.setdigest.SetDigestFunctions.intersectionCardinality_new;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -96,7 +96,7 @@ public class TestSetDigest
                 }
             }
 
-            long estimatedCardinality = intersectionCardinality(digest1.serialize(), digest2.serialize());
+            long estimatedCardinality = intersectionCardinality_new(digest1.serialize(), digest2.serialize());
             assertTrue(Math.abs(expectedCardinality - estimatedCardinality) / (double) expectedCardinality < 0.10,
                     format("Expected intersection cardinality %d +/- 10%%, got %d, for set of size %d", expectedCardinality, estimatedCardinality, size));
         }
@@ -177,7 +177,7 @@ public class TestSetDigest
             for (Map.Entry<SetDigest, Integer> pair : smallerSets.entrySet()) {
                 SetDigest digest2 = pair.getKey();
                 long estIntersectionCardinality =
-                        intersectionCardinality(digest1.serialize(), digest2.serialize());
+                        intersectionCardinality_new(digest1.serialize(), digest2.serialize());
                 double size2 = digest2.cardinality();
                 assertTrue(estIntersectionCardinality <= size2);
                 int expectedCardinality = pair.getValue();


### PR DESCRIPTION
SetDigest jaccard_index implementation Issue

https://en.wikipedia.org/wiki/Jaccard_index

 

For below query the jaccard_index should be equal to 0.3333333333333333 but the output is coming as 0.5 which is incorrect 

SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES ('abc', 'def'),('ee', 'abc')) T(value,value1);

 