### PR TITLE
Add noisy_avg_gaussian aggregation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -418,6 +418,65 @@ Approximate Aggregate Functions
         SELECT noisy_sum_gaussian(orderkey, 20.0, 10.0, 50.0, 321) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
         SELECT noisy_sum_gaussian(orderkey, 20.0, 10.0, 50.0, 321) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; --  (0 row)
 
+.. function:: noisy_avg_gaussian(x, noise_scale) -> double
+
+    Calculates the average (arithmetic mean) of all the input values and then adds random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale``.
+    All values are converted to double before being added to the avg, and the return type is double.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Noise is from a secure random. ::
+
+        SELECT noisy_avg_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_avg_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; -- (0 row)
+
+.. function:: noisy_avg_gaussian(x, noise_scale, random_seed) -> double
+
+    Calculates the average (arithmetic mean) of all the input values and then adds random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale``.
+    All values are converted to double before being added to the avg, and the return type is double.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Random seed is used to seed the random generator.
+    This method does not use a secure random. ::
+
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 321) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 321) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; --  (0 row)
+
+.. function:: noisy_avg_gaussian(x, noise_scale, lower, upper) -> double
+
+    Calculates the average (arithmetic mean) of all the input values and then adds random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale``.
+    All values are converted to double before being added to the avg, and the return type is double.
+
+    Each value is clipped to the range of ``[lower, upper]`` before adding to the avg.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Noise is from a secure random. ::
+
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 10.0, 50.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 10.0, 51.0) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; -- (0 row)
+
+.. function:: noisy_avg_gaussian(x, noise_scale, lower, upper, random_seed) -> double
+
+    Calculates the average (arithmetic mean) of all the input values and then adds random Gaussian noise
+    with 0 mean and standard deviation of ``noise_scale``.
+    All values are converted to double before being added to the avg, and the return type is double.
+
+    Each value is clipped to the range of ``[lower, upper]`` before adding to the avg.
+
+    When there are no input rows, this function returns ``NULL``.
+
+    Random seed is used to seed the random generator.
+    This method does not use a secure random. ::
+
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 10.0, 50.0, 321) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+        SELECT noisy_avg_gaussian(orderkey, 20.0, 10.0, 50.0, 321) FROM tpch.tiny.lineitem WHERE false  GROUP BY orderkey; --  (0 row)
+
+
 Statistical Aggregate Functions
 -------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -344,6 +344,10 @@ import static com.facebook.presto.operator.aggregation.minmaxby.MaxByAggregation
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByNAggregationFunction.MAX_BY_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.minmaxby.MinByAggregationFunction.MIN_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.MinByNAggregationFunction.MIN_BY_N_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyAverageGaussianAggregation.NOISY_AVERAGE_GAUSSIAN_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyAverageGaussianClippingAggregation.NOISY_AVERAGE_GAUSSIAN_CLIPPING_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyAverageGaussianClippingRandomSeedAggregation.NOISY_AVERAGE_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyAverageGaussianRandomSeedAggregation.NOISY_AVERAGE_GAUSSIAN_RANDOM_SEED_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnAggregation.NOISY_COUNT_GAUSSIAN_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountGaussianColumnRandomSeedAggregation.NOISY_COUNT_GAUSSIAN_RANDOM_SEED_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumGaussianAggregation.NOISY_SUM_GAUSSIAN_AGGREGATION;
@@ -669,6 +673,10 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(NOISY_SUM_GAUSSIAN_RANDOM_SEED_AGGREGATION)
                 .function(NOISY_SUM_GAUSSIAN_CLIPPING_AGGREGATION)
                 .function(NOISY_SUM_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION)
+                .function(NOISY_AVERAGE_GAUSSIAN_AGGREGATION)
+                .function(NOISY_AVERAGE_GAUSSIAN_CLIPPING_AGGREGATION)
+                .function(NOISY_AVERAGE_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION)
+                .function(NOISY_AVERAGE_GAUSSIAN_RANDOM_SEED_AGGREGATION)
                 .function(REAL_AVERAGE_AGGREGATION)
                 .aggregates(IntervalDayToSecondAverageAggregation.class)
                 .aggregates(IntervalYearToMonthAverageAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianClippingAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianClippingAggregation.java
@@ -56,7 +56,7 @@ import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unsca
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.combineStates;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.updateState;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisySumOutput;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisyAvgOutput;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -66,29 +66,29 @@ import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Float.intBitsToFloat;
 
-public class NoisySumGaussianClippingRandomSeedAggregation
+public class NoisyAverageGaussianClippingAggregation
         extends SqlAggregationFunction
 {
     // Constant references for short/long decimal types for use in operations that only manipulate unscaled values
     private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_PRECISION, 0);
     private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION, 0);
 
-    public static final NoisySumGaussianClippingRandomSeedAggregation NOISY_SUM_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION = new NoisySumGaussianClippingRandomSeedAggregation();
-    private static final String NAME = "noisy_sum_gaussian";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    public static final NoisyAverageGaussianClippingAggregation NOISY_AVERAGE_GAUSSIAN_CLIPPING_AGGREGATION = new NoisyAverageGaussianClippingAggregation();
+    private static final String NAME = "noisy_avg_gaussian";
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
 
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
 
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisyAverageGaussianClippingAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
 
-    public NoisySumGaussianClippingRandomSeedAggregation()
+    public NoisyAverageGaussianClippingAggregation()
     {
         super(NAME,
                 ImmutableList.of(typeVariable("T")),
@@ -97,15 +97,14 @@ public class NoisySumGaussianClippingRandomSeedAggregation
                 ImmutableList.of(parseTypeSignature("T"),
                         parseTypeSignature(StandardTypes.DOUBLE),
                         parseTypeSignature(StandardTypes.DOUBLE),
-                        parseTypeSignature(StandardTypes.DOUBLE),
-                        parseTypeSignature(StandardTypes.BIGINT)),
+                        parseTypeSignature(StandardTypes.DOUBLE)),
                 FunctionKind.AGGREGATE);
     }
 
     @Override
     public String getDescription()
     {
-        return "Calculates the sum over the input values where values are clipped to [lower, upper] range and then adds random Gaussian noise.  Random seed is used to seed random generator. This method does not use a secure random.";
+        return "Calculates the average (arithmetic mean) of all the input values where values are clipped to [lower, upper] range and then adds random Gaussian noise.";
     }
 
     @Override
@@ -117,11 +116,11 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
     {
-        DynamicClassLoader classLoader = new DynamicClassLoader(NoisySumGaussianClippingRandomSeedAggregation.class.getClassLoader());
+        DynamicClassLoader classLoader = new DynamicClassLoader(NoisyAverageGaussianClippingAggregation.class.getClassLoader());
 
         AccumulatorStateSerializer<?> stateSerializer = new NoisyCountAndSumStateSerializer();
         AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisyCountAndSumState.class, classLoader);
-        List<Type> inputTypes = ImmutableList.of(type, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+        List<Type> inputTypes = ImmutableList.of(type, DOUBLE, DOUBLE, DOUBLE);
 
         MethodHandle inputFunction;
         if (type instanceof DecimalType) {
@@ -180,70 +179,68 @@ public class NoisySumGaussianClippingRandomSeedAggregation
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
-                new ParameterMetadata(BLOCK_INPUT_CHANNEL, BIGINT),
                 new ParameterMetadata(BLOCK_INDEX));
     }
 
-    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(SHORT_DECIMAL_TYPE.getLong(valueBlock, position)))
                 .doubleValue();
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(LONG_DECIMAL_TYPE.getSlice(valueBlock, position)))
                 .doubleValue();
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = DOUBLE.getDouble(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = intBitsToFloat((int) REAL.getLong(valueBlock, position));
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = BIGINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = INTEGER.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = SMALLINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = TINYINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double noiseScale = DOUBLE.getDouble(noiseScaleBlock, position);
         double lower = DOUBLE.getDouble(lowerBlock, position);
         double upper = DOUBLE.getDouble(upperBlock, position);
-        long randomSeed = BIGINT.getLong(randomSeedBlock, position);
 
-        updateState(state, value, noiseScale, lower, upper, randomSeed);
+        updateState(state, value, noiseScale, lower, upper, null);
     }
 
     public static void combine(NoisyCountAndSumState state, NoisyCountAndSumState otherState)
@@ -253,6 +250,6 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     public static void output(NoisyCountAndSumState state, BlockBuilder out)
     {
-        writeNoisySumOutput(state, out);
+        writeNoisyAvgOutput(state, out);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianClippingRandomSeedAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianClippingRandomSeedAggregation.java
@@ -56,7 +56,7 @@ import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unsca
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.combineStates;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.updateState;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisySumOutput;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisyAvgOutput;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -66,29 +66,29 @@ import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Float.intBitsToFloat;
 
-public class NoisySumGaussianClippingRandomSeedAggregation
+public class NoisyAverageGaussianClippingRandomSeedAggregation
         extends SqlAggregationFunction
 {
     // Constant references for short/long decimal types for use in operations that only manipulate unscaled values
     private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_PRECISION, 0);
     private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION, 0);
 
-    public static final NoisySumGaussianClippingRandomSeedAggregation NOISY_SUM_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION = new NoisySumGaussianClippingRandomSeedAggregation();
-    private static final String NAME = "noisy_sum_gaussian";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    public static final NoisyAverageGaussianClippingRandomSeedAggregation NOISY_AVERAGE_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION = new NoisyAverageGaussianClippingRandomSeedAggregation();
+    private static final String NAME = "noisy_avg_gaussian";
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
 
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
 
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisyAverageGaussianClippingRandomSeedAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
 
-    public NoisySumGaussianClippingRandomSeedAggregation()
+    public NoisyAverageGaussianClippingRandomSeedAggregation()
     {
         super(NAME,
                 ImmutableList.of(typeVariable("T")),
@@ -105,7 +105,7 @@ public class NoisySumGaussianClippingRandomSeedAggregation
     @Override
     public String getDescription()
     {
-        return "Calculates the sum over the input values where values are clipped to [lower, upper] range and then adds random Gaussian noise.  Random seed is used to seed random generator. This method does not use a secure random.";
+        return "Calculates the average (arithmetic mean) of all the input values where values are clipped to [lower, upper] range and then adds random Gaussian noise.  Random seed is used to seed random generator. This method does not use a secure random.";
     }
 
     @Override
@@ -117,7 +117,7 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
     {
-        DynamicClassLoader classLoader = new DynamicClassLoader(NoisySumGaussianClippingRandomSeedAggregation.class.getClassLoader());
+        DynamicClassLoader classLoader = new DynamicClassLoader(NoisyAverageGaussianClippingRandomSeedAggregation.class.getClassLoader());
 
         AccumulatorStateSerializer<?> stateSerializer = new NoisyCountAndSumStateSerializer();
         AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisyCountAndSumState.class, classLoader);
@@ -253,6 +253,6 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     public static void output(NoisyCountAndSumState state, BlockBuilder out)
     {
-        writeNoisySumOutput(state, out);
+        writeNoisyAvgOutput(state, out);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianRandomSeedAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyAverageGaussianRandomSeedAggregation.java
@@ -56,7 +56,7 @@ import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unsca
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.combineStates;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.updateState;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisySumOutput;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisyAvgOutput;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -66,37 +66,35 @@ import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Float.intBitsToFloat;
 
-public class NoisySumGaussianClippingRandomSeedAggregation
+public class NoisyAverageGaussianRandomSeedAggregation
         extends SqlAggregationFunction
 {
     // Constant references for short/long decimal types for use in operations that only manipulate unscaled values
     private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_PRECISION, 0);
     private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION, 0);
 
-    public static final NoisySumGaussianClippingRandomSeedAggregation NOISY_SUM_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION = new NoisySumGaussianClippingRandomSeedAggregation();
-    private static final String NAME = "noisy_sum_gaussian";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    public static final NoisyAverageGaussianRandomSeedAggregation NOISY_AVERAGE_GAUSSIAN_RANDOM_SEED_AGGREGATION = new NoisyAverageGaussianRandomSeedAggregation();
+    private static final String NAME = "noisy_avg_gaussian";
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, int.class);
 
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
 
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianClippingRandomSeedAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisyAverageGaussianRandomSeedAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
 
-    public NoisySumGaussianClippingRandomSeedAggregation()
+    public NoisyAverageGaussianRandomSeedAggregation()
     {
         super(NAME,
                 ImmutableList.of(typeVariable("T")),
                 ImmutableList.of(),
                 parseTypeSignature(StandardTypes.DOUBLE),
                 ImmutableList.of(parseTypeSignature("T"),
-                        parseTypeSignature(StandardTypes.DOUBLE),
-                        parseTypeSignature(StandardTypes.DOUBLE),
                         parseTypeSignature(StandardTypes.DOUBLE),
                         parseTypeSignature(StandardTypes.BIGINT)),
                 FunctionKind.AGGREGATE);
@@ -105,7 +103,7 @@ public class NoisySumGaussianClippingRandomSeedAggregation
     @Override
     public String getDescription()
     {
-        return "Calculates the sum over the input values where values are clipped to [lower, upper] range and then adds random Gaussian noise.  Random seed is used to seed random generator. This method does not use a secure random.";
+        return "Calculates the average (arithmetic mean) of all the input values and then adds random Gaussian noise. Random seed is used to seed random generator. This method does not use a secure random.";
     }
 
     @Override
@@ -117,11 +115,11 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
     {
-        DynamicClassLoader classLoader = new DynamicClassLoader(NoisySumGaussianClippingRandomSeedAggregation.class.getClassLoader());
+        DynamicClassLoader classLoader = new DynamicClassLoader(NoisyAverageGaussianRandomSeedAggregation.class.getClassLoader());
 
         AccumulatorStateSerializer<?> stateSerializer = new NoisyCountAndSumStateSerializer();
         AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisyCountAndSumState.class, classLoader);
-        List<Type> inputTypes = ImmutableList.of(type, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+        List<Type> inputTypes = ImmutableList.of(type, DOUBLE, BIGINT);
 
         MethodHandle inputFunction;
         if (type instanceof DecimalType) {
@@ -178,72 +176,68 @@ public class NoisySumGaussianClippingRandomSeedAggregation
                 new ParameterMetadata(STATE),
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, type),
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
-                new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
-                new ParameterMetadata(BLOCK_INPUT_CHANNEL, DOUBLE),
                 new ParameterMetadata(BLOCK_INPUT_CHANNEL, BIGINT),
                 new ParameterMetadata(BLOCK_INDEX));
     }
 
-    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(SHORT_DECIMAL_TYPE.getLong(valueBlock, position)))
                 .doubleValue();
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(LONG_DECIMAL_TYPE.getSlice(valueBlock, position)))
                 .doubleValue();
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = DOUBLE.getDouble(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = intBitsToFloat((int) REAL.getLong(valueBlock, position));
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = BIGINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = INTEGER.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = SMALLINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double value = TINYINT.getLong(valueBlock, position);
-        input(state, value, noiseScaleBlock, lowerBlock, upperBlock, randomSeedBlock, position);
+        input(state, value, noiseScaleBlock, randomSeedBlock, position);
     }
 
-    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, Block randomSeedBlock, int position)
+    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, Block randomSeedBlock, int position)
     {
         double noiseScale = DOUBLE.getDouble(noiseScaleBlock, position);
-        double lower = DOUBLE.getDouble(lowerBlock, position);
-        double upper = DOUBLE.getDouble(upperBlock, position);
         long randomSeed = BIGINT.getLong(randomSeedBlock, position);
 
-        updateState(state, value, noiseScale, lower, upper, randomSeed);
+        updateState(state, value, noiseScale, null, null, randomSeed);
     }
 
     public static void combine(NoisyCountAndSumState state, NoisyCountAndSumState otherState)
@@ -253,6 +247,6 @@ public class NoisySumGaussianClippingRandomSeedAggregation
 
     public static void output(NoisyCountAndSumState state, BlockBuilder out)
     {
-        writeNoisySumOutput(state, out);
+        writeNoisyAvgOutput(state, out);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAndSumState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAndSumState.java
@@ -22,12 +22,14 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 
 /**
- * State class for noisy sum aggregation.
- * This class extends noisy count state to store the number of input rows explicitly
- * so that NULL can be returned if there is no input rows.
+ * State class for noisy sum and noisy avg aggregations.
+ * This class extends noisy count state to store the number of input rows explicitly.
+ * That count is used to compute noisy average.
+ * In the case of noisy sum, if there is no input rows, NULL should be returned
+ * and that count is used to check that condition.
  */
-@AccumulatorStateMetadata(stateSerializerClass = NoisySumStateSerializer.class)
-public interface NoisySumState
+@AccumulatorStateMetadata(stateSerializerClass = NoisyCountAndSumStateSerializer.class)
+public interface NoisyCountAndSumState
         extends NoisyCountState
 {
     @InitialBooleanValue(true)
@@ -62,7 +64,7 @@ public interface NoisySumState
                 SIZE_OF_DOUBLE; // sum
     }
 
-    static void writeToSerializer(NoisySumState state, SliceOutput output)
+    static void writeToSerializer(NoisyCountAndSumState state, SliceOutput output)
     {
         NoisyCountState.writeToSerializer(state, output);
 
@@ -74,7 +76,7 @@ public interface NoisySumState
         output.appendDouble(state.getSum());
     }
 
-    static void readFromSerializer(NoisySumState state, SliceInput input)
+    static void readFromSerializer(NoisyCountAndSumState state, SliceInput input)
     {
         NoisyCountState.readFromSerializer(state, input);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAndSumStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAndSumStateSerializer.java
@@ -23,8 +23,8 @@ import io.airlift.slice.Slices;
 
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 
-public class NoisySumStateSerializer
-        implements AccumulatorStateSerializer<NoisySumState>
+public class NoisyCountAndSumStateSerializer
+        implements AccumulatorStateSerializer<NoisyCountAndSumState>
 {
     @Override
     public Type getSerializedType()
@@ -33,19 +33,19 @@ public class NoisySumStateSerializer
     }
 
     @Override
-    public void serialize(NoisySumState state, BlockBuilder out)
+    public void serialize(NoisyCountAndSumState state, BlockBuilder out)
     {
-        SliceOutput output = Slices.allocate(NoisySumState.calculateSerializationCapacity())
+        SliceOutput output = Slices.allocate(NoisyCountAndSumState.calculateSerializationCapacity())
                 .getOutput();
-        NoisySumState.writeToSerializer(state, output);
+        NoisyCountAndSumState.writeToSerializer(state, output);
 
         VARBINARY.writeSlice(out, output.slice());
     }
 
     @Override
-    public void deserialize(Block block, int index, NoisySumState state)
+    public void deserialize(Block block, int index, NoisyCountAndSumState state)
     {
         SliceInput input = VARBINARY.getSlice(block, index).getInput();
-        NoisySumState.readFromSerializer(state, input);
+        NoisyCountAndSumState.readFromSerializer(state, input);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisySumGaussianAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisySumGaussianAggregation.java
@@ -54,9 +54,9 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.combineNoisySumStates;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.updateNoisySumState;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.writeNoisySumStateOutput;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.combineStates;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.updateState;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisySumOutput;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -75,18 +75,18 @@ public class NoisySumGaussianAggregation
 
     public static final NoisySumGaussianAggregation NOISY_SUM_GAUSSIAN_AGGREGATION = new NoisySumGaussianAggregation();
     private static final String NAME = "noisy_sum_gaussian";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputShortDecimal", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputLongDecimal", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputDouble", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputReal", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputBigInt", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputInteger", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputSmallInt", NoisySumState.class, Block.class, Block.class, int.class);
-    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputTinyInt", NoisySumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
+    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, int.class);
 
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "output", NoisySumState.class, BlockBuilder.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
 
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "combine", NoisySumState.class, NoisySumState.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
 
     public NoisySumGaussianAggregation()
     {
@@ -116,8 +116,8 @@ public class NoisySumGaussianAggregation
     {
         DynamicClassLoader classLoader = new DynamicClassLoader(NoisySumGaussianAggregation.class.getClassLoader());
 
-        AccumulatorStateSerializer<?> stateSerializer = new NoisySumStateSerializer();
-        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisySumState.class, classLoader);
+        AccumulatorStateSerializer<?> stateSerializer = new NoisyCountAndSumStateSerializer();
+        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisyCountAndSumState.class, classLoader);
         List<Type> inputTypes = ImmutableList.of(type, DOUBLE);
 
         MethodHandle inputFunction;
@@ -150,7 +150,7 @@ public class NoisySumGaussianAggregation
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 ImmutableList.of(new AccumulatorStateDescriptor(
-                        NoisySumState.class,
+                        NoisyCountAndSumState.class,
                         stateSerializer,
                         stateFactory)),
                 DOUBLE);
@@ -178,17 +178,17 @@ public class NoisySumGaussianAggregation
                 new ParameterMetadata(BLOCK_INDEX));
     }
 
-    public static void inputShortDecimal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(SHORT_DECIMAL_TYPE.getLong(valueBlock, position)))
                 .doubleValue();
         double noiseScale = DOUBLE.getDouble(noiseScaleBlock, position);
 
-        updateNoisySumState(state, value, noiseScale, null, null, null);
+        updateState(state, value, noiseScale, null, null, null);
     }
 
-    public static void inputLongDecimal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(LONG_DECIMAL_TYPE.getSlice(valueBlock, position)))
@@ -196,56 +196,56 @@ public class NoisySumGaussianAggregation
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputDouble(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = DOUBLE.getDouble(valueBlock, position);
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputReal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = intBitsToFloat((int) REAL.getLong(valueBlock, position));
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputBigInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = BIGINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputInteger(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = INTEGER.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputSmallInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = SMALLINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, position);
     }
 
-    public static void inputTinyInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, int position)
+    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, int position)
     {
         double value = TINYINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, position);
     }
 
-    private static void input(NoisySumState state, double value, Block noiseScaleBlock, int position)
+    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, int position)
     {
         double noiseScale = DOUBLE.getDouble(noiseScaleBlock, position);
 
-        updateNoisySumState(state, value, noiseScale, null, null, null);
+        updateState(state, value, noiseScale, null, null, null);
     }
 
-    public static void combine(NoisySumState state, NoisySumState otherState)
+    public static void combine(NoisyCountAndSumState state, NoisyCountAndSumState otherState)
     {
-        combineNoisySumStates(state, otherState);
+        combineStates(state, otherState);
     }
 
-    public static void output(NoisySumState state, BlockBuilder out)
+    public static void output(NoisyCountAndSumState state, BlockBuilder out)
     {
-        writeNoisySumStateOutput(state, out);
+        writeNoisySumOutput(state, out);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisySumGaussianClippingAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisySumGaussianClippingAggregation.java
@@ -54,9 +54,9 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.combineNoisySumStates;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.updateNoisySumState;
-import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumAggregationUtils.writeNoisySumStateOutput;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.combineStates;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.updateState;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountAndSumAggregationUtils.writeNoisySumOutput;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -75,18 +75,18 @@ public class NoisySumGaussianClippingAggregation
 
     public static final NoisySumGaussianClippingAggregation NOISY_SUM_GAUSSIAN_CLIPPING_AGGREGATION = new NoisySumGaussianClippingAggregation();
     private static final String NAME = "noisy_sum_gaussian";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputShortDecimal", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputLongDecimal", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputDouble", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputReal", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputBigInt", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputInteger", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputSmallInt", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
-    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputTinyInt", NoisySumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputShortDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputLongDecimal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputDouble", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle REAL_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputReal", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle BIGINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputBigInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle INTEGER_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputInteger", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle SMALLINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputSmallInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
+    private static final MethodHandle TINYINT_INPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "inputTinyInt", NoisyCountAndSumState.class, Block.class, Block.class, Block.class, Block.class, int.class);
 
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "output", NoisySumState.class, BlockBuilder.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "output", NoisyCountAndSumState.class, BlockBuilder.class);
 
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "combine", NoisySumState.class, NoisySumState.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(NoisySumGaussianClippingAggregation.class, "combine", NoisyCountAndSumState.class, NoisyCountAndSumState.class);
 
     public NoisySumGaussianClippingAggregation()
     {
@@ -118,8 +118,8 @@ public class NoisySumGaussianClippingAggregation
     {
         DynamicClassLoader classLoader = new DynamicClassLoader(NoisySumGaussianClippingAggregation.class.getClassLoader());
 
-        AccumulatorStateSerializer<?> stateSerializer = new NoisySumStateSerializer();
-        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisySumState.class, classLoader);
+        AccumulatorStateSerializer<?> stateSerializer = new NoisyCountAndSumStateSerializer();
+        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(NoisyCountAndSumState.class, classLoader);
         List<Type> inputTypes = ImmutableList.of(type, DOUBLE, DOUBLE, DOUBLE);
 
         MethodHandle inputFunction;
@@ -152,7 +152,7 @@ public class NoisySumGaussianClippingAggregation
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 ImmutableList.of(new AccumulatorStateDescriptor(
-                        NoisySumState.class,
+                        NoisyCountAndSumState.class,
                         stateSerializer,
                         stateFactory)),
                 DOUBLE);
@@ -182,7 +182,7 @@ public class NoisySumGaussianClippingAggregation
                 new ParameterMetadata(BLOCK_INDEX));
     }
 
-    public static void inputShortDecimal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputShortDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(SHORT_DECIMAL_TYPE.getLong(valueBlock, position)))
@@ -190,7 +190,7 @@ public class NoisySumGaussianClippingAggregation
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputLongDecimal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputLongDecimal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = unscaledDecimalToBigInteger(
                 unscaledDecimal(LONG_DECIMAL_TYPE.getSlice(valueBlock, position)))
@@ -198,58 +198,58 @@ public class NoisySumGaussianClippingAggregation
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputDouble(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputDouble(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = DOUBLE.getDouble(valueBlock, position);
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputReal(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputReal(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = intBitsToFloat((int) REAL.getLong(valueBlock, position));
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputBigInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputBigInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = BIGINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputInteger(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputInteger(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = INTEGER.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputSmallInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputSmallInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = SMALLINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    public static void inputTinyInt(NoisySumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    public static void inputTinyInt(NoisyCountAndSumState state, Block valueBlock, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double value = TINYINT.getLong(valueBlock, position);
         input(state, value, noiseScaleBlock, lowerBlock, upperBlock, position);
     }
 
-    private static void input(NoisySumState state, double value, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
+    private static void input(NoisyCountAndSumState state, double value, Block noiseScaleBlock, Block lowerBlock, Block upperBlock, int position)
     {
         double noiseScale = DOUBLE.getDouble(noiseScaleBlock, position);
         double lower = DOUBLE.getDouble(lowerBlock, position);
         double upper = DOUBLE.getDouble(upperBlock, position);
 
-        updateNoisySumState(state, value, noiseScale, lower, upper, null);
+        updateState(state, value, noiseScale, lower, upper, null);
     }
 
-    public static void combine(NoisySumState state, NoisySumState otherState)
+    public static void combine(NoisyCountAndSumState state, NoisyCountAndSumState otherState)
     {
-        combineNoisySumStates(state, otherState);
+        combineStates(state, otherState);
     }
 
-    public static void output(NoisySumState state, BlockBuilder out)
+    public static void output(NoisyCountAndSumState state, BlockBuilder out)
     {
-        writeNoisySumStateOutput(state, out);
+        writeNoisySumOutput(state, out);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAggregationUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAggregationUtils.java
@@ -24,10 +24,18 @@ import static com.facebook.presto.common.type.Decimals.MAX_PRECISION;
 
 public class TestNoisyAggregationUtils
 {
-    public static BiFunction<Object, Object, Boolean> notEqualDoubleAssertion = (actual, expected) -> !new Double(actual.toString()).equals(new Double(expected.toString()));
+    public static final BiFunction<Object, Object, Boolean> notEqualDoubleAssertion = (actual, expected) -> !new Double(actual.toString()).equals(new Double(expected.toString()));
 
     public static final BiFunction<Object, Object, Boolean> equalDoubleAssertion =
             (actual, expected) -> Math.abs(new Double(actual.toString()) - new Double(expected.toString())) <= 1e-12;
+
+    public static final double DEFAULT_TEST_STANDARD_DEVIATION = 1.0;
+
+    public static final BiFunction<Object, Object, Boolean> withinSomeStdAssertion = (actual, expected) -> {
+        double actualValue = new Double(actual.toString());
+        double expectedValue = new Double(expected.toString());
+        return expectedValue - 50 * DEFAULT_TEST_STANDARD_DEVIATION <= actualValue && actualValue <= expectedValue + 50 * DEFAULT_TEST_STANDARD_DEVIATION;
+    };
 
     private TestNoisyAggregationUtils()
     {
@@ -160,9 +168,29 @@ public class TestNoisyAggregationUtils
         return values.stream().mapToDouble(f -> f == null ? 0 : f).sum();
     }
 
-    public static long sumLong(List<Long> values)
+    public static double sumLong(List<Long> values)
     {
         return values.stream().mapToLong(v -> v == null ? 0 : v).sum();
+    }
+
+    public static double avg(List<Double> values)
+    {
+        return sum(values) / countNonNull(values);
+    }
+
+    public static double avgLong(List<Long> values)
+    {
+        return sumLong(values) / countNonNullLong(values);
+    }
+
+    public static double countNonNull(List<Double> values)
+    {
+        return values.stream().mapToLong(f -> f == null ? 0 : 1).sum();
+    }
+
+    public static long countNonNullLong(List<Long> values)
+    {
+        return values.stream().mapToLong(v -> v == null ? 0 : 1).sum();
     }
 
     public static List<String> toNullableStringList(List<Long> values)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianDoubleAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianDoubleAggregation.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.DEFAULT_TEST_STANDARD_DEVIATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.avg;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildData;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.createTestValues;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.equalDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.notEqualDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.withinSomeStdAssertion;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyAvgGaussianDoubleAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_avg_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    @Test
+    public void testNoisyAvgGaussianDoubleDefinitions()
+    {
+        getFunction(DOUBLE, DOUBLE); // (col, noiseScale)
+        getFunction(DOUBLE, DOUBLE, BIGINT); // (col, noiseScale, randomSeed)
+        getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE); // (col, noiseScale, lower, upper)
+        getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE, BIGINT); // (col, noiseScale, lower, upper, randomSeed)
+    }
+
+    // Test DOUBLE noiseScale < 0
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianDoubleInvalidNoiseScale()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale) with noiseScale < 0 which means errors",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(-123.0, numRows)),
+                expected);
+    }
+
+    // Test DOUBLE noiseScale == 0
+    @Test
+    public void testNoisyAvgGaussianDoubleZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale) with noiseScale=0 which means no noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale) with noiseScale=0 and 1 null row which means no noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    // Test DOUBLE noiseScale > 0
+    @Test
+    public void testNoisyAvgGaussianDoubleSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale) with noiseScale > 0 which means some noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE);
+
+        int numRows = 1000;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale) within some std from mean",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    // Test DOUBLE vs. normal AVG
+    @Test
+    public void testNoisyAvgGaussianDoubleNoiseScaleVsNormalAvg()
+    {
+        // Test DOUBLE AVG(col) producing the same values
+
+        int numRows = 10;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DOUBLE);
+        String query1 = String.format("SELECT AVG(%s) FROM %s", columnName, data);
+        String query2 = String.format("SELECT %s(%s, %f) FROM %s", FUNCTION_NAME, columnName, 0.0, data);
+
+        List<MaterializedRow> actualRows = runQuery(query1);
+        double result1 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        actualRows = runQuery(query2);
+        double result2 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        assertEquals(result2, result1);
+    }
+
+    // Test DOUBLE with clipping
+    @Test
+    public void testNoisyAvgGaussianDoubleClippingZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.7; // first value 0 is clipped to 2
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianDoubleClippingInvalidBound()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = -8.0;
+        double expected = 4.5;
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper) with clipping lower > upper ",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleClippingZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5; // 45 / 9
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping, with null values",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleClippingSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5; // 45 / 9
+        assertAggregation(
+                function,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper) with noiseScale > 0 which means some noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleClippingSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                function,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper) within some std from mean",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    // Test DOUBLE with clipping and randomSeed
+    @Test
+    public void testNoisyAvgGaussianDoubleClippingRandomSeed()
+    {
+        // Test DOUBLE with clipping
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = 5.0;
+        double expected = 3.8 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, lower, upper, randomSeed)",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    // Test DOUBLE with randomSeed
+    @Test
+    public void testNoisyAvgGaussianDoubleZeroNoiseScaleZeroRandomSeed()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double expected = avg(values);
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleSomeNoiseScaleFixedRandomSeed()
+    {
+        JavaAggregationFunctionImplementation function = getFunction(DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        assertAggregation(
+                function,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createDoublesBlock(values),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(10, numRows)),
+                15.496146759754); // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+    }
+
+    // Test DOUBLE 0-row input returns NULL
+    @Test
+    public void testNoisyAvgGaussianDoubleNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DOUBLE);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyAvgGaussianDoubleNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DOUBLE);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianLongDecimalAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianLongDecimalAggregation.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.Decimals.MAX_PRECISION;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.DEFAULT_TEST_STANDARD_DEVIATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.avgLong;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildData;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.createTestValues;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.equalDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.notEqualDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.toNullableStringList;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.withinSomeStdAssertion;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyAvgGaussianLongDecimalAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_avg_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_PRECISION, 0);
+
+    @Test
+    public void testNoisyAvgGaussianDecimalDefinitions()
+    {
+        getFunction(LONG_DECIMAL_TYPE, DOUBLE); // (col, noiseScale)
+        getFunction(LONG_DECIMAL_TYPE, DOUBLE, BIGINT); // (col, noiseScale, randomSeed)
+        getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE); // (col, noiseScale, lower, upper)
+        getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE, BIGINT); // (col, noiseScale, lower, upper, randomSeed)
+    }
+
+    // Test LONG DECIMAL noiseScale < 0
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianLongDecimalInvalidNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale) with noiseScale < 0 which means errors",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(-123.0, numRows)),
+                expected);
+    }
+
+    // Test LONG DECIMAL noiseScale == 0
+    @Test
+    public void testNoisyAvgGaussianLongDecimalZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale) with noiseScale=0 which means no noise",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale) with noiseScale=0 and 1 null row which means no noise",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    // Test LONG DECIMAL noiseScale > 0
+    @Test
+    public void testNoisyAvgGaussianLongDecimalSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale) with noiseScale > 0 which means some noise",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 1000;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale) within some std from mean",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    // Test LONG DECIMAL vs.normal AVG
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoiseScaleVsNormalAvg()
+    {
+        // Test Avg(col) producing the same values
+
+        int numRows = 10;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query1 = String.format("SELECT AVG(%s) FROM %s", columnName, data);
+        String query2 = String.format("SELECT %s(%s, %f) FROM %s", FUNCTION_NAME, columnName, 0.0, data);
+
+        List<MaterializedRow> actualRows = runQuery(query1);
+        double result1 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        actualRows = runQuery(query2);
+        double result2 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        assertEquals(result2, result1);
+    }
+
+    // Test LONG DECIMAL with clipping
+    @Test
+    public void testNoisyAvgGaussianLongDecimalClippingZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.7;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianLongDecimalClippingInvalidBound()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = -8.0;
+        double expected = 4.5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper) with clipping lower > upper ",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalClippingZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping, with null values",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalClippingSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.5;
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper) with noiseScale > 0 which means some noise",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalClippingSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.5;
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper) within some std from mean",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    // Test LONG DECIMAL clipping with random seed
+    @Test
+    public void testNoisyAvgGaussianLongDecimalClippingRandomSeed()
+    {
+        // Test with clipping
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = 5.0;
+        double expected = 3.8 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, lower, upper, randomSeed) that needs to fix sign",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    // Test 0-row input returns NULL
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    // Test LONG DECIMAL with randomSeed
+    @Test
+    public void testNoisyAvgGaussianLongDecimalZeroNoiseScaleZeroRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalSomeNoiseScaleFixedRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(LONG_DECIMAL_TYPE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double expected = 5 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(long decimal, noiseScale, randomSeed) with noiseScale=0 which means no noise and a random seed",
+                new Page(
+                        createLongDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianRealAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianRealAggregation.java
@@ -1,0 +1,413 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.block.BlockAssertions.createBlockOfReals;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.DEFAULT_TEST_STANDARD_DEVIATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.avg;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildData;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.createTestValues;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.equalDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.notEqualDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.withinSomeStdAssertion;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyAvgGaussianRealAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_avg_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    @Test
+    public void testNoisyAvgGaussianRealDefinitions()
+    {
+        getFunction(REAL, DOUBLE); // (col, noiseScale)
+        getFunction(REAL, DOUBLE, BIGINT); // (col, noiseScale, randomSeed)
+        getFunction(REAL, DOUBLE, DOUBLE, DOUBLE); // (col, noiseScale, lower, upper)
+        getFunction(REAL, DOUBLE, DOUBLE, DOUBLE, BIGINT); // (col, noiseScale, lower, upper, randomSeed)
+    }
+
+    // Test REAL noiseScale < 0
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianRealInvalidNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale) with noiseScale < 0 which means errors",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(-123.0, numRows)),
+                expected);
+    }
+
+    // Test REAL type, noiseScale == 0
+    @Test
+    public void testNoisyAvgGaussianRealZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale) with noiseScale=0 which means no noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale) with noiseScale=0 and 1 null row which means no noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    // Test REAL noiseScale > 0
+    @Test
+    public void testNoisyAvgGaussianRealSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale) with noiseScale > 0 which means some noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE);
+
+        int numRows = 1000;
+        List<Double> values = createTestValues(numRows, false, 1.0, true);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale) within some std from mean",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    // Test REAL vs. normal Avg
+    @Test
+    public void testNoisyAvgGaussianRealNoiseScaleVsNormalAvg()
+    {
+        // Test AVG(col) producing the same values
+
+        int numRows = 10;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.REAL);
+        String query1 = String.format("SELECT AVG(%s) FROM %s", columnName, data);
+        String query2 = String.format("SELECT %s(%s, %f) FROM %s", FUNCTION_NAME, columnName, 0.0, data);
+
+        List<MaterializedRow> actualRows = runQuery(query1);
+        double result1 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        actualRows = runQuery(query2);
+        double result2 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        assertEquals(result2, result1);
+    }
+
+    // Test REAL with clipping
+    @Test
+    public void testNoisyAvgGaussianRealClippingZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.7;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianRealClippingInvalidBound()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = -8.0;
+        double expected = 4.5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper) with clipping lower > upper ",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealClippingZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping, with null values",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealClippingSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper) with noiseScale > 0 which means some noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealClippingSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper) within some std from mean",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    // Test REAL with clipping and randomSeed
+    @Test
+    public void testNoisyAvgGaussianRealClippingRandomSeed()
+    {
+        // Test with clipping
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, false, 1.0, false);
+        double lower = 2.0;
+        double upper = 5.0;
+        double expected = 3.8 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, lower, upper, randomSeed)",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    // Test REAL with randomSeed
+    @Test
+    public void testNoisyAvgGaussianRealZeroNoiseScaleZeroRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double expected = avg(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(double, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealSomeNoiseScaleFixedRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(REAL, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Double> values = createTestValues(numRows, true, 1.0, false);
+        double expected = 5 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(real, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createBlockOfReals(doubleListToFloatList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    // Test REAL 0-row input returns NULL
+    @Test
+    public void testNoisyAvgGaussianRealNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.REAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyAvgGaussianRealNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.REAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private List<Float> doubleListToFloatList(List<Double> values)
+    {
+        return values.stream().map(f -> f == null ? null : f.floatValue()).collect(Collectors.toList());
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianShortDecimalAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyAvgGaussianShortDecimalAggregation.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createShortDecimalsBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.Decimals.MAX_SHORT_PRECISION;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.DEFAULT_TEST_STANDARD_DEVIATION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.avgLong;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildColumnName;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.buildData;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.createTestValues;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.equalDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.notEqualDoubleAssertion;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.toNullableStringList;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.TestNoisyAggregationUtils.withinSomeStdAssertion;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestNoisyAvgGaussianShortDecimalAggregation
+        extends AbstractTestFunctions
+{
+    private static final String FUNCTION_NAME = "noisy_avg_gaussian";
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
+    private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION, 0);
+
+    @Test
+    public void testNoisyAvgGaussianDecimalDefinitions()
+    {
+        getFunction(SHORT_DECIMAL_TYPE, DOUBLE); // (col, noiseScale)
+        getFunction(SHORT_DECIMAL_TYPE, DOUBLE, BIGINT); // (col, noiseScale, randomSeed)
+        getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE); // (col, noiseScale, lower, upper)
+        getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE, BIGINT); // (col, noiseScale, lower, upper, randomSeed)
+    }
+
+    // Test SHORT DECIMAL noiseScale < 0
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianShortDecimalInvalidNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale) with noiseScale < 0 which means errors",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(-123.0, numRows)),
+                expected);
+    }
+
+    // Test SHORT DECIMAL noiseScale == 0
+    @Test
+    public void testNoisyAvgGaussianShortDecimalZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale) with noiseScale=0 which means no noise",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale) with noiseScale=0 and 1 null row which means no noise",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows)),
+                expected);
+    }
+
+    // Test SHORT DECIMAL noiseScale > 0
+    @Test
+    public void testNoisyAvgGaussianShortDecimalSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale) with noiseScale > 0 which means some noise",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE);
+
+        int numRows = 1000;
+        List<Long> values = createTestValues(numRows, false, 1L, true);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale) within some std from mean",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows)),
+                expected);
+    }
+
+    // Test LONG DECIMAL vs. normal Avg
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoiseScaleVsNormalAvg()
+    {
+        // Test AVG(col) producing the same values
+
+        int numRows = 10;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query1 = String.format("SELECT AVG(%s) FROM %s", columnName, data);
+        String query2 = String.format("SELECT %s(%s, %f) FROM %s", FUNCTION_NAME, columnName, 0.0, data);
+
+        List<MaterializedRow> actualRows = runQuery(query1);
+        double result1 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        actualRows = runQuery(query2);
+        double result2 = Double.parseDouble(actualRows.get(0).getField(0).toString());
+
+        assertEquals(result2, result1);
+    }
+
+    // Test SHORT DECIMAL with clipping
+    @Test
+    public void testNoisyAvgGaussianShortDecimalClippingZeroNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 4.7;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNoisyAvgGaussianShortDecimalClippingInvalidBound()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = -8.0;
+        double expected = 4.5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper) with clipping lower > upper ",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalClippingZeroNoiseScaleWithNull()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper) with noiseScale=0 which means no noise, and clipping, with null values",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalClippingSomeNoiseScale()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                notEqualDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper) with noiseScale > 0 which means some noise",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalClippingSomeNoiseScaleWithinSomeStd()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double lower = 2.0;
+        double upper = 8.0;
+        double expected = 5;
+        assertAggregation(
+                noisyAvgGaussian,
+                withinSomeStdAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper) within some std from mean",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(DEFAULT_TEST_STANDARD_DEVIATION, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows)),
+                expected);
+    }
+
+    // Test Short decimal clipping with random seed
+    @Test
+    public void testNoisyAvgGaussianShortDecimalClippingRandomSeed()
+    {
+        // Test with clipping
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, DOUBLE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, false, 1L, false);
+        double lower = 2.0;
+        double upper = 5.0;
+        double expected = 3.8 + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, lower, upper, randomSeed)",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(lower, numRows),
+                        createRLEBlock(upper, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    // Test 0-row input returns NULL
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoInputRowsWithoutGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false";
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 1);
+        assertNull(actualRows.get(0).getField(0));
+    }
+
+    @Test
+    public void testNoisyAvgGaussianLongDecimalNoInputRowsWithGroupBy()
+    {
+        int numRows = 100;
+        String data = buildData(numRows, true, Arrays.asList(
+                StandardTypes.BIGINT,
+                StandardTypes.DOUBLE,
+                StandardTypes.REAL,
+                StandardTypes.DECIMAL));
+        String columnName = buildColumnName(StandardTypes.DECIMAL);
+        String query = "SELECT " + FUNCTION_NAME + "(" + columnName + ", 0) + 1 FROM " + data
+                + " WHERE false GROUP BY " + columnName;
+
+        List<MaterializedRow> actualRows = runQuery(query);
+        assertEquals(actualRows.size(), 0);
+    }
+
+    // Test SHORT DECIMAL with randomSeed
+    @Test
+    public void testNoisyAvgGaussianShortDecimalZeroNoiseScaleZeroRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double expected = avgLong(values);
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, randomSeed) with noiseScale=0 which means no noise",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(0.0, numRows),
+                        createRLEBlock(0, numRows)),
+                expected);
+    }
+
+    @Test
+    public void testNoisyAvgGaussianShortDecimalSomeNoiseScaleFixedRandomSeed()
+    {
+        JavaAggregationFunctionImplementation noisyAvgGaussian = getFunction(SHORT_DECIMAL_TYPE, DOUBLE, BIGINT);
+
+        int numRows = 10;
+        List<Long> values = createTestValues(numRows, true, 1L, false);
+        double expected = avgLong(values) + 10.4961467597545; // 10.4961467597545 is from noiseScale=12 and randomSeed=10
+        assertAggregation(
+                noisyAvgGaussian,
+                equalDoubleAssertion,
+                "Test noisy_avg_gaussian(short decimal, noiseScale, randomSeed) with noiseScale=0 which means no noise and a random seed",
+                new Page(
+                        createShortDecimalsBlock(toNullableStringList(values)),
+                        createRLEBlock(12.0, numRows),
+                        createRLEBlock(10, numRows)),
+                expected);
+    }
+
+    private List<MaterializedRow> runQuery(String query)
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(session);
+
+        MaterializedResult actualResults = runner.execute(query).toTestTypes();
+        return actualResults.getMaterializedRows();
+    }
+
+    private JavaAggregationFunctionImplementation getFunction(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                FUNCTION_AND_TYPE_MANAGER.lookupFunction(FUNCTION_NAME, fromTypes(arguments)));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestNoisyAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestNoisyAggregations.java
@@ -32,6 +32,17 @@ public class TestNoisyAggregations
         return TpchQueryRunnerBuilder.builder().build();
     }
 
+    // There is a type issue with the default expectedQueryRunner H2QueryRunner
+    // doing averages as ints instead of floats,
+    // e.g., it returns 3.0 for `SELECT avg(linenumber) FROM lineitem` which should be 3.004270876609888
+    // This override is to make sure that both queryRunner and expectedQueryRunner are the same type of query runner.
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder().build();
+    }
+
     @Test
     public void testNoisyCountGaussianZeroNoiseScaleVsNormalCount()
     {
@@ -70,6 +81,24 @@ public class TestNoisyAggregations
         assertQueryWithSingleDoubleRow("SELECT noisy_sum_gaussian(linenumber, 0, 10) FROM lineitem", "SELECT sum(linenumber) FROM lineitem"); // BIGINT
         assertQueryWithSingleDoubleRow("SELECT noisy_sum_gaussian(quantity, 0, 10) FROM lineitem", "SELECT sum(quantity) FROM lineitem"); // DOUBLE
         assertQueryWithSingleDoubleRow("SELECT noisy_sum_gaussian(nationkey, 0, 10) FROM nation", "SELECT sum(nationkey) FROM nation"); // INTEGER
+    }
+
+    @Test
+    public void testNoisyAvgGaussianZeroNoiseScaleVsNormalAvg()
+    {
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(1, 0) FROM lineitem", "SELECT avg(1) FROM lineitem");
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(linenumber, 0) FROM lineitem", "SELECT avg(linenumber) FROM lineitem"); // BIGINT
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(quantity, 0) FROM lineitem", "SELECT avg(quantity) FROM lineitem"); // DOUBLE
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(nationkey, 0) FROM nation", "SELECT avg(nationkey) FROM nation"); // INTEGER
+    }
+
+    @Test
+    public void testNoisyAvgGaussianZeroNoiseScaleRandomSeedVsNormalCount()
+    {
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(1, 0, 10) FROM lineitem", "SELECT avg(1) FROM lineitem");
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(linenumber, 0, 10) FROM lineitem", "SELECT avg(linenumber) FROM lineitem"); // BIGINT
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(quantity, 0, 10) FROM lineitem", "SELECT avg(quantity) FROM lineitem"); // DOUBLE
+        assertQueryWithSingleDoubleRow("SELECT noisy_avg_gaussian(nationkey, 0, 10) FROM nation", "SELECT avg(nationkey) FROM nation"); // INTEGER
     }
 
     private void assertQueryWithSingleDoubleRow(@Language("SQL") String actual, @Language("SQL") String expected)


### PR DESCRIPTION
## Description
This commit adds `noisy_avg_gaussian` aggregation. It can be used to replace `avg(col)` with `noisy_avg_gaussian(col, noiseScale[, lower, upper][, randomSeed])`. 
This is a continuation of the previous PR(s) supporting `noisy_count_gaussian` and `noisy_sum_gaussian`.

`col` can be of numerical types: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, DECIMAL.

Because noise is of type `double`, all values are converted to `double` before being added to the sum which is used to compute the avg, and the return type is `double`.

When a bound [lower, upper] is provided, each value is clipped to this range before being added to the sum, which is used to compute the avg.

Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes. If randomSeed is omitted, SecureRandom is used. If randomSeed is provided, Random is used.

## Motivation and Context
This is one of aggregations in our effort to add Presto UDF for noisy aggregations, used as building block for differential privacy in Presto.

The purpose is to help build systems/tools/framework that provide differential privacy guarantees. Differential privacy has been used by multiple teams within Meta to develop privacy-preserving systems. Current implementation involves complicated SQL operation even for simplest aggregations, increasing development time, complexity, maintenance and sharing cost, and sometimes completely blocking development of new features.

While these functions on their own do not guarantee 100% differential privacy, they are the building blocks for other systems. That is also why we do not call these functions “differentially private aggregations” but only “noisy aggregations” to avoid a wrong impression of achieving differential privacy solely by using these functions.

## Impact
This commit adds `noisy_avg_gaussian(col, noiseScale[, lower, upper][, randomSeed])` aggregation which calculates the average (arithmetic mean) of all the input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true avg. This also provides options to clip values to a range `[lower, upper]` and a random seed for reproducibility.

## Test Plan
- Unittest: Tested all of `noisy_avg_gaussian(col, noiseScale)`, `noisy_avg_gaussian(col, noiseScale, randomSeed)`, `noisy_avg_gaussian(col, noiseScale, lower, upper)`, `noisy_avg_gaussian(col, noiseScale, lower, upper randomSeed)`:
  - Available for all standard numerical data types: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, DECIMAL.
  - All following tests are for BIGINT, REAL, DOUBLE, DECIMAL types, while TINYINT, SMALLINT, INTEGER were only tested if such type can be processed because it is equivalent to BIGINT input
    - Tested with noiseScale < 0, noiseScale = 0, noiseScale = fixed value, with some noiseScale the output is within 50 x noiseScale
    - Tested with NULL rows
    - Tested with valid and invalid clipping bounds
    - Tested with random seed
    - Run local queries to test its output compared to `avg(col)`, and tested when input has 0 rows, with and without GROUP BY
  - Tested on tpch schema for `noisy_avg_gaussian(col, noiseScale)`, `noisy_avg_gaussian(col, noiseScale, randomSeed)` compared to normal AVG:
    - Clipping was not tested because normal AVG does not offer clipping
    - Only tested INTEGER, BIGINT, DOUBLE. Other types couldn't be found in the schema

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* Adds `noisy_avg_gaussian(col, noiseScale[, lower, upper][, randomSeed])` aggregation 
  which calculates the average (arithmetic mean) of all over the input values, 
  and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true avg. 
  This also provides options to clip values to a range `[lower, upper]` and a random seed for reproducibility.
  All values are converted to `double` before being added to the sum, which which is used to compute the avg, and the return type is `double`. 
  When there are no input rows, this function returns ``NULL``.
  When generating noise, if randomSeed is omitted, SecureRandom is used; otherwise, Random is used.