### PR TITLE
Fix broken event listener test

### DIFF
--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -37,6 +37,11 @@ jobs:
       group: ${{ github.workflow }}-product-tests-basic-environment-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Free Disk Space
+        run: |
+          df -h
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -122,7 +122,8 @@ public class TestEventListener
 
         List<SplitCompletedEvent> splitCompletedEvents = generatedEvents.getSplitCompletedEvents();
         assertEquals(splitCompletedEvents.get(0).getQueryId(), queryCompletedEvent.getMetadata().getQueryId());
-        assertEquals(splitCompletedEvents.get(0).getStatistics().getCompletedPositions(), 1);
+        // No input scanned for a constant query
+        assertEquals(splitCompletedEvents.get(0).getStatistics().getCompletedPositions(), 0L);
     }
 
     @Test


### PR DESCRIPTION
#20739 introduced changes to how raw input size is reported. This broke the `testConstantQuery` test w.r.t completed positions, i.e raw input positions for the constant query case  

== NO RELEASE NOTE ==


