### PR TITLE
Set initial number of tasks for scaled writer with HBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -292,6 +292,7 @@ public final class SystemSessionProperties
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
     public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
+    public static final String ENABLE_HISTORY_BASED_SCALED_WRITER = "enable_history_based_scaled_writer";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1751,6 +1752,11 @@ public final class SystemSessionProperties
                         INFER_INEQUALITY_PREDICATES,
                         "Infer nonequality predicates for joins",
                         featuresConfig.getInferInequalityPredicates(),
+                        false),
+                booleanProperty(
+                        ENABLE_HISTORY_BASED_SCALED_WRITER,
+                        "Enable setting the initial number of tasks for scaled writers with HBO",
+                        featuresConfig.isUseHBOForScaledWriters(),
                         false));
     }
 
@@ -2919,5 +2925,10 @@ public final class SystemSessionProperties
     public static boolean shouldInferInequalityPredicates(Session session)
     {
         return session.getSystemProperty(INFER_INEQUALITY_PREDICATES, Boolean.class);
+    }
+
+    public static boolean useHBOForScaledWriters(Session session)
+    {
+        return session.getSystemProperty(ENABLE_HISTORY_BASED_SCALED_WRITER, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableWriterNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableWriterNodeStatsEstimate.java
@@ -21,43 +21,34 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Double.NaN;
 
-public class JoinNodeStatsEstimate
+public class TableWriterNodeStatsEstimate
 {
-    private static final JoinNodeStatsEstimate UNKNOWN = new JoinNodeStatsEstimate(NaN, NaN);
+    private static final TableWriterNodeStatsEstimate UNKNOWN = new TableWriterNodeStatsEstimate(NaN);
 
-    private final double nullJoinBuildKeyCount;
-    private final double joinBuildKeyCount;
+    private final double taskCountIfScaledWriter;
 
     @JsonCreator
-    public JoinNodeStatsEstimate(@JsonProperty("nullJoinBuildKeyCount") double nullJoinBuildKeyCount, @JsonProperty("joinBuildKeyCount") double joinBuildKeyCount)
+    public TableWriterNodeStatsEstimate(@JsonProperty("taskNumberIfScaledWriter") double taskCountIfScaledWriter)
     {
-        this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
-        this.joinBuildKeyCount = joinBuildKeyCount;
+        this.taskCountIfScaledWriter = taskCountIfScaledWriter;
     }
 
-    public static JoinNodeStatsEstimate unknown()
+    public static TableWriterNodeStatsEstimate unknown()
     {
         return UNKNOWN;
     }
 
     @JsonProperty
-    public double getNullJoinBuildKeyCount()
+    public double getTaskCountIfScaledWriter()
     {
-        return nullJoinBuildKeyCount;
-    }
-
-    @JsonProperty
-    public double getJoinBuildKeyCount()
-    {
-        return joinBuildKeyCount;
+        return taskCountIfScaledWriter;
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("nullJoinBuildKeyCount", nullJoinBuildKeyCount)
-                .add("joinBuildKeyCount", joinBuildKeyCount)
+                .add("taskNumberIfScaledWriter", taskCountIfScaledWriter)
                 .toString();
     }
 
@@ -70,14 +61,13 @@ public class JoinNodeStatsEstimate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JoinNodeStatsEstimate that = (JoinNodeStatsEstimate) o;
-        return Double.compare(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) == 0 &&
-                Double.compare(joinBuildKeyCount, that.joinBuildKeyCount) == 0;
+        TableWriterNodeStatsEstimate that = (TableWriterNodeStatsEstimate) o;
+        return Double.compare(taskCountIfScaledWriter, that.taskCountIfScaledWriter) == 0;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+        return Objects.hash(taskCountIfScaledWriter);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableWriterNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableWriterNodeStatsEstimate.java
@@ -28,7 +28,7 @@ public class TableWriterNodeStatsEstimate
     private final double taskCountIfScaledWriter;
 
     @JsonCreator
-    public TableWriterNodeStatsEstimate(@JsonProperty("taskNumberIfScaledWriter") double taskCountIfScaledWriter)
+    public TableWriterNodeStatsEstimate(@JsonProperty("taskCountIfScaledWriter") double taskCountIfScaledWriter)
     {
         this.taskCountIfScaledWriter = taskCountIfScaledWriter;
     }
@@ -48,7 +48,7 @@ public class TableWriterNodeStatsEstimate
     public String toString()
     {
         return toStringHelper(this)
-                .add("taskNumberIfScaledWriter", taskCountIfScaledWriter)
+                .add("taskCountIfScaledWriter", taskCountIfScaledWriter)
                 .toString();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
@@ -48,6 +48,7 @@ public class ScaledWriterScheduler
 
     private final boolean optimizedScaleWriterProducerBuffer;
     private final long writerMinSizeBytes;
+    private final Optional<Integer> initialTaskCount;
 
     private final Set<InternalNode> scheduledNodes = new HashSet<>();
 
@@ -61,7 +62,8 @@ public class ScaledWriterScheduler
             NodeSelector nodeSelector,
             ScheduledExecutorService executor,
             DataSize writerMinSize,
-            boolean optimizedScaleWriterProducerBuffer)
+            boolean optimizedScaleWriterProducerBuffer,
+            Optional<Integer> initialTaskCount)
     {
         this.stage = requireNonNull(stage, "stage is null");
         this.sourceTasksProvider = requireNonNull(sourceTasksProvider, "sourceTasksProvider is null");
@@ -70,6 +72,7 @@ public class ScaledWriterScheduler
         this.executor = requireNonNull(executor, "executor is null");
         this.writerMinSizeBytes = requireNonNull(writerMinSize, "minWriterSize is null").toBytes();
         this.optimizedScaleWriterProducerBuffer = optimizedScaleWriterProducerBuffer;
+        this.initialTaskCount = requireNonNull(initialTaskCount, "initialTaskCount is null");
     }
 
     public void finish()
@@ -93,7 +96,7 @@ public class ScaledWriterScheduler
     private int getNewTaskCount()
     {
         if (scheduledNodes.isEmpty()) {
-            return 1;
+            return initialTaskCount.orElse(1);
         }
 
         double fullTasks = sourceTasksProvider.get().stream()

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -41,6 +41,7 @@ import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.sql.planner.NodePartitionMap;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PlanFragmenterUtils;
 import com.facebook.presto.sql.planner.SplitSourceFactory;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
@@ -309,6 +310,8 @@ public class SectionExecutionFactory
                     .map(RemoteTask::getTaskStatus)
                     .collect(toList());
 
+            Optional<Integer> taskNumberIfScaledWriter = PlanFragmenterUtils.getTableWriterTasks(plan.getFragment().getRoot());
+
             ScaledWriterScheduler scheduler = new ScaledWriterScheduler(
                     stageExecution,
                     sourceTasksProvider,
@@ -316,7 +319,8 @@ public class SectionExecutionFactory
                     nodeScheduler.createNodeSelector(session, null, nodePredicate),
                     scheduledExecutor,
                     getWriterMinSize(session),
-                    isOptimizedScaleWriterProducerBuffer(session));
+                    isOptimizedScaleWriterProducerBuffer(session),
+                    taskNumberIfScaledWriter);
             whenAllStages(childStageExecutions, StageExecutionState::isDone)
                     .addListener(scheduler::finish, directExecutor());
             return scheduler;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -281,6 +281,7 @@ public class FeaturesConfig
     private boolean rewriteConstantArrayContainsToIn;
 
     private boolean preProcessMetadataCalls;
+    private boolean useHBOForScaledWriters;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2800,6 +2801,19 @@ public class FeaturesConfig
     public FeaturesConfig setRewriteConstantArrayContainsToInEnabled(boolean rewriteConstantArrayContainsToIn)
     {
         this.rewriteConstantArrayContainsToIn = rewriteConstantArrayContainsToIn;
+        return this;
+    }
+
+    public boolean isUseHBOForScaledWriters()
+    {
+        return this.useHBOForScaledWriters;
+    }
+
+    @Config("optimizer.use-hbo-for-scaled-writers")
+    @ConfigDescription("Enable HBO for setting initial number of tasks for scaled writers")
+    public FeaturesConfig setUseHBOForScaledWriters(boolean useHBOForScaledWriters)
+    {
+        this.useHBOForScaledWriters = useHBOForScaledWriters;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -579,7 +579,8 @@ public abstract class BasePlanFragmenter
                                     outputNotNullColumnVariables,
                                     Optional.of(partitioningScheme),
                                     Optional.empty(),
-                                    enableStatsCollectionForTemporaryTable ? Optional.of(localAggregations.getPartialAggregation()) : Optional.empty())),
+                                    enableStatsCollectionForTemporaryTable ? Optional.of(localAggregations.getPartialAggregation()) : Optional.empty(),
+                                    Optional.empty())),
                     variableAllocator.newVariable("intermediaterows", BIGINT),
                     variableAllocator.newVariable("intermediatefragments", VARBINARY),
                     variableAllocator.newVariable("intermediatetablecommitcontext", VARBINARY),
@@ -599,7 +600,8 @@ public abstract class BasePlanFragmenter
                     outputNotNullColumnVariables,
                     Optional.of(partitioningScheme),
                     Optional.empty(),
-                    enableStatsCollectionForTemporaryTable ? Optional.of(aggregations.getPartialAggregation()) : Optional.empty());
+                    enableStatsCollectionForTemporaryTable ? Optional.of(aggregations.getPartialAggregation()) : Optional.empty(),
+                    Optional.empty());
         }
 
         return new TableFinishNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -119,7 +120,7 @@ public class CachingPlanCanonicalInfoProvider
             return planStatistics;
         }
         TableStatistics tableStatistics = metadata.getTableStatistics(session, key.getTableHandle(), key.getColumnHandles(), key.getConstraint());
-        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, JoinNodeStatistics.empty());
+        planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty());
         cache.put(key, planStatistics);
         return planStatistics;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -195,6 +195,7 @@ public class CanonicalPlanGenerator
                 ImmutableSet.of(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
         context.addPlan(node, new CanonicalPlan(result, strategy));
         return Optional.of(result);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -421,7 +421,8 @@ public class LogicalPlanner
                             preferredShufflePartitioningScheme,
                             // partial aggregation is run within the TableWriteOperator to calculate the statistics for
                             // the data consumed by the TableWriteOperator
-                            Optional.of(aggregations.getPartialAggregation())),
+                            Optional.of(aggregations.getPartialAggregation()),
+                            Optional.empty()),
                     Optional.of(target),
                     variableAllocator.newVariable("rows", BIGINT),
                     // final aggregation is run within the TableFinishOperator to summarize collected statistics
@@ -448,6 +449,7 @@ public class LogicalPlanner
                         notNullColumnVariables,
                         tablePartitioningScheme,
                         preferredShufflePartitioningScheme,
+                        Optional.empty(),
                         Optional.empty()),
                 Optional.of(target),
                 variableAllocator.newVariable("rows", BIGINT),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -36,6 +36,7 @@ import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.getExchangeMaterializationStrategy;
@@ -242,6 +243,16 @@ public class PlanFragmenterUtils
                 .filter(node -> node instanceof TableWriterNode)
                 .map(PlanNode::getId)
                 .collect(toImmutableSet());
+    }
+
+    public static Optional<Integer> getTableWriterTasks(PlanNode plan)
+    {
+        return stream(forTree(PlanNode::getSources).depthFirstPreOrder(plan))
+                .filter(node -> node instanceof TableWriterNode)
+                .map(x -> ((TableWriterNode) x).getTaskCountIfScaledWriter())
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .max(Integer::compareTo);
     }
 
     private static final class PartitioningHandleReassigner

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -117,6 +117,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RewriteConstantArrayContai
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.RuntimeReorderJoinSides;
+import com.facebook.presto.sql.planner.iterative.rule.ScaledWriterRule;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyCardinalityMap;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyCountOverConstant;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyRowExpressions;
@@ -705,6 +706,14 @@ public class PlanOptimizers
                         .build()));
 
         builder.add(new RemoveRedundantDistinctAggregation());
+
+        builder.add(
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.of(new ScaledWriterRule())));
 
         if (!forceSingleNode) {
             builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -565,6 +565,7 @@ public class RowExpressionRewriteRuleSet
                 return Result.ofPlanNode(new TableWriterNode(
                         node.getSourceLocation(),
                         node.getId(),
+                        node.getStatsEquivalentPlanNode(),
                         node.getSource(),
                         node.getTarget(),
                         node.getRowCountVariable(),
@@ -575,7 +576,8 @@ public class RowExpressionRewriteRuleSet
                         node.getNotNullColumnVariables(),
                         node.getTablePartitioningScheme(),
                         node.getPreferredShufflePartitioningScheme(),
-                        rewrittenStatisticsAggregation));
+                        rewrittenStatisticsAggregation,
+                        node.getTaskCountIfScaledWriter()));
             }
             return Result.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ScaledWriterRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ScaledWriterRule.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.useHBOForScaledWriters;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableWriterNode;
+import static com.google.common.base.Preconditions.checkState;
+
+public class ScaledWriterRule
+        implements Rule<TableWriterNode>
+{
+    @Override
+    public Pattern<TableWriterNode> getPattern()
+    {
+        return tableWriterNode().matching(x -> !x.getTaskCountIfScaledWriter().isPresent());
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return useHBOForScaledWriters(session);
+    }
+
+    @Override
+    public Result apply(TableWriterNode node, Captures captures, Context context)
+    {
+        double taskNumber = context.getStatsProvider().getStats(node).getTableWriterNodeStatsEstimate().getTaskCountIfScaledWriter();
+        if (Double.isNaN(taskNumber)) {
+            return Result.empty();
+        }
+        // We start from half of the original number
+        int initialTaskNumber = (int) Math.ceil(taskNumber / 2);
+        checkState(initialTaskNumber > 0, "taskCountIfScaledWriter should be at least 1");
+        return Result.ofPlanNode(new TableWriterNode(
+                node.getSourceLocation(),
+                node.getId(),
+                node.getStatsEquivalentPlanNode(),
+                node.getSource(),
+                node.getTarget(),
+                node.getRowCountVariable(),
+                node.getFragmentVariable(),
+                node.getTableCommitContextVariable(),
+                node.getColumns(),
+                node.getColumnNames(),
+                node.getNotNullColumnVariables(),
+                node.getTablePartitioningScheme(),
+                node.getPreferredShufflePartitioningScheme(),
+                node.getStatisticsAggregation(),
+                Optional.of(initialTaskNumber)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -575,7 +575,8 @@ public class AddLocalExchanges
                                     originalTableWriterNode.getNotNullColumnVariables(),
                                     originalTableWriterNode.getTablePartitioningScheme(),
                                     originalTableWriterNode.getPreferredShufflePartitioningScheme(),
-                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
+                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation),
+                                    originalTableWriterNode.getTaskCountIfScaledWriter()),
                             fixedParallelism(),
                             fixedParallelism());
                 }
@@ -599,7 +600,8 @@ public class AddLocalExchanges
                                     originalTableWriterNode.getNotNullColumnVariables(),
                                     originalTableWriterNode.getTablePartitioningScheme(),
                                     originalTableWriterNode.getPreferredShufflePartitioningScheme(),
-                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
+                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation),
+                                    originalTableWriterNode.getTaskCountIfScaledWriter()),
                             exchange.getProperties());
                 }
             }
@@ -627,7 +629,8 @@ public class AddLocalExchanges
                                 originalTableWriterNode.getNotNullColumnVariables(),
                                 originalTableWriterNode.getTablePartitioningScheme(),
                                 originalTableWriterNode.getPreferredShufflePartitioningScheme(),
-                                statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
+                                statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation),
+                                originalTableWriterNode.getTaskCountIfScaledWriter()),
                         exchange.getProperties());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -705,7 +705,8 @@ public class PruneUnreferencedOutputs
                     node.getNotNullColumnVariables(),
                     node.getTablePartitioningScheme(),
                     node.getPreferredShufflePartitioningScheme(),
-                    node.getStatisticsAggregation());
+                    node.getStatisticsAggregation(),
+                    node.getTaskCountIfScaledWriter());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -16,7 +16,7 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.cost.CachingStatsProvider;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.JoinNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -280,12 +280,13 @@ public class RandomizeNullKeyInOuterJoin
             PlanNode rewrittenLeft = context.rewrite(joinNode.getLeft(), context.get());
             PlanNode rewrittenRight = context.rewrite(joinNode.getRight(), context.get());
 
-            PlanNodeStatsEstimate joinEstimate = statsProvider.getStats(joinNode);
-            boolean enabledByCostModel = strategy.equals(COST_BASED) && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
-                    && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() / joinEstimate.getJoinNodeStatsEstimate().getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
+            JoinNodeStatsEstimate joinEstimate = statsProvider.getStats(joinNode).getJoinNodeStatsEstimate();
+            boolean isValidEstimate = !Double.isNaN(joinEstimate.getJoinBuildKeyCount()) && !Double.isNaN(joinEstimate.getNullJoinBuildKeyCount());
+            boolean enabledByCostModel = isValidEstimate && strategy.equals(COST_BASED) && joinEstimate.getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
+                    && joinEstimate.getNullJoinBuildKeyCount() / joinEstimate.getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
             String statsSource = null;
             if (enabledByCostModel) {
-                statsSource = joinEstimate.getSourceInfo().getSourceInfoName();
+                statsSource = statsProvider.getStats(joinNode).getSourceInfo().getSourceInfoName();
             }
             List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
                     .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -252,7 +252,8 @@ public class SymbolMapper
                 node.getNotNullColumnVariables(),
                 node.getTablePartitioningScheme().map(partitioningScheme -> canonicalize(partitioningScheme, source)),
                 node.getPreferredShufflePartitioningScheme().map(partitioningScheme -> canonicalize(partitioningScheme, source)),
-                node.getStatisticsAggregation().map(this::map));
+                node.getStatisticsAggregation().map(this::map),
+                node.getTaskCountIfScaledWriter());
     }
 
     public StatisticsWriterNode map(StatisticsWriterNode node, PlanNode source)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -55,6 +55,7 @@ public class TableWriterNode
     private final Optional<PartitioningScheme> preferredShufflePartitioningScheme;
     private final Optional<StatisticAggregations> statisticsAggregation;
     private final List<VariableReferenceExpression> outputs;
+    private final Optional<Integer> taskCountIfScaledWriter;
 
     @JsonCreator
     public TableWriterNode(
@@ -70,9 +71,10 @@ public class TableWriterNode
             @JsonProperty("notNullColumnVariables") Set<VariableReferenceExpression> notNullColumnVariables,
             @JsonProperty("partitioningScheme") Optional<PartitioningScheme> tablePartitioningScheme,
             @JsonProperty("preferredShufflePartitioningScheme") Optional<PartitioningScheme> preferredShufflePartitioningScheme,
-            @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation)
+            @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation,
+            @JsonProperty("taskCountIfScaledWriter") Optional<Integer> taskCountIfScaledWriter)
     {
-        this(sourceLocation, id, Optional.empty(), source, target, rowCountVariable, fragmentVariable, tableCommitContextVariable, columns, columnNames, notNullColumnVariables, tablePartitioningScheme, preferredShufflePartitioningScheme, statisticsAggregation);
+        this(sourceLocation, id, Optional.empty(), source, target, rowCountVariable, fragmentVariable, tableCommitContextVariable, columns, columnNames, notNullColumnVariables, tablePartitioningScheme, preferredShufflePartitioningScheme, statisticsAggregation, taskCountIfScaledWriter);
     }
 
     public TableWriterNode(
@@ -89,7 +91,8 @@ public class TableWriterNode
             Set<VariableReferenceExpression> notNullColumnVariables,
             Optional<PartitioningScheme> tablePartitioningScheme,
             Optional<PartitioningScheme> preferredShufflePartitioningScheme,
-            Optional<StatisticAggregations> statisticsAggregation)
+            Optional<StatisticAggregations> statisticsAggregation,
+            Optional<Integer> taskCountIfScaledWriter)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
 
@@ -121,6 +124,7 @@ public class TableWriterNode
             outputs.addAll(aggregation.getAggregations().keySet());
         });
         this.outputs = outputs.build();
+        this.taskCountIfScaledWriter = requireNonNull(taskCountIfScaledWriter, "taskCountIfScaledWriter is null");
     }
 
     @JsonProperty
@@ -201,6 +205,12 @@ public class TableWriterNode
         return outputs;
     }
 
+    @JsonProperty
+    public Optional<Integer> getTaskCountIfScaledWriter()
+    {
+        return taskCountIfScaledWriter;
+    }
+
     @Override
     public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
     {
@@ -224,7 +234,8 @@ public class TableWriterNode
                 notNullColumnVariables,
                 tablePartitioningScheme,
                 preferredShufflePartitioningScheme,
-                statisticsAggregation);
+                statisticsAggregation,
+                taskCountIfScaledWriter);
     }
 
     @Override
@@ -244,7 +255,8 @@ public class TableWriterNode
                 notNullColumnVariables,
                 tablePartitioningScheme,
                 preferredShufflePartitioningScheme,
-                statisticsAggregation);
+                statisticsAggregation,
+                taskCountIfScaledWriter);
     }
 
     // only used during planning -- will not be serialized

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -385,7 +385,7 @@ public class PlanPrinter
             double sdAmongTasks = Math.sqrt(squaredDifferences / tasks.size());
 
             builder.append(indentString(1))
-                    .append(format("CPU: %s, Scheduled: %s, Input: %s (%s); per task: avg.: %s std.dev.: %s, Output: %s (%s)%n",
+                    .append(format("CPU: %s, Scheduled: %s, Input: %s (%s); per task: avg.: %s std.dev.: %s, Output: %s (%s), %s tasks%n",
                             stageExecutionStats.getTotalCpuTime().convertToMostSuccinctTimeUnit(),
                             stageExecutionStats.getTotalScheduledTime().convertToMostSuccinctTimeUnit(),
                             formatPositions(stageExecutionStats.getProcessedInputPositions()),
@@ -393,7 +393,8 @@ public class PlanPrinter
                             formatDouble(avgPositionsPerTask),
                             formatDouble(sdAmongTasks),
                             formatPositions(stageExecutionStats.getOutputPositions()),
-                            stageExecutionStats.getOutputDataSize()));
+                            stageExecutionStats.getOutputDataSize(),
+                            tasks.size()));
         }
 
         PartitioningScheme partitioningScheme = fragment.getPartitioningScheme();

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFragmentStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFragmentStatsProvider.java
@@ -32,8 +32,8 @@ public class TestFragmentStatsProvider
         QueryId queryId2 = new QueryId("queryid2");
         PlanFragmentId planFragmentId1 = new PlanFragmentId(1);
         PlanFragmentId planFragmentId2 = new PlanFragmentId(2);
-        PlanNodeStatsEstimate planNodeStatsEstimate1 = new PlanNodeStatsEstimate(NaN, 10, true, ImmutableMap.of());
-        PlanNodeStatsEstimate planNodeStatsEstimate2 = new PlanNodeStatsEstimate(NaN, 100, true, ImmutableMap.of());
+        PlanNodeStatsEstimate planNodeStatsEstimate1 = new PlanNodeStatsEstimate(NaN, 10, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown());
+        PlanNodeStatsEstimate planNodeStatsEstimate2 = new PlanNodeStatsEstimate(NaN, 100, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown());
 
         assertEquals(fragmentStatsProvider.getStats(queryId1, planFragmentId1), PlanNodeStatsEstimate.unknown());
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -83,7 +84,7 @@ public class TestHistoricalPlanStatistics
 
     private PlanStatistics stats(double rows, double size)
     {
-        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1, JoinNodeStatistics.empty());
+        return new PlanStatistics(Estimate.of(rows), Estimate.of(size), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty());
     }
 
     private static HistoricalPlanStatistics updatePlanStatistics(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoryBasedStatsProvider.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.facebook.presto.sql.Optimizer;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.PlanAssert;
@@ -123,8 +124,8 @@ public class TestHistoryBasedStatsProvider
                             TableScanNode node = (TableScanNode) PlanNodeWithHash.getPlanNode();
                             if (node.getTable().toString().contains("orders")) {
                                 return new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
-                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty())))));
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
+                                        ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty())))));
                             }
                         }
                         return HistoricalPlanStatistics.empty();

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestRemoteSourceStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestRemoteSourceStatsRule.java
@@ -37,8 +37,8 @@ public class TestRemoteSourceStatsRule
         LocalQueryRunner localQueryRunner = new LocalQueryRunner(session);
         StatsCalculatorTester tester = new StatsCalculatorTester(localQueryRunner);
         FragmentStatsProvider fragmentStatsProvider = localQueryRunner.getFragmentStatsProvider();
-        fragmentStatsProvider.putStats(queryId, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
-        fragmentStatsProvider.putStats(queryId, new PlanFragmentId(2), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        fragmentStatsProvider.putStats(queryId, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
+        fragmentStatsProvider.putStats(queryId, new PlanFragmentId(2), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
         tester.assertStatsFor(planBuilder -> planBuilder.remoteSource(ImmutableList.of(new PlanFragmentId(1), new PlanFragmentId(2))))
                 .check(check -> check.totalSize(2000)
                         .outputRowsCountUnknown());

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -246,7 +246,8 @@ public class TestFeaturesConfig
                 .setAddPartialNodeForRowNumberWithLimitEnabled(true)
                 .setInferInequalityPredicates(false)
                 .setPullUpExpressionFromLambdaEnabled(false)
-                .setRewriteConstantArrayContainsToInEnabled(false));
+                .setRewriteConstantArrayContainsToInEnabled(false)
+                .setUseHBOForScaledWriters(false));
     }
 
     @Test
@@ -441,6 +442,7 @@ public class TestFeaturesConfig
                 .put("optimizer.infer-inequality-predicates", "true")
                 .put("optimizer.pull-up-expression-from-lambda", "true")
                 .put("optimizer.rewrite-constant-array-contains-to-in", "true")
+                .put("optimizer.use-hbo-for-scaled-writers", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -632,7 +634,8 @@ public class TestFeaturesConfig
                 .setAddPartialNodeForRowNumberWithLimitEnabled(false)
                 .setInferInequalityPredicates(true)
                 .setPullUpExpressionFromLambdaEnabled(true)
-                .setRewriteConstantArrayContainsToInEnabled(true);
+                .setRewriteConstantArrayContainsToInEnabled(true)
+                .setUseHBOForScaledWriters(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -869,6 +869,7 @@ public class PlanBuilder
                 ImmutableSet.of(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
@@ -18,8 +18,10 @@ import com.facebook.presto.Session;
 import com.facebook.presto.cost.FragmentStatsProvider;
 import com.facebook.presto.cost.HistoryBasedOptimizationConfig;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsCalculator;
+import com.facebook.presto.cost.JoinNodeStatsEstimate;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculatorTester;
+import com.facebook.presto.cost.TableWriterNodeStatsEstimate;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
@@ -32,6 +34,7 @@ import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.testing.InMemoryHistoryBasedPlanStatisticsProvider;
@@ -107,7 +110,7 @@ public class TestPrestoSparkStatsCalculator
     @Test
     public void testUsesHboStatsWhenMatchRuntime()
     {
-        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
         PlanBuilder planBuilder = new PlanBuilder(session, new PlanNodeIdAllocator(), metadata);
         PlanNode statsEquivalentRemoteSource = planBuilder
                 .registerVariable(planBuilder.variable("c1"))
@@ -123,7 +126,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1)), statsEquivalentRemoteSource))
@@ -134,7 +137,7 @@ public class TestPrestoSparkStatsCalculator
     @Test
     public void testUsesRuntimeStatsWhenNoHboStats()
     {
-        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))
                 .check(check -> check.totalSize(1000)
                         .outputRowsCountUnknown());
@@ -157,7 +160,7 @@ public class TestPrestoSparkStatsCalculator
         StatsCalculatorTester tester = new StatsCalculatorTester(
                 localQueryRunner,
                 prestoSparkStatsCalculator);
-        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
 
         PlanBuilder planBuilder = new PlanBuilder(session, new PlanNodeIdAllocator(), localQueryRunner.getMetadata());
         PlanNode statsEquivalentRemoteSource = planBuilder
@@ -172,7 +175,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
+                                        new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))
@@ -184,7 +187,7 @@ public class TestPrestoSparkStatsCalculator
     @Test
     public void testUsesRuntimeStatsWhenDiffersFromHbo()
     {
-        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of()));
+        fragmentStatsProvider.putStats(TEST_QUERY_ID, new PlanFragmentId(1), new PlanNodeStatsEstimate(NaN, 1000, true, ImmutableMap.of(), JoinNodeStatsEstimate.unknown(), TableWriterNodeStatsEstimate.unknown()));
 
         PlanBuilder planBuilder = new PlanBuilder(session, new PlanNodeIdAllocator(), metadata);
         PlanNode statsEquivalentRemoteSource = planBuilder
@@ -199,7 +202,7 @@ public class TestPrestoSparkStatsCalculator
                 new HistoricalPlanStatistics(
                         ImmutableList.of(
                                 new HistoricalPlanStatisticsEntry(
-                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1, JoinNodeStatistics.empty()),
+                                        new PlanStatistics(Estimate.of(10), Estimate.of(100), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
                                         ImmutableList.of())))));
 
         tester.assertStatsFor(pb -> pb.remoteSource(ImmutableList.of(new PlanFragmentId(1))))

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableWriterNodeStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableWriterNodeStatistics.java
@@ -24,25 +24,21 @@ import java.util.Objects;
 import static java.util.Objects.requireNonNull;
 
 @ThriftStruct
-public class JoinNodeStatistics
+public class TableWriterNodeStatistics
 {
-    private static final JoinNodeStatistics EMPTY = new JoinNodeStatistics(Estimate.unknown(), Estimate.unknown());
-    // Number of input rows from build side of a join which has at least one join column to be NULL
-    private final Estimate nullJoinBuildKeyCount;
-    // Number of input rows from build side of a join
-    private final Estimate joinBuildKeyCount;
+    private static final TableWriterNodeStatistics EMPTY = new TableWriterNodeStatistics(Estimate.unknown());
+    // Number of writer tasks when the writer is scaled writer, otherwise unknown
+    private final Estimate taskCountIfScaledWriter;
 
     @JsonCreator
     @ThriftConstructor
-    public JoinNodeStatistics(
-            @JsonProperty("nullJoinBuildKeyCount") Estimate nullJoinBuildKeyCount,
-            @JsonProperty("joinBuildKeyCount") Estimate joinBuildKeyCount)
+    public TableWriterNodeStatistics(
+            @JsonProperty("taskNumberIfScaledWriter") Estimate taskCountIfScaledWriter)
     {
-        this.nullJoinBuildKeyCount = requireNonNull(nullJoinBuildKeyCount, "nullJoinBuildKeyCount is null");
-        this.joinBuildKeyCount = requireNonNull(joinBuildKeyCount, "joinBuildKeyCount is null");
+        this.taskCountIfScaledWriter = requireNonNull(taskCountIfScaledWriter, "nullJoinBuildKeyCount is null");
     }
 
-    public static JoinNodeStatistics empty()
+    public static TableWriterNodeStatistics empty()
     {
         return EMPTY;
     }
@@ -54,16 +50,9 @@ public class JoinNodeStatistics
 
     @JsonProperty
     @ThriftField(1)
-    public Estimate getNullJoinBuildKeyCount()
+    public Estimate getTaskCountIfScaledWriter()
     {
-        return nullJoinBuildKeyCount;
-    }
-
-    @JsonProperty
-    @ThriftField(2)
-    public Estimate getJoinBuildKeyCount()
-    {
-        return joinBuildKeyCount;
+        return taskCountIfScaledWriter;
     }
 
     @Override
@@ -75,22 +64,21 @@ public class JoinNodeStatistics
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JoinNodeStatistics that = (JoinNodeStatistics) o;
-        return Objects.equals(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) && Objects.equals(joinBuildKeyCount, that.joinBuildKeyCount);
+        TableWriterNodeStatistics that = (TableWriterNodeStatistics) o;
+        return Objects.equals(taskCountIfScaledWriter, that.taskCountIfScaledWriter);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+        return Objects.hash(taskCountIfScaledWriter);
     }
 
     @Override
     public String toString()
     {
-        return "JoinNodeStatistics{" +
-                "nullJoinBuildKeyCount=" + nullJoinBuildKeyCount +
-                ", joinBuildKeyCount=" + joinBuildKeyCount +
+        return "TableWriterNodeStatistics{" +
+                "taskNumberIfScaledWriter=" + taskCountIfScaledWriter +
                 '}';
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableWriterNodeStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableWriterNodeStatistics.java
@@ -33,9 +33,9 @@ public class TableWriterNodeStatistics
     @JsonCreator
     @ThriftConstructor
     public TableWriterNodeStatistics(
-            @JsonProperty("taskNumberIfScaledWriter") Estimate taskCountIfScaledWriter)
+            @JsonProperty("taskCountIfScaledWriter") Estimate taskCountIfScaledWriter)
     {
-        this.taskCountIfScaledWriter = requireNonNull(taskCountIfScaledWriter, "nullJoinBuildKeyCount is null");
+        this.taskCountIfScaledWriter = requireNonNull(taskCountIfScaledWriter, "taskCountIfScaledWriter is null");
     }
 
     public static TableWriterNodeStatistics empty()
@@ -78,7 +78,7 @@ public class TableWriterNodeStatistics
     public String toString()
     {
         return "TableWriterNodeStatistics{" +
-                "taskNumberIfScaledWriter=" + taskCountIfScaledWriter +
+                "taskCountIfScaledWriter=" + taskCountIfScaledWriter +
                 '}';
     }
 }

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoricalStatisticsSerde.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatisticsEntry;
 import com.facebook.presto.spi.statistics.JoinNodeStatistics;
 import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -36,8 +37,8 @@ public class TestHistoricalStatisticsSerde
     public void testSimpleHistoricalStatisticsEncoderDecoder()
     {
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(ImmutableList.of(new HistoricalPlanStatisticsEntry(
-                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty()),
-                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty())))));
+                new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
+                ImmutableList.of(new PlanStatistics(Estimate.of(15000), Estimate.unknown(), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty())))));
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
 
         // Test PlanHash
@@ -54,8 +55,8 @@ public class TestHistoricalStatisticsSerde
     {
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()),
-                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0, JoinNodeStatistics.empty()))));
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
+                    ImmutableList.of(new PlanStatistics(Estimate.of(100), Estimate.of(i), 0, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()))));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);
         HistoricalStatisticsSerde historicalStatisticsEncoderDecoder = new HistoricalStatisticsSerde();
@@ -81,11 +82,11 @@ public class TestHistoricalStatisticsSerde
     {
         List<PlanStatistics> planStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()));
+            planStatisticsEntryList.add(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()));
         }
         List<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntryList = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty()),
+            historicalPlanStatisticsEntryList.add(new HistoricalPlanStatisticsEntry(new PlanStatistics(Estimate.of(i * 5), Estimate.of(i * 5), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty()),
                     planStatisticsEntryList));
         }
         HistoricalPlanStatistics samplePlanStatistics = new HistoricalPlanStatistics(historicalPlanStatisticsEntryList);


### PR DESCRIPTION
## Description
Addresses https://github.com/prestodb/presto/issues/20355
Record the number of tasks used in scaled writers in HBO, and use HBO to set the initial number of writers to begin with for scaled writers.

## Motivation and Context
Scaled writers first have only 1 task to write data out, and increase the number of tasks as needed when the source is throttled. In this PR, the scaled writer will start with a number based on the number of previous runs, so that it can have larger parallelism in the beginning and hence improve latency.

## Impact
Latency improvement for scaled writer pipelines

## Test Plan
[Test query
](https://www.internalfb.com/intern/presto/query/?query_id=20230928_000135_00011_tjg5s#plan)

Also run with [verifier suite](https://www.internalfb.com/intern/presto/verifier/results/?test_id=140376&build=&user=&limit=200&error_regex=&suite=)

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add optimization for scaled writers with HBO, it can improve latency for query with scaled writer enabled. It's controlled by session property `enable_hbo_for_scaled_writer` and default to false.
```


