### PR TITLE
Enforce JWT authentication without bearer token for internal endpoints

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.airlift.http.client.HttpClientConfig;
 import com.facebook.airlift.http.client.spnego.KerberosConfig;
+import com.facebook.presto.server.security.InternalAuthenticationFilter;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
@@ -28,6 +29,7 @@ import static com.facebook.airlift.configuration.ConditionalModule.installModule
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.facebook.airlift.http.server.KerberosConfig.HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB;
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static com.facebook.presto.server.InternalCommunicationConfig.INTERNAL_COMMUNICATION_KERBEROS_ENABLED;
 import static com.google.common.base.Verify.verify;
 
@@ -54,6 +56,7 @@ public class InternalCommunicationModule
         install(installModuleIf(InternalCommunicationConfig.class, InternalCommunicationConfig::isKerberosEnabled, kerberosInternalCommunicationModule()));
         binder.bind(InternalAuthenticationManager.class);
         httpClientBinder(binder).bindGlobalFilter(InternalAuthenticationManager.class);
+        jaxrsBinder(binder).bind(InternalAuthenticationFilter.class);
     }
 
     private Module kerberosInternalCommunicationModule()

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -15,7 +15,6 @@ package com.facebook.presto.server.security;
 
 import com.facebook.airlift.http.server.AuthenticationException;
 import com.facebook.airlift.http.server.Authenticator;
-import com.facebook.presto.server.InternalAuthenticationManager;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -47,13 +46,11 @@ public class AuthenticationFilter
         implements Filter
 {
     private final List<Authenticator> authenticators;
-    private final InternalAuthenticationManager internalAuthenticationManager;
 
     @Inject
-    public AuthenticationFilter(List<Authenticator> authenticators, InternalAuthenticationManager internalAuthenticationManager)
+    public AuthenticationFilter(List<Authenticator> authenticators)
     {
         this.authenticators = ImmutableList.copyOf(requireNonNull(authenticators, "authenticators is null"));
-        this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
     }
 
     @Override
@@ -68,16 +65,6 @@ public class AuthenticationFilter
     {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
-
-        if (internalAuthenticationManager.isInternalRequest(request)) {
-            Principal principal = internalAuthenticationManager.authenticateInternalRequest(request);
-            if (principal == null) {
-                response.sendError(SC_UNAUTHORIZED);
-                return;
-            }
-            nextFilter.doFilter(withPrincipal(request, principal), response);
-            return;
-        }
 
         // skip authentication if non-secure or not configured
         if (!doesRequestSupportAuthentication(request)) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/InternalAuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/InternalAuthenticationFilter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security;
+
+import com.facebook.presto.server.InternalAuthenticationManager;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.facebook.presto.server.security.RoleType.INTERNAL;
+import static java.util.Objects.requireNonNull;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static javax.ws.rs.core.Response.ResponseBuilder;
+
+@Provider
+public class InternalAuthenticationFilter
+        implements ContainerRequestFilter
+{
+    private final InternalAuthenticationManager internalAuthenticationManager;
+    private Optional<Principal> principal = Optional.empty();
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Inject
+    public InternalAuthenticationFilter(InternalAuthenticationManager internalAuthenticationManager)
+    {
+        this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
+    }
+
+    public InternalAuthenticationFilter(InternalAuthenticationManager internalAuthenticationManager, ResourceInfo resourceInfo)
+    {
+        this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
+        this.resourceInfo = requireNonNull(resourceInfo, "resourceInfo is null");
+    }
+
+    public Optional<Principal> getPrincipal()
+    {
+        return principal;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext context)
+    {
+        if (internalAuthenticationManager.isInternalRequest(context) ||
+                (internalAuthenticationManager.isInternalJwtEnabled() && isAccessingInternalEndpoint(resourceInfo))) {
+            Principal authenticatedPrincipal = internalAuthenticationManager.authenticateInternalRequest(context);
+            if (authenticatedPrincipal == null) {
+                ResponseBuilder responseBuilder = Response.serverError();
+                responseBuilder.status(SC_UNAUTHORIZED, "Unauthorized");
+                context.abortWith(responseBuilder.build());
+            }
+            else {
+                principal = Optional.of(authenticatedPrincipal);
+            }
+        }
+    }
+
+    private static boolean isAccessingInternalEndpoint(ResourceInfo resourceInfo)
+    {
+        if (resourceInfo != null) {
+            Class<?> resourceClass = resourceInfo.getResourceClass();
+            Method resourceMethod = resourceInfo.getResourceMethod();
+            if ((resourceClass != null && resourceClass.isAnnotationPresent(RolesAllowed.class) &&
+                    Arrays.asList(resourceClass.getAnnotation(RolesAllowed.class).value()).contains(INTERNAL)) ||
+                    (resourceMethod != null && resourceMethod.isAnnotationPresent(RolesAllowed.class) &&
+                            Arrays.asList(resourceMethod.getAnnotation(RolesAllowed.class).value()).contains(INTERNAL))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/MockContainerRequestContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockContainerRequestContext.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.google.common.collect.ListMultimap;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class MockContainerRequestContext
+        implements ContainerRequestContext
+{
+    private final ListMultimap<String, String> headers;
+    private Response response;
+
+    public MockContainerRequestContext(ListMultimap<String, String> headers)
+    {
+        this.headers = headers;
+        this.response = Response.ok().build();
+    }
+
+    @Override
+    public Object getProperty(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getPropertyNames()
+    {
+        return null;
+    }
+
+    @Override
+    public void setProperty(String name, Object object) {}
+
+    @Override
+    public void removeProperty(String name) {}
+
+    @Override
+    public UriInfo getUriInfo()
+    {
+        return null;
+    }
+
+    @Override
+    public void setRequestUri(URI requestUri) {}
+
+    @Override
+    public void setRequestUri(URI baseUri, URI requestUri) {}
+
+    @Override
+    public Request getRequest()
+    {
+        return null;
+    }
+
+    @Override
+    public String getMethod()
+    {
+        return null;
+    }
+
+    @Override
+    public void setMethod(String method)
+    {}
+
+    @Override
+    public MultivaluedMap<String, String> getHeaders()
+    {
+        return null;
+    }
+
+    @Override
+    public String getHeaderString(String name)
+    {
+        if (headers.containsKey(name)) {
+            return headers.get(name).get(0);
+        }
+        return null;
+    }
+
+    @Override
+    public Date getDate()
+    {
+        return null;
+    }
+
+    @Override
+    public Locale getLanguage()
+    {
+        return null;
+    }
+
+    @Override
+    public int getLength()
+    {
+        return 0;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return null;
+    }
+
+    @Override
+    public List<MediaType> getAcceptableMediaTypes()
+    {
+        return null;
+    }
+
+    @Override
+    public List<Locale> getAcceptableLanguages()
+    {
+        return null;
+    }
+
+    @Override
+    public Map<String, Cookie> getCookies()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean hasEntity()
+    {
+        return false;
+    }
+
+    @Override
+    public InputStream getEntityStream()
+    {
+        return null;
+    }
+
+    @Override
+    public void setEntityStream(InputStream input) {}
+
+    @Override
+    public SecurityContext getSecurityContext()
+    {
+        return null;
+    }
+
+    @Override
+    public void setSecurityContext(SecurityContext context) {}
+
+    @Override
+    public void abortWith(Response response)
+    {
+        this.response = response;
+    }
+
+    public Response getResponse()
+    {
+        return response;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security;
+
+import com.facebook.presto.server.InternalAuthenticationManager;
+import com.facebook.presto.server.MockContainerRequestContext;
+import com.facebook.presto.server.TaskResource;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.hash.Hashing;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.container.ResourceInfo;
+
+import java.lang.reflect.Method;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static com.facebook.presto.server.InternalAuthenticationManager.PRESTO_INTERNAL_BEARER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestInternalAuthenticationFilter
+{
+    @Test
+    public void testJwtAuthenticationRejectsWithNoBearerTokenJwtEnabled()
+    {
+        String sharedSecret = "secret";
+        boolean internalJwtEnabled = true;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        InternalAuthenticationFilter internalAuthenticationFilter =
+                new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+
+        MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of());
+
+        internalAuthenticationFilter.filter(containerRequestContext);
+
+        assertEquals(containerRequestContext.getResponse().getStatus(), SC_UNAUTHORIZED);
+        assertEquals("Unauthorized", containerRequestContext.getResponse().getStatusInfo().getReasonPhrase());
+    }
+
+    @Test
+    public void testJwtAuthenticationPassesWithNoBearerTokenJwtDisabledNoAuthenticators()
+    {
+        String sharedSecret = "secret";
+        boolean internalJwtEnabled = false;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        InternalAuthenticationFilter internalAuthenticationFilter =
+                new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+        MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of());
+
+        internalAuthenticationFilter.filter(containerRequestContext);
+
+        assertEquals(containerRequestContext.getResponse().getStatus(), SC_OK);
+        assertFalse(internalAuthenticationFilter.getPrincipal().isPresent());
+    }
+
+    @Test
+    public void testJwtAuthenticationPassesWithBearerTokenJwtEnabled()
+    {
+        String sharedSecret = "secret";
+        String principalString = "456";
+        boolean internalJwtEnabled = true;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        InternalAuthenticationFilter internalAuthenticationFilter =
+                new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+        String jwtToken = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .setSubject(principalString)
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .compact();
+
+        MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken));
+
+        internalAuthenticationFilter.filter(containerRequestContext);
+
+        assertTrue(internalAuthenticationFilter.getPrincipal().isPresent());
+        assertEquals(internalAuthenticationFilter.getPrincipal().get().toString(), principalString);
+        assertEquals(containerRequestContext.getResponse().getStatus(), SC_OK);
+    }
+
+    @Test
+    public void testJwtAuthenticationRejectsWithBearerTokenJwtDisabled()
+    {
+        String sharedSecret = "secret";
+        String principalString = "456";
+        boolean internalJwtEnabled = false;
+
+        InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
+        InternalAuthenticationFilter internalAuthenticationFilter =
+                new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+        String jwtToken = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .setSubject(principalString)
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .compact();
+
+        MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken));
+
+        internalAuthenticationFilter.filter(containerRequestContext);
+
+        assertEquals(containerRequestContext.getResponse().getStatus(), SC_UNAUTHORIZED);
+        assertEquals("Unauthorized", containerRequestContext.getResponse().getStatusInfo().getReasonPhrase());
+        assertFalse(internalAuthenticationFilter.getPrincipal().isPresent());
+    }
+
+    private static class ResourceInfoBuilder
+    {
+        private final Class<?> clazz;
+        private final String methodName;
+
+        private final Class<?>[] parameterTypes;
+        ResourceInfoBuilder(Class<?> clazz, String methodName, Class<?>... parameterTypes)
+        {
+            this.clazz = clazz;
+            this.methodName = methodName;
+            this.parameterTypes = parameterTypes;
+        }
+
+        ResourceInfo build()
+        {
+            return new ResourceInfo()
+            {
+                @Override
+                public Method getResourceMethod()
+                {
+                    if (methodName == null || methodName.isEmpty()) {
+                        return null;
+                    }
+
+                    Method method = null;
+                    try {
+                        method = clazz.getMethod(methodName, parameterTypes);
+                    }
+                    catch (NoSuchMethodException e) { }
+                    return method;
+                }
+
+                @Override
+                public Class<?> getResourceClass()
+                {
+                    return clazz;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Description
Enforces JWT authentication for all internal endpoints when enabled.

## Motivation and Context
When JWT authentication is enabled for internal communication, need to enforce that no internal endpoints can be accessed by external agents. 

## Impact
No public facing changes.

## Test Plan

```
== NO RELEASE NOTE ==
```

