### PR TITLE
Remove requirement on metastore uri when using native Iceberg catalog

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -150,15 +150,8 @@ Iceberg connector supports Hadoop catalog
 .. code-block:: none
 
     connector.name=iceberg
-    hive.metastore.uri=hostname:port
     iceberg.catalog.type=hadoop
-
-.. note::
-
-    To use the Hadoop catalog with the Iceberg table, it requires the ``hive.metastore.uri`` property, even
-    though it doesn't rely on the metastore to provide the actual URI when using the Hadoop Catalog.
-    You can provide any value to this property, for example, ``hive.metastore.uri=thrift://localhost:9083``.
-    This will be fixed in a future release of Presto (:issue:`20579`).
+    iceberg.catalog.warehouse=hdfs://hostname:port
 
 Configuration Properties
 ------------------------
@@ -177,9 +170,12 @@ Property Name                                      Description                  
 ``hive.metastore.uri``                             The URI(s) of the Hive metastore to connect to using the
                                                    Thrift protocol. If multiple URIs are provided, the first
                                                    URI is used by default, and the rest of the URIs are
-                                                   fallback metastores. This property is required.
+                                                   fallback metastores.
                                                    Example: ``thrift://192.0.2.3:9083`` or
                                                    ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
+                                                   This property is required if the
+                                                   ``iceberg.catalog.type`` is ``hive``. Otherwise, it will
+                                                   be ignored.
 
 ``iceberg.file-format``                            The storage file format for Iceberg tables. The available     ``ORC``
                                                    values are ``PARQUET`` and ``ORC``.
@@ -194,12 +190,12 @@ Property Name                                      Description                  
 
 ``iceberg.catalog.warehouse``                      The catalog warehouse root path for Iceberg tables.
                                                    ``Example: hdfs://nn:8020/warehouse/path``
-                                                   This property is required if the iceberg.catalog.type is
-                                                   hadoop. Otherwise, it will be ignored.
+                                                   This property is required if the ``iceberg.catalog.type`` is
+                                                   ``hadoop``. Otherwise, it will be ignored.
 
 ``iceberg.catalog.cached-catalog-num``             The number of Iceberg catalogs to cache. This property is     ``10``
-                                                   required if the iceberg.catalog.type is hadoop. Otherwise,
-                                                   it will be ignored.
+                                                   required if the ``iceberg.catalog.type`` is ``hadoop``.
+                                                   Otherwise, it will be ignored.
 
 ``iceberg.hadoop.config.resources``                The path(s) for Hadoop configuration resources.
                                                    ``Example: /etc/hadoop/conf/core-site.xml.`` This property

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergHiveMetadataFactory
+        implements IcebergMetadataFactory
+{
+    final ExtendedHiveMetastore metastore;
+    final HdfsEnvironment hdfsEnvironment;
+    final TypeManager typeManager;
+    final JsonCodec<CommitTaskData> commitTaskCodec;
+
+    @Inject
+    public IcebergHiveMetadataFactory(
+            IcebergConfig config,
+            ExtendedHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> commitTaskCodec)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
+        requireNonNull(config, "config is null");
+    }
+
+    public ConnectorMetadata create()
+    {
+        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.PartitionMutator;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
+import com.facebook.presto.hive.metastore.HiveMetastoreModule;
+import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.MetastoreCacheStats;
+import com.facebook.presto.hive.metastore.MetastoreConfig;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class IcebergHiveModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String connectorId;
+    private final Optional<ExtendedHiveMetastore> metastore;
+
+    public IcebergHiveModule(String connectorId, Optional<ExtendedHiveMetastore> metastore)
+    {
+        this.connectorId = connectorId;
+        this.metastore = metastore;
+    }
+
+    @Override
+    public void setup(Binder binder)
+    {
+        install(new HiveMetastoreModule(this.connectorId, this.metastore));
+        binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(MetastoreClientConfig.class);
+        binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);
+
+        binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
+
+        binder.bind(IcebergMetadataFactory.class).to(IcebergHiveMetadataFactory.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(HiveClientConfig.class);
+        configBinder(binder).bindConfig(MetastoreConfig.class);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
@@ -13,54 +13,9 @@
  */
 package com.facebook.presto.iceberg;
 
-import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.common.type.TypeManager;
-import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 
-import javax.inject.Inject;
-
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-import static java.util.Objects.requireNonNull;
-
-public class IcebergMetadataFactory
+public interface IcebergMetadataFactory
 {
-    private final ExtendedHiveMetastore metastore;
-    private final HdfsEnvironment hdfsEnvironment;
-    private final TypeManager typeManager;
-    private final JsonCodec<CommitTaskData> commitTaskCodec;
-    private final IcebergResourceFactory resourceFactory;
-    private final CatalogType catalogType;
-
-    @Inject
-    public IcebergMetadataFactory(
-            IcebergConfig config,
-            IcebergResourceFactory resourceFactory,
-            ExtendedHiveMetastore metastore,
-            HdfsEnvironment hdfsEnvironment,
-            TypeManager typeManager,
-            JsonCodec<CommitTaskData> commitTaskCodec)
-    {
-        this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
-        this.metastore = requireNonNull(metastore, "metastore is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
-        requireNonNull(config, "config is null");
-        this.catalogType = config.getCatalogType();
-    }
-
-    public ConnectorMetadata create()
-    {
-        switch (catalogType) {
-            case HADOOP:
-            case NESSIE:
-                return new IcebergNativeMetadata(resourceFactory, typeManager, commitTaskCodec, catalogType);
-            case HIVE:
-                return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
-        }
-        throw new PrestoException(NOT_SUPPORTED, "Unsupported Presto Iceberg catalog type " + catalogType);
-    }
+    ConnectorMetadata create();
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergNativeMetadataFactory
+        implements IcebergMetadataFactory
+{
+    final TypeManager typeManager;
+    final JsonCodec<CommitTaskData> commitTaskCodec;
+    final IcebergResourceFactory resourceFactory;
+    final CatalogType catalogType;
+
+    @Inject
+    public IcebergNativeMetadataFactory(
+            IcebergConfig config,
+            IcebergResourceFactory resourceFactory,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> commitTaskCodec)
+    {
+        this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
+        requireNonNull(config, "config is null");
+        this.catalogType = config.getCatalogType();
+    }
+
+    public ConnectorMetadata create()
+    {
+        return new IcebergNativeMetadata(resourceFactory, typeManager, commitTaskCodec, catalogType);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeModule.java
@@ -13,26 +13,16 @@
  */
 package com.facebook.presto.iceberg;
 
-import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.google.inject.Binder;
-import com.google.inject.Module;
+import com.google.inject.Scopes;
 
-import javax.inject.Inject;
-
-public class IcebergMetastoreModule
-        implements Module
+public class IcebergNativeModule
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    public void setup(Binder binder)
     {
-        binder.bind(MetastoreValidator.class).asEagerSingleton();
-    }
-
-    public static class MetastoreValidator
-    {
-        @Inject
-        public MetastoreValidator(ExtendedHiveMetastore metastore)
-        {
-        }
+        binder.bind(IcebergMetadataFactory.class).to(IcebergNativeMetadataFactory.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -105,10 +105,9 @@ public final class IcebergQueryRunner
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.file-format", format.name())
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
-                .put("iceberg.file-format", format.name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
                 .putAll(extraConnectorProperties)
                 .build();
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
@@ -13,10 +13,25 @@
  */
 package com.facebook.presto.iceberg.hadoop;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
+import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
+import java.util.Map;
+
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 @Test
 public class TestIcebergDistributedHadoop
@@ -25,5 +40,36 @@ public class TestIcebergDistributedHadoop
     public TestIcebergDistributedHadoop()
     {
         super(HADOOP);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema("tpch")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(ImmutableMap.of("iceberg.catalog.type", HADOOP.name()))
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+
+        return queryRunner;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
@@ -13,25 +13,35 @@
  */
 package com.facebook.presto.iceberg.hadoop;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
+import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.iceberg.nessie.NessieConfig;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.apache.iceberg.Table;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.lang.String.format;
 
 @Test
@@ -48,6 +58,37 @@ public class TestIcebergSmokeHadoop
     {
         File tempLocation = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().toFile();
         return format("%s%s/%s", tempLocation.toURI(), schema, table);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema("tpch")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(ImmutableMap.of("iceberg.catalog.type", HADOOP.name()))
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+
+        return queryRunner;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -13,17 +13,29 @@
  */
 package com.facebook.presto.iceberg.nessie;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
-import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
+import java.util.Map;
+
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 @Test
 public class TestIcebergDistributedNessie
@@ -58,6 +70,30 @@ public class TestIcebergDistributedNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema("tpch")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+
+        return queryRunner;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -13,12 +13,13 @@
  */
 package com.facebook.presto.iceberg.nessie;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
-import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
@@ -26,19 +27,26 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.apache.iceberg.Table;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -90,7 +98,31 @@ public class TestIcebergSmokeNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema("tpch")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+
+        return queryRunner;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -74,8 +74,6 @@ public class TestIcebergSystemTablesNessie
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
-                .put("hive.metastore", "file")
-                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
                 .put("iceberg.catalog.warehouse", catalogDirectory.getParent().toFile().toURI().toString())
                 .build();
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -14,12 +14,16 @@
 package com.facebook.presto.iceberg.nessie;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
@@ -33,11 +37,17 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
@@ -87,7 +97,31 @@ public class TestNessieMultiBranching
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema("tpch")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+
+        return queryRunner;
     }
 
     @Test


### PR DESCRIPTION
## Description
Refactors portions of the Iceberg connector in order to remove requirement on metastore URI when using native Iceberg catalogs. More specifically, this PR separates the Iceberg binding modules into native (`IcebergNativeModule`) and Hive (`IcebergHiveModule`) modules, conditionally installing on the basis of the `catalog.type` value of the Iceberg config. A third new module (`IcebergCommonModule`) handles the bindings that apply to all catalog types. In a similar fashion, the `IcebergMetadataFactory` has been converted to an interface, with `IcebergNativeMetadataFactory` and `IcebergHiveMetadataFactory` implementations handling creation of the relevant `Metadata`.

As a result, the `hive.metastore.uri` config property is still required for the Hive catalog type whereas the (erroneous) requirement for the same has been removed for Nessie and Hadoop catalogs.

## Motivation and Context
Fixes #20579 

## Impact
NA

## Test Plan
In native tests, the `createQueryRunner` method is overridden in order to build a config that does not include `hive.metastore.uri`.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

