### PR TITLE
Optimize latency for HBO optimizer

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -64,5 +65,25 @@ public class Constraint<T>
     public Optional<Predicate<Map<T, NullableValue>>> predicate()
     {
         return predicate;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Constraint)) {
+            return false;
+        }
+
+        Constraint other = (Constraint) obj;
+        return this.summary.equals(other.summary) && this.predicate.equals(other.predicate);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(summary, predicate);
     }
 }


### PR DESCRIPTION
## Description
Part of https://github.com/prestodb/presto/issues/20355

Improve latency of HBO, specifically getting input table statistics by fixing bug in cache.

## Motivation and Context
In HBO, input table statistics are fetched for history match. However, fetching input table statistics can be expensive. In order to avoid this cost, we build a cache to cache the input table statistics. While debugging, I found that the cache is not working as expected, due to the lack of overriding function of `equal/hashcode` function for `Constraint` which is part of the `InputTableCacheKey`. This means that for the key with the same value, it will be considered as different and not using the cache. This PR fix it by overriding function of `equal/hashcode` function for `Constraint`.

In addition to this, I also added timeout check for loading PlanNodeCanonicalInfo information.

## Impact
Reduce latency for HBO

## Test Plan
Existing unit tests and local end to end test [before](https://www.internalfb.com/intern/presto/query/?query_id=20230913_082505_12690_e7sxm#sql) vs. [after](https://www.internalfb.com/intern/presto/query/?query_id=20230913_182053_00008_spf9p#runtime_stats)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix the cache usage in HBO optimization. This will reduce the number of access to meta data for input table statistics.
```


