### PR TITLE
[native] Add a function to schedule task once in PeriodicTaskManager.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -68,6 +68,14 @@ class PeriodicTaskManager {
         func, std::chrono::microseconds{periodMicros}, taskName);
   }
 
+  /// Add a task to run once.
+  template <typename TFunc>
+  void
+  addTaskOnce(TFunc&& func, size_t periodMicros, const std::string& taskName) {
+    scheduler_.addFunctionOnce(
+        func, taskName, std::chrono::microseconds{periodMicros});
+  }
+
   /// Stops all periodic tasks. Returns only when everything is stopped.
   void stop();
 


### PR DESCRIPTION
Exposing `addFunctionOnce` so that we can pass tasks that can run only once.