### PR TITLE
[native] Add 'remote-function' in the excludedGroups in all-non-parquet-tests profile

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -230,7 +230,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludedGroups combine.self="override">parquet</excludedGroups>
+                            <excludedGroups combine.self="override">parquet,remote-function</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Add 'remote-function' in the excludedGroups in all-non-parquet-tests profile as it override excludedGroups so we need to add 'remote-function' to exclude it.

```
== NO RELEASE NOTE ==
```

