### PR TITLE
Add function names to ColumnStatisticType

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -3300,7 +3300,7 @@ public class HiveMetadata
     private List<ColumnStatisticMetadata> getColumnStatisticMetadata(String columnName, Set<ColumnStatisticType> statisticTypes)
     {
         return statisticTypes.stream()
-                .map(type -> new ColumnStatisticMetadata(columnName, type))
+                .map(type -> type.getColumnStatisticMetadata(columnName))
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
@@ -14,15 +14,13 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.operator.aggregation.MaxDataSizeForStats;
-import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.relation.CallExpression;
-import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
@@ -41,7 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.google.common.base.Verify.verify;
@@ -99,7 +97,7 @@ public class StatisticsAggregationPlanner
             ColumnStatisticType statisticType = columnStatisticMetadata.getStatisticType();
             VariableReferenceExpression inputVariable = columnToVariableMap.get(columnName);
             verify(inputVariable != null, "inputVariable is null");
-            ColumnStatisticsAggregation aggregation = createColumnAggregation(statisticType, inputVariable);
+            ColumnStatisticsAggregation aggregation = createColumnAggregation(columnStatisticMetadata, inputVariable);
             VariableReferenceExpression variable = variableAllocator.newVariable(statisticType + ":" + columnName, aggregation.getOutputType());
             aggregations.put(variable, aggregation.getAggregation());
             descriptor.addColumnStatistic(columnStatisticMetadata, variable);
@@ -109,38 +107,18 @@ public class StatisticsAggregationPlanner
         return new TableStatisticAggregation(aggregation, descriptor.build());
     }
 
-    private ColumnStatisticsAggregation createColumnAggregation(ColumnStatisticType statisticType, VariableReferenceExpression input)
+    private ColumnStatisticsAggregation createColumnAggregation(ColumnStatisticMetadata columnStatisticMetadata, VariableReferenceExpression input)
     {
-        switch (statisticType) {
-            case MIN_VALUE:
-                return createAggregation("min", input, input.getType(), input.getType());
-            case MAX_VALUE:
-                return createAggregation("max", input, input.getType(), input.getType());
-            case NUMBER_OF_DISTINCT_VALUES:
-                return createAggregation("approx_distinct", input, input.getType(), BIGINT);
-            case NUMBER_OF_NON_NULL_VALUES:
-                return createAggregation("count", input, input.getType(), BIGINT);
-            case NUMBER_OF_TRUE_VALUES:
-                return createAggregation("count_if", input, BOOLEAN, BIGINT);
-            case TOTAL_SIZE_IN_BYTES:
-                return createAggregation(SumDataSizeForStats.NAME, input, input.getType(), BIGINT);
-            case MAX_VALUE_SIZE_IN_BYTES:
-                return createAggregation(MaxDataSizeForStats.NAME, input, input.getType(), BIGINT);
-            default:
-                throw new IllegalArgumentException("Unsupported statistic type: " + statisticType);
-        }
-    }
-
-    private ColumnStatisticsAggregation createAggregation(String functionName, RowExpression input, Type inputType, Type outputType)
-    {
-        FunctionHandle functionHandle = functionAndTypeResolver.lookupFunction(functionName, TypeSignatureProvider.fromTypes(ImmutableList.of(inputType)));
-        Type resolvedType = functionAndTypeResolver.getType(getOnlyElement(functionAndTypeResolver.getFunctionMetadata(functionHandle).getArgumentTypes()));
-        verify(resolvedType.equals(inputType), "resolved function input type does not match the input type: %s != %s", resolvedType, inputType);
+        FunctionHandle functionHandle = functionAndTypeResolver.lookupFunction(columnStatisticMetadata.getFunctionName(), TypeSignatureProvider.fromTypes(ImmutableList.of(input.getType())));
+        FunctionMetadata functionMeta = functionAndTypeResolver.getFunctionMetadata(functionHandle);
+        Type inputType = functionAndTypeResolver.getType(getOnlyElement(functionMeta.getArgumentTypes()));
+        Type outputType = functionAndTypeResolver.getType(functionMeta.getReturnType());
+        verify(inputType.equals(input.getType()) || input.getType().equals(UNKNOWN), "resolved function input type does not match the input type: %s != %s", inputType, input.getType());
         return new ColumnStatisticsAggregation(
                 new AggregationNode.Aggregation(
                         new CallExpression(
                                 input.getSourceLocation(),
-                                functionName,
+                                columnStatisticMetadata.getFunctionName(),
                                 functionHandle,
                                 outputType,
                                 ImmutableList.of(input)),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
@@ -173,7 +173,7 @@ public class StatisticAggregationsDescriptor<T>
         @VisibleForTesting
         static String serialize(ColumnStatisticMetadata value)
         {
-            return value.getStatisticType().name() + ":" + value.getColumnName();
+            return value.getStatisticType().name() + ":" + value.getFunctionName() + ":" + value.getColumnName();
         }
     }
 
@@ -189,11 +189,9 @@ public class StatisticAggregationsDescriptor<T>
         @VisibleForTesting
         static ColumnStatisticMetadata deserialize(String value)
         {
-            int separatorIndex = value.indexOf(':');
-            checkArgument(separatorIndex >= 0, "separator not found: %s", value);
-            String statisticType = value.substring(0, separatorIndex);
-            String column = value.substring(separatorIndex + 1);
-            return new ColumnStatisticMetadata(column, ColumnStatisticType.valueOf(statisticType));
+            String[] values = value.split(":", 3);
+            checkArgument(values.length == 3, "separator(s) not found: %s", value);
+            return new ColumnStatisticMetadata(values[2], ColumnStatisticType.valueOf(values[0]), values[1]);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
@@ -101,7 +101,7 @@ public class TestTableFinishOperator
     {
         TestingTableFinisher tableFinisher = new TestingTableFinisher();
         TestingPageSinkCommitter pageSinkCommitter = new TestingPageSinkCommitter();
-        ColumnStatisticMetadata statisticMetadata = new ColumnStatisticMetadata("column", MAX_VALUE);
+        ColumnStatisticMetadata statisticMetadata = MAX_VALUE.getColumnStatisticMetadata("column");
         StatisticAggregationsDescriptor<Integer> descriptor = new StatisticAggregationsDescriptor<>(
                 ImmutableMap.of(),
                 ImmutableMap.of(),
@@ -182,7 +182,7 @@ public class TestTableFinishOperator
     {
         TestingTableFinisher tableFinisher = new TestingTableFinisher();
         TestingPageSinkCommitter pageSinkCommitter = new TestingPageSinkCommitter();
-        ColumnStatisticMetadata statisticMetadata = new ColumnStatisticMetadata("column", MAX_VALUE);
+        ColumnStatisticMetadata statisticMetadata = MAX_VALUE.getColumnStatisticMetadata("column");
         StatisticAggregationsDescriptor<Integer> descriptor = new StatisticAggregationsDescriptor<>(
                 ImmutableMap.of(),
                 ImmutableMap.of(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticAggregationsDescriptor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticAggregationsDescriptor.java
@@ -31,7 +31,7 @@ public class TestStatisticAggregationsDescriptor
     {
         for (String column : COLUMNS) {
             for (ColumnStatisticType type : ColumnStatisticType.values()) {
-                ColumnStatisticMetadata expected = new ColumnStatisticMetadata(column, type);
+                ColumnStatisticMetadata expected = type.getColumnStatisticMetadata(column);
                 assertEquals(deserialize(serialize(expected)), expected);
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.testing.TestingHandleResolver;
@@ -92,7 +91,7 @@ public class TestStatisticsWriterNode
         VariableAllocator variableAllocator = new VariableAllocator();
         for (String column : COLUMNS) {
             for (ColumnStatisticType type : ColumnStatisticType.values()) {
-                builder.addColumnStatistic(new ColumnStatisticMetadata(column, type), testVariable(variableAllocator));
+                builder.addColumnStatistic(type.getColumnStatisticMetadata(column), testVariable(variableAllocator));
             }
             builder.addGrouping(column, testVariable(variableAllocator));
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticMetadata.java
@@ -25,13 +25,17 @@ public class ColumnStatisticMetadata
     private final String columnName;
     private final ColumnStatisticType statisticType;
 
+    private final String functionName;
+
     @JsonCreator
     public ColumnStatisticMetadata(
             @JsonProperty("columnName") String columnName,
-            @JsonProperty("statisticType") ColumnStatisticType statisticType)
+            @JsonProperty("statisticType") ColumnStatisticType statisticType,
+            @JsonProperty("functionName") String functionName)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.statisticType = requireNonNull(statisticType, "statisticType is null");
+        this.functionName = requireNonNull(functionName, "functionName is null");
     }
 
     @JsonProperty
@@ -44,6 +48,12 @@ public class ColumnStatisticMetadata
     public ColumnStatisticType getStatisticType()
     {
         return statisticType;
+    }
+
+    @JsonProperty
+    public String getFunctionName()
+    {
+        return functionName;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
@@ -15,11 +15,32 @@ package com.facebook.presto.spi.statistics;
 
 public enum ColumnStatisticType
 {
-    MIN_VALUE,
-    MAX_VALUE,
-    NUMBER_OF_DISTINCT_VALUES,
-    NUMBER_OF_NON_NULL_VALUES,
-    NUMBER_OF_TRUE_VALUES,
-    MAX_VALUE_SIZE_IN_BYTES,
-    TOTAL_SIZE_IN_BYTES,
+    MAX_VALUE("max"),
+    MAX_VALUE_SIZE_IN_BYTES("max_data_size_for_stats"),
+    MIN_VALUE("min"),
+    NUMBER_OF_DISTINCT_VALUES("approx_distinct"),
+    NUMBER_OF_NON_NULL_VALUES("count"),
+    NUMBER_OF_TRUE_VALUES("count_if"),
+    TOTAL_SIZE_IN_BYTES("sum_data_size_for_stats");
+    private final String functionName;
+
+    public String getDefaultFunctionName()
+    {
+        return functionName;
+    }
+
+    ColumnStatisticType(String functionName)
+    {
+        this.functionName = functionName;
+    }
+
+    public ColumnStatisticMetadata getColumnStatisticMetadata(String columnName)
+    {
+        return new ColumnStatisticMetadata(columnName, this, this.functionName);
+    }
+
+    public ColumnStatisticMetadata getColumnStatisticMetadataWithCustomFunction(String columnName, String functionName)
+    {
+        return new ColumnStatisticMetadata(columnName, this, functionName);
+    }
 }


### PR DESCRIPTION
## Description

This change adds function name parameters to the enum values of ColumnStatisticType. The function names are used when generating ColumnStatisticMetadata for the ANALYZE query.

This change is in preparation to allow connectors to override the function used to execute the statistics aggregations. Mainly it is to support connectors that have differing underlying histogram or NDV representations. For example, Hive natively generates KLL sketches from Apache Datasketches for histograms, Spark has it's own custom format. Some other connectors like mysql use a JSON format. Iceberg tables can store NDV estimates in Apache DataSketches Theta sketches. If we intend to support a variety of stats from other connectors this change is necessary.

Allowing the connector to override the function for each statistic type will let us generate statistic data in the format needed by the connector in order to store it in the connector-specific catalog metadata.

## Motivation and Context

Eventual implementation of more column statistics

## Impact

No user facing impact

## Test Plan

No additional features need to be tested

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

