### PR TITLE
[native] Add remote function server end to end tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -120,6 +120,7 @@ jobs:
           root: presto-native-execution
           paths:
             - _build/debug/presto_cpp/main/presto_server
+            - _build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main
 
   linux-presto-e2e-tests:
     executor: build
@@ -136,6 +137,7 @@ jobs:
           name: 'Run presto-native e2e tests'
           command: |
             export PRESTO_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+            export REMOTE_FUNCTION_SERVER_PATH="${HOME}/project/presto-native-execution/_build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main"
             export TEMP_PATH="/tmp"
             TESTFILES=$(circleci tests glob "presto-native-execution/src/test/**/TestPrestoNative*.java" | circleci tests split --split-by=timings)
             # Convert file paths to comma separated class names
@@ -147,8 +149,22 @@ jobs:
               export TESTCLASSES="${TESTCLASSES},$test_class"
             done
             export TESTCLASSES=${TESTCLASSES#,}
+
+            # TODO: neeed to enable remote function tests with
+            # "-Ppresto-native-execution-remote-functions" once
+            # > https://github.com/facebookincubator/velox/discussions/6163
+            # is fixed.
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Ppresto-native-execution-remote-functions
+                -Dtest="${TESTCLASSES}" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DREMOTE_FUNCTION_SERVER=${REMOTE_FUNCTION_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-spark-e2e-tests:
@@ -177,7 +193,14 @@ jobs:
             done
             export TESTCLASSES=${TESTCLASSES#,}
             if [ ! -z $TESTCLASSES ]; then
-              mvn test ${MAVEN_TEST} -pl 'presto-native-execution' -Dtest="${TESTCLASSES}" -DPRESTO_SERVER=${PRESTO_SERVER_PATH} -DDATA_DIR=${TEMP_PATH} -Duser.timezone=America/Bahia_Banderas -T1C
+              mvn test \
+                ${MAVEN_TEST} \
+                -pl 'presto-native-execution' \
+                -Dtest="${TESTCLASSES}" \
+                -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+                -DDATA_DIR=${TEMP_PATH} \
+                -Duser.timezone=America/Bahia_Banderas \
+                -T1C
             fi
 
   linux-build-all:

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -192,6 +192,7 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <excludedGroups>remote-function</excludedGroups>
                     <systemPropertyVariables>
                         <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
                         <DATA_DIR>/tmp/velox</DATA_DIR>
@@ -200,4 +201,26 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>presto-native-execution-remote-functions</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups combine.self="override" />
+                            <groups>remote-function</groups>
+                            <systemPropertyVariables>
+                                <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
+                                <REMOTE_FUNCTION_SERVER>/root/project/build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main</REMOTE_FUNCTION_SERVER>
+                                <DATA_DIR>/tmp/velox</DATA_DIR>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_CATALOG_NAME;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_JSON_SIGNATURES;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.setupJsonFunctionNamespaceManager;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.startRemoteFunctionServer;
+import static java.util.Objects.requireNonNull;
+
+@Test(groups = "remote-function")
+public abstract class AbstractTestNativeRemoteFunctions
+        extends AbstractTestQueryFramework
+{
+    // The unix domain socket (UDS) path to communicate with the remote fuction server.
+    protected String remoteFunctionServerUds;
+
+    // The path to the compiled remote function server binary.
+    private String remoteFunctionServerBinaryPath;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        preInitQueryRunners();
+        super.init();
+        postInitQueryRunners();
+    }
+
+    protected void preInitQueryRunners()
+    {
+        // Initialize the remote function thrift server process.
+        String propertyName = "REMOTE_FUNCTION_SERVER";
+        remoteFunctionServerBinaryPath = System.getenv(propertyName);
+        if (remoteFunctionServerBinaryPath == null) {
+            remoteFunctionServerBinaryPath = System.getProperty(propertyName);
+        }
+
+        requireNonNull(remoteFunctionServerBinaryPath, "Remote function server path missing. Add -DREMOTE_FUNCTION_SERVER=<path/to/binary> to your JVM arguments.");
+        remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
+    }
+
+    protected void postInitQueryRunners()
+    {
+        // Install json function registration namespace manager.
+        setupJsonFunctionNamespaceManager(getQueryRunner(), REMOTE_FUNCTION_JSON_SIGNATURES, REMOTE_FUNCTION_CATALOG_NAME);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        // Create some tpch tables.
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+    }
+
+    @Test
+    public void testRemoteFunction()
+    {
+        assertQuery("SELECT remote.schema.ceil(linenumber) FROM lineitem", "SELECT ceil(linenumber) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount) FROM lineitem", "SELECT ceil(discount) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(discount * 7) FROM lineitem", "SELECT ceil(discount * 7) FROM lineitem");
+        assertQuery("SELECT remote.schema.ceil(ceil(discount)) FROM lineitem", "SELECT ceil(ceil(discount * 7)) FROM lineitem");
+
+        assertQuery("SELECT remote.schema.concat(returnflag, linestatus) FROM lineitem", "SELECT concat(returnflag, linestatus) FROM lineitem");
+        assertQuery("SELECT remote.schema.concat('asd', linestatus) FROM lineitem", "SELECT concat('asd', linestatus) FROM lineitem");
+
+        // TODO: `throwOnError` needs to be implemented in the server so we can have remote functions as function parameters.
+        // https://github.com/facebookincubator/velox/issues/5288
+        //
+        // "(?s)" enables DOTALL mode so that "." can match newlines.
+        assertQueryFails("SELECT remote.schema.ceil(remote.schema.ceil(discount)) FROM lineitem", "(?s).*Error.*");
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -39,7 +39,15 @@ import static org.testng.Assert.assertNotNull;
 
 public class PrestoNativeQueryRunnerUtils
 {
+    private static final Logger log = Logger.get(PrestoNativeQueryRunnerUtils.class);
+
     private static final String DEFAULT_STORAGE_FORMAT = "DWRF";
+
+    // The unix domain socket (UDS) used to communicate with the remote function server.
+    public static final String REMOTE_FUNCTION_UDS = "remote_function_server.socket";
+    public static final String REMOTE_FUNCTION_JSON_SIGNATURES = "remote_function_server.json";
+    public static final String REMOTE_FUNCTION_CATALOG_NAME = "remote";
+
     private PrestoNativeQueryRunnerUtils() {}
 
     public static QueryRunner createQueryRunner()
@@ -81,7 +89,7 @@ public class PrestoNativeQueryRunnerUtils
 
         defaultQueryRunner.close();
 
-        return createNativeQueryRunner(dataDirectory.get().toString(), prestoServerPath.get(), workerCount, cacheMaxSize, true, storageFormat);
+        return createNativeQueryRunner(dataDirectory.get().toString(), prestoServerPath.get(), workerCount, cacheMaxSize, true, Optional.empty(), storageFormat);
     }
 
     public static QueryRunner createJavaQueryRunner() throws Exception
@@ -133,6 +141,7 @@ public class PrestoNativeQueryRunnerUtils
             Optional<Integer> workerCount,
             int cacheMaxSize,
             boolean useThrift,
+            Optional<String> remoteFunctionServerUds,
             String storageFormat)
             throws Exception
     {
@@ -154,18 +163,25 @@ public class PrestoNativeQueryRunnerUtils
                 Optional.of((workerIndex, discoveryUri) -> {
                     try {
                         Path tempDirectoryPath = Files.createTempDirectory(PrestoNativeQueryRunnerUtils.class.getSimpleName());
-                        Logger log = Logger.get(PrestoNativeQueryRunnerUtils.class);
                         log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
                         int port = 1234 + workerIndex;
 
                         // Write config files
                         Files.write(tempDirectoryPath.resolve("velox.properties"), "".getBytes());
-                        Files.write(tempDirectoryPath.resolve("config.properties"),
-                                format("discovery.uri=%s%n" +
-                                        "presto.version=testversion%n" +
-                                        "http_exec_threads=8%n" +
-                                        "system-memory-gb=4%n" +
-                                        "http-server.http.port=%d", discoveryUri, port).getBytes());
+                        String configProperties = format("discovery.uri=%s%n" +
+                                "presto.version=testversion%n" +
+                                "http_exec_threads=8%n" +
+                                "system-memory-gb=4%n" +
+                                "http-server.http.port=%d", discoveryUri, port);
+
+                        if (remoteFunctionServerUds.isPresent()) {
+                            String jsonSignaturesPath = Resources.getResource(REMOTE_FUNCTION_JSON_SIGNATURES).getFile();
+                            configProperties = format("%s%n" +
+                                    "remote-function-server.catalog-name=%s%n" +
+                                    "remote-function-server.thrift.uds-path=%s%n" +
+                                    "remote-function-server.signature.files.directory.path=%s%n", configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
+                        }
+                        Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
                         Files.write(tempDirectoryPath.resolve("node.properties"),
                                 format("node.id=%s%n" +
                                         "node.ip=127.0.0.1%n" +
@@ -208,6 +224,12 @@ public class PrestoNativeQueryRunnerUtils
                 }));
     }
 
+    public static QueryRunner createNativeQueryRunner(String remoteFunctionServerUds)
+            throws Exception
+    {
+        return createNativeQueryRunner(false, DEFAULT_STORAGE_FORMAT, Optional.ofNullable(remoteFunctionServerUds));
+    }
+
     public static QueryRunner createNativeQueryRunner(boolean useThrift)
             throws Exception
     {
@@ -215,6 +237,12 @@ public class PrestoNativeQueryRunnerUtils
     }
 
     public static QueryRunner createNativeQueryRunner(boolean useThrift, String storageFormat)
+            throws Exception
+    {
+        return createNativeQueryRunner(useThrift, storageFormat, Optional.empty());
+    }
+
+    public static QueryRunner createNativeQueryRunner(boolean useThrift, String storageFormat, Optional<String> remoteFunctionServerUds)
             throws Exception
     {
         String prestoServerPath = System.getProperty("PRESTO_SERVER");
@@ -225,7 +253,28 @@ public class PrestoNativeQueryRunnerUtils
         assertNotNull(prestoServerPath, "Native worker binary path is missing. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.");
         assertNotNull(dataDirectory, "Data directory path is missing. Add -DDATA_DIR=<path/to/data> to your JVM arguments.");
 
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(dataDirectory, prestoServerPath, Optional.ofNullable(workerCount).map(Integer::parseInt), cacheMaxSize, useThrift, storageFormat);
+        return createNativeQueryRunner(dataDirectory, prestoServerPath, Optional.ofNullable(workerCount).map(Integer::parseInt), cacheMaxSize, useThrift, remoteFunctionServerUds, storageFormat);
+    }
+
+    // Start the remote function server. Return the UDS path used to communicate with it.
+    public static String startRemoteFunctionServer(String remoteFunctionServerBinaryPath)
+    {
+        try {
+            Path tempDirectoryPath = Files.createTempDirectory("RemoteFunctionServer");
+            Path remoteFunctionServerUdsPath = tempDirectoryPath.resolve(REMOTE_FUNCTION_UDS);
+            log.info("Temp directory for Remote Function Server: %s", tempDirectoryPath.toString());
+
+            Process p = new ProcessBuilder(remoteFunctionServerBinaryPath, "--uds_path", remoteFunctionServerUdsPath.toString(), "--function_prefix", REMOTE_FUNCTION_CATALOG_NAME + ".schema.")
+                                .directory(tempDirectoryPath.toFile())
+                                .redirectErrorStream(true)
+                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("thrift_server.out").toFile()))
+                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("thrift_server.err").toFile()))
+                                .start();
+            return remoteFunctionServerUdsPath.toString();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public static void setupJsonFunctionNamespaceManager(QueryRunner queryRunner, String jsonFileName, String catalogName)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestPrestoNativeRemoteFunctions
+        extends AbstractTestNativeRemoteFunctions
+{
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(remoteFunctionServerUds);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+}

--- a/presto-native-execution/src/test/resources/remote_function_server.json
+++ b/presto-native-execution/src/test/resources/remote_function_server.json
@@ -1,0 +1,51 @@
+{
+  "udfSignatureMap": {
+    "ceil":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "INTEGER",
+        "paramTypes": [
+          "INTEGER"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      },
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "DOUBLE",
+        "paramTypes": [
+          "DOUBLE"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ],
+    "concat":[
+      {
+        "docString": "",
+        "functionKind": "SCALAR",
+        "outputType": "VARCHAR",
+        "paramTypes": [
+          "VARCHAR",
+          "VARCHAR"
+        ],
+        "schema": "schema",
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The new test suite requires a REMOTE_FUNCTION_SERVER property to be set containing the remote function server binary to be run. In case the property is not set, the test is skipped.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

