### PR TITLE
Fix issue #20835: Lead/Lag does not return default value when offset is null

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/window/LagFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/LagFunction.java
@@ -44,7 +44,13 @@ public class LagFunction
     public void processRow(BlockBuilder output, int frameStart, int frameEnd, int currentPosition)
     {
         if ((offsetChannel >= 0) && windowIndex.isNull(offsetChannel, currentPosition)) {
-            output.appendNull();
+            // If defaultValue is specified then return default value.
+            if (defaultChannel >= 0) {
+                windowIndex.appendTo(defaultChannel, currentPosition, output);
+            }
+            else {
+                output.appendNull();
+            }
         }
         else {
             long offset = (offsetChannel < 0) ? 1 : windowIndex.getLong(offsetChannel, currentPosition);

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/LeadFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/LeadFunction.java
@@ -44,7 +44,13 @@ public class LeadFunction
     public void processRow(BlockBuilder output, int frameStart, int frameEnd, int currentPosition)
     {
         if ((offsetChannel >= 0) && windowIndex.isNull(offsetChannel, currentPosition)) {
-            output.appendNull();
+            // If defaultValue is specified then return default value.
+            if (defaultChannel >= 0) {
+                windowIndex.appendTo(defaultChannel, currentPosition, output);
+            }
+            else {
+                output.appendNull();
+            }
         }
         else {
             long offset = (offsetChannel < 0) ? 1 : windowIndex.getLong(offsetChannel, currentPosition);

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestLagFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestLagFunction.java
@@ -152,16 +152,16 @@ public class TestLagFunction
 
         assertWindowQuery("lag(orderkey, null, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, INTEGER, VARCHAR, BIGINT)
-                        .row(3, "F", null)
-                        .row(5, "F", null)
-                        .row(6, "F", null)
-                        .row(33, "F", null)
-                        .row(1, "O", null)
-                        .row(2, "O", null)
-                        .row(4, "O", null)
-                        .row(7, "O", null)
-                        .row(32, "O", null)
-                        .row(34, "O", null)
+                        .row(3, "F", -1)
+                        .row(5, "F", -1)
+                        .row(6, "F", -1)
+                        .row(33, "F", -1)
+                        .row(1, "O", -1)
+                        .row(2, "O", -1)
+                        .row(4, "O", -1)
+                        .row(7, "O", -1)
+                        .row(32, "O", -1)
+                        .row(34, "O", -1)
                         .build());
 
         assertWindowQuery("lag(orderkey, 0) OVER (PARTITION BY orderstatus ORDER BY orderkey)",

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestLeadFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestLeadFunction.java
@@ -152,16 +152,16 @@ public class TestLeadFunction
 
         assertWindowQuery("lead(orderkey, null, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
-                        .row(3, "F", null)
-                        .row(5, "F", null)
-                        .row(6, "F", null)
-                        .row(33, "F", null)
-                        .row(1, "O", null)
-                        .row(2, "O", null)
-                        .row(4, "O", null)
-                        .row(7, "O", null)
-                        .row(32, "O", null)
-                        .row(34, "O", null)
+                        .row(3, "F", -1)
+                        .row(5, "F", -1)
+                        .row(6, "F", -1)
+                        .row(33, "F", -1)
+                        .row(1, "O", -1)
+                        .row(2, "O", -1)
+                        .row(4, "O", -1)
+                        .row(7, "O", -1)
+                        .row(32, "O", -1)
+                        .row(34, "O", -1)
                         .build());
 
         assertWindowQuery("lead(orderkey, 0) OVER (PARTITION BY orderstatus ORDER BY orderkey)",


### PR DESCRIPTION
## Description

Fix issue #20835: Lead/Lag does not return default value when offset is null

## Motivation and Context

It is a bug(I think), as described in #20835

## Impact

Will correct the behaviour of Lead/Lag when offset is null to return default value is specified.

## Test Plan

Corrected the corresponding test case.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix window function lead/lag to return default value if specified when offset is null.
```

