### PR TITLE
Make parseToJson optional

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -39,6 +39,7 @@ public class ServerConfig
     private boolean queryResultsCompressionEnabled = true;
     private NodePoolType poolType = DEFAULT;
     private Duration clusterStatsExpirationDuration = new Duration(0, MILLISECONDS);
+    private boolean nestedDataSerializationEnabled = true;
 
     public boolean isResourceManager()
     {
@@ -199,6 +200,18 @@ public class ServerConfig
     public ServerConfig setClusterStatsExpirationDuration(Duration clusterStatsExpirationDuration)
     {
         this.clusterStatsExpirationDuration = clusterStatsExpirationDuration;
+        return this;
+    }
+
+    public boolean isNestedDataSerializationEnabled()
+    {
+        return nestedDataSerializationEnabled;
+    }
+
+    @Config("nested-data-serialization-enabled")
+    public ServerConfig setNestedDataSerializationEnabled(boolean nestedDataSerializationEnabled)
+    {
+        this.nestedDataSerializationEnabled = nestedDataSerializationEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
@@ -69,6 +69,7 @@ public class ExecutingStatementResource
     private final BoundedExecutor responseExecutor;
     private final LocalQueryProvider queryProvider;
     private final boolean compressionEnabled;
+    private final boolean nestedDataSerializationEnabled;
     private final QueryBlockingRateLimiter queryRateLimiter;
 
     @Inject
@@ -81,6 +82,7 @@ public class ExecutingStatementResource
         this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
         this.queryProvider = requireNonNull(queryProvider, "queryProvider is null");
         this.compressionEnabled = requireNonNull(serverConfig, "serverConfig is null").isQueryResultsCompressionEnabled();
+        this.nestedDataSerializationEnabled = requireNonNull(serverConfig, "serverConfig is null").isNestedDataSerializationEnabled();
         this.queryRateLimiter = requireNonNull(queryRateLimiter, "queryRateLimiter is null");
     }
 
@@ -132,7 +134,7 @@ public class ExecutingStatementResource
                 responseExecutor);
         ListenableFuture<Response> queryResultsFuture = transform(
                 waitForResultsAsync,
-                results -> toResponse(query, results, xPrestoPrefixUrl, compressionEnabled),
+                results -> toResponse(query, results, xPrestoPrefixUrl, compressionEnabled, nestedDataSerializationEnabled),
                 directExecutor());
         bindAsyncResponse(asyncResponse, queryResultsFuture, responseExecutor);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -149,15 +149,19 @@ public final class QueryResourceUtil
         return response.build();
     }
 
-    public static Response toResponse(Query query, QueryResults queryResults, String xPrestoPrefixUri, boolean compressionEnabled)
+    public static Response toResponse(Query query, QueryResults queryResults, String xPrestoPrefixUri, boolean compressionEnabled, boolean nestedDataSerializationEnabled)
     {
+        Iterable<List<Object>> queryResultsData = queryResults.getData();
+        if (nestedDataSerializationEnabled) {
+            queryResultsData = prepareJsonData(queryResults.getColumns(), queryResultsData);
+        }
         QueryResults resultsClone = new QueryResults(
                 queryResults.getId(),
                 prependUri(queryResults.getInfoUri(), xPrestoPrefixUri),
                 prependUri(queryResults.getPartialCancelUri(), xPrestoPrefixUri),
                 prependUri(queryResults.getNextUri(), xPrestoPrefixUri),
                 queryResults.getColumns(),
-                prepareJsonData(queryResults.getColumns(), queryResults.getData()),
+                queryResultsData,
                 queryResults.getBinaryData(),
                 queryResults.getStats(),
                 queryResults.getError(),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -46,7 +46,8 @@ public class TestServerConfig
                 .setCatalogServer(false)
                 .setCatalogServerEnabled(false)
                 .setPoolType(DEFAULT)
-                .setClusterStatsExpirationDuration(new Duration(0, MILLISECONDS)));
+                .setClusterStatsExpirationDuration(new Duration(0, MILLISECONDS))
+                .setNestedDataSerializationEnabled(true));
     }
 
     @Test
@@ -66,6 +67,7 @@ public class TestServerConfig
                 .put("catalog-server", "true")
                 .put("pool-type", "LEAF")
                 .put("cluster-stats-expiration-duration", "10s")
+                .put("nested-data-serialization-enabled", "false")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -81,7 +83,8 @@ public class TestServerConfig
                 .setCatalogServer(true)
                 .setCatalogServerEnabled(true)
                 .setPoolType(LEAF)
-                .setClusterStatsExpirationDuration(new Duration(10, SECONDS));
+                .setClusterStatsExpirationDuration(new Duration(10, SECONDS))
+                .setNestedDataSerializationEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
To compatible with the clients who are dependent on previous formatting, make parseToJson an optional feature. Developers can toggle it off by setting `nested-data-serialize-enabled` in config.properties.

## Description
This PR aims to enable user to choose from legacy formatting or new formatting of the response data.

## Motivation and Context
The previous [#20558](https://github.com/prestodb/presto/pull/20558) fixed the nested data render issue but changed the behavior of response data.

## Impact


## Test Plan
Tested with the `testExplicitPropertyMappings` and `testDefaults` funcions in `TestServerConfig.java`.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==
General Changes
* Add support for serializing nested data structures via server-side configuration properties. The new pre-serialization feature can be disabled server-wide by using the configuration property: ``nested-data-serialization-enabled``.
```
