### PR TITLE
[Native] Add connector config

### DIFF
--- a/presto-native-execution/etc/catalog/hive.properties
+++ b/presto-native-execution/etc/catalog/hive.properties
@@ -1,3 +1,1 @@
 connector.name=hive
-
-cache.enabled=true

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -567,6 +567,22 @@ int32_t SystemConfig::oldTaskCleanUpMs() const {
   return optionalProperty<int32_t>(kOldTaskCleanUpMs).value();
 }
 
+ConnectorConfig::ConnectorConfig() {
+  registeredProps_ =
+      std::unordered_map<std::string, folly::Optional<std::string>>{
+          NONE_PROP(kConnectorName),
+          BOOL_PROP(kHiveImmutablePartitions, false),
+      };
+}
+
+std::string ConnectorConfig::connectorName() const {
+  return requiredProperty(kConnectorName);
+}
+
+bool ConnectorConfig::hiveImmutablePartitions() const {
+  return optionalProperty<bool>(kHiveImmutablePartitions).value();
+}
+
 NodeConfig::NodeConfig() {
   registeredProps_ =
       std::unordered_map<std::string, folly::Optional<std::string>>{

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -130,6 +130,10 @@ class ConfigBase {
     return config_->valuesCopy();
   }
 
+  std::shared_ptr<velox::Config> config() const {
+    return config_;
+  }
+
  protected:
   ConfigBase();
 
@@ -137,7 +141,7 @@ class ConfigBase {
   void checkRegisteredProperties(
       const std::unordered_map<std::string, std::string>& values);
 
-  std::unique_ptr<velox::Config> config_;
+  std::shared_ptr<velox::Config> config_;
   std::string filePath_;
   // Map of registered properties with their default values.
   std::unordered_map<std::string, folly::Optional<std::string>>
@@ -459,6 +463,21 @@ class SystemConfig : public ConfigBase {
   bool includeNodeInSpillPath() const;
 
   int32_t oldTaskCleanUpMs() const;
+};
+
+/// Provides access to connector properties defined in
+/// catalog/$connector_name.properties file.
+class ConnectorConfig : public ConfigBase {
+ public:
+  static constexpr std::string_view kConnectorName{"connector.name"};
+  static constexpr std::string_view kHiveImmutablePartitions{
+      "hive.immutable-partitions"};
+
+  ConnectorConfig();
+
+  std::string connectorName() const;
+
+  bool hiveImmutablePartitions() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -151,6 +151,16 @@ TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }
 
+TEST_F(ConfigTest, defaultConnectorConfig) {
+  ConnectorConfig config;
+  init(config, {});
+  ASSERT_EQ(config.hiveImmutablePartitions(), false);
+  init(
+      config,
+      {{std::string(ConnectorConfig::kHiveImmutablePartitions), "true"}});
+  ASSERT_EQ(config.hiveImmutablePartitions(), true);
+}
+
 TEST_F(ConfigTest, remoteFunctionServer) {
   SystemConfig config;
   init(config, {});


### PR DESCRIPTION
Hive connector properties is a key-value structure read from config
file, however, it won't have the configs that are not present in config 
file.

This PR adds the infrastructural support for hive connector config to
include all.