### PR TITLE
[native] Cancel function before adding once in PeriodicTaskManager.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -68,10 +68,12 @@ class PeriodicTaskManager {
         func, std::chrono::microseconds{periodMicros}, taskName);
   }
 
-  /// Add a task to run once.
+  /// Add a task to run once. Before adding, cancels the any task that has same
+  /// name.
   template <typename TFunc>
   void
   addTaskOnce(TFunc&& func, size_t periodMicros, const std::string& taskName) {
+    scheduler_.cancelFunction(taskName);
     scheduler_.addFunctionOnce(
         func, taskName, std::chrono::microseconds{periodMicros});
   }


### PR DESCRIPTION
Sometimes it's required to cancel a function that was registered in PeriodicTaskManager. Exposing cancel function through public method.