### PR TITLE
Clear HBO stats cache after the query completes when HBO write disabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -198,6 +198,7 @@ public class HistoryBasedPlanStatisticsTracker
     {
         Session session = queryInfo.getSession().toSession(sessionPropertyManager);
         if (!trackHistoryBasedPlanStatisticsEnabled(session)) {
+            historyBasedStatisticsCacheManager.invalidate(queryInfo.getQueryId());
             return;
         }
         Map<PlanNodeWithHash, PlanStatisticsWithSourceInfo> planStatistics = getQueryStats(queryInfo);


### PR DESCRIPTION
## Description
As title, we failed to invalidate cache when `track_history_based_plan_statistics` is false.

## Motivation and Context
Bug fix, we should always invalidate a cache when the query completes

## Impact
Bug fix

## Test Plan
Easy change

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

