### PR TITLE
Heap Memory Based Worker Flag to stop processing new split when in low memory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -24,6 +24,8 @@ import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
 import io.airlift.units.MinDuration;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -87,6 +89,8 @@ public class TaskManagerConfig
     private TaskPriorityTracking taskPriorityTracking = TaskPriorityTracking.TASK_FAIR;
 
     private Duration interruptRunawaySplitsTimeout = new Duration(600, SECONDS);
+
+    private double memoryBasedSlowDownThreshold = 1.0;
 
     @MinDuration("1ms")
     @MaxDuration("10s")
@@ -573,6 +577,22 @@ public class TaskManagerConfig
     public TaskManagerConfig setInterruptRunawaySplitsTimeout(Duration interruptRunawaySplitsTimeout)
     {
         this.interruptRunawaySplitsTimeout = interruptRunawaySplitsTimeout;
+        return this;
+    }
+
+    //Allowing low value to be 70 percent to avoid slowing down overall cluster by setting it too low
+    @DecimalMin("0.7")
+    @DecimalMax("1.0")
+    public double getMemoryBasedSlowDownThreshold()
+    {
+        return memoryBasedSlowDownThreshold;
+    }
+
+    @Config("task.memory-based-slowdown-threshold")
+    @ConfigDescription("Pause processing new leaf split if heap memory usage crosses the threshold")
+    public TaskManagerConfig setMemoryBasedSlowDownThreshold(double memoryBasedSlowDownThreshold)
+    {
+        this.memoryBasedSlowDownThreshold = memoryBasedSlowDownThreshold;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -174,11 +174,14 @@ public class TaskExecutor
     // shared between SplitRunners
     private final CounterStat globalCpuTimeMicros = new CounterStat();
     private final CounterStat globalScheduledTimeMicros = new CounterStat();
+    private final CounterStat splitSkippedDueToMemoryPressure = new CounterStat();
 
     private final TimeStat blockedQuantaWallTime = new TimeStat(MICROSECONDS);
     private final TimeStat unblockedQuantaWallTime = new TimeStat(MICROSECONDS);
 
     private volatile boolean closed;
+
+    private volatile boolean lowMemory;
 
     @Inject
     public TaskExecutor(TaskManagerConfig config, EmbedVersion embedVersion, MultilevelSplitQueue splitQueue)
@@ -483,6 +486,13 @@ public class TaskExecutor
 
     private synchronized void scheduleTaskIfNecessary(TaskHandle taskHandle)
     {
+        // Worker skip processing split if jvm heap usage crosses configured threhold
+        // Helps reduce memory pressure on the worker and avoid OOMs
+        if (isLowMemory()) {
+            log.debug("Skip task scheduling due to low memory");
+            splitSkippedDueToMemoryPressure.update(1);
+            return;
+        }
         // if task has less than the minimum guaranteed splits running,
         // immediately schedule a new split for this task.  This assures
         // that a task gets its fair amount of consideration (you have to
@@ -498,6 +508,14 @@ public class TaskExecutor
 
     private synchronized void addNewEntrants()
     {
+        // Worker skip processing split if jvm heap usage crosses configured threhold
+        // Helps reduce memory pressure on the worker and avoid OOMs
+        if (isLowMemory()) {
+            log.debug("Skip polling next split worker due to low memory");
+            splitSkippedDueToMemoryPressure.update(1);
+            return;
+        }
+
         // Ignore intermediate splits when checking minimumNumberOfDrivers.
         // Otherwise with (for example) minimumNumberOfDrivers = 100, 200 intermediate splits
         // and 100 leaf splits, depending on order of appearing splits, number of
@@ -904,6 +922,13 @@ public class TaskExecutor
         return globalCpuTimeMicros;
     }
 
+    @Managed
+    @Nested
+    public CounterStat getSplitSkippedDueToMemoryPressure()
+    {
+        return splitSkippedDueToMemoryPressure;
+    }
+
     private synchronized int getRunningTasksForLevel(int level)
     {
         int count = 0;
@@ -1031,5 +1056,15 @@ public class TaskExecutor
     public ThreadPoolExecutorMBean getProcessorExecutor()
     {
         return executorMBean;
+    }
+
+    public void setLowMemory(boolean lowMemory)
+    {
+        this.lowMemory = lowMemory;
+    }
+
+    public boolean isLowMemory()
+    {
+        return this.lowMemory;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryMonitor.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.execution.executor.TaskExecutor;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
+public class LowMemoryMonitor
+{
+    private static final Logger log = Logger.get(LowMemoryMonitor.class);
+    private final ScheduledExecutorService lowMemoryExecutor = newScheduledThreadPool(1, daemonThreadsNamed("low-memory-monitor-executor"));
+    private final TaskExecutor taskExecutor;
+    private final double threshold;
+    private static final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+
+    @Inject
+    public LowMemoryMonitor(TaskExecutor taskExecutor, TaskManagerConfig taskManagerConfig)
+    {
+        this.taskExecutor = requireNonNull(taskExecutor, "taskExecutor is null");
+        this.threshold = taskManagerConfig.getMemoryBasedSlowDownThreshold();
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (threshold < 1.0) {
+            lowMemoryExecutor.scheduleWithFixedDelay(() -> checkLowMemory(), 1, 1, TimeUnit.SECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        lowMemoryExecutor.shutdown();
+    }
+
+    private void checkLowMemory()
+    {
+        MemoryUsage memoryUsage = memoryMXBean.getHeapMemoryUsage();
+
+        long usedMemory = memoryUsage.getUsed();
+        long maxMemory = memoryUsage.getMax();
+        long memoryThreshold = (long) (maxMemory * threshold);
+
+        if (usedMemory > memoryThreshold) {
+            if (!taskExecutor.isLowMemory()) {
+                log.debug("Enabling Low Memory: Used: %s Max: %s Threshold: %s", usedMemory, maxMemory, memoryThreshold);
+                taskExecutor.setLowMemory(true);
+            }
+        }
+        else {
+            if (taskExecutor.isLowMemory()) {
+                log.debug("Disabling Low Memory: Used: %s Max: %s Threshold: %s", usedMemory, maxMemory, memoryThreshold);
+                taskExecutor.setLowMemory(false);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/WorkerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WorkerModule.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.resourceGroups.NoOpResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.failureDetector.FailureDetector;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
+import com.facebook.presto.memory.LowMemoryMonitor;
 import com.facebook.presto.transaction.NoOpTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.inject.Binder;
@@ -55,6 +56,8 @@ public class WorkerModule
         binder.bind(NodeResourceStatusProvider.class).toInstance(newProxy(NodeResourceStatusProvider.class, (proxy, method, args) -> {
             return true;
         }));
+
+        binder.bind(LowMemoryMonitor.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -70,7 +70,8 @@ public class TestTaskManagerConfig
                 .setStatisticsCpuTimerEnabled(true)
                 .setLegacyLifespanCompletionCondition(false)
                 .setTaskPriorityTracking(TASK_FAIR)
-                .setInterruptRunawaySplitsTimeout(new Duration(600, SECONDS)));
+                .setInterruptRunawaySplitsTimeout(new Duration(600, SECONDS))
+                .setMemoryBasedSlowDownThreshold(1.0));
     }
 
     @Test
@@ -112,6 +113,7 @@ public class TestTaskManagerConfig
                 .put("task.legacy-lifespan-completion-condition", "true")
                 .put("task.task-priority-tracking", "QUERY_FAIR")
                 .put("task.interrupt-runaway-splits-timeout", "599s")
+                .put("task.memory-based-slowdown-threshold", "0.9")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -149,7 +151,8 @@ public class TestTaskManagerConfig
                 .setStatisticsCpuTimerEnabled(false)
                 .setLegacyLifespanCompletionCondition(true)
                 .setTaskPriorityTracking(QUERY_FAIR)
-                .setInterruptRunawaySplitsTimeout(new Duration(599, SECONDS));
+                .setInterruptRunawaySplitsTimeout(new Duration(599, SECONDS))
+                .setMemoryBasedSlowDownThreshold(0.9);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Introducing low memory monitor to keep an eye on heap usage. And when the heap usage crosses configured threshold, worker will stop processing new splits but continue processing the existing running, waiting and blocked splits. When the heap memory usage goes below threshold, worker start accepting new splits. 

## Motivation and Context
In Meta, we observed workers crashing due to out of memory. And the worker crashing are running lot more splits (running + waiting) when memory usage spikes. Given the Multi Level Split Queue behavior, workers keep running all the splits unless they are blocked. If the number of non blocked splits are high, this result in memory pressure on the worker and chances of OOM is higher. With this change, we can configure worker to avoid processing more splits if memory usage is high.

## Impact
No Impact

## Test Plan
Unit Tests and Meta verifier run

JMX metric showing when worker memory usage crosses threshold, skip split counter spikes. And it goes down as memory goes below threhold.

Five Minute Counter for Split Skip
<img width="914" alt="Screenshot 2023-10-03 at 3 35 24 PM" src="https://github.com/prestodb/presto/assets/489436/18be5edb-a781-4c8b-a061-5d73e2436a75">

Heap Memory Usage
<img width="917" alt="Screenshot 2023-10-03 at 3 35 46 PM" src="https://github.com/prestodb/presto/assets/489436/36b37bcc-3a0d-4be6-b669-0ab70e75a99f">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add config to enable memory based split processing slow down. This can be enabled via `task.memory-based-slowdown-threshold`
```

