### PR TITLE
[native] Add a profile to excclude parquet in pom.xml under presto-native-execution

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -222,5 +222,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>all-non-parquet-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups combine.self="override">parquet</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Add a profile 'all-non-parquet-tests' to exclude parquet in pom.xml under presto-native-execution. The existing config sets excludedGroups to empty which will override excludedGroups given command line.

```
== NO RELEASE NOTE ==
```

