### PR TITLE
Refactor struct for statistics of HBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.statistics.HistoryBasedSourceInfo;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 import com.facebook.presto.sql.planner.CanonicalPlan;
@@ -162,8 +163,7 @@ public class HistoryBasedPlanStatisticsTracker
                                                     Estimate.of(outputPositions),
                                                     Double.isNaN(outputBytes) ? Estimate.unknown() : Estimate.of(outputBytes),
                                                     1.0,
-                                                    Estimate.of(nullJoinBuildKeyCount),
-                                                    Estimate.of(joinBuildKeyCount)),
+                                                    new JoinNodeStatistics(Estimate.of(nullJoinBuildKeyCount), Estimate.of(joinBuildKeyCount))),
                                             new HistoryBasedSourceInfo(Optional.of(hash), Optional.of(inputTableStatistics))));
                         }
                     }

--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinNodeStatsEstimate.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.Double.NaN;
+
+public class JoinNodeStatsEstimate
+{
+    private static final JoinNodeStatsEstimate UNKNOWN = new JoinNodeStatsEstimate(NaN, NaN);
+
+    private final double nullJoinBuildKeyCount;
+    private final double joinBuildKeyCount;
+
+    public JoinNodeStatsEstimate(double nullJoinBuildKeyCount, double joinBuildKeyCount)
+    {
+        this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
+        this.joinBuildKeyCount = joinBuildKeyCount;
+    }
+
+    public static JoinNodeStatsEstimate unknown()
+    {
+        return UNKNOWN;
+    }
+
+    public double getNullJoinBuildKeyCount()
+    {
+        return nullJoinBuildKeyCount;
+    }
+
+    public double getJoinBuildKeyCount()
+    {
+        return joinBuildKeyCount;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("nullJoinBuildKeyCount", nullJoinBuildKeyCount)
+                .add("joinBuildKeyCount", joinBuildKeyCount)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JoinNodeStatsEstimate that = (JoinNodeStatsEstimate) o;
+        return Double.compare(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) == 0 &&
+                Double.compare(joinBuildKeyCount, that.joinBuildKeyCount) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.statistics.CostBasedSourceInfo;
 import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 import com.facebook.presto.spi.statistics.SourceInfo;
@@ -56,8 +57,7 @@ public class PlanNodeStatsEstimate
 
     private final SourceInfo sourceInfo;
 
-    private final double nullJoinBuildKeyCount;
-    private final double joinBuildKeyCount;
+    private final JoinNodeStatsEstimate joinNodeStatsEstimate;
 
     public static PlanNodeStatsEstimate unknown()
     {
@@ -81,19 +81,18 @@ public class PlanNodeStatsEstimate
 
     public PlanNodeStatsEstimate(double outputRowCount, double totalSize, PMap<VariableReferenceExpression, VariableStatsEstimate> variableStatistics, SourceInfo sourceInfo)
     {
-        this(outputRowCount, totalSize, variableStatistics, sourceInfo, NaN, NaN);
+        this(outputRowCount, totalSize, variableStatistics, sourceInfo, JoinNodeStatsEstimate.unknown());
     }
 
     public PlanNodeStatsEstimate(double outputRowCount, double totalSize, PMap<VariableReferenceExpression, VariableStatsEstimate> variableStatistics, SourceInfo sourceInfo,
-            double nullJoinBuildKeyCount, double joinBuildKeyCount)
+            JoinNodeStatsEstimate joinNodeStatsEstimate)
     {
         checkArgument(isNaN(outputRowCount) || outputRowCount >= 0, "outputRowCount cannot be negative");
         this.outputRowCount = outputRowCount;
         this.totalSize = totalSize;
         this.variableStatistics = variableStatistics;
         this.sourceInfo = requireNonNull(sourceInfo, "SourceInfo is null");
-        this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
-        this.joinBuildKeyCount = joinBuildKeyCount;
+        this.joinNodeStatsEstimate = requireNonNull(joinNodeStatsEstimate, "joinNodeSpecificStatsEstimate is null");
     }
 
     /**
@@ -118,19 +117,14 @@ public class PlanNodeStatsEstimate
         return sourceInfo.isConfident();
     }
 
-    public double getNullJoinBuildKeyCount()
-    {
-        return nullJoinBuildKeyCount;
-    }
-
-    public double getJoinBuildKeyCount()
-    {
-        return joinBuildKeyCount;
-    }
-
     public SourceInfo getSourceInfo()
     {
         return sourceInfo;
+    }
+
+    public JoinNodeStatsEstimate getJoinNodeStatsEstimate()
+    {
+        return joinNodeStatsEstimate;
     }
 
     /**
@@ -247,8 +241,9 @@ public class PlanNodeStatsEstimate
                     planStatistics.getOutputSize().getValue(),
                     variableStatistics,
                     statsSourceInfo,
-                    planStatistics.getNullJoinBuildKeyCount().getValue(),
-                    planStatistics.getJoinBuildKeyCount().getValue());
+                    new JoinNodeStatsEstimate(
+                            planStatistics.getJoinNodeStatistics().getNullJoinBuildKeyCount().getValue(),
+                            planStatistics.getJoinNodeStatistics().getJoinBuildKeyCount().getValue()));
         }
         return this;
     }
@@ -261,6 +256,7 @@ public class PlanNodeStatsEstimate
                 .add("totalSize", totalSize)
                 .add("variableStatistics", variableStatistics)
                 .add("sourceInfo", sourceInfo)
+                .add("joinNodeSpecificStatsEstimate", joinNodeStatsEstimate)
                 .toString();
     }
 
@@ -277,13 +273,14 @@ public class PlanNodeStatsEstimate
         return Double.compare(outputRowCount, that.outputRowCount) == 0 &&
                 Double.compare(totalSize, that.totalSize) == 0 &&
                 Objects.equals(variableStatistics, that.variableStatistics) &&
-                Objects.equals(sourceInfo, that.sourceInfo);
+                Objects.equals(sourceInfo, that.sourceInfo) &&
+                Objects.equals(joinNodeStatsEstimate, that.joinNodeStatsEstimate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(outputRowCount, totalSize, variableStatistics, sourceInfo);
+        return Objects.hash(outputRowCount, totalSize, variableStatistics, sourceInfo, joinNodeStatsEstimate);
     }
 
     public PlanStatisticsWithSourceInfo toPlanStatisticsWithSourceInfo(PlanNodeId id)
@@ -294,8 +291,9 @@ public class PlanNodeStatsEstimate
                         Estimate.estimateFromDouble(outputRowCount),
                         Estimate.estimateFromDouble(totalSize),
                         sourceInfo.isConfident() ? 1 : 0,
-                        Estimate.estimateFromDouble(nullJoinBuildKeyCount),
-                        Estimate.estimateFromDouble(joinBuildKeyCount)),
+                        new JoinNodeStatistics(
+                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getNullJoinBuildKeyCount()),
+                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getJoinBuildKeyCount()))),
                 sourceInfo);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
@@ -22,7 +22,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
-import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -119,7 +119,7 @@ public class CachingPlanCanonicalInfoProvider
             return planStatistics;
         }
         TableStatistics tableStatistics = metadata.getTableStatistics(session, key.getTableHandle(), key.getColumnHandles(), key.getConstraint());
-        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, Estimate.unknown(), Estimate.unknown());
+        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, JoinNodeStatistics.empty());
         cache.put(key, planStatistics);
         return planStatistics;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -275,8 +275,8 @@ public class RandomizeNullKeyInOuterJoin
             PlanNode rewrittenRight = context.rewrite(joinNode.getRight(), context.get());
 
             PlanNodeStatsEstimate joinEstimate = statsProvider.getStats(joinNode);
-            boolean enabledByCostModel = strategy.equals(COST_BASED) && joinEstimate.getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
-                    && joinEstimate.getNullJoinBuildKeyCount() / joinEstimate.getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
+            boolean enabledByCostModel = strategy.equals(COST_BASED) && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
+                    && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() / joinEstimate.getJoinNodeStatsEstimate().getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
             List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
                     .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
                     .filter(x -> enabledByCostModel || strategy.equals(ALWAYS) || enabledForJoinKeyFromOuterJoin(context.get(), x))

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -236,7 +236,7 @@ public class TextRenderer
             PlanNodeStatsEstimate stats = node.getEstimatedStats().get(i);
             PlanCostEstimate cost = node.getEstimatedCost().get(i);
             String formatStr = "{source: %s, rows: %s (%s), cpu: %s, memory: %s, network: %s%s%s}";
-            boolean hasHashtableStats = stats.getJoinBuildKeyCount() > 0 || stats.getNullJoinBuildKeyCount() > 0;
+            boolean hasHashtableStats = stats.getJoinNodeStatsEstimate().getJoinBuildKeyCount() > 0 || stats.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() > 0;
             if (hasHashtableStats) {
                 formatStr = "{source: %s, rows: %s (%s), cpu: %s, memory: %s, network: %s, hashtable size: %s, hashtable null: %s}";
             }
@@ -247,8 +247,8 @@ public class TextRenderer
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMaxMemory()),
                     formatDouble(cost.getNetworkCost()),
-                    hasHashtableStats ? formatDouble(stats.getJoinBuildKeyCount()) : "",
-                    hasHashtableStats ? formatDouble(stats.getNullJoinBuildKeyCount()) : ""));
+                    hasHashtableStats ? formatDouble(stats.getJoinNodeStatsEstimate().getJoinBuildKeyCount()) : "",
+                    hasHashtableStats ? formatDouble(stats.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount()) : ""));
 
             if (i < estimateCount - 1) {
                 output.append("/");

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -82,7 +83,7 @@ public class TestHistoricalPlanStatistics
 
     private PlanStatistics stats(double rows, double size)
     {
-        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1, Estimate.unknown(), Estimate.unknown());
+        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1, JoinNodeStatistics.empty());
     }
 
     private static HistoricalPlanStatistics updatePlanStatistics(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.sql.Optimizer;
 import com.facebook.presto.sql.planner.Plan;
@@ -122,8 +123,8 @@ public class TestHistoryBasedStatsProvider
                             TableScanNode node = (TableScanNode) PlanNodeWithHash.getPlanNode();
                             if (node.getTable().toString().contains("orders")) {
                                 return new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
-                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, Estimate.unknown(), Estimate.unknown())))));
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
+                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty())))));
                             }
                         }
                         return HistoricalPlanStatistics.empty();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinBuildKeyCountMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinBuildKeyCountMatcher.java
@@ -39,8 +39,8 @@ public class StatsJoinBuildKeyCountMatcher
     @Override
     public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
-        return new MatchResult(Double.compare(stats.getStats(node).getJoinBuildKeyCount(), expectedJoinBuildKeyCount) == 0
-                && Double.compare(stats.getStats(node).getNullJoinBuildKeyCount(), expectedNullJoinBuildKeyCount) == 0);
+        return new MatchResult(Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getJoinBuildKeyCount(), expectedJoinBuildKeyCount) == 0
+                && Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getNullJoinBuildKeyCount(), expectedNullJoinBuildKeyCount) == 0);
     }
 
     @Override

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
@@ -122,7 +123,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1)), statsEquivalentRemoteSource))
@@ -171,7 +172,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))
@@ -198,7 +199,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1, Estimate.unknown(), Estimate.unknown()),
+                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1, JoinNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/JoinNodeStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/JoinNodeStatistics.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public class JoinNodeStatistics
+{
+    private static final JoinNodeStatistics EMPTY = new JoinNodeStatistics(Estimate.unknown(), Estimate.unknown());
+    // Number of input rows from build side of a join which has at least one join column to be NULL
+    private final Estimate nullJoinBuildKeyCount;
+    // Number of input rows from build side of a join
+    private final Estimate joinBuildKeyCount;
+
+    @JsonCreator
+    @ThriftConstructor
+    public JoinNodeStatistics(
+            @JsonProperty("nullJoinBuildKeyCount") Estimate nullJoinBuildKeyCount,
+            @JsonProperty("joinBuildKeyCount") Estimate joinBuildKeyCount)
+    {
+        this.nullJoinBuildKeyCount = requireNonNull(nullJoinBuildKeyCount, "nullJoinBuildKeyCount is null");
+        this.joinBuildKeyCount = requireNonNull(joinBuildKeyCount, "joinBuildKeyCount is null");
+    }
+
+    public static JoinNodeStatistics empty()
+    {
+        return EMPTY;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public Estimate getNullJoinBuildKeyCount()
+    {
+        return nullJoinBuildKeyCount;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public Estimate getJoinBuildKeyCount()
+    {
+        return joinBuildKeyCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JoinNodeStatistics that = (JoinNodeStatistics) o;
+        return Objects.equals(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) && Objects.equals(joinBuildKeyCount, that.joinBuildKeyCount);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "JoinNodeStatistics{" +
+                "nullJoinBuildKeyCount=" + nullJoinBuildKeyCount +
+                ", joinBuildKeyCount=" + joinBuildKeyCount +
+                '}';
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
@@ -21,21 +21,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
 import static java.util.Objects.requireNonNull;
 
 @ThriftStruct
 public class PlanStatistics
 {
-    private static final PlanStatistics EMPTY = new PlanStatistics(Estimate.unknown(), Estimate.unknown(), 0, Estimate.unknown(), Estimate.unknown());
+    private static final PlanStatistics EMPTY = new PlanStatistics(Estimate.unknown(), Estimate.unknown(), 0, JoinNodeStatistics.empty());
 
     private final Estimate rowCount;
     private final Estimate outputSize;
     // A number ranging between 0 and 1, reflecting our confidence in the statistics
     private final double confidence;
-    // Number of input rows from build side of a join which has at least one join column to be NULL
-    private final Estimate nullJoinBuildKeyCount;
-    // Number of input rows from build side of a join
-    private final Estimate joinBuildKeyCount;
+    // Join node specific statistics
+    private final JoinNodeStatistics joinNodeStatistics;
 
     public static PlanStatistics empty()
     {
@@ -47,15 +46,13 @@ public class PlanStatistics
     public PlanStatistics(@JsonProperty("rowCount") Estimate rowCount,
             @JsonProperty("outputSize") Estimate outputSize,
             @JsonProperty("confidence") double confidence,
-            @JsonProperty("nullJoinBuildKeyCount") Estimate nullJoinBuildKeyCount,
-            @JsonProperty("joinBuildKeyCount") Estimate joinBuildKeyCount)
+            @JsonProperty("joinNodeStatistics") JoinNodeStatistics joinNodeStatistics)
     {
         this.rowCount = requireNonNull(rowCount, "rowCount is null");
         this.outputSize = requireNonNull(outputSize, "outputSize is null");
         checkArgument(confidence >= 0 && confidence <= 1, "confidence should be between 0 and 1");
         this.confidence = confidence;
-        this.nullJoinBuildKeyCount = requireNonNull(nullJoinBuildKeyCount, "nullJoinBuildKeyCount is null");
-        this.joinBuildKeyCount = requireNonNull(joinBuildKeyCount, "joinBuildKeyCount is null");
+        this.joinNodeStatistics = requireNonNull(joinNodeStatistics == null ? JoinNodeStatistics.empty() : joinNodeStatistics, "joinNodeStatistics is null");
     }
 
     @JsonProperty
@@ -80,18 +77,13 @@ public class PlanStatistics
     }
 
     @JsonProperty
-    @ThriftField(4)
-    public Estimate getNullJoinBuildKeyCount()
+    @ThriftField(value = 6, requiredness = OPTIONAL)
+    public JoinNodeStatistics getJoinNodeStatistics()
     {
-        return nullJoinBuildKeyCount;
+        return joinNodeStatistics;
     }
 
-    @JsonProperty
-    @ThriftField(5)
-    public Estimate getJoinBuildKeyCount()
-    {
-        return joinBuildKeyCount;
-    }
+    // Next ThriftField value 7
 
     private static void checkArgument(boolean condition, String message)
     {
@@ -111,13 +103,13 @@ public class PlanStatistics
         }
         PlanStatistics that = (PlanStatistics) o;
         return Double.compare(that.confidence, confidence) == 0 && Objects.equals(rowCount, that.rowCount) && Objects.equals(outputSize, that.outputSize)
-                && Objects.equals(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) && Objects.equals(joinBuildKeyCount, that.joinBuildKeyCount);
+                && Objects.equals(joinNodeStatistics, that.joinNodeStatistics);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(rowCount, outputSize, confidence, nullJoinBuildKeyCount, joinBuildKeyCount);
+        return Objects.hash(rowCount, outputSize, confidence, joinNodeStatistics);
     }
 
     @Override
@@ -127,8 +119,7 @@ public class PlanStatistics
                 "rowCount=" + rowCount +
                 ", outputSize=" + outputSize +
                 ", confidence=" + confidence +
-                ", nullJoinBuildKeyCount=" + nullJoinBuildKeyCount +
-                ", joinBuildKeyCount=" + joinBuildKeyCount +
+                ", joinNodeStatistics=" + joinNodeStatistics +
                 '}';
     }
 }

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
@@ -16,6 +16,7 @@ package com.facebook.presto.statistic;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -35,8 +36,8 @@ public class TestHistoricalStatisticsSerde
     public void testSimpleHistoricalStatisticsEncoderDecoder()
     {
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, Estimate.unknown(), Estimate.unknown()),
-                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, Estimate.unknown(), Estimate.unknown())))));
+                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
+                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty())))));
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
 
         // Test PlanHash
@@ -53,8 +54,8 @@ public class TestHistoricalStatisticsSerde
     {
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()),
-                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0, Estimate.unknown(), Estimate.unknown()))));
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()),
+                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0, JoinNodeStatistics.empty()))));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
@@ -80,11 +81,11 @@ public class TestHistoricalStatisticsSerde
     {
         List<PlanStatistics> planStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()));
+            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()));
         }
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, Estimate.unknown(), Estimate.unknown()),
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()),
                     planStatisticsEntryList));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);


### PR DESCRIPTION
## Description
As we plan to add more cost based optimizations for HBO, we expect to add and collect more statistics. We need to refactor the statistics structure. The change is in `PlanStatistics` and `PlanNodeStatsEstimate`, where a Join specific class is added for the join specific stats. We can create more classes for other node specific stats in the future.

## Motivation and Context
Organize the code so that node specific stats stays within one class.

## Impact
Code cleaner.

## Test Plan
Existing unit tests, also tested locally

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

