### PR TITLE
Log error stacktrace when parallel parsing of partition values fails

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -185,7 +185,7 @@ public class HivePartitionManager
                         return result.iterator();
                     }
                     catch (InterruptedException | ExecutionException e) {
-                        log.error("Parallel parsing of partition values failed with error message:%s", e.getMessage());
+                        log.error(e, "Parallel parsing of partition values failed");
                     }
                 }
                 return getPartitionListFromPartitionNames(partitionNames, tableName, partitionColumns, partitionTypes, constraint).iterator();


### PR DESCRIPTION
This is a minor fix for the earlier PR https://github.com/prestodb/presto/pull/20748.
This PR makes sure the exception trace is logged when error happens.

```
== NO RELEASE NOTE ==
```

