### PR TITLE
Add aggregate function bitwise_xor_agg

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -177,6 +177,10 @@ Bitwise Aggregate Functions
 
     Returns the bitwise OR of all input values in 2's complement representation.
 
+.. function:: bitwise_xor_agg(x) -> bigint
+
+    Returns the bitwise XOR of all input values in 2's complement representation.
+
 Map Aggregate Functions
 -----------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -51,6 +51,7 @@ import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
 import com.facebook.presto.operator.aggregation.AverageAggregations;
 import com.facebook.presto.operator.aggregation.BitwiseAndAggregation;
 import com.facebook.presto.operator.aggregation.BitwiseOrAggregation;
+import com.facebook.presto.operator.aggregation.BitwiseXorAggregation;
 import com.facebook.presto.operator.aggregation.BooleanAndAggregation;
 import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
 import com.facebook.presto.operator.aggregation.CentralMomentsAggregation;
@@ -682,6 +683,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(RealCorrelationAggregation.class)
                 .aggregates(BitwiseOrAggregation.class)
                 .aggregates(BitwiseAndAggregation.class)
+                .aggregates(BitwiseXorAggregation.class)
                 .aggregates(ClassificationMissRateAggregation.class)
                 .aggregates(ClassificationFallOutAggregation.class)
                 .aggregates(ClassificationPrecisionAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BitwiseXorAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BitwiseXorAggregation.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+@AggregationFunction("bitwise_xor_agg")
+public class BitwiseXorAggregation
+{
+    private BitwiseXorAggregation() {}
+
+    @InputFunction
+    public static void bitXor(@AggregationState NullableLongState state, @SqlType(StandardTypes.BIGINT) long value)
+    {
+        if (state.isNull()) {
+            state.setLong(value);
+        }
+        else {
+            state.setLong(state.getLong() ^ value);
+        }
+
+        state.setNull(false);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState otherState)
+    {
+        if (state.isNull()) {
+            state.setNull(otherState.isNull());
+            state.setLong(otherState.getLong());
+        }
+        else if (!otherState.isNull()) {
+            state.setLong(state.getLong() ^ otherState.getLong());
+        }
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+    {
+        NullableLongState.write(BigintType.BIGINT, state, out);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseXorAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseXorAggregation.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+
+public class TestBitwiseXorAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
+
+        for (int i = start; i < start + length; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+        return LongStream.range(start, start + length).reduce(0, (x, y) -> x ^ y);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "bitwise_xor_agg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.BIGINT);
+    }
+
+    @Test
+    public void testNulls()
+    {
+        testAggregation(1L, createLongsBlock(1L, null));
+        testAggregation(1L, createLongsBlock(null, 1L));
+    }
+}


### PR DESCRIPTION

## Description

Currently we have bitwise_and_agg and bitwise_or_agg, adding bitwise_xor_agg will makes it complete. Fixes #20930 

## Motivation and Context

Currently we have bitwise_and_agg and bitwise_or_agg, adding bitwise_xor_agg will makes it complete.

## Impact

N/A

## Test Plan

Added UT.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add aggregate function: bitwise_xor_agg
```

