### PR TITLE
[native-pos]Improve velox memory init and cache stats logging

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -373,6 +373,7 @@ void PeriodicTaskManager::updateCacheStats() {
         kCounterSsdCacheCumulativeReadCheckpointErrors,
         memoryCacheStats.ssdStats->readCheckpointErrors);
   }
+  LOG(INFO) << "Cache stats:\n" << memoryCacheStats.toString();
 }
 
 void PeriodicTaskManager::addCacheStatsUpdateTask() {


### PR DESCRIPTION
Print out the node memory capacity, total query memory capacity and
per query memory capacity
Print out cache stats from periodic task manager

```
== NO RELEASE NOTE ==
```

