### PR TITLE
Make config in FeaturesConfig be the same with that in FileFragmentRe…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -1564,7 +1564,8 @@ public class FeaturesConfig
         return fragmentResultCachingEnabled;
     }
 
-    @Config("experimental.fragment-result-caching-enabled")
+    @Config("fragment-result-cache.enabled")
+    @LegacyConfig("experimental.fragment-result-caching-enabled")
     @ConfigDescription("Enable fragment result caching and read/write leaf fragment result pages from/to cache when applicable")
     public FeaturesConfig setFragmentResultCachingEnabled(boolean fragmentResultCachingEnabled)
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -259,7 +259,7 @@ public class TestFeaturesConfig
                 .put("dynamic-filtering-max-per-driver-row-count", "256")
                 .put("dynamic-filtering-max-per-driver-size", "64kB")
                 .put("dynamic-filtering-range-row-limit-per-driver", "1000")
-                .put("experimental.fragment-result-caching-enabled", "true")
+                .put("fragment-result-cache.enabled", "true")
                 .put("experimental.enable-stats-calculator", "false")
                 .put("experimental.enable-stats-collection-for-temporary-table", "true")
                 .put("optimizer.ignore-stats-calculator-failures", "false")


### PR DESCRIPTION
## Description
There is a bug in fragment cache. We expect to enable fragment cache by setting `fragment-result-cache.enabled=true` in `config.properties`. But if we only set that in `config.properties`, it doesn't work. We still need to set the session property `fragment-result-cache.enabled=true` when using the `presto-cli`, since the default session value of `fragment-result-cache.enabled` is set by `experimental.fragment-result-caching-enabled`. That means we have to set both `fragment-result-cache.enabled` and `experimental.fragment-result-caching-enabled` to true if we want to enable fragment cache. This is intuitive and easily misunderstood.  Actually, one configuration `fragment-result-cache.enabled` is enough.

## Impact
We don't need to set both `fragment-result-cache.enabled` and `experimental.fragment-result-caching-enabled` to `true` if we want to enable fragment cache. Now only `fragment-result-cache.enabled=true` is required. 

## Test Plan
Remove the configuration `experimental.fragment-result-caching-enabled` and only set `fragment-result-cache.enabled=true` to test if fragment cache is enabled correctly. I tested it and it turns out that it works.

```
== NO RELEASE NOTE ==
```

