### PR TITLE
[native]Add spilling memory usage monitoring and logs improvement

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -554,6 +554,8 @@ void PrestoServer::initializeVeloxMemory() {
   memory::MemoryManagerOptions options;
   options.capacity = memoryBytes;
   options.checkUsageLeak = systemConfig->enableMemoryLeakCheck();
+  options.trackDefaultUsage =
+      systemConfig->enableSystemMemoryPoolUsageTracking();
   if (!systemConfig->memoryArbitratorKind().empty()) {
     options.arbitratorKind = systemConfig->memoryArbitratorKind();
     const uint64_t queryMemoryGb = systemConfig->queryMemoryGb();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -484,10 +484,9 @@ uint64_t SystemConfig::memoryPoolTransferCapacity() const {
       .value_or(kMemoryPoolTransferCapacityDefault);
 }
 
-uint32_t SystemConfig::reservedMemoryPoolCapacityPct() const {
-  static constexpr uint64_t kReservedMemoryPoolCapacityPctDefault = 10;
-  return optionalProperty<uint32_t>(kReservedMemoryPoolCapacityPct)
-      .value_or(kReservedMemoryPoolCapacityPctDefault);
+bool SystemConfig::enableSystemMemoryPoolUsageTracking() const {
+  return optionalProperty<bool>(kEnableSystemMemoryPoolUsageTracking)
+      .value_or(true);
 }
 
 bool SystemConfig::enableHttpAccessLog() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -229,12 +229,10 @@ class SystemConfig : public ConfigBase {
   /// NOTE: this config only applies if the memory arbitration has been enabled.
   static constexpr std::string_view kMemoryPoolTransferCapacity{
       "memory-pool-transfer-capacity"};
-  /// The percentage of memory pool capacity reserved for system usage such as
-  /// the disk spilling memory usage.
-  ///
-  /// NOTE: this config only applies if the memory arbitration has been enabled.
-  static constexpr std::string_view kReservedMemoryPoolCapacityPct{
-      "reserved-memory-pool-capacity-pct"};
+  /// Enables the memory usage tracking for the system memory pool used for
+  /// cases such as disk spilling.
+  static constexpr std::string_view kEnableSystemMemoryPoolUsageTracking{
+      "enable_system_memory_pool_usage_tracking"};
   static constexpr std::string_view kEnableVeloxTaskLogging{
       "enable_velox_task_logging"};
   static constexpr std::string_view kEnableVeloxExprSetLogging{
@@ -426,7 +424,7 @@ class SystemConfig : public ConfigBase {
 
   uint64_t memoryPoolTransferCapacity() const;
 
-  uint32_t reservedMemoryPoolCapacityPct() const;
+  bool enableSystemMemoryPoolUsageTracking() const;
 
   bool enableHttpAccessLog() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -216,6 +216,14 @@ void registerPrestoCppCounters() {
       kCounterSpillFlushTimeUs, facebook::velox::StatType::SUM);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterSpillWriteTimeUs, facebook::velox::StatType::SUM);
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterSpillMemoryBytes, facebook::velox::StatType::AVG);
+  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
+      kCounterSpillPeakMemoryBytes,
+      1l * 512 * 1024 * 1024,
+      0,
+      20l * 1024 * 1024 * 1024, // max bucket value: 20GB
+      100);
   // Memory arbitrator stats.
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterArbitratorNumRequests, facebook::velox::StatType::SUM);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -196,6 +196,12 @@ constexpr folly::StringPiece kCounterSpillFlushTimeUs{
 /// The time spent on writing spilled rows to disk.
 constexpr folly::StringPiece kCounterSpillWriteTimeUs{
     "presto_cpp.spill_write_time_us"};
+/// The current spilling memory usage in bytes.
+constexpr folly::StringPiece kCounterSpillMemoryBytes{
+    "presto_cpp.spill_memory_bytes"};
+/// The peak spilling memory usage in bytes.
+constexpr folly::StringPiece kCounterSpillPeakMemoryBytes{
+    "presto_cpp.spill_peak_memory_bytes"};
 
 /// ================== Cache Counters ==================
 


### PR DESCRIPTION
Adds to track current and peak spilling memory usage
Also improve spilling and arbitration logs to include both delta
change and latest stats.

```
== NO RELEASE NOTE ==
```

