### PR TITLE
[native] Use presto_native as prefix for spill path.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -356,13 +356,11 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
       : "1970-01-01";
 
   std::string path;
-  folly::toAppend(fmt::format("{}/", baseSpillPath), &path);
+  folly::toAppend(fmt::format("{}/presto_native/", baseSpillPath), &path);
   if (includeNodeInSpillPath) {
     folly::toAppend(fmt::format("{}_{}/", nodeIp, nodeId), &path);
   }
-  folly::toAppend(
-      fmt::format("{}/presto_native/{}/{}/", dateString, queryId, taskId),
-      &path);
+  folly::toAppend(fmt::format("{}/{}/{}/", dateString, queryId, taskId), &path);
   return path;
 }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -937,11 +937,11 @@ TEST_F(TaskManagerTest, aggregationSpill) {
 
 TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
   EXPECT_EQ(
-      "fs::/base/192.168.10.2_19/2022-12-20/presto_native/20221220-Q/Task1/",
+      "fs::/base/presto_native/192.168.10.2_19/2022-12-20/20221220-Q/Task1/",
       TaskManager::buildTaskSpillDirectoryPath(
           "fs::/base", "192.168.10.2", "19", "20221220-Q", "Task1", true));
   EXPECT_EQ(
-      "fsx::/root/192.16.10.2_sample_node_id/1970-01-01/presto_native/Q100/Task22/",
+      "fsx::/root/presto_native/192.16.10.2_sample_node_id/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
           "fsx::/root",
           "192.16.10.2",
@@ -950,11 +950,11 @@ TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
           "Task22",
           true));
   EXPECT_EQ(
-      "fs::/base/2022-12-20/presto_native/20221220-Q/Task1/",
+      "fs::/base/presto_native/2022-12-20/20221220-Q/Task1/",
       TaskManager::buildTaskSpillDirectoryPath(
           "fs::/base", "192.168.10.2", "19", "20221220-Q", "Task1", false));
   EXPECT_EQ(
-      "fsx::/root/1970-01-01/presto_native/Q100/Task22/",
+      "fsx::/root/presto_native/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
           "fsx::/root",
           "192.16.10.2",


### PR DESCRIPTION
Instead of putting date as prefix of spill path, using presto-native as its easier to manager for remote storage.

