### PR TITLE
Fix #20906: make sure the value of param N of minN/maxN is unique

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -131,6 +131,9 @@ public abstract class AbstractMinMaxNAggregationFunction
             heap = new TypedHeap(comparator, type, toIntExact(n));
             state.setTypedHeap(heap);
         }
+        else {
+            checkCondition(n == heap.getCapacity(), INVALID_FUNCTION_ARGUMENT, "Count argument is not constant: found multiple values [%s, %s]", n, heap.getCapacity());
+        }
         long startSize = heap.getEstimatedSize();
         heap.add(block, blockIndex);
         state.addMemoryUsage(heap.getEstimatedSize() - startSize);
@@ -147,6 +150,9 @@ public abstract class AbstractMinMaxNAggregationFunction
             state.setTypedHeap(otherHeap);
             return;
         }
+
+        checkCondition(otherHeap.getCapacity() == heap.getCapacity(), INVALID_FUNCTION_ARGUMENT, "Count argument is not constant: found multiple values [%s, %s]: %s", otherHeap.getCapacity(), heap.getCapacity());
+
         long startSize = heap.getEstimatedSize();
         heap.addAll(otherHeap);
         state.addMemoryUsage(heap.getEstimatedSize() - startSize);


### PR DESCRIPTION
## Description
Fix #20906: make sure the value of param N of minN/maxN is unique

## Motivation and Context
Currently the uniqueness/consistency of param N of minN/maxN is not checked.

## Impact
The following sql will now fail(as expected):

```sql
presto> SELECT max(c0, c1)
     -> FROM (
     ->   VALUES
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '0', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '1', BIGINT '3'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '2', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '3', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '4', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '5', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '6', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '7', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '8', BIGINT '2'),
     ->     (cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->     (BIGINT '9', BIGINT '2')
     -> ) AS tmp (c0, c1);

Query 20230919_060731_00000_jkurk, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
[Latency: client-side: 0:01, server-side: 462ms] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20230919_060731_00000_jkurk failed: second argument of max_n/min_n is not unique: [2, 3] are seen.
```

## Test Plan
Added UT.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* minN/maxN's second argument is now checked to be unique.


