### PR TITLE
Allow Presto clients to receive query results in binary format

### DIFF
--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -96,6 +96,7 @@ public abstract class AbstractCliTest
                 null,
                 ImmutableList.of(new Column("_col0", BigintType.BIGINT)),
                 ImmutableList.of(ImmutableList.of(123)),
+                null,
                 StatementStats.builder().setState("FINISHED").build(),
                 null,
                 ImmutableList.of(),

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -41,6 +41,7 @@ public class QueryResults
     private final URI nextUri;
     private final List<Column> columns;
     private final Iterable<List<Object>> data;
+    private final Iterable<String> binaryData;
     private final StatementStats stats;
     private final QueryError error;
     private final List<PrestoWarning> warnings;
@@ -55,6 +56,7 @@ public class QueryResults
             @JsonProperty("nextUri") URI nextUri,
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("data") List<List<Object>> data,
+            @JsonProperty("binaryData") List<String> binaryData,
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("warnings") List<PrestoWarning> warnings,
@@ -68,6 +70,7 @@ public class QueryResults
                 nextUri,
                 columns,
                 fixData(columns, data),
+                binaryData,
                 stats,
                 error,
                 firstNonNull(warnings, ImmutableList.of()),
@@ -82,6 +85,7 @@ public class QueryResults
             URI nextUri,
             List<Column> columns,
             Iterable<List<Object>> data,
+            Iterable<String> binaryData,
             StatementStats stats,
             QueryError error,
             List<PrestoWarning> warnings,
@@ -94,7 +98,8 @@ public class QueryResults
         this.nextUri = nextUri;
         this.columns = (columns != null) ? ImmutableList.copyOf(columns) : null;
         this.data = (data != null) ? unmodifiableIterable(data) : null;
-        checkArgument(data == null || columns != null, "data present without columns");
+        this.binaryData = (binaryData != null) ? unmodifiableIterable(binaryData) : null;
+        checkArgument((data == null && binaryData == null) || columns != null, "data present without columns");
         this.stats = requireNonNull(stats, "stats is null");
         this.error = error;
         this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
@@ -170,6 +175,16 @@ public class QueryResults
     }
 
     /**
+     * Returns an iterator to the payload (results) in binary format
+     */
+    @Nullable
+    @JsonProperty
+    public Iterable<String> getBinaryData()
+    {
+        return binaryData;
+    }
+
+    /**
      * Returns cumulative statistics on the query being executed
      * @return {@link com.facebook.presto.client.StatementStats}
      */
@@ -237,6 +252,7 @@ public class QueryResults
                 .add("nextUri", nextUri)
                 .add("columns", columns)
                 .add("hasData", data != null)
+                .add("hasBinaryData", binaryData != null)
                 .add("stats", stats)
                 .add("error", error)
                 .add("updateType", updateType)

--- a/presto-docs/src/main/sphinx/develop/client-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/client-protocol.rst
@@ -35,6 +35,11 @@ the columns returned by the query.  Most of the response headers should be treat
 browser cookies by the client, and echoed back as request headers in subsequent client requests,
 as documented below.
 
+To request the results in binary format, include binaryResults=true query parameter in the initial
+``/v1/statement`` ``POST`` request. The response JSON document will contain ``binaryData`` field
+with a list of base64-encoded pages in :doc:`SerializedPage </develop/serialized-page>` format. The
+``data`` field will not be present.
+
 If the JSON document returned by the ``POST`` to ``/v1/statement`` does not contain a ``nextUri`` link, the query has completed,
 either successfully or unsuccessfully, and no additional requests need to be made.  If the ``nextUri`` link is present in
 the document, there are more query results to be fetched.  The client should loop executing a ``GET`` request

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -90,6 +90,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
+                null,
                 StatementStats.builder()
                         .setState(state)
                         .setWaitingForPrerequisites(state.equals("WAITING_FOR_PREREQUISITES"))

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
@@ -29,6 +29,7 @@ import org.weakref.jmx.Nested;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -99,6 +100,7 @@ public class ExecutingStatementResource
             @QueryParam("slug") String slug,
             @QueryParam("maxWait") Duration maxWait,
             @QueryParam("targetResultSize") DataSize targetResultSize,
+            @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String proto,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo,
@@ -125,7 +127,7 @@ public class ExecutingStatementResource
                 acquirePermitAsync,
                 acquirePermitTimeSeconds -> {
                     queryRateLimiter.addRateLimiterBlockTime(new Duration(acquirePermitTimeSeconds, SECONDS));
-                    return query.waitForResults(token, uriInfo, effectiveFinalProto, wait, effectiveFinalTargetResultSize);
+                    return query.waitForResults(token, uriInfo, effectiveFinalProto, wait, effectiveFinalTargetResultSize, binaryResults);
                 },
                 responseExecutor);
         ListenableFuture<Response> queryResultsFuture = transform(

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -158,6 +158,7 @@ public final class QueryResourceUtil
                 prependUri(queryResults.getNextUri(), xPrestoPrefixUri),
                 queryResults.getColumns(),
                 prepareJsonData(queryResults.getColumns(), queryResults.getData()),
+                queryResults.getBinaryData(),
                 queryResults.getStats(),
                 queryResults.getError(),
                 queryResults.getWarnings(),

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -47,6 +47,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -60,6 +61,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import java.net.URI;
@@ -129,7 +131,6 @@ public class QueuedStatementResource
     private final SessionPropertyManager sessionPropertyManager;     // We may need some system default session property values at early query stage even before session is created.
 
     private final QueryBlockingRateLimiter queryRateLimiter;
-    private final TimeStat queuedRateLimiterBlockTime = new TimeStat();
 
     @Inject
     public QueuedStatementResource(
@@ -199,6 +200,7 @@ public class QueuedStatementResource
     @Produces(APPLICATION_JSON)
     public Response postStatement(
             String statement,
+            @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context HttpServletRequest servletRequest,
@@ -220,7 +222,7 @@ public class QueuedStatementResource
         Query query = new Query(statement, sessionContext, dispatchManager, queryResultsProvider, 0);
         queries.put(query.getQueryId(), query);
 
-        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl)), compressionEnabled).build();
+        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults)), compressionEnabled).build();
     }
 
     /**
@@ -235,6 +237,7 @@ public class QueuedStatementResource
     @Produces(APPLICATION_JSON)
     public Response retryFailedQuery(
             @PathParam("queryId") QueryId queryId,
+            @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo)
@@ -268,7 +271,7 @@ public class QueuedStatementResource
             }
         }
 
-        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl)), compressionEnabled).build();
+        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults)), compressionEnabled).build();
     }
 
     /**
@@ -289,6 +292,7 @@ public class QueuedStatementResource
             @PathParam("token") long token,
             @QueryParam("slug") String slug,
             @QueryParam("maxWait") Duration maxWait,
+            @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo,
@@ -314,7 +318,7 @@ public class QueuedStatementResource
         // when state changes, fetch the next result
         ListenableFuture<Response> queryResultsFuture = transformAsync(
                 futureStateChange,
-                ignored -> query.toResponse(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait), compressionEnabled),
+                ignored -> query.toResponse(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait), compressionEnabled, binaryResults),
                 responseExecutor);
         bindAsyncResponse(asyncResponse, queryResultsFuture, responseExecutor);
     }
@@ -371,16 +375,19 @@ public class QueuedStatementResource
         return QueryResourceUtil.prependUri(uri, xPrestoPrefixUrl);
     }
 
-    private static URI getQueuedUri(QueryId queryId, String slug, long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl)
+    private static URI getQueuedUri(QueryId queryId, String slug, long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, boolean binaryResults)
     {
-        URI uri = uriInfo.getBaseUriBuilder()
+        UriBuilder uriBuilder = uriInfo.getBaseUriBuilder()
                 .scheme(getScheme(xForwardedProto, uriInfo))
-                .replacePath("/v1/statement/queued/")
+                .replacePath("/v1/statement/queued")
                 .path(queryId.toString())
                 .path(String.valueOf(token))
                 .replaceQuery("")
-                .queryParam("slug", slug)
-                .build();
+                .queryParam("slug", slug);
+        if (binaryResults) {
+            uriBuilder.queryParam("binaryResults", "true");
+        }
+        URI uri = uriBuilder.build();
         return QueryResourceUtil.prependUri(uri, xPrestoPrefixUrl);
     }
 
@@ -406,6 +413,7 @@ public class QueuedStatementResource
                 getQueryHtmlUri(queryId, uriInfo, xForwardedProto, xPrestoPrefixUrl),
                 null,
                 nextUri,
+                null,
                 null,
                 null,
                 StatementStats.builder()
@@ -542,7 +550,7 @@ public class QueuedStatementResource
          * @param xForwardedProto Forwarded protocol (http or https)
          * @return {@link com.facebook.presto.client.QueryResults}
          */
-        public synchronized QueryResults getInitialQueryResults(UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl)
+        public synchronized QueryResults getInitialQueryResults(UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, boolean binaryResults)
         {
             verify(lastToken.get() == 0);
             verify(querySubmissionFuture == null);
@@ -551,10 +559,11 @@ public class QueuedStatementResource
                     uriInfo,
                     xForwardedProto,
                     xPrestoPrefixUrl,
-                    DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION));
+                    DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION),
+                    binaryResults);
         }
 
-        public ListenableFuture<Response> toResponse(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, Duration maxWait, boolean compressionEnabled)
+        public ListenableFuture<Response> toResponse(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, Duration maxWait, boolean compressionEnabled, boolean binaryResults)
         {
             long lastToken = this.lastToken.get();
             // token should be the last token or the next token
@@ -572,7 +581,8 @@ public class QueuedStatementResource
                             uriInfo,
                             xForwardedProto,
                             xPrestoPrefixUrl,
-                            DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION));
+                            DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION),
+                            binaryResults);
                     return immediateFuture(withCompressionConfiguration(Response.ok(queryResults), compressionEnabled).build());
                 }
             }
@@ -586,7 +596,7 @@ public class QueuedStatementResource
             }
 
             if (!waitForDispatched().isDone()) {
-                return immediateFuture(withCompressionConfiguration(Response.ok(createQueryResults(token + 1, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo.get())), compressionEnabled).build());
+                return immediateFuture(withCompressionConfiguration(Response.ok(createQueryResults(token + 1, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo.get(), binaryResults)), compressionEnabled).build());
             }
 
             com.facebook.presto.server.protocol.Query query;
@@ -594,12 +604,12 @@ public class QueuedStatementResource
                 query = queryProvider.getQuery(queryId, slug);
             }
             catch (WebApplicationException e) {
-                return immediateFuture(withCompressionConfiguration(Response.ok(createQueryResults(token + 1, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo.get())), compressionEnabled).build());
+                return immediateFuture(withCompressionConfiguration(Response.ok(createQueryResults(token + 1, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo.get(), binaryResults)), compressionEnabled).build());
             }
             // If this future completes successfully, the next URI will redirect to the executing statement endpoint.
             // Hence it is safe to hardcode the token to be 0.
             return transform(
-                    query.waitForResults(0, uriInfo, getScheme(xForwardedProto, uriInfo), maxWait, TARGET_RESULT_SIZE),
+                    query.waitForResults(0, uriInfo, getScheme(xForwardedProto, uriInfo), maxWait, TARGET_RESULT_SIZE, binaryResults),
                     results -> QueryResourceUtil.toResponse(query, results, xPrestoPrefixUrl, compressionEnabled),
                     directExecutor());
         }
@@ -609,9 +619,9 @@ public class QueuedStatementResource
             querySubmissionFuture.addListener(() -> dispatchManager.cancelQuery(queryId), directExecutor());
         }
 
-        private QueryResults createQueryResults(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo)
+        private QueryResults createQueryResults(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
         {
-            URI nextUri = getNextUri(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo);
+            URI nextUri = getNextUri(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo, binaryResults);
 
             Optional<QueryError> queryError = dispatchInfo.getFailureInfo()
                     .map(this::toQueryError);
@@ -628,13 +638,13 @@ public class QueuedStatementResource
                     dispatchInfo.getWaitingForPrerequisitesTime());
         }
 
-        private URI getNextUri(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo)
+        private URI getNextUri(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
         {
             // if failed, query is complete
             if (dispatchInfo.getFailureInfo().isPresent()) {
                 return null;
             }
-            return getQueuedUri(queryId, slug, token, uriInfo, xForwardedProto, xPrestoPrefixUrl);
+            return getQueuedUri(queryId, slug, token, uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults);
         }
 
         private QueryError toQueryError(ExecutionFailureInfo executionFailureInfo)


### PR DESCRIPTION
Introduce 'binaryResults=true' query parameter to request query results returned in binary format https://prestodb.io/docs/current/develop/serialized-page.html

With binaryResults=true, the result json will contain 'binaryData' field of type array with one or
more pages of the results. The 'data' field will not be included in the result JSON.

See #20886

```
== NO RELEASE NOTE ==
```

