### PR TITLE
[Iceberg] Reduce code duplication in Iceberg metadata

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.iceberg.util.IcebergPrestoModelConverters;
@@ -25,14 +24,10 @@ import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
-import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
-import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableNotFoundException;
-import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -50,23 +45,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
-import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
-import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
-import static com.facebook.presto.iceberg.TableType.DATA;
-import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergNamespace;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -97,6 +86,28 @@ public class IcebergNativeMetadata
     }
 
     @Override
+    protected Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        return getNativeIcebergTable(resourceFactory, session, schemaTableName);
+    }
+
+    @Override
+    protected boolean tableExists(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        IcebergTableName name = IcebergTableName.from(schemaTableName.getTableName());
+        TableIdentifier tableIdentifier = toIcebergTableIdentifier(schemaTableName.getSchemaName(), name.getTableName());
+
+        try {
+            resourceFactory.getCatalog(session).loadTable(tableIdentifier);
+        }
+        catch (NoSuchTableException e) {
+            // return null to throw
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
         SupportsNamespaces supportsNamespaces = resourceFactory.getNamespaces(session);
@@ -104,56 +115,6 @@ public class IcebergNativeMetadata
                 .stream()
                 .map(IcebergPrestoModelConverters::toPrestoSchemaName)
                 .collect(toList());
-    }
-
-    @Override
-    public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
-    {
-        IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        verify(name.getTableType() == DATA, "Wrong table type: " + name.getTableType());
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(tableName.getSchemaName(), name.getTableName());
-
-        Table table;
-        try {
-            table = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        }
-        catch (NoSuchTableException e) {
-            // return null to throw
-            return null;
-        }
-
-        validateTableMode(session, table);
-
-        return new IcebergTableHandle(
-                tableName.getSchemaName(),
-                name.getTableName(),
-                name.getTableType(),
-                resolveSnapshotIdByName(table, name),
-                TupleDomain.all());
-    }
-
-    @Override
-    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
-    {
-        IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        if (name.getTableType() == DATA) {
-            return Optional.empty();
-        }
-
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(tableName.getSchemaName(), name.getTableName());
-        Table table;
-        try {
-            table = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        }
-        catch (NoSuchTableException e) {
-            return Optional.empty();
-        }
-
-        if (name.getSnapshotId().isPresent() && table.snapshot(name.getSnapshotId().get()) == null) {
-            throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, format("Invalid snapshot [%s] for table: %s", name.getSnapshotId().get(), table));
-        }
-
-        return getIcebergSystemTable(tableName, table);
     }
 
     @Override
@@ -284,35 +245,6 @@ public class IcebergNativeMetadata
     }
 
     @Override
-    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
-    {
-        if (!column.isNullable()) {
-            throw new PrestoException(NOT_SUPPORTED, "This connector does not support add column with non null");
-        }
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(((IcebergTableHandle) tableHandle).getSchemaTableName());
-        Table icebergTable = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();
-    }
-
-    @Override
-    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
-    {
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(((IcebergTableHandle) tableHandle).getSchemaTableName());
-        Table icebergTable = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        IcebergColumnHandle handle = (IcebergColumnHandle) column;
-        icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
-    }
-
-    @Override
-    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
-    {
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(((IcebergTableHandle) tableHandle).getSchemaTableName());
-        Table icebergTable = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
-        icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
-    }
-
-    @Override
     protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
     {
         Table icebergTable;
@@ -326,13 +258,5 @@ public class IcebergNativeMetadata
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
 
         return new ConnectorTableMetadata(table, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
-    }
-
-    @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
-    {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        Table icebergTable = getNativeIcebergTable(resourceFactory, session, handle.getSchemaTableName());
-        return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
     }
 }


### PR DESCRIPTION
## Description

This change is a refactor of the IcebergAbstractMetadata, IcebergHiveMetadata, and IcebergNativeMetadata which
reduces some of the duplicate code between the Hive and Native implementations.

## Motivation and Context

Better maintainability

## Impact

None

## Test Plan

Just a refactor, shouldn't require new tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

