### PR TITLE
Support persistent CTE's

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
@@ -1,0 +1,807 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.QueryAssertions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.PARTITIONING_PROVIDER_CATALOG;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.NATION;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static io.airlift.tpch.TpchTable.PART;
+import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
+import static io.airlift.tpch.TpchTable.REGION;
+import static io.airlift.tpch.TpchTable.SUPPLIER;
+
+@Test(singleThreaded = true)
+public class TestCteExecution
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER, LINE_ITEM, PART_SUPPLIER, NATION, REGION, PART, SUPPLIER),
+                ImmutableMap.of(
+                        "query.partitioning-provider-catalog", "hive"),
+                "sql-standard",
+                ImmutableMap.of("hive.pushdown-filter-enabled", "true",
+                        "hive.enable-parquet-dereference-pushdown", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testSimplePersistentCte()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        "WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                                "SELECT * FROM temp t1 "),
+                queryRunner.execute(getSession(),
+                        "WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                                "SELECT * FROM temp t1 "));
+    }
+
+    @Test
+    public void testPersistentCteWithTimeStampWithTimeZoneType()
+    {
+        String testQuery = "WITH cte AS (" +
+                "  SELECT ts FROM (VALUES " +
+                "    (CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE)), " +
+                "    (CAST('2023-06-01 12:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE)), " +
+                "    (CAST('2023-12-31 23:59:59.999 UTC' AS TIMESTAMP WITH TIME ZONE))" +
+                "  ) AS t(ts)" +
+                ")" +
+                "SELECT ts FROM cte";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        testQuery),
+                queryRunner.execute(getSession(),
+                        testQuery));
+    }
+
+    @Test
+    public void testPersistentCteWithStructTypes()
+    {
+        String testQuery = "WITH temp AS (" +
+                "  SELECT * FROM (VALUES " +
+                "    (CAST(ROW('example_status', 100) AS ROW(status VARCHAR, amount INTEGER)), 1)," +
+                "    (CAST(ROW('another_status', 200) AS ROW(status VARCHAR, amount INTEGER)), 2)" +
+                "  ) AS t (order_details, orderkey)" +
+                ") SELECT * FROM temp";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        testQuery),
+                queryRunner.execute(getSession(),
+                        testQuery));
+    }
+
+    @Test
+    public void testCteWithZeroLengthVarchar()
+    {
+        String testQuery = "WITH temp AS (" +
+                "  SELECT * FROM (VALUES " +
+                "    (CAST('' AS VARCHAR(0)), 9)" +
+                "  ) AS t (text_column, number_column)" +
+                ") SELECT * FROM temp";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        testQuery),
+                queryRunner.execute(getSession(),
+                        testQuery));
+    }
+
+    @Test
+    public void testDependentPersistentCtes()
+    {
+        String testQuery = "WITH  cte1 AS (SELECT orderkey FROM ORDERS WHERE orderkey < 100), " +
+                "      cte2 AS (SELECT * FROM cte1 WHERE orderkey > 50) " +
+                "SELECT * FROM cte2";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testMultipleIndependentPersistentCtes()
+    {
+        String testQuery = "WITH  cte1 AS (SELECT orderkey FROM ORDERS WHERE orderkey < 100), " +
+                "      cte2 AS (SELECT custkey FROM CUSTOMER WHERE custkey < 50) " +
+                "SELECT * FROM cte1, cte2 WHERE cte1.orderkey = cte2.custkey";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testNestedPersistentCtes()
+    {
+        String testQuery = "WITH  cte1 AS (" +
+                "   SELECT orderkey FROM ORDERS WHERE orderkey IN " +
+                "       (WITH  cte2 AS (SELECT orderkey FROM ORDERS WHERE orderkey < 100) " +
+                "        SELECT orderkey FROM cte2 WHERE orderkey > 50)" +
+                ") SELECT * FROM cte1";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testRefinedCtesOutsideScope()
+    {
+        String testQuery = "WITH  cte1 AS ( WITH cte2 as (SELECT orderkey FROM ORDERS WHERE orderkey < 100)" +
+                "SELECT * FROM cte2), " +
+                " cte2 AS (SELECT * FROM customer WHERE custkey < 50) " +
+                "SELECT * FROM cte2  JOIN cte1 ON true";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testComplexRefinedCtesOutsideScope()
+    {
+        String testQuery = "WITH " +
+                "cte1 AS ( " +
+                "   SELECT orderkey, totalprice FROM ORDERS WHERE orderkey < 100 " +
+                "), " +
+                "cte2 AS ( " +
+                "   WITH cte3 AS ( WITH cte4 AS (SELECT orderkey, totalprice FROM cte1 WHERE totalprice > 1000) SELECT * FROM cte4) " +
+                "   SELECT cte3.orderkey FROM cte3 " +
+                "), " +
+                "cte3 AS ( " +
+                "   SELECT * FROM customer WHERE custkey < 50 " +
+                ") " +
+                "SELECT cte3.*, cte2.orderkey FROM cte3 JOIN cte2 ON cte3.custkey = cte2.orderkey";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testChainedPersistentCtes()
+    {
+        String testQuery = "WITH  cte1 AS (SELECT orderkey FROM ORDERS WHERE orderkey < 100), " +
+                "      cte2 AS (SELECT orderkey FROM cte1 WHERE orderkey > 50), " +
+                "     cte3 AS (SELECT orderkey FROM cte2 WHERE orderkey < 75) " +
+                "SELECT * FROM cte3";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testSimplePersistentCteWithJoinInCteDef()
+    {
+        String testQuery = "WITH  temp as " +
+                "(SELECT * FROM ORDERS o1 " +
+                "JOIN ORDERS o2 ON o1.orderkey = o2.orderkey) " +
+                "SELECT * FROM temp t1 ";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testSimplePersistentCteMultipleUses()
+    {
+        String testQuery = " WITH  temp as" +
+                " (SELECT * FROM ORDERS) " +
+                "SELECT * FROM temp t1 JOIN temp t2 on " +
+                "t1.orderkey = t2.orderkey WHERE t1.orderkey < 10";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testPersistentCteMultipleColumns()
+    {
+        String testQuery = " WITH  temp as (SELECT * FROM ORDERS) " +
+                "SELECT * FROM temp t1";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testJoinAndAggregationWithPersistentCtes()
+    {
+        String testQuery = "WITH  cte1 AS (" +
+                "   SELECT orderkey, COUNT(*) as item_count FROM lineitem" +
+                "   GROUP BY orderkey)," +
+                "    cte2 AS (" +
+                "   SELECT c.custkey, c.name FROM CUSTOMER c" +
+                "   WHERE c.mktsegment = 'BUILDING')" +
+                "   SELECT * FROM cte1" +
+                "   JOIN cte2 ON cte1.orderkey = cte2.custkey";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testNestedPersistentCtes2()
+    {
+        String testQuery = "WITH  cte1 AS (" +
+                "   WITH  cte2 AS (" +
+                "       SELECT nationkey FROM NATION" +
+                "       WHERE regionkey = 1)" +
+                "   SELECT * FROM cte2" +
+                "   WHERE nationkey < 5)" +
+                "SELECT * FROM cte1";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testPersistentCteWithUnion()
+    {
+        String testQuery = "WITH  cte AS (" +
+                "   SELECT orderkey FROM ORDERS WHERE orderkey < 100" +
+                "   UNION" +
+                "   SELECT orderkey FROM ORDERS WHERE orderkey > 500)" +
+                "SELECT * FROM cte";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testPersistentCteWithSelfJoin()
+    {
+        String testQuery = "WITH  cte AS (" +
+                "   SELECT * FROM ORDERS)" +
+                "SELECT * FROM cte c1" +
+                " JOIN cte c2 ON c1.orderkey = c2.orderkey WHERE c1.orderkey < 100";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testPersistentCteWithWindowFunction()
+    {
+        String testQuery = "WITH cte AS (" +
+                "   SELECT *, ROW_NUMBER() OVER(PARTITION BY orderstatus ORDER BY orderkey) as row" +
+                "   FROM ORDERS)" +
+                "SELECT * FROM cte WHERE row <= 5";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testPersistentCteWithMultipleDependentSubCtes()
+    {
+        String testQuery = "WITH  cte1 AS (" +
+                "   SELECT * FROM ORDERS)," +
+                "     cte2 AS (SELECT * FROM cte1 WHERE orderkey < 100)," +
+                "     cte3 AS (SELECT * FROM cte1 WHERE orderkey >= 100)" +
+                "SELECT * FROM cte2 UNION ALL SELECT * FROM cte3";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testTopCustomersByOrderValue()
+    {
+        String testQuery = "WITH  cte AS (" +
+                "   SELECT c.custkey, c.name, SUM(o.totalprice) as total_spent " +
+                "   FROM CUSTOMER c JOIN ORDERS o ON c.custkey = o.custkey " +
+                "   GROUP BY c.custkey, c.name)" +
+                "SELECT * FROM cte " +
+                "ORDER BY total_spent DESC " +
+                "LIMIT 5";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery), true);
+    }
+
+    @Test
+    public void testSupplierDataAnalysis()
+    {
+        String testQuery = "WITH cte AS (" +
+                "   SELECT s.suppkey, s.name, n.name as nation, r.name as region, ROUND(SUM(ps.supplycost), 8)  as total_supply_cost " +
+                "   FROM partsupp ps JOIN SUPPLIER s ON ps.suppkey = s.suppkey " +
+                "                        JOIN NATION n ON s.nationkey = n.nationkey " +
+                "                        JOIN REGION r ON n.regionkey = r.regionkey " +
+                "   GROUP BY s.suppkey, s.name, n.name, r.name) " +
+                "SELECT * FROM cte " +
+                "WHERE total_supply_cost > 1000";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testCustomerOrderPatternAnalysis()
+    {
+        String testQuery = "WITH  cte AS (" +
+                "   SELECT c.name as customer_name, r.name as region_name, EXTRACT(year FROM o.orderdate) as order_year, COUNT(*) as order_count " +
+                "   FROM CUSTOMER c JOIN ORDERS o ON c.custkey = o.custkey " +
+                "                  JOIN NATION n ON c.nationkey = n.nationkey " +
+                "                  JOIN REGION r ON n.regionkey = r.regionkey " +
+                "   GROUP BY c.name, r.name, EXTRACT(year FROM o.orderdate)) " +
+                "SELECT * FROM cte " +
+                "ORDER BY customer_name, order_year";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testLowStockAnalysis()
+    {
+        String testQuery = "WITH cte AS (" +
+                "   SELECT p.partkey, p.name, p.type, SUM(ps.availqty) as total_qty " +
+                "   FROM PART p JOIN partsupp ps ON p.partkey = ps.partkey " +
+                "   GROUP BY p.partkey, p.name, p.type) " +
+                "SELECT * FROM cte " +
+                "WHERE total_qty < 100";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testComplexChainOfDependentAndNestedPersistentCtes()
+    {
+        String testQuery = "WITH  " +
+                "    cte1 AS (" +
+                "        SELECT * FROM ORDERS WHERE orderkey < 1000" +
+                "    )," +
+                "    cte2 AS (" +
+                "        SELECT * FROM cte1 WHERE custkey < 500" +
+                "    )," +
+                "     cte3 AS (" +
+                "        SELECT cte2.*, cte1.totalprice AS cte1_totalprice " +
+                "        FROM cte2 " +
+                "        JOIN cte1 ON cte2.orderkey = cte1.orderkey " +
+                "        WHERE cte1.totalprice < 150000" +
+                "    )," +
+                "     cte4 AS (" +
+                "        SELECT * FROM cte3 WHERE orderstatus = 'O'" +
+                "    )," +
+                "    cte5 AS (" +
+                "        SELECT orderkey FROM cte4 WHERE cte1_totalprice < 100000" +
+                "    )," +
+                "    cte6 AS (" +
+                "        SELECT * FROM cte5, LATERAL (" +
+                "            SELECT * FROM cte2 WHERE cte2.orderkey = cte5.orderkey" +
+                "        ) x" +
+                "    )" +
+                "SELECT * FROM cte6";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testComplexQuery1()
+    {
+        String testQuery = "WITH  customer_nation AS (" +
+                "   SELECT c.custkey, c.name, n.name AS nation_name, r.name AS region_name " +
+                "   FROM CUSTOMER c " +
+                "   JOIN NATION n ON c.nationkey = n.nationkey " +
+                "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                " customer_orders AS (" +
+                "   SELECT co.custkey, co.name, co.nation_name, co.region_name, o.orderkey, o.orderdate " +
+                "   FROM customer_nation co " +
+                "   JOIN ORDERS o ON co.custkey = o.custkey), " +
+                "order_lineitems AS (" +
+                "   SELECT co.*, l.partkey, l.quantity, l.extendedprice " +
+                "   FROM customer_orders co " +
+                "   JOIN lineitem l ON co.orderkey = l.orderkey), " +
+                " customer_part_analysis AS (" +
+                "   SELECT ol.*, p.name AS part_name, p.type AS part_type " +
+                "   FROM order_lineitems ol " +
+                "   JOIN PART p ON ol.partkey = p.partkey) " +
+                "SELECT * FROM customer_part_analysis " +
+                "WHERE region_name = 'AMERICA' " +
+                "ORDER BY nation_name, custkey, orderdate";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testComplexQuery2()
+    {
+        String testQuery = "WITH  supplier_region AS (" +
+                "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                "   FROM SUPPLIER s " +
+                "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                " supplier_parts AS (" +
+                "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                "   FROM supplier_region sr " +
+                "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                "parts_info AS (" +
+                "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                "   FROM supplier_parts sp " +
+                "   JOIN PART p ON sp.partkey = p.partkey), " +
+                " full_supplier_part_info AS (" +
+                "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                "   FROM parts_info pi " +
+                "   JOIN NATION n ON pi.nation_name = n.name " +
+                "   JOIN REGION r ON pi.region_name = r.name) " +
+                "SELECT * FROM full_supplier_part_info " +
+                "WHERE part_type LIKE '%BRASS' " +
+                "ORDER BY region_name, supplier_name";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
+    public void testSimplePersistentCteForCtasQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        // Create tables with Ctas
+        queryRunner.execute(getMaterializedSession(),
+                "CREATE TABLE persistent_table as (WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp t1 )");
+        queryRunner.execute(getSession(),
+                "CREATE TABLE non_persistent_table as (WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp t1) ");
+
+        // Compare contents with a select
+        compareResults(queryRunner.execute(getSession(),
+                        "SELECT * FROM persistent_table"),
+                queryRunner.execute(getSession(),
+                        "SELECT * FROM non_persistent_table"));
+
+        // drop tables
+        queryRunner.execute(getSession(),
+                "DROP TABLE persistent_table");
+        queryRunner.execute(getSession(),
+                "DROP TABLE non_persistent_table");
+    }
+
+    @Test
+    public void testComplexPersistentCteForCtasQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        // Create tables with Ctas
+        queryRunner.execute(getMaterializedSession(),
+                "CREATE TABLE persistent_table as ( " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name)");
+        queryRunner.execute(getSession(),
+                "CREATE TABLE non_persistent_table as ( " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name)");
+
+        // Compare contents with a select
+        compareResults(queryRunner.execute(getSession(),
+                        "SELECT * FROM persistent_table"),
+                queryRunner.execute(getSession(),
+                        "SELECT * FROM non_persistent_table"));
+
+        // drop tables
+        queryRunner.execute(getSession(),
+                "DROP TABLE persistent_table");
+        queryRunner.execute(getSession(),
+                "DROP TABLE non_persistent_table");
+    }
+
+    @Test
+    public void testSimplePersistentCteForInsertQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        // Create tables without data
+        queryRunner.execute(getSession(),
+                "CREATE TABLE persistent_table (orderkey BIGINT)");
+        queryRunner.execute(getSession(),
+                "CREATE TABLE non_persistent_table (orderkey BIGINT)");
+
+        // Insert data into tables using CTEs
+        queryRunner.execute(getMaterializedSession(),
+                "INSERT INTO persistent_table " +
+                        "WITH  temp AS (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp");
+        queryRunner.execute(getSession(),
+                "INSERT INTO non_persistent_table " +
+                        "WITH temp AS (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp");
+
+        // Compare contents with a select
+        compareResults(queryRunner.execute(getSession(),
+                        "SELECT * FROM persistent_table"),
+                queryRunner.execute(getSession(),
+                        "SELECT * FROM non_persistent_table"));
+
+        // drop tables
+        queryRunner.execute(getSession(),
+                "DROP TABLE persistent_table");
+        queryRunner.execute(getSession(),
+                "DROP TABLE non_persistent_table");
+    }
+
+    @Test
+    public void testComplexPersistentCteForInsertQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        // Create tables without data
+        // Create tables
+        String createTableBase = " (suppkey BIGINT, supplier_name VARCHAR, nation_name VARCHAR, region_name VARCHAR, " +
+                "partkey BIGINT, availqty BIGINT, supplycost DOUBLE, " +
+                "part_name VARCHAR, part_type VARCHAR, part_size BIGINT, " +
+                "nation_comment VARCHAR, region_comment VARCHAR)";
+
+        queryRunner.execute(getSession(),
+                "CREATE TABLE persistent_table" + createTableBase);
+
+        queryRunner.execute(getSession(),
+                "CREATE TABLE non_persistent_table" + createTableBase);
+
+        queryRunner.execute(getMaterializedSession(),
+                "INSERT INTO persistent_table  " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name");
+        queryRunner.execute(getSession(),
+                "INSERT INTO non_persistent_table  " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name");
+
+        // Compare contents with a select
+        compareResults(queryRunner.execute(getSession(),
+                        "SELECT * FROM persistent_table"),
+                queryRunner.execute(getSession(),
+                        "SELECT * FROM non_persistent_table"));
+
+        // drop tables
+        queryRunner.execute(getSession(),
+                "DROP TABLE persistent_table");
+        queryRunner.execute(getSession(),
+                "DROP TABLE non_persistent_table");
+    }
+
+    @Test
+    public void testSimplePersistentCteForViewQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        // Create views
+        queryRunner.execute(getMaterializedSession(),
+                "CREATE VIEW persistent_view AS WITH  temp AS (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp");
+        queryRunner.execute(getSession(),
+                "CREATE VIEW non_persistent_view AS WITH temp AS (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp");
+        // Compare contents of views with a select
+        compareResults(queryRunner.execute(getMaterializedSession(), "SELECT * FROM persistent_view"),
+                queryRunner.execute(getSession(), "SELECT * FROM non_persistent_view"));
+
+        // Drop views
+        queryRunner.execute(getSession(), "DROP VIEW persistent_view");
+        queryRunner.execute(getSession(), "DROP VIEW non_persistent_view");
+    }
+
+    @Test
+    public void testComplexPersistentCteForViewQueries()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        // Create Views
+        queryRunner.execute(getMaterializedSession(),
+                "CREATE View persistent_view as " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name");
+        queryRunner.execute(getSession(),
+                "CREATE View non_persistent_view as " +
+                        "WITH  supplier_region AS (" +
+                        "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                        "   FROM SUPPLIER s " +
+                        "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                        "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                        " supplier_parts AS (" +
+                        "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                        "   FROM supplier_region sr " +
+                        "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                        "parts_info AS (" +
+                        "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                        "   FROM supplier_parts sp " +
+                        "   JOIN PART p ON sp.partkey = p.partkey), " +
+                        " full_supplier_part_info AS (" +
+                        "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                        "   FROM parts_info pi " +
+                        "   JOIN NATION n ON pi.nation_name = n.name " +
+                        "   JOIN REGION r ON pi.region_name = r.name) " +
+                        "SELECT * FROM full_supplier_part_info " +
+                        "WHERE part_type LIKE '%BRASS' " +
+                        "ORDER BY region_name, supplier_name");
+
+        // Compare contents with a select
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        "SELECT * FROM persistent_view"),
+                queryRunner.execute(getSession(),
+                        "SELECT * FROM non_persistent_view"));
+
+        // drop views
+        queryRunner.execute(getSession(),
+                "DROP View persistent_view");
+        queryRunner.execute(getSession(),
+                "DROP View non_persistent_view");
+    }
+
+    private void compareResults(MaterializedResult actual, MaterializedResult expected)
+    {
+        compareResults(actual, expected, false);
+    }
+
+    private void compareResults(MaterializedResult actual, MaterializedResult expected, boolean checkOrdering)
+    {
+        // Verify result count
+        assertEquals(actual.getRowCount(),
+                expected.getRowCount(), String.format("Expected %d rows got %d rows", expected.getRowCount(), actual.getRowCount()));
+        if (checkOrdering) {
+            assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows(), "Correctness check failed! Rows are not equal");
+            return;
+        }
+        QueryAssertions.assertEqualsIgnoreOrder(actual, expected, "Correctness check failed! Rows are not equal");
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "NONE")
+                .build();
+    }
+    protected Session getMaterializedSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "ALL")
+                .setSystemProperty(PARTITIONING_PROVIDER_CATALOG, "hive")
+                .build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
@@ -186,6 +187,7 @@ public final class SystemSessionProperties
     public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
     public static final String MAX_TASKS_PER_STAGE = "max_tasks_per_stage";
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
+    public static final String CTE_MATERIALIZATION_STRATEGY = "cte_materialization_strategy";
     public static final String DEFAULT_JOIN_SELECTIVITY_COEFFICIENT = "default_join_selectivity_coefficient";
     public static final String PUSH_LIMIT_THROUGH_OUTER_JOIN = "push_limit_through_outer_join";
     public static final String OPTIMIZE_CONSTANT_GROUPING_KEYS = "optimize_constant_grouping_keys";
@@ -1038,6 +1040,18 @@ public final class SystemSessionProperties
                         "use a default filter factor for unknown filters in a filter node",
                         featuresConfig.isDefaultFilterFactorEnabled(),
                         false),
+                new PropertyMetadata<>(
+                        CTE_MATERIALIZATION_STRATEGY,
+                        format("The strategy to materialize common table expressions. Options are %s",
+                                Stream.of(CteMaterializationStrategy.values())
+                                        .map(CteMaterializationStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        CteMaterializationStrategy.class,
+                        featuresConfig.getCteMaterializationStrategy(),
+                        false,
+                        value -> CteMaterializationStrategy.valueOf(((String) value).toUpperCase()),
+                        CteMaterializationStrategy::name),
                 new PropertyMetadata<>(
                         DEFAULT_JOIN_SELECTIVITY_COEFFICIENT,
                         "use a default join selectivity coefficient factor when column statistics are not available in a join node",
@@ -2308,6 +2322,11 @@ public final class SystemSessionProperties
     public static DataSize getFilterAndProjectMinOutputPageSize(Session session)
     {
         return session.getSystemProperty(FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE, DataSize.class);
+    }
+
+    public static CteMaterializationStrategy getCteMaterializationStrategy(Session session)
+    {
+        return session.getSystemProperty(CTE_MATERIALIZATION_STRATEGY, CteMaterializationStrategy.class);
     }
 
     public static int getFilterAndProjectMinOutputPageRowCount(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.NewTableLayout;
+import com.facebook.presto.metadata.PartitioningMetadata;
+import com.facebook.presto.metadata.TableLayout;
+import com.facebook.presto.metadata.TableLayoutResult;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorNewTableLayout;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableMetadata;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
+import com.facebook.presto.sql.planner.BasePlanFragmenter;
+import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.StatisticsAggregationPlanner;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.StatisticAggregations;
+import com.facebook.presto.sql.planner.plan.TableFinishNode;
+import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
+import static com.facebook.presto.SystemSessionProperties.isTableWriterMergeOperatorEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.ensureSourceOrderingGatheringExchange;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.gatheringExchange;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.partitionedExchange;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.concat;
+import static java.lang.String.format;
+import static java.util.function.Function.identity;
+
+// Planner Util for creating temporary tables
+public class TemporaryTableUtil
+{
+    private TemporaryTableUtil()
+    {
+    }
+
+    public static TableScanNode createTemporaryTableScan(
+            Metadata metadata,
+            Session session,
+            PlanNodeIdAllocator idAllocator,
+            Optional<SourceLocation> sourceLocation,
+            TableHandle tableHandle,
+            List<VariableReferenceExpression> outputVariables,
+            Map<VariableReferenceExpression, ColumnMetadata> variableToColumnMap,
+            PartitioningMetadata expectedPartitioningMetadata)
+    {
+        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
+        Map<VariableReferenceExpression, ColumnMetadata> outputColumns = outputVariables.stream()
+                .collect(toImmutableMap(identity(), variableToColumnMap::get));
+        Set<ColumnHandle> outputColumnHandles = outputColumns.values().stream()
+                .map(ColumnMetadata::getName)
+                .map(columnHandles::get)
+                .collect(toImmutableSet());
+
+        TableLayoutResult selectedLayout = metadata.getLayout(session, tableHandle, Constraint.alwaysTrue(), Optional.of(outputColumnHandles));
+        verify(selectedLayout.getUnenforcedConstraint().equals(TupleDomain.all()), "temporary table layout shouldn't enforce any constraints");
+        verify(!selectedLayout.getLayout().getColumns().isPresent(), "temporary table layout must provide all the columns");
+        TableLayout.TablePartitioning expectedPartitioning = new TableLayout.TablePartitioning(
+                expectedPartitioningMetadata.getPartitioningHandle(),
+                expectedPartitioningMetadata.getPartitionColumns().stream()
+                        .map(columnHandles::get)
+                        .collect(toImmutableList()));
+        verify(selectedLayout.getLayout().getTablePartitioning().equals(Optional.of(expectedPartitioning)), "invalid temporary table partitioning");
+
+        Map<VariableReferenceExpression, ColumnHandle> assignments = outputVariables.stream()
+                .collect(toImmutableMap(identity(), variable -> columnHandles.get(outputColumns.get(variable).getName())));
+
+        return new TableScanNode(
+                sourceLocation,
+                idAllocator.getNextId(),
+                selectedLayout.getLayout().getNewTableHandle(),
+                outputVariables,
+                assignments,
+                TupleDomain.all(),
+                TupleDomain.all());
+    }
+
+    public static Map<VariableReferenceExpression, ColumnMetadata> assignTemporaryTableColumnNames(Collection<VariableReferenceExpression> outputVariables,
+            Collection<VariableReferenceExpression> constantPartitioningVariables)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, ColumnMetadata> result = ImmutableMap.builder();
+        int column = 0;
+        for (VariableReferenceExpression outputVariable : concat(outputVariables, constantPartitioningVariables)) {
+            String columnName = format("_c%d_%s", column, outputVariable.getName());
+            result.put(outputVariable, new ColumnMetadata(columnName, outputVariable.getType()));
+            column++;
+        }
+        return result.build();
+    }
+
+    public static BasePlanFragmenter.PartitioningVariableAssignments assignPartitioningVariables(VariableAllocator variableAllocator,
+            Partitioning partitioning)
+    {
+        ImmutableList.Builder<VariableReferenceExpression> variables = ImmutableList.builder();
+        ImmutableMap.Builder<VariableReferenceExpression, RowExpression> constants = ImmutableMap.builder();
+        for (RowExpression argument : partitioning.getArguments()) {
+            checkArgument(argument instanceof ConstantExpression || argument instanceof VariableReferenceExpression,
+                    format("Expect argument to be ConstantExpression or VariableReferenceExpression, got %s (%s)", argument.getClass(), argument));
+            VariableReferenceExpression variable;
+            if (argument instanceof ConstantExpression) {
+                variable = variableAllocator.newVariable(argument.getSourceLocation(), "constant_partition", argument.getType());
+                constants.put(variable, argument);
+            }
+            else {
+                variable = (VariableReferenceExpression) argument;
+            }
+            variables.add(variable);
+        }
+        return new BasePlanFragmenter.PartitioningVariableAssignments(variables.build(), constants.build());
+    }
+
+    public static TableFinishNode createTemporaryTableWriteWithoutExchanges(
+            Metadata metadata,
+            Session session,
+            PlanNodeIdAllocator idAllocator,
+            VariableAllocator variableAllocator,
+            PlanNode source,
+            TableHandle tableHandle,
+            List<VariableReferenceExpression> outputs,
+            Map<VariableReferenceExpression, ColumnMetadata> variableToColumnMap,
+            PartitioningMetadata partitioningMetadata,
+            VariableReferenceExpression outputVar)
+    {
+        SchemaTableName schemaTableName = metadata.getTableMetadata(session, tableHandle).getTable();
+        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName);
+        List<String> outputColumnNames = outputs.stream()
+                .map(variableToColumnMap::get)
+                .map(ColumnMetadata::getName)
+                .collect(toImmutableList());
+        Set<VariableReferenceExpression> outputNotNullColumnVariables = outputs.stream()
+                .filter(variable -> variableToColumnMap.get(variable) != null && !(variableToColumnMap.get(variable).isNullable()))
+                .collect(Collectors.toSet());
+        PartitioningHandle partitioningHandle = partitioningMetadata.getPartitioningHandle();
+        List<String> partitionColumns = partitioningMetadata.getPartitionColumns();
+        Map<String, VariableReferenceExpression> columnNameToVariable = variableToColumnMap.entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getValue().getName(), Map.Entry::getKey));
+        List<VariableReferenceExpression> partitioningVariables = partitionColumns.stream()
+                .map(columnNameToVariable::get)
+                .collect(toImmutableList());
+        PartitioningScheme partitioningScheme = new PartitioningScheme(
+                Partitioning.create(partitioningHandle, partitioningVariables),
+                outputs,
+                Optional.empty(),
+                false,
+                Optional.empty());
+        return new TableFinishNode(
+                source.getSourceLocation(),
+                idAllocator.getNextId(),
+                new TableWriterNode(
+                        source.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        source,
+                        Optional.of(insertReference),
+                        variableAllocator.newVariable("rows", BIGINT),
+                        variableAllocator.newVariable("fragments", VARBINARY),
+                        variableAllocator.newVariable("commitcontext", VARBINARY),
+                        outputs,
+                        outputColumnNames,
+                        outputNotNullColumnVariables,
+                        Optional.of(partitioningScheme),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                Optional.of(insertReference),
+                outputVar,
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public static TableFinishNode createTemporaryTableWriteWithExchanges(
+            Metadata metadata,
+            Session session,
+            PlanNodeIdAllocator idAllocator,
+            VariableAllocator variableAllocator,
+            StatisticsAggregationPlanner statisticsAggregationPlanner,
+            Optional<SourceLocation> sourceLocation,
+            TableHandle tableHandle,
+            Map<VariableReferenceExpression, ColumnMetadata> variableToColumnMap,
+            List<VariableReferenceExpression> outputs,
+            List<List<VariableReferenceExpression>> inputs,
+            List<PlanNode> sources,
+            Map<VariableReferenceExpression, RowExpression> constantExpressions,
+            PartitioningMetadata partitioningMetadata)
+    {
+        if (!constantExpressions.isEmpty()) {
+            List<VariableReferenceExpression> constantVariables = ImmutableList.copyOf(constantExpressions.keySet());
+            outputs = ImmutableList.<VariableReferenceExpression>builder()
+                    .addAll(outputs)
+                    .addAll(constantVariables)
+                    .build();
+            inputs = inputs.stream()
+                    .map(input -> ImmutableList.<VariableReferenceExpression>builder()
+                            .addAll(input)
+                            .addAll(constantVariables)
+                            .build())
+                    .collect(toImmutableList());
+
+            // update sources
+            sources = sources.stream()
+                    .map(source -> {
+                        Assignments.Builder assignments = Assignments.builder();
+                        source.getOutputVariables().forEach(variable -> assignments.put(variable, new VariableReferenceExpression(variable.getSourceLocation(), variable.getName(), variable.getType())));
+                        constantVariables.forEach(variable -> assignments.put(variable, constantExpressions.get(variable)));
+                        return new ProjectNode(source.getSourceLocation(), idAllocator.getNextId(), source, assignments.build(), ProjectNode.Locality.LOCAL);
+                    })
+                    .collect(toImmutableList());
+        }
+
+        NewTableLayout insertLayout = metadata.getInsertLayout(session, tableHandle)
+                // TODO: support insert into non partitioned table
+                .orElseThrow(() -> new IllegalArgumentException("insertLayout for the temporary table must be present"));
+
+        PartitioningHandle partitioningHandle = partitioningMetadata.getPartitioningHandle();
+        List<String> partitionColumns = partitioningMetadata.getPartitionColumns();
+        ConnectorNewTableLayout expectedNewTableLayout = new ConnectorNewTableLayout(partitioningHandle.getConnectorHandle(), partitionColumns);
+        verify(insertLayout.getLayout().equals(expectedNewTableLayout), "unexpected new table layout");
+
+        Map<String, VariableReferenceExpression> columnNameToVariable = variableToColumnMap.entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getValue().getName(), Map.Entry::getKey));
+        List<VariableReferenceExpression> partitioningVariables = partitionColumns.stream()
+                .map(columnNameToVariable::get)
+                .collect(toImmutableList());
+
+        List<String> outputColumnNames = outputs.stream()
+                .map(variableToColumnMap::get)
+                .map(ColumnMetadata::getName)
+                .collect(toImmutableList());
+        Set<VariableReferenceExpression> outputNotNullColumnVariables = outputs.stream()
+                .filter(variable -> variableToColumnMap.get(variable) != null && !(variableToColumnMap.get(variable).isNullable()))
+                .collect(Collectors.toSet());
+
+        SchemaTableName schemaTableName = metadata.getTableMetadata(session, tableHandle).getTable();
+        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName);
+
+        PartitioningScheme partitioningScheme = new PartitioningScheme(
+                Partitioning.create(partitioningHandle, partitioningVariables),
+                outputs,
+                Optional.empty(),
+                false,
+                Optional.empty());
+
+        ExchangeNode writerRemoteSource = new ExchangeNode(
+                sourceLocation,
+                idAllocator.getNextId(),
+                REPARTITION,
+                REMOTE_STREAMING,
+                partitioningScheme,
+                sources,
+                inputs,
+                false,
+                Optional.empty());
+
+        ExchangeNode writerSource;
+        if (getTaskPartitionedWriterCount(session) == 1) {
+            writerSource = gatheringExchange(
+                    idAllocator.getNextId(),
+                    LOCAL,
+                    writerRemoteSource);
+        }
+        else {
+            writerSource = partitionedExchange(
+                    idAllocator.getNextId(),
+                    LOCAL,
+                    writerRemoteSource,
+                    partitioningScheme);
+        }
+
+        String catalogName = tableHandle.getConnectorId().getCatalogName();
+        TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
+        TableStatisticsMetadata statisticsMetadata = metadata.getStatisticsCollectionMetadataForWrite(session, catalogName, tableMetadata.getMetadata());
+        StatisticsAggregationPlanner.TableStatisticAggregation statisticsResult = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnNameToVariable);
+        StatisticAggregations.Parts aggregations = statisticsResult.getAggregations().splitIntoPartialAndFinal(variableAllocator, metadata.getFunctionAndTypeManager());
+        PlanNode tableWriterMerge;
+
+        // Disabled by default. Enable when the column statistics are essential for future runtime adaptive plan optimizations
+        boolean enableStatsCollectionForTemporaryTable = SystemSessionProperties.isEnableStatsCollectionForTemporaryTable(session);
+
+        if (isTableWriterMergeOperatorEnabled(session)) {
+            StatisticAggregations.Parts localAggregations = aggregations.getPartialAggregation().splitIntoPartialAndIntermediate(variableAllocator, metadata.getFunctionAndTypeManager());
+            tableWriterMerge = new TableWriterMergeNode(
+                    sourceLocation,
+                    idAllocator.getNextId(),
+                    gatheringExchange(
+                            idAllocator.getNextId(),
+                            LOCAL,
+                            new TableWriterNode(
+                                    sourceLocation,
+                                    idAllocator.getNextId(),
+                                    writerSource,
+                                    Optional.of(insertReference),
+                                    variableAllocator.newVariable("partialrows", BIGINT),
+                                    variableAllocator.newVariable("partialfragments", VARBINARY),
+                                    variableAllocator.newVariable("partialtablecommitcontext", VARBINARY),
+                                    outputs,
+                                    outputColumnNames,
+                                    outputNotNullColumnVariables,
+                                    Optional.of(partitioningScheme),
+                                    Optional.empty(),
+                                    enableStatsCollectionForTemporaryTable ? Optional.of(localAggregations.getPartialAggregation()) : Optional.empty(),
+                                    Optional.empty())),
+                    variableAllocator.newVariable("intermediaterows", BIGINT),
+                    variableAllocator.newVariable("intermediatefragments", VARBINARY),
+                    variableAllocator.newVariable("intermediatetablecommitcontext", VARBINARY),
+                    enableStatsCollectionForTemporaryTable ? Optional.of(localAggregations.getIntermediateAggregation()) : Optional.empty());
+        }
+        else {
+            tableWriterMerge = new TableWriterNode(
+                    sourceLocation,
+                    idAllocator.getNextId(),
+                    writerSource,
+                    Optional.of(insertReference),
+                    variableAllocator.newVariable("partialrows", BIGINT),
+                    variableAllocator.newVariable("partialfragments", VARBINARY),
+                    variableAllocator.newVariable("partialtablecommitcontext", VARBINARY),
+                    outputs,
+                    outputColumnNames,
+                    outputNotNullColumnVariables,
+                    Optional.of(partitioningScheme),
+                    Optional.empty(),
+                    enableStatsCollectionForTemporaryTable ? Optional.of(aggregations.getPartialAggregation()) : Optional.empty(),
+                    Optional.empty());
+        }
+
+        return new TableFinishNode(
+                sourceLocation,
+                idAllocator.getNextId(),
+                ensureSourceOrderingGatheringExchange(
+                        idAllocator.getNextId(),
+                        REMOTE_STREAMING,
+                        tableWriterMerge),
+                Optional.of(insertReference),
+                variableAllocator.newVariable("rows", BIGINT),
+                enableStatsCollectionForTemporaryTable ? Optional.of(aggregations.getFinalAggregation()) : Optional.empty(),
+                enableStatsCollectionForTemporaryTable ? Optional.of(statisticsResult.getDescriptor()) : Optional.empty());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
@@ -23,14 +23,19 @@ public class CTEInformationCollector
 {
     private final HashMap<String, CTEInformation> cteInformationMap = new HashMap<>();
 
-    public void addCTEReference(String cteName, boolean isView)
+    public void addCTEReference(String cteName, boolean isView, boolean isMaterialized)
     {
-        cteInformationMap.putIfAbsent(cteName, new CTEInformation(cteName, 0, isView));
+        cteInformationMap.putIfAbsent(cteName, new CTEInformation(cteName, 0, isView, isMaterialized));
         cteInformationMap.get(cteName).incrementReferences();
     }
 
     public List<CTEInformation> getCTEInformationList()
     {
         return ImmutableList.copyOf(cteInformationMap.values());
+    }
+
+    public HashMap<String, CTEInformation> getCteInformationMap()
+    {
+        return cteInformationMap;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -90,6 +90,8 @@ public class FeaturesConfig
     private DataSize maxRevocableMemoryPerTask = new DataSize(500, MEGABYTE);
     private JoinReorderingStrategy joinReorderingStrategy = JoinReorderingStrategy.AUTOMATIC;
     private PartialMergePushdownStrategy partialMergePushdownStrategy = PartialMergePushdownStrategy.NONE;
+
+    private CteMaterializationStrategy cteMaterializationStrategy = CteMaterializationStrategy.NONE;
     private int maxReorderedJoins = 9;
     private boolean useHistoryBasedPlanStatistics;
     private boolean trackHistoryBasedPlanStatistics;
@@ -348,6 +350,12 @@ public class FeaturesConfig
         }
     }
 
+    public enum CteMaterializationStrategy
+    {
+        ALL, // Materialize all CTES
+        NONE // Materialize no ctes
+    }
+
     public enum TaskSpillingStrategy
     {
         ORDER_BY_CREATE_TIME, // When spilling is triggered, revoke tasks in order of oldest to newest
@@ -562,6 +570,19 @@ public class FeaturesConfig
     public FeaturesConfig setLegacyMapSubscript(boolean value)
     {
         this.legacyMapSubscript = value;
+        return this;
+    }
+
+    public CteMaterializationStrategy getCteMaterializationStrategy()
+    {
+        return cteMaterializationStrategy;
+    }
+
+    @Config("cte-materialization-strategy")
+    @ConfigDescription("Set strategy used to determine whether to materialize ctes (ALL, NONE)")
+    public FeaturesConfig setCteMaterializationStrategy(CteMaterializationStrategy cteMaterializationStrategy)
+    {
+        this.cteMaterializationStrategy = cteMaterializationStrategy;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -579,7 +579,7 @@ public class FeaturesConfig
     }
 
     @Config("cte-materialization-strategy")
-    @ConfigDescription("Set strategy used to determine whether to materialize ctes (ALL, NONE)")
+    @ConfigDescription("Set strategy used to determine whether to materialize CTEs (ALL, NONE)")
     public FeaturesConfig setCteMaterializationStrategy(CteMaterializationStrategy cteMaterializationStrategy)
     {
         this.cteMaterializationStrategy = cteMaterializationStrategy;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.Output;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.base.VerifyException;
@@ -58,6 +59,14 @@ public class OutputExtractor
             checkState(schemaTableName == null || schemaTableName.equals(writerTarget.getSchemaTableName()),
                     "cannot have more than a single create, insert or delete in a query");
             schemaTableName = writerTarget.getSchemaTableName();
+            return null;
+        }
+
+        public Void visitSequence(SequenceNode node, Void context)
+        {
+            // Left children of sequence are ignored since they don't output anything
+            node.getPrimarySource().accept(this, context);
+
             return null;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -144,12 +144,14 @@ import com.facebook.presto.sql.planner.optimizations.ImplementIntersectAndExcept
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
 import com.facebook.presto.sql.planner.optimizations.KeyBasedSampler;
 import com.facebook.presto.sql.planner.optimizations.LimitPushDown;
+import com.facebook.presto.sql.planner.optimizations.LogicalCteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MergeJoinForSortedInputOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MergePartialAggregationsWithFilter;
 import com.facebook.presto.sql.planner.optimizations.MetadataDeleteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MetadataQueryOptimizer;
 import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggregations;
 import com.facebook.presto.sql.planner.optimizations.PayloadJoinOptimizer;
+import com.facebook.presto.sql.planner.optimizations.PhysicalCteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PrefilterForLimitingAggregation;
@@ -274,6 +276,8 @@ public class PlanOptimizers
                 new PruneWindowColumns(),
                 new PruneLimitColumns(),
                 new PruneTableScanColumns());
+
+        builder.add(new LogicalCteOptimizer(metadata));
 
         IterativeOptimizer inlineProjections = new IterativeOptimizer(
                 metadata,
@@ -760,6 +764,7 @@ public class PlanOptimizers
                             statsCalculator,
                             estimatedExchangesCostCalculator,
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
+            builder.add(new PhysicalCteOptimizer(metadata)); // Must run before AddExchanges
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, sqlParser, partitioningProviderManager)));
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -22,6 +22,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.cost.TaskCountEstimator;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -198,7 +199,7 @@ public class DetermineJoinDistributionType
         }
 
         List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
-                .whereIsInstanceOfAny(ImmutableList.of(TableScanNode.class, ValuesNode.class, RemoteSourceNode.class))
+                .whereIsInstanceOfAny(ImmutableList.of(TableScanNode.class, ValuesNode.class, RemoteSourceNode.class, CteConsumerNode.class))
                 .findAll();
 
         return sourceNodes.stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -19,6 +19,9 @@ import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -55,6 +58,9 @@ public class ApplyConnectorOptimization
         implements PlanOptimizer
 {
     static final Set<Class<? extends PlanNode>> CONNECTOR_ACCESSIBLE_PLAN_NODES = ImmutableSet.of(
+            CteProducerNode.class,
+            CteConsumerNode.class,
+            CteReferenceNode.class,
             DistinctLimitNode.class,
             FilterNode.class,
             TableScanNode.class,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.common.type.Varchars;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+
+public class CteUtils
+{
+    private CteUtils()
+    {
+    }
+
+    // Determines whether the CTE can be materialized.
+    public static boolean isCteMaterializable(List<VariableReferenceExpression> outputVariables)
+    {
+        return outputVariables.stream().anyMatch(CteUtils::isVariableMaterializable)
+                && outputVariables.stream()
+                .allMatch(variableReferenceExpression -> {
+                    if (Varchars.isVarcharType(variableReferenceExpression.getType())) {
+                        return isSupportedVarcharType((VarcharType) variableReferenceExpression.getType());
+                    }
+                    return true;
+                });
+    }
+
+    /*
+        Fetches the index of the first variable that can be materialized.
+        ToDo: Implement usage of NDV (number of distinct values) statistics to identify the best partitioning variable,
+         as temporary tables are bucketed.
+    */
+    public static Integer getCtePartitionIndex(List<VariableReferenceExpression> outputVariables)
+    {
+        for (int i = 0; i < outputVariables.size(); i++) {
+            if (isVariableMaterializable(outputVariables.get(i))) {
+                return i;
+            }
+        }
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, "No Partitioning index found");
+    }
+
+    /*
+        Currently, Hive bucketing does not support the Presto type 'ROW'.
+    */
+    public static boolean isVariableMaterializable(VariableReferenceExpression var)
+    {
+        return !(var.getType() instanceof RowType);
+    }
+
+    /*
+        While Presto supports Varchar of length 0 (as discussed in https://github.com/trinodb/trino/issues/1136),
+        Hive does not support this.
+     */
+    private static boolean isSupportedVarcharType(VarcharType varcharType)
+    {
+        return (varcharType.isUnbounded() || varcharType.getLengthSafe() != 0);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.eventlistener.CTEInformation;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.SequenceNode;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import com.google.common.graph.Traverser;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Stack;
+
+import static com.facebook.presto.SystemSessionProperties.getCteMaterializationStrategy;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy.ALL;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * Transformation of CTE Reference Nodes:
+ * This process converts CTE reference nodes into corresponding CteProducers and Consumers.
+ * Makes sure that execution deadlocks do not exist
+ *
+ * Example:
+ * Before Transformation:
+ *   JOIN
+ *   |-- CTEReference(cte2)
+ *   |   `-- TABLESCAN2
+ *   `-- CTEReference(cte3)
+ *       `-- TABLESCAN3
+ *
+ * After Transformation:
+ *   SEQUENCE(cte1)
+ *   |-- CTEProducer(cte2)
+ *   |   `-- TABLESCAN2
+ *   |-- CTEProducer(cte3)
+ *   |   `-- TABLESCAN3
+ *   `-- JOIN
+ *       |-- CTEConsumer(cte2)
+ *       `-- CTEConsumer(cte3)
+ */
+public class LogicalCteOptimizer
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public LogicalCteOptimizer(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(variableAllocator, "variableAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+        requireNonNull(warningCollector, "warningCollector is null");
+        if (!getCteMaterializationStrategy(session).equals(ALL)
+                || session.getCteInformationCollector().getCTEInformationList().stream().noneMatch(CTEInformation::isMaterialized)) {
+            return PlanOptimizerResult.optimizerResult(plan, false);
+        }
+        CteEnumerator cteEnumerator = new CteEnumerator(idAllocator, variableAllocator);
+        PlanNode rewrittenPlan = cteEnumerator.transformPersistentCtes(plan);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, cteEnumerator.isPlanRewritten());
+    }
+
+    public class CteEnumerator
+    {
+        private PlanNodeIdAllocator planNodeIdAllocator;
+        private VariableAllocator variableAllocator;
+
+        private boolean isPlanRewritten;
+
+        public CteEnumerator(PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator)
+        {
+            this.planNodeIdAllocator = requireNonNull(planNodeIdAllocator, "planNodeIdAllocator must not be null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator must not be null");
+        }
+
+        public PlanNode transformPersistentCtes(PlanNode root)
+        {
+            checkArgument(root.getSources().size() == 1, "expected newChildren to contain 1 node");
+            CteTransformerContext context = new CteTransformerContext();
+            PlanNode transformedCte = SimplePlanRewriter.rewriteWith(new CteConsumerTransformer(planNodeIdAllocator, variableAllocator),
+                    root, context);
+            List<PlanNode> topologicalOrderedList = context.getTopologicalOrdering();
+            if (topologicalOrderedList.isEmpty()) {
+                isPlanRewritten = false;
+                return root;
+            }
+            isPlanRewritten = true;
+            SequenceNode sequenceNode = new SequenceNode(root.getSourceLocation(), planNodeIdAllocator.getNextId(), topologicalOrderedList,
+                    transformedCte.getSources().get(0));
+            return root.replaceChildren(Arrays.asList(sequenceNode));
+        }
+
+        public boolean isPlanRewritten()
+        {
+            return isPlanRewritten;
+        }
+    }
+
+    public class CteConsumerTransformer
+            extends SimplePlanRewriter<CteTransformerContext>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        private final VariableAllocator variableAllocator;
+
+        public CteConsumerTransformer(PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator must not be null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator must not be null");
+        }
+
+        @Override
+        public PlanNode visitCteReference(CteReferenceNode node, RewriteContext<CteTransformerContext> context)
+        {
+            context.get().addDependency(node.getCteName());
+            context.get().pushActiveCte(node.getCteName());
+            // So that dependent CTEs are processed properly
+            PlanNode actualSource = context.rewrite(node.getSource(), context.get());
+            context.get().popActiveCte();
+            CteProducerNode cteProducerSource = new CteProducerNode(node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    actualSource,
+                    node.getCteName(),
+                    variableAllocator.newVariable("rows", BIGINT), node.getOutputVariables());
+            context.get().addProducer(node.getCteName(), cteProducerSource);
+            return new CteConsumerNode(node.getSourceLocation(), idAllocator.getNextId(), actualSource.getOutputVariables(), node.getCteName());
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<CteTransformerContext> context)
+        {
+            return new ApplyNode(node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    context.rewrite(node.getInput(),
+                            context.get()),
+                    context.rewrite(node.getSubquery(),
+                            context.get()),
+                    node.getSubqueryAssignments(),
+                    node.getCorrelation(),
+                    node.getOriginSubqueryError(),
+                    node.getMayParticipateInAntiJoin());
+        }}
+
+    public class CteTransformerContext
+    {
+        public Map<String, CteProducerNode> cteProducerMap;
+
+        // a -> b indicates that b needs to be processed before a
+        MutableGraph<String> graph;
+        public Stack<String> activeCteStack;
+
+        public CteTransformerContext()
+        {
+            cteProducerMap = new HashMap<>();
+            // The cte graph will never have cycles because sql won't allow it
+            graph = GraphBuilder.directed().build();
+            activeCteStack = new Stack<>();
+        }
+
+        public Map<String, CteProducerNode> getCteProducerMap()
+        {
+            return ImmutableMap.copyOf(cteProducerMap);
+        }
+
+        public void addProducer(String cteName, CteProducerNode cteProducer)
+        {
+            cteProducerMap.putIfAbsent(cteName, cteProducer);
+        }
+
+        public void pushActiveCte(String cte)
+        {
+            this.activeCteStack.push(cte);
+        }
+
+        public String popActiveCte()
+        {
+            return this.activeCteStack.pop();
+        }
+
+        public Optional<String> peekActiveCte()
+        {
+            return (this.activeCteStack.isEmpty()) ? Optional.empty() : Optional.ofNullable(this.activeCteStack.peek());
+        }
+
+        public void addDependency(String currentCte)
+        {
+            graph.addNode(currentCte);
+            Optional<String> parentCte = peekActiveCte();
+            parentCte.ifPresent(s -> graph.putEdge(currentCte, s));
+        }
+
+        public List<PlanNode> getTopologicalOrdering()
+        {
+            ImmutableList.Builder<PlanNode> topSortedCteProducerListBuilder = ImmutableList.builder();
+            Traverser.forGraph(graph).depthFirstPostOrder(graph.nodes())
+                    .forEach(cteName -> topSortedCteProducerListBuilder.add(cteProducerMap.get(cteName)));
+            return topSortedCteProducerListBuilder.build();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.PartitioningMetadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.eventlistener.CTEInformation;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.BasePlanFragmenter;
+import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.getCteMaterializationStrategy;
+import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
+import static com.facebook.presto.SystemSessionProperties.getPartitioningProviderCatalog;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.sql.TemporaryTableUtil.assignPartitioningVariables;
+import static com.facebook.presto.sql.TemporaryTableUtil.assignTemporaryTableColumnNames;
+import static com.facebook.presto.sql.TemporaryTableUtil.createTemporaryTableScan;
+import static com.facebook.presto.sql.TemporaryTableUtil.createTemporaryTableWriteWithoutExchanges;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy.ALL;
+import static com.facebook.presto.sql.planner.optimizations.CteUtils.getCtePartitionIndex;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * PhysicalCteOptimizer Transformation:
+ * This optimizer modifies the logical plan by transforming CTE producers into table writes
+ * and CTE consumers into table scans.
+ *
+ * Example:
+ * Before Transformation:
+ *   CTEProducer(cteX)
+ *   |-- SomeOperation
+ *   `-- CTEConsumer(cteX)
+ *
+ * After Transformation:
+ *   TableWrite(cteX)
+ *   |-- SomeOperation
+ *   `-- TableScan(cteX) *
+ */
+public class PhysicalCteOptimizer
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public PhysicalCteOptimizer(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(variableAllocator, "variableAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+        requireNonNull(warningCollector, "warningCollector is null");
+        if (!getCteMaterializationStrategy(session).equals(ALL)
+                || session.getCteInformationCollector().getCTEInformationList().stream().noneMatch(CTEInformation::isMaterialized)) {
+            return PlanOptimizerResult.optimizerResult(plan, false);
+        }
+        PhysicalCteTransformerContext context = new PhysicalCteTransformerContext();
+        CteProducerRewiter cteProducerRewiter = new CteProducerRewiter(session, idAllocator, variableAllocator);
+        CteConsumerRewrite cteConsumerRewrite = new CteConsumerRewrite(session, idAllocator, variableAllocator);
+        PlanNode producerReplaced = SimplePlanRewriter.rewriteWith(cteProducerRewiter, plan, context);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(cteConsumerRewrite, producerReplaced, context);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan,
+                cteConsumerRewrite.isPlanRewritten() || cteProducerRewiter.isPlanRewritten());
+    }
+
+    public class CteProducerRewiter
+            extends SimplePlanRewriter<PhysicalCteTransformerContext>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        private final VariableAllocator variableAllocator;
+
+        private final Session session;
+
+        private boolean isPlanRewritten;
+
+        public CteProducerRewiter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator must not be null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator must not be null");
+            this.session = requireNonNull(session, "session must not be null");
+        }
+
+        @Override
+        public PlanNode visitCteProducer(CteProducerNode node, RewriteContext<PhysicalCteTransformerContext> context)
+        {
+            isPlanRewritten = true;
+            // Create Table Metadata
+            PlanNode actualSource = node.getSource();
+            VariableReferenceExpression partitionVariable = actualSource.getOutputVariables()
+                    .get(getCtePartitionIndex(actualSource.getOutputVariables()));
+            List<Type> partitioningTypes = Arrays.asList(partitionVariable.getType());
+            String partitioningProviderCatalog = getPartitioningProviderCatalog(session);
+            // First column is taken as the partitioning column
+            Partitioning partitioning = Partitioning.create(
+                    metadata.getPartitioningHandleForExchange(session, partitioningProviderCatalog,
+                            getHashPartitionCount(session), partitioningTypes),
+                    Arrays.asList(partitionVariable));
+            BasePlanFragmenter.PartitioningVariableAssignments partitioningVariableAssignments
+                    = assignPartitioningVariables(variableAllocator, partitioning);
+            Map<VariableReferenceExpression, ColumnMetadata> variableToColumnMap =
+                    assignTemporaryTableColumnNames(actualSource.getOutputVariables(),
+                            partitioningVariableAssignments.getConstants().keySet());
+            List<VariableReferenceExpression> partitioningVariables = partitioningVariableAssignments.getVariables();
+            List<String> partitionColumns = partitioningVariables.stream()
+                    .map(variable -> variableToColumnMap.get(variable).getName())
+                    .collect(toImmutableList());
+            PartitioningMetadata partitioningMetadata = new PartitioningMetadata(partitioning.getHandle(), partitionColumns);
+
+            TableHandle temporaryTableHandle;
+            try {
+                temporaryTableHandle = metadata.createTemporaryTable(
+                        session,
+                        partitioningProviderCatalog,
+                        ImmutableList.copyOf(variableToColumnMap.values()),
+                        Optional.of(partitioningMetadata));
+                context.get().put(node.getCteName(),
+                        new PhysicalCteTransformerContext.TemporaryTableInfo(
+                                createTemporaryTableScan(
+                                        metadata,
+                                        session,
+                                        idAllocator,
+                                        node.getSourceLocation(),
+                                        temporaryTableHandle,
+                                        actualSource.getOutputVariables(),
+                                        variableToColumnMap,
+                                        partitioningMetadata), node.getOutputVariables()));
+            }
+            catch (PrestoException e) {
+                if (e.getErrorCode().equals(NOT_SUPPORTED.toErrorCode())) {
+                    throw new PrestoException(
+                            NOT_SUPPORTED,
+                            format("Temporary table cannot be created in catalog \"%s\": %s", partitioningProviderCatalog, e.getMessage()),
+                            e);
+                }
+                throw e;
+            }
+            // Create the writer
+            return createTemporaryTableWriteWithoutExchanges(
+                    metadata,
+                    session,
+                    idAllocator,
+                    variableAllocator,
+                    actualSource,
+                    temporaryTableHandle,
+                    actualSource.getOutputVariables(),
+                    variableToColumnMap,
+                    partitioningMetadata,
+                    node.getRowCountVariable());
+        }
+
+        public boolean isPlanRewritten()
+        {
+            return isPlanRewritten;
+        }
+    }
+
+    public class CteConsumerRewrite
+            extends SimplePlanRewriter<PhysicalCteTransformerContext>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        private final VariableAllocator variableAllocator;
+
+        private final Session session;
+
+        private boolean isPlanRewritten;
+
+        public CteConsumerRewrite(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator must not be null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator must not be null");
+            this.session = requireNonNull(session, "session must not be null");
+        }
+
+        @Override
+        public PlanNode visitCteConsumer(CteConsumerNode node, RewriteContext<PhysicalCteTransformerContext> context)
+        {
+            isPlanRewritten = true;
+            // Create Table Metadata
+            PhysicalCteTransformerContext.TemporaryTableInfo tableInfo = context.get().getTableInfo(node.getCteName());
+            TableScanNode tempScan = tableInfo.getTableScanNode();
+
+            // Need to create new Variables for temp table scans to avoid duplicate references
+            List<VariableReferenceExpression> newOutputVariables = new ArrayList<>();
+            Map<VariableReferenceExpression, ColumnHandle> newColumnAssignmentsMap = new HashMap<>();
+            for (VariableReferenceExpression oldVariable : tempScan.getOutputVariables()) {
+                VariableReferenceExpression newVariable = variableAllocator.newVariable(oldVariable);
+                newOutputVariables.add(newVariable);
+                newColumnAssignmentsMap.put(newVariable, tempScan.getAssignments().get(oldVariable));
+            }
+
+            TableScanNode tableScanNode = new TableScanNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    tempScan.getTable(),
+                    newOutputVariables,
+                    newColumnAssignmentsMap,
+                    tempScan.getCurrentConstraint(),
+                    tempScan.getEnforcedConstraint());
+
+            // The temporary table scan might have columns removed by the UnaliasSymbolReferences and other optimizers (its a plan tree after all),
+            // use originalOutputVariables (which are also canonicalized and maintained) and add them back
+            Map<VariableReferenceExpression, VariableReferenceExpression> intermediateReferenceMap = new HashMap<>();
+            for (int i = 0; i < tempScan.getOutputVariables().size(); i++) {
+                intermediateReferenceMap.put(tempScan.getOutputVariables().get(i), newOutputVariables.get(i));
+            }
+
+            Assignments.Builder assignments = Assignments.builder();
+            for (int i = 0; i < tableInfo.getOriginalOutputVariables().size(); i++) {
+                assignments.put(node.getOutputVariables().get(i), intermediateReferenceMap.get(tableInfo.getOriginalOutputVariables().get(i)));
+            }
+            return new ProjectNode(Optional.empty(), idAllocator.getNextId(), Optional.empty(),
+                    tableScanNode, assignments.build(), ProjectNode.Locality.LOCAL);
+        }
+
+        public boolean isPlanRewritten()
+        {
+            return isPlanRewritten;
+        }
+    }
+
+    public static class PhysicalCteTransformerContext
+    {
+        private Map<String, TemporaryTableInfo> cteNameToTableInfo = new HashMap<>();
+
+        public PhysicalCteTransformerContext()
+        {
+            cteNameToTableInfo = new HashMap<>();
+        }
+
+        public void put(String cteName, TemporaryTableInfo handle)
+        {
+            cteNameToTableInfo.put(cteName, handle);
+        }
+
+        public TemporaryTableInfo getTableInfo(String cteName)
+        {
+            return cteNameToTableInfo.get(cteName);
+        }
+
+        public static class TemporaryTableInfo
+        {
+            private final TableScanNode tableScanNode;
+            private final List<VariableReferenceExpression> originalOutputVariables;
+
+            public TemporaryTableInfo(TableScanNode tableScanNode, List<VariableReferenceExpression> originalOutputVariables)
+            {
+                this.tableScanNode = requireNonNull(tableScanNode, "tableScanNode must not be null");
+                this.originalOutputVariables = requireNonNull(originalOutputVariables, "originalOutputVariables must not be null");
+            }
+
+            public List<VariableReferenceExpression> getOriginalOutputVariables()
+            {
+                return originalOutputVariables;
+            }
+
+            public TableScanNode getTableScanNode()
+            {
+                return tableScanNode;
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -754,6 +755,12 @@ public class PropertyDerivations
             return ActualProperties.builder()
                     .global(singleStreamPartition())
                     .build();
+        }
+
+        public ActualProperties visitSequence(SequenceNode node, List<ActualProperties> context)
+        {
+            // Return the rightmost node properties
+            return context.get(context.size() - 1);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.function.LambdaArgumentDescriptor;
 import com.facebook.presto.spi.function.LambdaDescriptor;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -281,6 +282,13 @@ public class PushdownSubfields
         public PlanNode visitOutput(OutputNode node, RewriteContext<Context> context)
         {
             context.get().variables.addAll(node.getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitCteProducer(CteProducerNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSource().getOutputVariables());
             return context.defaultRewrite(node, context.get());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
@@ -269,6 +270,11 @@ public final class StreamPropertyDerivations
         //
         // Source nodes
         //
+        @Override
+        public StreamProperties visitSequence(SequenceNode node, List<StreamProperties> inputProperties)
+        {
+            return new StreamProperties(MULTIPLE, Optional.empty(), false);
+        }
 
         @Override
         public StreamProperties visitValues(ValuesNode node, List<StreamProperties> context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.plan.PlanVisitor;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.sql.planner.CanonicalJoinNode;
 import com.facebook.presto.sql.planner.CanonicalTableScanNode;
 import com.facebook.presto.sql.planner.StatsEquivalentPlanNodeWithLimit;
@@ -178,6 +179,10 @@ public abstract class InternalPlanVisitor<R, C>
     }
 
     public R visitStatsEquivalentPlanNodeWithLimit(StatsEquivalentPlanNodeWithLimit node, C context)
+    {
+        return visitPlan(node, context);
+    }
+    public R visitSequence(SequenceNode node, C context)
     {
         return visitPlan(node, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -37,6 +37,9 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -48,6 +51,7 @@ import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
@@ -111,6 +115,7 @@ import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -830,6 +835,41 @@ public class PlanPrinter
         }
 
         @Override
+        public Void visitSequence(SequenceNode node, Void context)
+        {
+            NodeRepresentation nodeOutput;
+            nodeOutput = addNode(node, "Sequence");
+            nodeOutput.appendDetails(getCteExecutionOrder(node));
+
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitCteConsumer(CteConsumerNode node, Void context)
+        {
+            NodeRepresentation nodeOutput;
+            nodeOutput = addNode(node, "CteConsumer");
+            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteName());
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitCteProducer(CteProducerNode node, Void context)
+        {
+            NodeRepresentation nodeOutput;
+            nodeOutput = addNode(node, "CteProducer");
+            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteName());
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitCteReference(CteReferenceNode node, Void context)
+        {
+            addNode(node, "CteReference");
+            return processChildren(node, context);
+        }
+
+        @Override
         public Void visitValues(ValuesNode node, Void context)
         {
             NodeRepresentation nodeOutput;
@@ -1352,6 +1392,22 @@ public class PlanPrinter
             representation.addNode(nodeOutput);
             return nodeOutput;
         }
+    }
+
+    public static String getCteExecutionOrder(SequenceNode node)
+    {
+        List<CteProducerNode> cteProducers = node.getCteProducers().stream()
+                .filter(c -> (c instanceof CteProducerNode))
+                .map(CteProducerNode.class::cast)
+                .collect(Collectors.toList());
+        if (cteProducers.isEmpty()) {
+            return "";
+        }
+        Collections.reverse(cteProducers);
+        return format("executionOrder = %s",
+                cteProducers.stream()
+                        .map(CteProducerNode::getCteName)
+                        .collect(Collectors.joining(" -> ", "{", "}")));
     }
 
     public static String getDynamicFilterAssignments(AbstractJoinNode node)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -19,6 +19,7 @@ import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementa
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
@@ -254,7 +255,8 @@ public class TestFeaturesConfig
                 .setUseHBOForScaledWriters(false)
                 .setRemoveRedundantCastToVarcharInJoin(true)
                 .setHandleComplexEquiJoins(false)
-                .setSkipHashGenerationForJoinWithTableScanInput(false));
+                .setSkipHashGenerationForJoinWithTableScanInput(false)
+                .setCteMaterializationStrategy(CteMaterializationStrategy.NONE));
     }
 
     @Test
@@ -455,6 +457,7 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-constant-array-contains-to-in", "true")
                 .put("optimizer.use-hbo-for-scaled-writers", "true")
                 .put("optimizer.remove-redundant-cast-to-varchar-in-join", "false")
+                .put("cte-materialization-strategy", "ALL")
                 .put("optimizer.handle-complex-equi-joins", "true")
                 .put("optimizer.skip-hash-generation-for-join-with-table-scan-input", "true")
                 .build();
@@ -656,7 +659,8 @@ public class TestFeaturesConfig
                 .setUseHBOForScaledWriters(true)
                 .setRemoveRedundantCastToVarcharInJoin(false)
                 .setHandleComplexEquiJoins(true)
-                .setSkipHashGenerationForJoinWithTableScanInput(true);
+                .setSkipHashGenerationForJoinWithTableScanInput(true)
+                .setCteMaterializationStrategy(CteMaterializationStrategy.ALL);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteConsumerMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteConsumerMatcher.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.PlanNode;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class CteConsumerMatcher
+        implements Matcher
+{
+    private final String expectedCteName;
+
+    public CteConsumerMatcher(String cteName)
+    {
+        this.expectedCteName = requireNonNull(cteName, "expectedCteName is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof CteConsumerNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        CteConsumerNode otherNode = (CteConsumerNode) node;
+        if (!expectedCteName.equalsIgnoreCase(otherNode.getCteName())) {
+            return NO_MATCH;
+        }
+
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("expectedCteName", expectedCteName)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteProducerMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteProducerMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.PlanNode;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class CteProducerMatcher
+        implements Matcher
+{
+    private final String expectedCteName;
+    public CteProducerMatcher(String cteName)
+    {
+        this.expectedCteName = requireNonNull(cteName, "expectedCteName is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof CteProducerNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        CteProducerNode otherNode = (CteProducerNode) node;
+        if (!expectedCteName.equalsIgnoreCase(otherNode.getCteName())) {
+            return NO_MATCH;
+        }
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("expectedCteName", expectedCteName)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -21,6 +21,8 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
@@ -29,6 +31,7 @@ import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -437,6 +440,23 @@ public final class PlanMatchPattern
 
         return node(JoinNode.class, anyTree(node(FilterNode.class, leftSource).with(dynamicFilterMatcher)), right)
                 .with(joinMatcher);
+    }
+
+    public static PlanMatchPattern cteConsumer(String cteName)
+    {
+        CteConsumerMatcher cteConsumerMatcher = new CteConsumerMatcher(cteName);
+        return node(CteConsumerNode.class).with(cteConsumerMatcher);
+    }
+
+    public static PlanMatchPattern cteProducer(String cteName, PlanMatchPattern source)
+    {
+        CteProducerMatcher cteProducerMatcher = new CteProducerMatcher(cteName);
+        return node(CteProducerNode.class, source).with(cteProducerMatcher);
+    }
+
+    public static PlanMatchPattern sequence(PlanMatchPattern... sources)
+    {
+        return node(SequenceNode.class, sources);
     }
 
     public static PlanMatchPattern spatialJoin(String expectedFilter, PlanMatchPattern left, PlanMatchPattern right)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.Optimizer;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
+import static com.facebook.presto.sql.planner.SqlPlannerContext.NestedCteStack.delimiter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.cteConsumer;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.cteProducer;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sequence;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestLogicalCteOptimizer
+        extends BasePlanTest
+{
+    @Test
+    public void testConvertSimpleCte()
+    {
+        assertUnitPlan("WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                        "SELECT * FROM temp t1 ",
+                anyTree(
+                        sequence(cteProducer("temp", anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer("temp")))));
+    }
+
+    @Test
+    public void testSimpleRedefinedCteWithSameName()
+    {
+        assertUnitPlan("WITH  temp as " +
+                        "( with temp as (SELECT orderkey FROM ORDERS) SELECT * FROM temp) " +
+                        "SELECT * FROM temp",
+                anyTree(
+                        sequence(
+                                cteProducer("temp", anyTree(cteConsumer("temp" + delimiter + "temp"))),
+                                cteProducer("temp" + delimiter + "temp", anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer("temp")))));
+    }
+
+    @Test
+    public void testComplexRedefinedNestedCtes()
+    {
+        assertUnitPlan(
+                "WITH " +
+                        "cte1 AS ( " +
+                        "   SELECT orderkey, totalprice FROM ORDERS WHERE orderkey < 100 " +
+                        "), " +
+                        "cte2 AS ( " +
+                        "   WITH cte3 AS ( WITH cte4 AS (SELECT orderkey, totalprice FROM cte1 WHERE totalprice > 1000) SELECT * FROM cte4) " +
+                        "   SELECT cte3.orderkey FROM cte3 " +
+                        "), " +
+                        "cte3 AS ( " +
+                        "   SELECT * FROM customer WHERE custkey < 50 " +
+                        ") " +
+                        "SELECT cte3.*, cte2.orderkey FROM cte3 JOIN cte2 ON cte3.custkey = cte2.orderkey",
+                anyTree(
+                        sequence(
+                                cteProducer("cte3", anyTree(tableScan("customer"))),
+                                cteProducer("cte2", anyTree(cteConsumer("cte2" + delimiter + "cte3"))),
+                                cteProducer("cte2" + delimiter + "cte3", anyTree(cteConsumer("cte2" + delimiter + "cte3" + delimiter + "cte4"))),
+                                cteProducer("cte2" + delimiter + "cte3" + delimiter + "cte4", anyTree(cteConsumer("cte1"))),
+                                cteProducer("cte1", anyTree(tableScan("orders"))),
+                                anyTree(
+                                        join(
+                                                anyTree(cteConsumer("cte3")),
+                                                anyTree(cteConsumer("cte2")))))));
+    }
+
+    @Test
+    public void testRedefinedCtesInDifferentScope()
+    {
+        assertUnitPlan("WITH  cte1 AS ( WITH cte2 as (SELECT orderkey FROM ORDERS WHERE orderkey < 100)" +
+                        "SELECT * FROM cte2), " +
+                        " cte2 AS (SELECT * FROM customer WHERE custkey < 50) " +
+                        "SELECT * FROM cte2  JOIN cte1 ON true",
+                anyTree(
+                        sequence(
+                                cteProducer("cte2", anyTree(tableScan("customer"))),
+                                cteProducer("cte1", anyTree(cteConsumer("cte1" + delimiter + "cte2"))),
+                                cteProducer("cte1" + delimiter + "cte2", anyTree(tableScan("orders"))),
+                                anyTree(join(anyTree(cteConsumer("cte2")), anyTree(cteConsumer("cte1")))))));
+    }
+
+    @Test
+    public void testNestedCte()
+    {
+        assertUnitPlan("WITH  temp1 as (SELECT orderkey FROM ORDERS), " +
+                        " temp2 as (SELECT * FROM temp1) " +
+                        "SELECT * FROM temp2",
+                anyTree(
+                        sequence(cteProducer("temp2", anyTree(cteConsumer("temp1"))),
+                                cteProducer("temp1", anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer("temp2")))));
+    }
+
+    @Test
+    public void testMultipleIndependentCtes()
+    {
+        assertUnitPlan("WITH  temp1 as (SELECT orderkey FROM ORDERS), " +
+                        " temp2 as (SELECT custkey FROM CUSTOMER) " +
+                        "SELECT * FROM temp1, temp2",
+                anyTree(
+                        sequence(cteProducer("temp1", anyTree(tableScan("orders"))),
+                                cteProducer("temp2", anyTree(tableScan("customer"))),
+                                anyTree(join(anyTree(cteConsumer("temp1")), anyTree(cteConsumer("temp2")))))));
+    }
+
+    @Test
+    public void testDependentCtes()
+    {
+        assertUnitPlan("WITH  temp1 as (SELECT orderkey FROM ORDERS), " +
+                        " temp2 as (SELECT orderkey FROM temp1) " +
+                        "SELECT * FROM temp2 , temp1",
+                anyTree(
+                        sequence(cteProducer("temp2", anyTree(cteConsumer("temp1"))),
+                                cteProducer("temp1", anyTree(tableScan("orders"))),
+                                anyTree(join(anyTree(cteConsumer("temp2")), anyTree(cteConsumer("temp1")))))));
+    }
+
+    @Test
+    public void testComplexCteWithJoins()
+    {
+        assertUnitPlan(
+                "WITH  cte_orders AS (SELECT orderkey, custkey FROM ORDERS), " +
+                        " cte_line_item AS (SELECT l.orderkey, l.suppkey FROM lineitem l JOIN cte_orders o ON l.orderkey = o.orderkey) " +
+                        "SELECT li.orderkey, s.suppkey, s.name FROM cte_line_item li JOIN SUPPLIER s ON li.suppkey = s.suppkey",
+                anyTree(
+                        sequence(
+                                cteProducer("cte_line_item",
+                                        anyTree(
+                                                join(
+                                                        anyTree(tableScan("lineitem")),
+                                                        anyTree(cteConsumer("cte_orders"))))),
+                                cteProducer("cte_orders", anyTree(tableScan("orders"))),
+                                anyTree(
+                                        join(
+                                                anyTree(cteConsumer("cte_line_item")),
+                                                anyTree(tableScan("supplier")))))));
+    }
+
+    @Test
+    public void tesNoPersistentCteOnlyWithRowType()
+    {
+        assertUnitPlan("WITH temp AS " +
+                        "( SELECT CAST(ROW('example_status', 100) AS ROW(status VARCHAR, amount INTEGER)) AS order_details" +
+                        " FROM (VALUES (1))" +
+                        ") SELECT * FROM temp",
+                anyTree(values("1")));
+    }
+
+    @Test
+    public void testSimplePersistentCteWithRowTypeAndNonRowType()
+    {
+        assertUnitPlan("WITH temp AS (" +
+                        "  SELECT * FROM (VALUES " +
+                        "    (CAST(ROW('example_status', 100) AS ROW(status VARCHAR, amount INTEGER)), 1)," +
+                        "    (CAST(ROW('another_status', 200) AS ROW(status VARCHAR, amount INTEGER)), 2)" +
+                        "  ) AS t (order_details, orderkey)" +
+                        ") SELECT * FROM temp",
+                anyTree(
+                        sequence(
+                                cteProducer("temp", anyTree(values("status", "amount"))),
+                                anyTree(cteConsumer("temp")))));
+    }
+
+    @Test
+    public void testNoPersistentCteWithZeroLengthVarcharType()
+    {
+        assertUnitPlan("WITH temp AS (" +
+                        "  SELECT * FROM (VALUES " +
+                        "    (CAST('' AS VARCHAR(0)), 9)" +
+                        "  ) AS t (text_column, number_column)" +
+                        ") SELECT * FROM temp",
+                anyTree(values("text_column", "number_column")));
+    }
+
+    private void assertUnitPlan(String sql, PlanMatchPattern pattern)
+    {
+        List<PlanOptimizer> optimizers = ImmutableList.of(
+                new LogicalCteOptimizer(getQueryRunner().getMetadata()));
+        assertPlan(sql, getSession(), Optimizer.PlanStage.OPTIMIZED, pattern, optimizers);
+    }
+
+    private Session getSession()
+    {
+        return Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "ALL")
+                .build();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/CTEInformation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/CTEInformation.java
@@ -25,22 +25,31 @@ public class CTEInformation
     //number of references of the CTE in the query
     private int numberOfReferences;
     private final boolean isView;
+    private final boolean isMaterialized;
 
     @JsonCreator
     public CTEInformation(
             @JsonProperty("cteName") String cteName,
             @JsonProperty("numberOfReferences") int numberOfReferences,
-            @JsonProperty("isView") boolean isView)
+            @JsonProperty("isView") boolean isView,
+            @JsonProperty("isMaterialized") boolean isMaterialized)
     {
         this.cteName = requireNonNull(cteName, "cteName is null");
         this.numberOfReferences = numberOfReferences;
         this.isView = isView;
+        this.isMaterialized = isMaterialized;
     }
 
     @JsonProperty
     public String getCteName()
     {
         return cteName;
+    }
+
+    @JsonProperty
+    public boolean isMaterialized()
+    {
+        return isMaterialized;
     }
 
     @JsonProperty

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteReferenceNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteReferenceNode.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+
+@Immutable
+public final class CteReferenceNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final String cteName;
+
+    @JsonCreator
+    public CteReferenceNode(
+            Optional<SourceLocation> sourceLocation,
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("cteName") String cteName)
+    {
+        this(sourceLocation, id, Optional.empty(), source, cteName);
+    }
+
+    public CteReferenceNode(
+            Optional<SourceLocation> sourceLocation,
+            PlanNodeId id,
+            Optional<PlanNode> statsEquivalentPlanNode,
+            PlanNode source,
+            String cteName)
+    {
+        super(sourceLocation, id, statsEquivalentPlanNode);
+        this.cteName = cteName;
+        this.source = source;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return singletonList(source);
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return source.getOutputVariables();
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        checkArgument(newChildren.size() == 1, "expected newChildren to contain 1 node");
+        return new CteReferenceNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), cteName);
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return new CteReferenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, cteName);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitCteReference(this, context);
+    }
+
+    public String getCteName()
+    {
+        return cteName;
+    }
+
+    private static void checkArgument(boolean condition, String message)
+    {
+        if (!condition) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
@@ -84,4 +84,24 @@ public abstract class PlanVisitor<R, C>
     {
         return visitPlan(node, context);
     }
+
+    public R visitCteReference(CteReferenceNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitCteProducer(CteProducerNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitCteConsumer(CteConsumerNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitSequence(SequenceNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class SequenceNode
+        extends PlanNode
+{
+    // cteProducers {l1,l2,l3} will be in {l3, l2,l1} order
+    private final List<PlanNode> cteProducers;
+    private final PlanNode primarySource;
+
+    @JsonCreator
+    public SequenceNode(Optional<SourceLocation> sourceLocation,
+            @JsonProperty("id") PlanNodeId planNodeId,
+            @JsonProperty("cteProducers") List<PlanNode> left,
+            @JsonProperty("primarySource") PlanNode primarySource)
+    {
+        this(sourceLocation, planNodeId, Optional.empty(), left, primarySource);
+    }
+
+    public SequenceNode(Optional<SourceLocation> sourceLocation,
+            PlanNodeId planNodeId,
+            Optional<PlanNode> statsEquivalentPlanNode,
+            List<PlanNode> leftList,
+            PlanNode primarySource)
+    {
+        super(sourceLocation, planNodeId, statsEquivalentPlanNode);
+        this.cteProducers = leftList;
+        this.primarySource = primarySource;
+    }
+
+    @JsonProperty
+    public List<PlanNode> getCteProducers()
+    {
+        return this.cteProducers;
+    }
+
+    @JsonProperty
+    public PlanNode getPrimarySource()
+    {
+        return this.primarySource;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        List<PlanNode> children = new ArrayList<>(cteProducers);
+        children.add(primarySource);
+        return children;
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return primarySource.getOutputVariables();
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        return new SequenceNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(),
+                newChildren.subList(0, newChildren.size() - 1), newChildren.get(newChildren.size() - 1));
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return new SequenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, cteProducers, this.getPrimarySource());
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitSequence(this, context);
+    }
+}


### PR DESCRIPTION
## Description

Support persistent query-level CTEs

The goal is to allow users to define persistent ctes and support them
Session property cte_materialization_strategy is added which when set to ALL will materialize all ctes to HDFS

This will be the first step for [19744](https://github.com/prestodb/presto/issues/19744).

## Motivation and Context
This change is based on the [design](https://docs.google.com/document/d/10J9_j08imqe6xEH9iepteG0DA5B-IpmYv4lSRvCgdJA/edit#heading=h.pz9gj1ifu7su). The eventual goal is to materialize or stream the CTEs (either in local memory or remote) using CBO rules and the architecture reflects that.
The temporary tables created for each cte will be partitioned on the first input column
In the current implementation, all CTEs will be evaluated **before** the query is run.


This change has 5 main commits
### [Add session property and ast changes](https://github.com/prestodb/presto/pull/20887/commits/25fc788d5f031443a47008c359d8d1591c4330a7)

This change adds the session property which allows CTE materialization. This information is also added to the CTEInformation collector.
The relational planner has the main change where a CTEReference Node is added if a CTE is persistent. This reference node will be used by the LogicalCteOptimizer to process.


### Planner changes 
Main changes 
**LogicalCteOptimizer** - Processes the CTE references into CteConsumers and CteProducers. It also creates a sequence node which is added as a child below the topmost node. The sequence node has a list of leftSources and a right source. The leftSources list has the ctes ordered in a topological order of execution. {a,b,c,d} --> order of execution {d->c->b->a}.
 
**PhysicalCteOptimizer** - Processes the CteConsumers and CteProducers into table writes and temporary table scan. The processing code is based on [basePlanFragmenter](https://github.com/prestodb/presto/blob/70ecc392450b9e4dc2cb08652c630733bea54adb/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java#L313). From logical to physical optimizers, the CteProducer, CteConsumers, and Sequence Node are present to enable further logical optimizations. Physical optimization is applied just before adding exchanges. Post this optimization stage, CteConsumers and CteProducers are no longer present.

Code change in other optimizers  and visitors
	
_AddExchanges.java_ - Handling Sequence Node
_HashGenerationOptimizer.java_ - Handling Sequence Node
_StreamPropertyDerivations.java_ - Handling Sequence Node
_PropertyDerivations.java_ - Handling Sequence Node
_PruneUnreferencedOutputs.java_ - Handling CteConsumer, CteProducer and Sequnce
_PushdownSubfields.java_ - handling CteProducer Node
_StreamPropertyDerivations.java_ - handling sequence
_UnaliasSymbolReferences.java_ - Handling CteConsumer, CteProducer and Sequnce


### Scheduling changes
_BasePlanFragmenter_ - Handle and transform sequence nodes. {a,b,c,d} --> order of execution {d->c->b->a}
We will create a chain of different sections of plans {d->c->b->a} and add it as a child of the main query section. 

[StreamingPlanSection](https://github.com/prestodb/presto/blob/70ecc392450b9e4dc2cb08652c630733bea54adb/presto-main/src/main/java/com/facebook/presto/execution/scheduler/StreamingPlanSection.java#L28) will make sure that the children are scheduled and executed before the parent


###  Tests
Integration test to test end to end and result correctness
Testing logical cte optimizer 

Current wips

- [x] Handle UnaliasSymbolReferences.java. 
- [x] Handle ValidateDependenciesChecker.java
- [x] Check if result correctness can be done at a record level
- [x] Add parser and planner unit tests

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Production tested with ALL CTEs materialized


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

Todo in future PRs

1. Integrate with HBO and cost model
2. Local auto replacement of cte in the optimizer
3. Select the top five candidate strategies from the optimizer, execute the planning process for each from the logical to the physical stage within the optimizer, and determine the most optimal one.
4. Support non partitioned temporary tables 

Final Quality ToDos
- [x] Fix cases where the bucketing is done on unsupported buckets 
- [x] Production test again with changes



## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* New Feature: Materialization of Common Table Expressions (CTEs) in Queries
* The relevant user connectors must support creating temporary tables 
* By materializing CTEs, users can take advantage of reusing common table expressions within their queries, which can lead to reductions in both storage operations and computational costs

## Recommended Configurations

1. CTE Materialization Strategy:
   - Enable by setting the session property ``cte_materialization_strategy`` or the configuration property ``cte-materialization-strategy`` to ``ALL``.
2. Temporary Table Storage Format:
   - For faster processing, set the configuration ``hive.temporary-table-storage-format`` or the session property ``temporary_table_storage_format`` to ``PAGEFILE``.
3. Temporary Table Schema:
   - It is recommended to set the configuration ``hive.temporary-table-schema`` or the session property ``temporary_table_schema`` to use the user's schema.
 4. Partitioning Provider Catalog
 - The config property ``query.partitioning-provider-catalog`` ``partitioning_provider_catalog`` session property must be set to enable cte materialization. The catalog must support providing a custom partitioning and ability to store temporary tables.
