### PR TITLE
[native] Allow updating spill directory in TaskManager.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -42,6 +42,8 @@ class TaskManager {
 
   void setBaseSpillDirectory(const std::string& baseSpillDirectory);
 
+  bool emptyBaseSpillDirectory() const;
+
   /// Sets the time (ms) that a task is considered to be old for cleanup since
   /// its completion.
   void setOldTaskCleanUpMs(int32_t oldTaskCleanUpMs);
@@ -172,7 +174,7 @@ class TaskManager {
 
   std::string baseUri_;
   std::string nodeId_;
-  std::string baseSpillDir_;
+  folly::Synchronized<std::string> baseSpillDir_;
   int32_t oldTaskCleanUpMs_;
   std::shared_ptr<velox::exec::PartitionedOutputBufferManager> bufferManager_;
   folly::Synchronized<TaskMap> taskMap_;


### PR DESCRIPTION
It's possible that spill root directory is not available during server startup. For such cases, it's required to update spill directory (e.g. periodically). To support update, adding a lock to the spill directory path and exposing if it's empty method.