### PR TITLE
[native] Remove unnecessary velox check.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -513,7 +513,6 @@ void PeriodicTaskManager::addArbitratorStatsTask() {
 }
 
 void PeriodicTaskManager::updateArbitratorStatsTask() {
-  VELOX_CHECK_NOT_NULL(arbitrator_);
   const auto updatedArbitratorStats = arbitrator_->stats();
   VELOX_CHECK_GE(updatedArbitratorStats, lastArbitratorStats_);
   const auto deltaArbitratorStats =


### PR DESCRIPTION
This is already checked [here](https://github.com/prestodb/presto/blob/7550889bd51ae5e3ebf7e38ef1df825ea870bead/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp#L105) before adding periodic task. No need to check in every invocation of periodic task.