### PR TITLE
Avoid the last unnecessary loop when positionCount is an integer multiple of positionsInStep.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHash.java
@@ -78,7 +78,7 @@ public final class PagesHash
         long hashCollisionsLocal = 0;
         long positionIsNullCountLocal = 0;
 
-        for (int step = 0; step * positionsInStep <= positionCount; step++) {
+        for (int step = 0; step * positionsInStep < positionCount; step++) {
             int stepBeginPosition = step * positionsInStep;
             int stepEndPosition = Math.min((step + 1) * positionsInStep, positionCount);
             int stepSize = stepEndPosition - stepBeginPosition;


### PR DESCRIPTION

## Description

When positionCount happen to be an integer multiple of positionsInStep, current implementation  allow the last time loop to run, in which the stepSize's value is always 0. We can simply avoid this.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

