### PR TITLE
Fix a binding issue in presto-verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MySqlSourceQueryConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/MySqlSourceQueryConfig.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class MySqlSourceQueryConfig
 {
-    private String database;
+    private String database = "jdbc:mysql://localhost:3306";
     private String tableName = "verifier_queries";
     private String snapshotTableName = "verifier_snapshots";
     private List<String> suites = ImmutableList.of();

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
@@ -47,11 +47,13 @@ public class SourceQueryModule
         String sourceQuerySupplierType = buildConfigObject(VerifierConfig.class).getSourceQuerySupplier();
         checkArgument(supportedSourceQuerySupplierTypes.contains(sourceQuerySupplierType), "Unsupported SourceQuerySupplier: %s", sourceQuerySupplierType);
 
+        // Snapshots are supported by Mysql only
+        configBinder(binder).bindConfig(MySqlSourceQueryConfig.class, SOURCE_QUERY_CONFIG_PREFIX);
+        binder.bind(SnapshotQuerySupplier.class).to(MysqlSnapshotQuerySupplier.class).in(SINGLETON);
+        binder.bind(SnapshotQueryConsumer.class).to(MysqlSnapshotQueryConsumer.class).in(SINGLETON);
+
         if (MYSQL_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {
-            configBinder(binder).bindConfig(MySqlSourceQueryConfig.class, SOURCE_QUERY_CONFIG_PREFIX);
             binder.bind(SourceQuerySupplier.class).to(MySqlSourceQuerySupplier.class).in(SINGLETON);
-            binder.bind(SnapshotQuerySupplier.class).to(MysqlSnapshotQuerySupplier.class).in(SINGLETON);
-            binder.bind(SnapshotQueryConsumer.class).to(MysqlSnapshotQueryConsumer.class).in(SINGLETON);
         }
 
         if (PRESTO_QUERY_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestMySqlSourceQueryConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestMySqlSourceQueryConfig.java
@@ -28,7 +28,7 @@ public class TestMySqlSourceQueryConfig
     public void testDefault()
     {
         assertRecordedDefaults(recordDefaults(MySqlSourceQueryConfig.class)
-                .setDatabase(null)
+                .setDatabase("jdbc:mysql://localhost:3306")
                 .setTableName("verifier_queries")
                 .setSnapshotTableName("verifier_snapshots")
                 .setSuites("")

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestSourceQueryModule.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestSourceQueryModule.java
@@ -52,6 +52,44 @@ public class TestSourceQueryModule
     }
 
     @Test
+    public void testMysqlSnapshotQuerySupplier()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                ImmutableList.<Module>builder()
+                        .add(new SourceQueryModule(ImmutableSet.of()))
+                        .build());
+        Injector injector = app
+                .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                        .putAll(DEFAULT_CONFIGURATION_PROPERTIES)
+                        .put("source-query.database", "jdbc://localhost:1080")
+                        .put("source-query.suites", "test")
+                        .put("source-query.max-queries-per-suite", "1000")
+                        .build())
+                .initialize();
+        assertTrue(injector.getInstance(SnapshotQuerySupplier.class) instanceof MysqlSnapshotQuerySupplier);
+    }
+
+    @Test
+    public void testMysqlSnapshotQueryConsumer()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                ImmutableList.<Module>builder()
+                        .add(new SourceQueryModule(ImmutableSet.of()))
+                        .build());
+        Injector injector = app
+                .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                        .putAll(DEFAULT_CONFIGURATION_PROPERTIES)
+                        .put("source-query.database", "jdbc://localhost:1080")
+                        .put("source-query.suites", "test")
+                        .put("source-query.max-queries-per-suite", "1000")
+                        .build())
+                .initialize();
+        assertTrue(injector.getInstance(SnapshotQueryConsumer.class) instanceof MysqlSnapshotQueryConsumer);
+    }
+
+    @Test
     public void testCustomSourceQuerySupplier()
             throws Exception
     {


### PR DESCRIPTION
## Description

The bindings are in SourceQueryModule.java, but are guarded by an if statement. Move them out of the if statement and add tests to make sure the bindings work.

com.google.inject.CreationException: Unable to create injector, see the following errors:
1) Explicit bindings are required and
  com.facebook.presto.verifier.source.SnapshotQueryConsumer is not
  explicitly bound. while locating
  com.facebook.presto.verifier.source.SnapshotQueryConsumer for
  the 2nd parameter of
  com.facebook.presto.verifier.framework.VerificationManager.<init>
  (VerificationManager.java:133) at
  com.facebook.presto.verifier.framework.VerifierModule.setup
  (VerifierModule.java:130)
2) Explicit bindings are required and
  com.facebook.presto.verifier.source.SnapshotQuerySupplier is not
  explicitly bound. while locating
  com.facebook.presto.verifier.source.SnapshotQuerySupplier for
  the 3rd parameter of
  com.facebook.presto.verifier.framework.VerificationManager.<init>
  (VerificationManager.java:133) at
  com.facebook.presto.verifier.framework.VerifierModule.setup
  (VerifierModule.java:130)

## Motivation and Context
Quick fix for the binding issue, see Description above.

## Impact
Fixes #20828

## Test Plan
Make sure all tests pass.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

