### PR TITLE
Skip pre hash computation for join when input is table scan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -300,6 +300,7 @@ public final class SystemSessionProperties
     public static final String TRACK_PARTIAL_AGGREGATION_HISTORY = "track_partial_aggregation_history";
     public static final String REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN = "remove_redundant_cast_to_varchar_in_join";
     public static final String HANDLE_COMPLEX_EQUI_JOINS = "handle_complex_equi_joins";
+    public static final String SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT = "skip_hash_generation_for_join_with_table_scan_input";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1805,6 +1806,11 @@ public final class SystemSessionProperties
                         HANDLE_COMPLEX_EQUI_JOINS,
                         "Handle complex equi-join conditions to open up join space for join reordering",
                         featuresConfig.getHandleComplexEquiJoins(),
+                        false),
+                booleanProperty(
+                        SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT,
+                        "Skip hash generation for join, when input is table scan node",
+                        featuresConfig.isSkipHashGenerationForJoinWithTableScanInput(),
                         false));
     }
 
@@ -3013,5 +3019,10 @@ public final class SystemSessionProperties
     public static boolean shouldHandleComplexEquiJoins(Session session)
     {
         return session.getSystemProperty(HANDLE_COMPLEX_EQUI_JOINS, Boolean.class);
+    }
+
+    public static boolean skipHashGenerationForJoinWithTableScanInput(Session session)
+    {
+        return session.getSystemProperty(SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -291,6 +291,7 @@ public class FeaturesConfig
     private boolean trackPartialAggregationHistory = true;
 
     private boolean removeRedundantCastToVarcharInJoin = true;
+    private boolean skipHashGenerationForJoinWithTableScanInput;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2899,6 +2900,19 @@ public class FeaturesConfig
     public FeaturesConfig setHandleComplexEquiJoins(boolean handleComplexEquiJoins)
     {
         this.handleComplexEquiJoins = handleComplexEquiJoins;
+        return this;
+    }
+
+    public boolean isSkipHashGenerationForJoinWithTableScanInput()
+    {
+        return skipHashGenerationForJoinWithTableScanInput;
+    }
+
+    @Config("optimizer.skip-hash-generation-for-join-with-table-scan-input")
+    @ConfigDescription("Skip hash generation for join, when input is table scan node")
+    public FeaturesConfig setSkipHashGenerationForJoinWithTableScanInput(boolean skipHashGenerationForJoinWithTableScanInput)
+    {
+        this.skipHashGenerationForJoinWithTableScanInput = skipHashGenerationForJoinWithTableScanInput;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -253,7 +253,8 @@ public class TestFeaturesConfig
                 .setRewriteConstantArrayContainsToInEnabled(false)
                 .setUseHBOForScaledWriters(false)
                 .setRemoveRedundantCastToVarcharInJoin(true)
-                .setHandleComplexEquiJoins(false));
+                .setHandleComplexEquiJoins(false)
+                .setSkipHashGenerationForJoinWithTableScanInput(false));
     }
 
     @Test
@@ -455,6 +456,7 @@ public class TestFeaturesConfig
                 .put("optimizer.use-hbo-for-scaled-writers", "true")
                 .put("optimizer.remove-redundant-cast-to-varchar-in-join", "false")
                 .put("optimizer.handle-complex-equi-joins", "true")
+                .put("optimizer.skip-hash-generation-for-join-with-table-scan-input", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -653,7 +655,8 @@ public class TestFeaturesConfig
                 .setRewriteConstantArrayContainsToInEnabled(true)
                 .setUseHBOForScaledWriters(true)
                 .setRemoveRedundantCastToVarcharInJoin(false)
-                .setHandleComplexEquiJoins(true);
+                .setHandleComplexEquiJoins(true)
+                .setSkipHashGenerationForJoinWithTableScanInput(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestHashGenerationOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestHashGenerationOptimizer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestHashGenerationOptimizer
+        extends BasePlanTest
+{
+    @Test
+    public void testSkipHashGenerationForJoinWithTableScanInput()
+    {
+        Session enable = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, ELIMINATE_CROSS_JOINS.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
+                .setSystemProperty(SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT, "true")
+                .build();
+        assertPlanWithSession("select * from lineitem l join orders o on l.partkey=o.custkey",
+                enable,
+                false,
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("partkey", "custkey")),
+                                tableScan("lineitem", ImmutableMap.of("partkey", "partkey")),
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPLICATE,
+                                                anyTree(
+                                                        tableScan("orders", ImmutableMap.of("custkey", "custkey"))))))));
+
+        Session disable = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, ELIMINATE_CROSS_JOINS.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
+                .setSystemProperty(SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT, "false")
+                .build();
+        assertPlanWithSession("select * from lineitem l join orders o on l.partkey=o.custkey",
+                disable,
+                false,
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("partkey", "custkey")),
+                                project(
+                                        tableScan("lineitem", ImmutableMap.of("partkey", "partkey"))),
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPLICATE,
+                                                anyTree(
+                                                        tableScan("orders", ImmutableMap.of("custkey", "custkey"))))))));
+    }
+}


### PR DESCRIPTION
## Description
Skip hash generation for a join, when the input is table scan, and the hash is on a single big int and is not reused later.

## Motivation and Context
We observed in production query that, hash precomputation actually hurts performance (both cpu and latency) for the case described above. Hence add an option to disable hash precomputation for it.

## Impact
CPU and latency improvement for the targeted queries.

## Test Plan
Existing unit tests and [verifier test](https://our.internmc.facebook.com/intern/presto/verifier/results/?test_id=144305)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a session property to skip hash precomputation for join when the input is table scan, and the hash is on a single big int and is not reused later. It's controlled by session property `skip_hash_generation_for_join_with_table_scan_input` and default to not enabled.
```

