### PR TITLE
Add FunctionCall expression rewriter to presto.verifier

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateMaterializedView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateMaterializedView.java
@@ -31,6 +31,11 @@ public class CreateMaterializedView
     private final List<Property> properties;
     private final Optional<String> comment;
 
+    public CreateMaterializedView(QualifiedName name, Query query, boolean notExists, List<Property> properties, Optional<String> comment)
+    {
+        this(Optional.empty(), name, query, notExists, properties, comment);
+    }
+
     public CreateMaterializedView(Optional<NodeLocation> location, QualifiedName name, Query query, boolean notExists, List<Property> properties, Optional<String> comment)
     {
         super(location);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -1,0 +1,730 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.rewrite;
+
+import com.facebook.presto.sql.tree.AddColumn;
+import com.facebook.presto.sql.tree.AliasedRelation;
+import com.facebook.presto.sql.tree.Analyze;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.Call;
+import com.facebook.presto.sql.tree.CallArgument;
+import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.CreateMaterializedView;
+import com.facebook.presto.sql.tree.CreateSchema;
+import com.facebook.presto.sql.tree.CreateTable;
+import com.facebook.presto.sql.tree.CreateTableAsSelect;
+import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Cube;
+import com.facebook.presto.sql.tree.Deallocate;
+import com.facebook.presto.sql.tree.Delete;
+import com.facebook.presto.sql.tree.Except;
+import com.facebook.presto.sql.tree.Execute;
+import com.facebook.presto.sql.tree.Explain;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.GroupingSets;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Insert;
+import com.facebook.presto.sql.tree.Intersect;
+import com.facebook.presto.sql.tree.Join;
+import com.facebook.presto.sql.tree.JoinCriteria;
+import com.facebook.presto.sql.tree.JoinOn;
+import com.facebook.presto.sql.tree.Lateral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.Prepare;
+import com.facebook.presto.sql.tree.Property;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QueryBody;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.RefreshMaterializedView;
+import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Return;
+import com.facebook.presto.sql.tree.Rollup;
+import com.facebook.presto.sql.tree.Row;
+import com.facebook.presto.sql.tree.SampledRelation;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.ShowStats;
+import com.facebook.presto.sql.tree.SimpleGroupBy;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.SortItem;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.TableElement;
+import com.facebook.presto.sql.tree.TableSubquery;
+import com.facebook.presto.sql.tree.Union;
+import com.facebook.presto.sql.tree.Unnest;
+import com.facebook.presto.sql.tree.Values;
+import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.facebook.presto.sql.tree.With;
+import com.facebook.presto.sql.tree.WithQuery;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A default implementation of {@link AstVisitor} that reconstructs a node if any of its children is reconstructed.
+ * Expression node reconstruction is not supported and left to the users. At the moment it is only used for presto.verifier package.
+ * Generalize it with caution.
+ */
+public class DefaultTreeRewriter<C>
+        extends AstVisitor<Node, C>
+{
+    @Override
+    protected Node visitNode(Node node, C context)
+    {
+        return node;
+    }
+
+    @Override
+    protected Node visitExpression(Expression node, C context)
+    {
+        throw new UnsupportedOperationException("Not yet implemented: " + getClass().getSimpleName() + " for " + node.getClass().getName());
+    }
+
+    @Override
+    protected Node visitAddColumn(AddColumn node, C context)
+    {
+        Node column = process(node.getColumn(), context);
+        if (node.getColumn() == column) {
+            return node;
+        }
+
+        return new AddColumn(node.getName(), (ColumnDefinition) column, node.isTableExists(), node.isColumnNotExists());
+    }
+
+    @Override
+    protected Node visitAliasedRelation(AliasedRelation node, C context)
+    {
+        Node relation = process(node.getRelation(), context);
+        Node alias = process(node.getAlias(), context);
+        List<Identifier> columnNames = process(node.getColumnNames(), context);
+        if (node.getRelation() == relation && node.getAlias() == alias && sameElements(node.getColumnNames(), columnNames)) {
+            return node;
+        }
+
+        return new AliasedRelation((Relation) relation, (Identifier) alias, columnNames);
+    }
+
+    @Override
+    protected Node visitAnalyze(Analyze node, C context)
+    {
+        List<Property> properties = process(node.getProperties(), context);
+        if (sameElements(node.getProperties(), properties)) {
+            return node;
+        }
+
+        return new Analyze(node.getTableName(), properties);
+    }
+
+    @Override
+    protected Node visitCall(Call node, C context)
+    {
+        List<CallArgument> arguments = process(node.getArguments(), context);
+        if (sameElements(node.getArguments(), arguments)) {
+            return node;
+        }
+
+        return new Call(node.getName(), arguments);
+    }
+
+    @Override
+    protected Node visitCallArgument(CallArgument node, C context)
+    {
+        Node value = process(node.getValue(), context);
+        if (node.getValue() == value) {
+            return node;
+        }
+
+        return node.getName().isPresent() ? new CallArgument(node.getName().get(), (Expression) value) : new CallArgument((Expression) value);
+    }
+
+    @Override
+    protected Node visitColumnDefinition(ColumnDefinition node, C context)
+    {
+        Node name = process(node.getName(), context);
+        List<Property> properties = process(node.getProperties(), context);
+        if (node.getName() == name && sameElements(node.getProperties(), properties)) {
+            return node;
+        }
+
+        return new ColumnDefinition((Identifier) name, node.getType(), node.isNullable(), properties, node.getComment());
+    }
+
+    @Override
+    protected Node visitCreateMaterializedView(CreateMaterializedView node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        List<Property> properties = process(node.getProperties(), context);
+        if (node.getQuery() == query && node.getProperties() == properties) {
+            return node;
+        }
+
+        return new CreateMaterializedView(node.getName(), (Query) query, node.isNotExists(), properties, node.getComment());
+    }
+
+    @Override
+    protected Node visitCreateSchema(CreateSchema node, C context)
+    {
+        List<Property> properties = process(node.getProperties(), context);
+        if (sameElements(node.getProperties(), properties)) {
+            return node;
+        }
+
+        return new CreateSchema(node.getSchemaName(), node.isNotExists(), properties);
+    }
+
+    @Override
+    protected Node visitCreateTable(CreateTable node, C context)
+    {
+        List<TableElement> elements = process(node.getElements(), context);
+        List<Property> properties = process(node.getProperties(), context);
+        if (sameElements(node.getElements(), elements) && sameElements(node.getProperties(), properties)) {
+            return node;
+        }
+
+        return new CreateTable(node.getName(), elements, node.isNotExists(), properties, node.getComment());
+    }
+
+    @Override
+    protected Node visitCreateTableAsSelect(CreateTableAsSelect node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        List<Property> properties = process(node.getProperties(), context);
+        Optional<List<Identifier>> columnAliases = node.getColumnAliases().map(aliases -> process(aliases, context));
+        if (node.getQuery() == query && node.getProperties() == properties && (!columnAliases.isPresent() || sameElements(node.getColumnAliases().get(), columnAliases.get()))) {
+            return node;
+        }
+
+        return new CreateTableAsSelect(node.getName(), (Query) query, node.isNotExists(), properties, node.isWithData(), node.getColumnAliases(), node.getComment());
+    }
+
+    @Override
+    protected Node visitCreateView(CreateView node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        if (node.getQuery() == query) {
+            return node;
+        }
+
+        return new CreateView(node.getName(), (Query) query, node.isReplace(), node.getSecurity());
+    }
+
+    @Override
+    protected Node visitCube(Cube node, C context)
+    {
+        List<Expression> expressions = process(node.getExpressions(), context);
+        if (sameElements(node.getExpressions(), expressions)) {
+            return node;
+        }
+
+        return new Cube(expressions);
+    }
+
+    @Override
+    protected Node visitDeallocate(Deallocate node, C context)
+    {
+        Node name = process(node.getName(), context);
+        if (node.getName() == name) {
+            return node;
+        }
+
+        return new Deallocate((Identifier) name);
+    }
+
+    @Override
+    protected Node visitDelete(Delete node, C context)
+    {
+        Node table = process(node.getTable(), context);
+        Optional<Expression> where = process(node.getWhere(), context);
+        if (node.getTable() == table && sameElement(node.getWhere(), where)) {
+            return node;
+        }
+
+        return new Delete((Table) table, where);
+    }
+
+    @Override
+    protected Node visitExcept(Except node, C context)
+    {
+        Node left = process(node.getLeft(), context);
+        Node right = process(node.getRight(), context);
+        if (node.getLeft() == left && node.getRight() == right) {
+            return node;
+        }
+
+        return new Except((Relation) left, (Relation) right, node.isDistinct());
+    }
+
+    @Override
+    protected Node visitExecute(Execute node, C context)
+    {
+        Node name = process(node.getName(), context);
+        List<Expression> parameters = process(node.getParameters(), context);
+        if (node.getName() == name && sameElements(node.getParameters(), parameters)) {
+            return node;
+        }
+
+        return new Execute(node.getName(), parameters);
+    }
+
+    @Override
+    protected Node visitExplain(Explain node, C context)
+    {
+        Node statement = process(node.getStatement(), context);
+        if (node.getStatement() == statement) {
+            return node;
+        }
+
+        return new Explain((Statement) statement, node.isAnalyze(), node.isVerbose(), node.getOptions());
+    }
+
+    @Override
+    protected Node visitFrameBound(FrameBound node, C context)
+    {
+        Optional<Expression> value = process(node.getValue(), context);
+        if (sameElement(node.getValue(), value)) {
+            return node;
+        }
+
+        return value.isPresent() ? new FrameBound(node.getType(), value.get()) : new FrameBound(node.getType());
+    }
+
+    @Override
+    protected Node visitGroupBy(GroupBy node, C context)
+    {
+        List<GroupingElement> groupingElements = process(node.getGroupingElements(), context);
+        if (sameElements(node.getGroupingElements(), groupingElements)) {
+            return node;
+        }
+
+        return new GroupBy(node.isDistinct(), groupingElements);
+    }
+
+    @Override
+    protected Node visitGroupingSets(GroupingSets node, C context)
+    {
+        List<List<Expression>> sets = node.getSets().stream().map(expressionList -> process(expressionList, context)).collect(ImmutableList.toImmutableList());
+
+        if (sameElements(node.getSets(), sets)) {
+            return node;
+        }
+
+        return new GroupingSets(sets);
+    }
+
+    @Override
+    protected Node visitInsert(Insert node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        Optional<List<Identifier>> columns = node.getColumns().map(columnList -> process(columnList, context));
+        if (node.getQuery() == query && (!columns.isPresent() || sameElements(node.getColumns().get(), columns.get()))) {
+            return node;
+        }
+
+        return new Insert(node.getTarget(), columns, (Query) query);
+    }
+
+    @Override
+    protected Node visitIntersect(Intersect node, C context)
+    {
+        List<Relation> relations = process(node.getRelations(), context);
+        if (sameElements(node.getRelations(), relations)) {
+            return node;
+        }
+
+        return new Intersect(relations, node.isDistinct());
+    }
+
+    @Override
+    protected Node visitJoin(Join node, C context)
+    {
+        Node left = process(node.getLeft(), context);
+        Node right = process(node.getRight(), context);
+        Optional<JoinCriteria> joinCriteria = node.getCriteria()
+                .map(criteria -> {
+                    if (criteria instanceof JoinOn) {
+                        Node expression = process(((JoinOn) criteria).getExpression(), context);
+                        if (((JoinOn) criteria).getExpression() == expression) {
+                            return criteria;
+                        }
+                        return new JoinOn((Expression) expression);
+                    }
+                    return criteria;
+                });
+        if (node.getLeft() == left && node.getRight() == right && node.getCriteria() == joinCriteria) {
+            return node;
+        }
+
+        return new Join(node.getType(), (Relation) left, (Relation) right, joinCriteria);
+    }
+
+    @Override
+    protected Node visitLateral(Lateral node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        if (node.getQuery() == query) {
+            return node;
+        }
+
+        return new Lateral((Query) query);
+    }
+
+    @Override
+    protected Node visitOrderBy(OrderBy node, C context)
+    {
+        List<SortItem> sortItems = process(node.getSortItems(), context);
+        if (sameElements(node.getSortItems(), sortItems)) {
+            return node;
+        }
+
+        return new OrderBy(sortItems);
+    }
+
+    @Override
+    protected Node visitPrepare(Prepare node, C context)
+    {
+        Node statement = process(node.getStatement(), context);
+        if (node.getStatement() == statement) {
+            return node;
+        }
+
+        return new Prepare(node.getName(), (Statement) statement);
+    }
+
+    @Override
+    protected Node visitProperty(Property node, C context)
+    {
+        Node name = process(node.getName(), context);
+        Node value = process(node.getValue(), context);
+        if (node.getName() == name && node.getValue() == value) {
+            return node;
+        }
+
+        return new Property((Identifier) name, (Expression) value);
+    }
+
+    @Override
+    protected Node visitQuery(Query node, C context)
+    {
+        Optional<With> with = process(node.getWith(), context);
+        Node queryBody = process(node.getQueryBody(), context);
+        Optional<OrderBy> orderBy = process(node.getOrderBy(), context);
+        if (node.getQueryBody() == queryBody && sameElement(node.getWith(), with) && sameElement(node.getOrderBy(), orderBy)) {
+            return node;
+        }
+
+        return new Query(with, (QueryBody) queryBody, orderBy, node.getOffset(), node.getLimit());
+    }
+
+    @Override
+    protected Node visitQuerySpecification(QuerySpecification node, C context)
+    {
+        Node select = process(node.getSelect(), context);
+        Optional<Relation> from = process(node.getFrom(), context);
+        Optional<Expression> where = process(node.getWhere(), context);
+        Optional<GroupBy> groupBy = process(node.getGroupBy(), context);
+        Optional<Expression> having = process(node.getHaving(), context);
+        Optional<OrderBy> orderBy = process(node.getOrderBy(), context);
+        if (node.getSelect() ==
+                select && sameElement(node.getFrom(), from) && sameElement(node.getWhere(), where) && sameElement(node.getGroupBy(), groupBy) && sameElement(node.getHaving(),
+                having) && sameElement(node.getOrderBy(), orderBy)) {
+            return node;
+        }
+
+        return new QuerySpecification(
+                (Select) select,
+                from,
+                where,
+                groupBy,
+                having,
+                orderBy,
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    @Override
+    protected Node visitRefreshMaterializedView(RefreshMaterializedView node, C context)
+    {
+        Node table = process(node.getTarget(), context);
+        Node where = process(node.getWhere(), context);
+        if (node.getTarget() == table && node.getWhere() == where) {
+            return node;
+        }
+
+        return new RefreshMaterializedView((Table) table, (Expression) where);
+    }
+
+    @Override
+    protected Node visitReturn(Return node, C context)
+    {
+        Node expression = process(node.getExpression(), context);
+        if (node.getExpression() == expression) {
+            return node;
+        }
+
+        return new Return((Expression) expression);
+    }
+
+    @Override
+    protected Node visitRollup(Rollup node, C context)
+    {
+        List<Expression> expressions = process(node.getExpressions(), context);
+        if (sameElements(node.getExpressions(), expressions)) {
+            return node;
+        }
+
+        return new Rollup(expressions);
+    }
+
+    @Override
+    protected Node visitRow(Row node, C context)
+    {
+        List<Expression> items = process(node.getItems(), context);
+        if (sameElements(node.getItems(), items)) {
+            return node;
+        }
+
+        return new Row(items);
+    }
+
+    @Override
+    protected Node visitSampledRelation(SampledRelation node, C context)
+    {
+        Node relation = process(node.getRelation(), context);
+        Node samplePercentage = process(node.getSamplePercentage(), context);
+        if (node.getRelation() == relation && node.getSamplePercentage() == samplePercentage) {
+            return node;
+        }
+
+        return new SampledRelation((Relation) relation, node.getType(), (Expression) samplePercentage);
+    }
+
+    @Override
+    protected Node visitSelect(Select node, C context)
+    {
+        List<SelectItem> selectItems = process(node.getSelectItems(), context);
+        if (sameElements(node.getSelectItems(), selectItems)) {
+            return node;
+        }
+
+        return new Select(node.isDistinct(), selectItems);
+    }
+
+    @Override
+    protected Node visitShowStats(ShowStats node, C context)
+    {
+        Node relation = process(node.getRelation(), context);
+        if (node.getRelation() == relation) {
+            return node;
+        }
+
+        return new ShowStats((Relation) relation);
+    }
+
+    @Override
+    protected Node visitSimpleGroupBy(SimpleGroupBy node, C context)
+    {
+        List<Expression> columns = process(node.getExpressions(), context);
+        if (sameElements(node.getExpressions(), columns)) {
+            return node;
+        }
+
+        return new SimpleGroupBy(columns);
+    }
+
+    @Override
+    protected Node visitSingleColumn(SingleColumn node, C context)
+    {
+        Node expression = process(node.getExpression(), context);
+        if (node.getExpression() == expression) {
+            return node;
+        }
+
+        return new SingleColumn((Expression) expression, node.getAlias());
+    }
+
+    @Override
+    protected Node visitSortItem(SortItem node, C context)
+    {
+        Node sortKey = process(node.getSortKey(), context);
+        if (node.getSortKey() == sortKey) {
+            return node;
+        }
+
+        return new SortItem((Expression) sortKey, node.getOrdering(), node.getNullOrdering());
+    }
+
+    @Override
+    protected Node visitTableSubquery(TableSubquery node, C context)
+    {
+        Node query = process(node.getQuery(), context);
+        if (node.getQuery() == query) {
+            return node;
+        }
+
+        return new TableSubquery((Query) query);
+    }
+
+    @Override
+    protected Node visitUnion(Union node, C context)
+    {
+        List<Relation> relations = process(node.getRelations(), context);
+        if (sameElements(node.getRelations(), relations)) {
+            return node;
+        }
+
+        return new Union(relations, node.isDistinct());
+    }
+
+    @Override
+    protected Node visitUnnest(Unnest node, C context)
+    {
+        List<Expression> expressions = process(node.getExpressions(), context);
+        if (sameElements(node.getExpressions(), expressions)) {
+            return node;
+        }
+
+        return new Unnest(expressions, node.isWithOrdinality());
+    }
+
+    @Override
+    protected Node visitValues(Values node, C context)
+    {
+        List<Expression> expressions = process(node.getRows(), context);
+        if (sameElements(node.getRows(), expressions)) {
+            return node;
+        }
+
+        return new Values(expressions);
+    }
+
+    @Override
+    protected Node visitWindow(Window node, C context)
+    {
+        List<Expression> partitionBy = process(node.getPartitionBy(), context);
+        Optional<OrderBy> orderBy = process(node.getOrderBy(), context);
+        Optional<WindowFrame> frame = process(node.getFrame(), context);
+        if (sameElements(node.getPartitionBy(), partitionBy) && sameElement(node.getOrderBy(), orderBy) && sameElement(node.getFrame(), frame)) {
+            return node;
+        }
+
+        return new Window(partitionBy, orderBy, frame);
+    }
+
+    @Override
+    protected Node visitWindowFrame(WindowFrame node, C context)
+    {
+        Node start = process(node.getStart(), context);
+        Optional<FrameBound> end = process(node.getEnd(), context);
+        if (node.getStart() == start && sameElement(node.getEnd(), end)) {
+            return node;
+        }
+
+        return new WindowFrame(node.getType(), (FrameBound) start, end);
+    }
+
+    @Override
+    protected Node visitWith(With node, C context)
+    {
+        List<WithQuery> queries = process(node.getQueries(), context);
+        if (sameElements(node.getQueries(), queries)) {
+            return node;
+        }
+
+        return new With(node.isRecursive(), queries);
+    }
+
+    @Override
+    protected Node visitWithQuery(WithQuery node, C context)
+    {
+        Node name = process(node.getName(), context);
+        Node query = process(node.getQuery(), context);
+        Optional<List<Identifier>> columnNames = node.getColumnNames().map(columnNamesList -> process(columnNamesList, context));
+        if (node.getName() == name && node.getQuery() == query && sameElement(node.getColumnNames(), columnNames)) {
+            return node;
+        }
+
+        return new WithQuery(node.getName(), (Query) query, node.getColumnNames());
+    }
+
+    private <T extends Node> List<T> process(List<T> elements, C context)
+    {
+        if (elements == null) {
+            return null;
+        }
+        List<T> result = elements.stream().map(element -> (T) process(element, context)).collect(ImmutableList.toImmutableList());
+        return sameElements(elements, result) ? elements : result;
+    }
+
+    private <T extends Node> Optional<T> process(Optional<T> element, C context)
+    {
+        if (element == null) {
+            return null;
+        }
+        Optional<T> result = element.map(e -> (T) process(e, context));
+        return sameElement(element, result) ? element : result;
+    }
+
+    private static <T> boolean sameElement(Optional<T> a, Optional<T> b)
+    {
+        if (a == null && b == null) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        if (!a.isPresent() && !b.isPresent()) {
+            return true;
+        }
+        else if (a.isPresent() != b.isPresent()) {
+            return false;
+        }
+
+        return a.get() == b.get();
+    }
+
+    @SuppressWarnings("ObjectEquality")
+    private static <T> boolean sameElements(Iterable<? extends T> a, Iterable<? extends T> b)
+    {
+        if (a == null && b == null) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+
+        if (Iterables.size(a) != Iterables.size(b)) {
+            return false;
+        }
+
+        Iterator<? extends T> first = a.iterator();
+        Iterator<? extends T> second = b.iterator();
+
+        while (first.hasNext() && second.hasNext()) {
+            if (first.next() != second.next()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.rewrite;
+
+import com.facebook.presto.sql.ExpressionFormatter;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class FunctionCallRewriter
+        extends DefaultTreeRewriter<FunctionCallRewriter.Context>
+{
+    public static class FunctionCallSubstitute
+    {
+        private final QualifiedName name;
+        private final List<Integer> originalArgumentIndices;
+
+        public FunctionCallSubstitute(QualifiedName name, List<Integer> originalArgumentIndices)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.originalArgumentIndices = ImmutableList.copyOf(requireNonNull(originalArgumentIndices, "originalArgumentIndices is null"));
+        }
+
+        public QualifiedName name()
+        {
+            return name;
+        }
+
+        public List<Integer> originalArgumentIndices()
+        {
+            return originalArgumentIndices;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FunctionCallSubstitute that = (FunctionCallSubstitute) o;
+            return name.equals(that.name) && Objects.equals(originalArgumentIndices, that.originalArgumentIndices);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, originalArgumentIndices);
+        }
+    }
+
+    // Pattern of a function call with function name and a comma-separated argument list, ex., func_x(c_0,c_1), func_x(_,c_1) or func_x(,c_1).
+    private static final Pattern FUNCTION_CALL_PATTERN = Pattern.compile("(\\w+)\\(([\\w|,]+)\\)");
+    // Pattern to specify function call substitution, with the first element as the original and the second element as the substitute.
+    private static final Pattern FUNCTION_CALL_SUBSTITUTION_PATTERN = Pattern.compile(String.format("/%s/%s/", FUNCTION_CALL_PATTERN, FUNCTION_CALL_PATTERN));
+
+    private final Map<QualifiedName, FunctionCallSubstitute> functionCallSubstituteMap;
+
+    private List<List<FunctionCall>> processedFunctionCallSubstitutes = ImmutableList.of();
+
+    private FunctionCallRewriter(Map<QualifiedName, FunctionCallSubstitute> functionCallSubstituteMap)
+    {
+        this.functionCallSubstituteMap = requireNonNull(functionCallSubstituteMap, "functionCallSubstituteMap is null.");
+    }
+
+    public static FunctionCallRewriter getInstance(String functionCallSubstitutes)
+    {
+        Map<QualifiedName, FunctionCallSubstitute> functionCallSubstituteMap = constructFunctionCallSubstituteMap(functionCallSubstitutes);
+        return functionCallSubstituteMap.isEmpty() ? null : new FunctionCallRewriter(functionCallSubstituteMap);
+    }
+
+    public static boolean validateFunctionCallSubstitutes(String functionCallSubstitutes)
+    {
+        if (functionCallSubstitutes == null) {
+            return false;
+        }
+
+        Matcher matcher = FUNCTION_CALL_SUBSTITUTION_PATTERN.matcher(functionCallSubstitutes);
+        return matcher.find();
+    }
+
+    public static Map<QualifiedName, FunctionCallSubstitute> constructFunctionCallSubstituteMap(String functionCallSubstitutes)
+    {
+        ImmutableMap.Builder<QualifiedName, FunctionCallSubstitute> map = ImmutableMap.builder();
+        if (functionCallSubstitutes == null) {
+            return map.build();
+        }
+
+        Matcher matcher = FUNCTION_CALL_SUBSTITUTION_PATTERN.matcher(functionCallSubstitutes);
+
+        while (matcher.find()) {
+            String originalName = matcher.group(1);
+            List<String> originalArgumentList = ImmutableList.copyOf(matcher.group(2).split(","));
+
+            String substituteName = matcher.group(3);
+            List<String> substituteArgumentList = ImmutableList.copyOf(matcher.group(4).split(","));
+            List<Integer> originalArgumentIndices = substituteArgumentList.stream().map(originalArgumentList::indexOf).collect(Collectors.toList());
+            FunctionCallSubstitute substitute = new FunctionCallSubstitute(QualifiedName.of(substituteName), originalArgumentIndices);
+
+            map.put(QualifiedName.of(originalName), substitute);
+        }
+
+        return map.build();
+    }
+
+    public Node rewrite(Node root)
+    {
+        Context context = new Context();
+        Node rewritten = process(root, context);
+        processedFunctionCallSubstitutes = context.getFunctionCallSubstitutes();
+        return rewritten;
+    }
+
+    public String getProcessedFunctionCallSubstitutes()
+    {
+        return processedFunctionCallSubstitutes.stream().map(functionCallSubstitute -> {
+                    String formattedOriginal = ExpressionFormatter.formatExpression(functionCallSubstitute.get(0), Optional.empty());
+                    String formattedSubstitute = ExpressionFormatter.formatExpression(functionCallSubstitute.get(1), Optional.empty());
+                    return String.format("% is substituted with %s", formattedOriginal, formattedSubstitute);
+                }
+        ).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    protected Node visitExpression(Expression node, FunctionCallRewriter.Context context)
+    {
+        FunctionCallRewriter nodeRewritter = this;
+
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteFunctionCall(FunctionCall expression, Void voidContext, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (!functionCallSubstituteMap.containsKey(expression.getName())) {
+                    return expression;
+                }
+
+                FunctionCall defaultRewrite = treeRewriter.defaultRewrite(expression, voidContext);
+
+                FunctionCallSubstitute substitute = functionCallSubstituteMap.get(expression.getName());
+                List<Expression> originalArguments = expression.getArguments();
+                List<Expression> rewrittenArguments = substitute.originalArgumentIndices.stream()
+                        .map(originalIndex -> {
+                            Expression originalArgument = originalArguments.get(originalIndex);
+                            return treeRewriter.rewrite(originalArgument, voidContext);
+                        }).collect(toImmutableList());
+
+                FunctionCall rewritten = new FunctionCall(substitute.name, defaultRewrite.getWindow(), defaultRewrite.getFilter(), defaultRewrite.getOrderBy(),
+                        defaultRewrite.isDistinct(), defaultRewrite.isIgnoreNulls(), rewrittenArguments);
+                context.addFunctionCallSubstitute(expression, rewritten);
+
+                return rewritten;
+            }
+
+            public Expression rewriteSubqueryExpression(SubqueryExpression expression, Void voidContext, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                Node query = nodeRewritter.process(expression.getQuery(), context);
+                if (expression.getQuery() == query) {
+                    return expression;
+                }
+
+                return new SubqueryExpression((Query) query);
+            }
+        }, node);
+    }
+
+    public static class Context
+    {
+        private List<List<FunctionCall>> functionCallSubstitutes = new ArrayList<>();
+
+        public void addFunctionCallSubstitute(FunctionCall original, FunctionCall substitute)
+        {
+            functionCallSubstitutes.add(Arrays.asList(original, substitute));
+        }
+
+        public List<List<FunctionCall>> getFunctionCallSubstitutes()
+        {
+            return ImmutableList.copyOf(functionCallSubstitutes);
+        }
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.tests.StandaloneQueryRunner;
@@ -34,6 +35,7 @@ import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
 import com.facebook.presto.verifier.prestoaction.QueryActionsConfig;
 import com.facebook.presto.verifier.retry.RetryConfig;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,9 +53,13 @@ import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
 import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
+import static com.facebook.presto.verifier.framework.ClusterType.TEST;
+import static com.facebook.presto.verifier.rewrite.FunctionCallRewriter.FunctionCallSubstitute;
+import static com.facebook.presto.verifier.rewrite.FunctionCallRewriter.constructFunctionCallSubstituteMap;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsDeep;
 import static org.testng.Assert.assertTrue;
 
 @Test
@@ -294,6 +300,174 @@ public class TestQueryRewriter
                         "    CAST(ROW (NULL) AS ROW(BIGINT))");
     }
 
+    @Test
+    public void testConstructMakeFunctionCallSubstituteMap()
+    {
+        assertEqualsDeep(constructFunctionCallSubstituteMap("/max_by(a,b)/max(b)/"),
+                ImmutableMap.of(QualifiedName.of("max_by"), new FunctionCallSubstitute(QualifiedName.of("max"), ImmutableList.of(1))));
+        assertEqualsDeep(constructFunctionCallSubstituteMap("/func1(,,1c)/func2(1c)/"),
+                ImmutableMap.of(QualifiedName.of("func1"), new FunctionCallSubstitute(QualifiedName.of("func2"), ImmutableList.of(2))));
+        assertEqualsDeep(constructFunctionCallSubstituteMap("/func1(a,_,b)/func2(_)/"),
+                ImmutableMap.of(QualifiedName.of("func1"), new FunctionCallSubstitute(QualifiedName.of("func2"), ImmutableList.of(1))));
+        assertEqualsDeep(constructFunctionCallSubstituteMap("/func1(a,b)/func2(b)/,/func3(a,)/func4(a)/"),
+                ImmutableMap.of(QualifiedName.of("func1"), new FunctionCallSubstitute(QualifiedName.of("func2"), ImmutableList.of(1)),
+                        QualifiedName.of("func3"), new FunctionCallSubstitute(QualifiedName.of("func4"), ImmutableList.of(0))));
+
+        assertTrue(constructFunctionCallSubstituteMap("").isEmpty());
+        assertTrue(constructFunctionCallSubstituteMap("/func1(a,b)//").isEmpty());
+    }
+
+    @Test
+    public void testRewriteFunctionCalls()
+    {
+        QueryRewriter queryRewriter = getQueryRewriter(Optional.of("/approx_distinct(x)/count(x)/," +
+                "/approx_percentile(x,_)/avg(x)/," +
+                "/arbitrary(x)/min(x)/," +
+                "/first_value(x)/min(x)/," +
+                "/max_by(x,_)/max(x)/," +
+                "/min_by(x,_)/min(x)/"));
+
+        // Test rewriting window functions
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT\n" +
+                                "    FIRST_VALUE(a) OVER (\n" +
+                                "        PARTITION BY b\n" +
+                                "    )\n" +
+                                "FROM test_table",
+                        CONTROL).getQuery(),
+                "SELECT\n" +
+                        "    MIN(a) OVER (\n" +
+                        "        PARTITION BY b\n" +
+                        "    )\n" +
+                        "FROM test_table");
+
+        // Test rewriting columns with nested function calls
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT\n" +
+                                "    IF(APPROX_DISTINCT(a) > 10, TRUE, FALSE)\n" +
+                                "FROM test_table",
+                        CONTROL).getQuery(),
+                "SELECT\n" +
+                        "    IF(COUNT(a) > 10, TRUE, FALSE)\n" +
+                        "FROM test_table");
+
+        // Test rewriting columns in Join
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT *\n" +
+                                "FROM test_table x\n" +
+                                "JOIN (\n" +
+                                "    SELECT\n" +
+                                "        b,\n" +
+                                "        APPROX_PERCENTILE(a, 0.5) AS a\n" +
+                                "    FROM test_table\n" +
+                                "    GROUP BY\n" +
+                                "        1\n" +
+                                ") y\n" +
+                                "    ON (x.b = y.b)",
+                        CONTROL).getQuery(),
+                "SELECT *\n" +
+                        "FROM test_table x\n" +
+                        "JOIN (\n" +
+                        "    SELECT\n" +
+                        "        b,\n" +
+                        "        AVG(a) AS a\n" +
+                        "    FROM test_table\n" +
+                        "    GROUP BY\n" +
+                        "        1\n" +
+                        ") y\n" +
+                        "    ON (x.b = y.b)");
+
+        // Test rewriting columns in SubqueryExpression
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT a, b\n" +
+                                "FROM test_table\n" +
+                                "WHERE a IN (\n" +
+                                "    SELECT\n" +
+                                "        ARBITRARY(a)\n" +
+                                "    FROM test_table\n" +
+                                ")",
+                        CONTROL).getQuery(),
+                "SELECT a, b\n" +
+                        "FROM test_table\n" +
+                        "WHERE a IN (\n" +
+                        "    SELECT\n" +
+                        "        MIN(a)\n" +
+                        "    FROM test_table\n" +
+                        ")");
+
+        // Test rewriting columns in TableSubquery
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT one\n" +
+                                "FROM (\n" +
+                                "    SELECT\n" +
+                                "        ARBITRARY(b) AS one\n" +
+                                "    FROM test_table\n" +
+                                ") x",
+                        CONTROL).getQuery(),
+                "SELECT one\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        MIN(b) AS one\n" +
+                        "    FROM test_table\n" +
+                        ") x");
+
+        // Test rewriting columns in With
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "WITH x AS (\n" +
+                                "    SELECT\n" +
+                                "        MAX_BY(a, b) AS a\n" +
+                                "    FROM test_table\n" +
+                                ")\n" +
+                                "SELECT\n" +
+                                "    a\n" +
+                                "FROM x", CONTROL).getQuery(),
+                "WITH x AS (\n" +
+                        "    SELECT\n" +
+                        "        MAX(a) AS a\n" +
+                        "    FROM test_table\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    a\n" +
+                        "FROM x");
+
+        // Test rewriting columns in Union
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT\n" +
+                                "    ARBITRARY(a)\n" +
+                                "FROM (\n" +
+                                "    SELECT \n" +
+                                "       MIN_BY(a, b) AS a\n" +
+                                "    FROM test_table\n" +
+                                "\n" +
+                                "    UNION ALL\n" +
+                                "\n" +
+                                "    SELECT \n" +
+                                "       MIN_BY(a, b) AS a\n" +
+                                "    FROM test_table\n" +
+                                ") x",
+                        CONTROL).getQuery(),
+                "SELECT\n" +
+                        "    MIN(a)\n" +
+                        "FROM (\n" +
+                        "    SELECT \n" +
+                        "       MIN(a) AS a\n" +
+                        "    FROM test_table\n" +
+                        "\n" +
+                        "    UNION ALL\n" +
+                        "\n" +
+                        "    SELECT \n" +
+                        "       MIN(a) AS a\n" +
+                        "    FROM test_table\n" +
+                        ") x");
+    }
+
     private void assertShadowed(
             QueryRewriter queryRewriter,
             @Language("SQL") String query,
@@ -354,5 +528,16 @@ public class TestQueryRewriter
     private QueryRewriter getQueryRewriter(QueryRewriteConfig config)
     {
         return new VerificationQueryRewriterFactory(sqlParser, createTypeManager(), config, config).create(prestoAction);
+    }
+
+    private QueryRewriter getQueryRewriter(Optional<String> nonDeterministicFunctionSubstitutes)
+    {
+        return new QueryRewriter(
+                sqlParser,
+                createTypeManager(),
+                prestoAction,
+                ImmutableMap.of(CONTROL, QualifiedName.of("control"), TEST, QualifiedName.of("test")),
+                ImmutableMap.of(CONTROL, ImmutableList.of(), TEST, ImmutableList.of()),
+                nonDeterministicFunctionSubstitutes);
     }
 }


### PR DESCRIPTION
This change creates a FunctionCallRewriter that overrides the base class AstVisitor,
substituting the FunctionCall node and reconstructing the AST of the source query.

```
== NO RELEASE NOTE ==
```

