### PR TITLE
Support Parquet writer versions V1 and V2

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.apache.parquet.column.ParquetProperties;
 
 import javax.inject.Inject;
 
@@ -85,6 +86,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     public static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
@@ -539,6 +541,15 @@ public final class HiveSessionProperties
                         "Experimental: Enable optimized writer",
                         parquetFileWriterConfig.isParquetOptimizedWriterEnabled(),
                         false),
+                new PropertyMetadata<>(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer version",
+                        VARCHAR,
+                        ParquetProperties.WriterVersion.class,
+                        parquetFileWriterConfig.getWriterVersion(),
+                        false,
+                        value -> ParquetProperties.WriterVersion.valueOf(((String) value).toUpperCase()),
+                        ParquetProperties.WriterVersion::name),
                 booleanProperty(
                         PARQUET_BATCH_READ_OPTIMIZATION_ENABLED,
                         "Is Parquet batch read optimization enabled",
@@ -1110,6 +1121,11 @@ public final class HiveSessionProperties
     public static boolean isParquetOptimizedWriterEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_OPTIMIZED_WRITER_ENABLED, Boolean.class);
+    }
+
+    public static ParquetProperties.WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, ParquetProperties.WriterVersion.class);
     }
 
     public static BucketFunctionType getBucketFunctionTypeForExchange(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.parquet.writer.ParquetWriterOptions;
 import io.airlift.units.DataSize;
 import org.apache.parquet.hadoop.ParquetWriter;
 
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion;
 
 public class ParquetFileWriterConfig
 {
@@ -25,6 +27,7 @@ public class ParquetFileWriterConfig
 
     private DataSize blockSize = new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE);
     private DataSize pageSize = new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE);
+    private WriterVersion writerVersion = ParquetWriterOptions.DEFAULT_WRITER_VERSION;
 
     public DataSize getBlockSize()
     {
@@ -47,6 +50,18 @@ public class ParquetFileWriterConfig
     public ParquetFileWriterConfig setPageSize(DataSize pageSize)
     {
         this.pageSize = pageSize;
+        return this;
+    }
+
+    public WriterVersion getWriterVersion()
+    {
+        return writerVersion;
+    }
+
+    @Config("hive.parquet.writer.version")
+    public ParquetFileWriterConfig setWriterVersion(WriterVersion writerVersion)
+    {
+        this.writerVersion = writerVersion;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Callable;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterBlockSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterPageSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetOptimizedWriterEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static java.util.Objects.requireNonNull;
@@ -103,6 +104,7 @@ public class ParquetFileWriterFactory
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setWriterVersion(getParquetWriterVersion(session))
                 .build();
 
         CompressionCodecName compressionCodecName = getCompression(conf);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
@@ -20,9 +20,12 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.hive.HiveSessionProperties.isCacheEnabled;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -74,5 +77,25 @@ public class TestHiveSessionProperties
                         new ParquetFileWriterConfig(),
                         new CacheConfig().setCachingEnabled(true)).getSessionProperties());
         assertTrue(isCacheEnabled(connectorSession));
+    }
+
+    @Test
+    public void testParquetWriterVersionConfig()
+    {
+        ConnectorSession connectorSession = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig(),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig(),
+                        new CacheConfig().setCachingEnabled(true)).getSessionProperties());
+        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_2_0);
+
+        connectorSession = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig(),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig().setWriterVersion(PARQUET_1_0),
+                        new CacheConfig().setCachingEnabled(true)).getSessionProperties());
+        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_1_0);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.testng.annotations.Test;
 
@@ -34,7 +35,8 @@ public class TestParquetFileWriterConfig
         assertRecordedDefaults(recordDefaults(ParquetFileWriterConfig.class)
                 .setParquetOptimizedWriterEnabled(false)
                 .setBlockSize(new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE))
-                .setPageSize(new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE)));
+                .setPageSize(new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE))
+                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0));
     }
 
     @Test
@@ -44,12 +46,14 @@ public class TestParquetFileWriterConfig
                 .put("hive.parquet.optimized-writer.enabled", "true")
                 .put("hive.parquet.writer.block-size", "234MB")
                 .put("hive.parquet.writer.page-size", "11MB")
+                .put("hive.parquet.writer.version", "PARQUET_1_0")
                 .build();
 
         ParquetFileWriterConfig expected = new ParquetFileWriterConfig()
                 .setParquetOptimizedWriterEnabled(true)
                 .setBlockSize(new DataSize(234, MEGABYTE))
-                .setPageSize(new DataSize(11, MEGABYTE));
+                .setPageSize(new DataSize(11, MEGABYTE))
+                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -25,6 +25,7 @@ import com.facebook.presto.parquet.cache.CachingParquetMetadataSource;
 import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.parquet.cache.ParquetFileMetadata;
 import com.facebook.presto.parquet.cache.ParquetMetadataSource;
+import com.facebook.presto.parquet.writer.ParquetWriterOptions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.AbstractIterator;
@@ -1628,7 +1629,8 @@ public abstract class AbstractTestParquetReader
                     columnNames,
                     new Iterable<?>[] {values},
                     10,
-                    CompressionCodecName.GZIP);
+                    CompressionCodecName.GZIP,
+                    ParquetWriterOptions.DEFAULT_WRITER_VERSION);
             long tempFileCreationTime = System.currentTimeMillis();
 
             testSingleRead(new Iterable<?>[] {values},

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.gen.PageFunctionCompiler;
 import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ColumnIOConverter;
@@ -259,7 +260,8 @@ public class BenchmarkParquetPageSource
                     columnNames,
                     values,
                     ROWS,
-                    compressionCodecName);
+                    compressionCodecName,
+                    ParquetProperties.WriterVersion.PARQUET_2_0);
 
             //Set up PageProcessor
             List<RowExpression> projections = getProjections(type);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
@@ -19,6 +19,7 @@ import com.facebook.presto.parquet.Field;
 import com.facebook.presto.parquet.FileParquetDataSource;
 import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.parquet.reader.ParquetReader;
+import com.facebook.presto.parquet.writer.ParquetWriterOptions;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -87,7 +88,8 @@ public class TestParquetReaderMemoryTracking
                 ImmutableList.of("c1"),
                 new Iterable<?>[] {generateValues()},
                 ROWS,
-                compressionCodecName);
+                compressionCodecName,
+                ParquetWriterOptions.DEFAULT_WRITER_VERSION);
     }
 
     private List<Integer> generateValues()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxBuff
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterValidateMode;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcStreamBufferSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcOptimizedWriterValidate;
 import static com.facebook.presto.iceberg.TypeConverter.toOrcType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
@@ -142,6 +143,7 @@ public class IcebergFileWriterFactory
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
+                    .setWriterVersion(getParquetWriterVersion(session))
                     .build();
 
             return new IcebergParquetFileWriter(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties;
 
 import javax.inject.Inject;
 
@@ -50,6 +51,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";
     private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
@@ -130,6 +132,15 @@ public final class IcebergSessionProperties
                         "Parquet: Writer page size",
                         parquetFileWriterConfig.getPageSize(),
                         false),
+                new PropertyMetadata<>(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer version",
+                        VARCHAR,
+                        ParquetProperties.WriterVersion.class,
+                        parquetFileWriterConfig.getWriterVersion(),
+                        false,
+                        value -> ParquetProperties.WriterVersion.valueOf(((String) value).toUpperCase()),
+                        ParquetProperties.WriterVersion::name),
                 booleanProperty(
                         ORC_BLOOM_FILTERS_ENABLED,
                         "ORC: Enable bloom filters for predicate pushdown",
@@ -305,6 +316,11 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static ParquetProperties.WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, ParquetProperties.WriterVersion.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -48,7 +48,6 @@ import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.BROTLI;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.LZ4;
@@ -100,7 +99,7 @@ public class ParquetWriter
         this.messageType = requireNonNull(messageType, "messageType is null");
 
         ParquetProperties parquetProperties = ParquetProperties.builder()
-                .withWriterVersion(PARQUET_2_0)
+                .withWriterVersion(writerOption.getWriterVersion())
                 .withPageSize(writerOption.getMaxPageSize())
                 .withDictionaryPageSize(writerOption.getMaxDictionaryPageSize())
                 .build();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.parquet.writer;
 
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -22,6 +23,7 @@ public class ParquetWriterOptions
 {
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
+    public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_2_0;
 
     public static ParquetWriterOptions.Builder builder()
     {
@@ -31,12 +33,14 @@ public class ParquetWriterOptions
     private final int maxRowGroupSize;
     private final int maxPageSize;
     private final int maxDictionaryPageSize;
+    private final WriterVersion writerVersion;
 
-    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize, DataSize maxDictionaryPageSize)
+    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize, DataSize maxDictionaryPageSize, WriterVersion writerVersion)
     {
         this.maxRowGroupSize = toIntExact(requireNonNull(maxRowGroupSize, "maxRowGroupSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
         this.maxDictionaryPageSize = toIntExact(requireNonNull(maxDictionaryPageSize, "maxDictionaryPageSize is null").toBytes());
+        this.writerVersion = requireNonNull(writerVersion, "writerVersion is null");
     }
 
     public int getMaxRowGroupSize()
@@ -54,12 +58,18 @@ public class ParquetWriterOptions
         return maxDictionaryPageSize;
     }
 
+    public WriterVersion getWriterVersion()
+    {
+        return writerVersion;
+    }
+
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
         // By default, we set maxDictionaryPageSize to the same default value as maxPageSize, to keep consistent with parquet-mr.
         private DataSize maxDictionaryPageSize = DEFAULT_MAX_PAGE_SIZE;
+        private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -79,9 +89,15 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setWriterVersion(WriterVersion writerVersion)
+        {
+            this.writerVersion = writerVersion;
+            return this;
+        }
+
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize, maxDictionaryPageSize);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize, maxDictionaryPageSize, writerVersion);
         }
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -26,7 +26,6 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -37,64 +36,53 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.parquet.writer.ParquetCompressor.getCompressor;
 import static com.facebook.presto.parquet.writer.ParquetDataOutput.createDataOutput;
-import static com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables.getIterator;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.bytes.BytesInput.copy;
 
-public class PrimitiveColumnWriter
+public abstract class PrimitiveColumnWriter
         implements ColumnWriter
 {
-    private final Type type;
-    private final ColumnDescriptor columnDescriptor;
-    private final CompressionCodecName compressionCodec;
-
-    private final PrimitiveValueWriter primitiveValueWriter;
-    private final RunLengthBitPackingHybridEncoder definitionLevelEncoder;
-    private final RunLengthBitPackingHybridEncoder repetitionLevelEncoder;
-
-    private final ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
-
-    private boolean closed;
-    private boolean getDataStreamsCalled;
-
-    // current page stats
-    private int currentPageRows;
-    private int currentPageNullCounts;
-    private int currentPageRowCount;
-
-    // column meta data stats
-    private final Set<Encoding> encodings;
-    private long totalCompressedSize;
-    private long totalUnCompressedSize;
-    private long totalRows;
-    private Statistics<?> columnStatistics;
-
-    private final int maxDefinitionLevel;
-
-    private final List<ParquetDataOutput> pageBuffer = new ArrayList<>();
+    protected final ColumnDescriptor columnDescriptor;
+    protected final PrimitiveValueWriter primitiveValueWriter;
+    protected final ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
+    protected final Set<Encoding> encodings;
+    protected final int maxDefinitionLevel;
+    protected final List<ParquetDataOutput> pageBuffer = new ArrayList<>();
 
     @Nullable
-    private final ParquetCompressor compressor;
+    protected final ParquetCompressor compressor;
+    protected final int pageSizeThreshold;
 
-    private final int pageSizeThreshold;
+    private final Type type;
+    private final CompressionCodecName compressionCodec;
 
-    public PrimitiveColumnWriter(Type type, ColumnDescriptor columnDescriptor, PrimitiveValueWriter primitiveValueWriter, RunLengthBitPackingHybridEncoder definitionLevelEncoder, RunLengthBitPackingHybridEncoder repetitionLevelEncoder, CompressionCodecName compressionCodecName, int pageSizeThreshold)
+    protected boolean closed;
+    protected boolean getDataStreamsCalled;
+
+    // current page stats
+    protected int valueCount;
+    protected int currentPageNullCounts;
+
+    // column meta data stats
+    protected long totalCompressedSize;
+    protected long totalUnCompressedSize;
+    protected long totalValues;
+    protected Statistics<?> columnStatistics;
+
+    public PrimitiveColumnWriter(Type type, ColumnDescriptor columnDescriptor, PrimitiveValueWriter primitiveValueWriter, CompressionCodecName compressionCodecName, int pageSizeThreshold)
     {
         this.type = requireNonNull(type, "type is null");
         this.columnDescriptor = requireNonNull(columnDescriptor, "columnDescriptor is null");
         this.maxDefinitionLevel = columnDescriptor.getMaxDefinitionLevel();
 
-        this.definitionLevelEncoder = requireNonNull(definitionLevelEncoder, "definitionLevelEncoder is null");
-        this.repetitionLevelEncoder = requireNonNull(repetitionLevelEncoder, "repetitionLevelEncoder is null");
         this.primitiveValueWriter = requireNonNull(primitiveValueWriter, "primitiveValueWriter is null");
         this.encodings = new HashSet<>();
         this.compressionCodec = requireNonNull(compressionCodecName, "compressionCodecName is null");
@@ -123,26 +111,7 @@ public class PrimitiveColumnWriter
         // write values
         primitiveValueWriter.write(columnChunk.getBlock());
 
-        // write definition levels
-        Iterator<Integer> defIterator = DefinitionLevelIterables.getIterator(current.getDefinitionLevelIterables());
-        while (defIterator.hasNext()) {
-            int next = defIterator.next();
-            definitionLevelEncoder.writeInt(next);
-            if (next != maxDefinitionLevel) {
-                currentPageNullCounts++;
-            }
-            currentPageRows++;
-        }
-
-        // write repetition levels
-        Iterator<Integer> repIterator = getIterator(current.getRepetitionLevelIterables());
-        while (repIterator.hasNext()) {
-            int next = repIterator.next();
-            repetitionLevelEncoder.writeInt(next);
-            if (next == 0) {
-                currentPageRowCount++;
-            }
-        }
+        writeDefinitionAndRepetitionLevels(current);
 
         if (getBufferedBytes() >= pageSizeThreshold) {
             flushCurrentPageToBuffer();
@@ -164,7 +133,7 @@ public class PrimitiveColumnWriter
     }
 
     // Returns ColumnMetaData that offset is invalid
-    private ColumnMetaData getColumnMetaData()
+    protected ColumnMetaData getColumnMetaData()
     {
         checkState(getDataStreamsCalled);
 
@@ -173,7 +142,7 @@ public class PrimitiveColumnWriter
                 encodings.stream().map(parquetMetadataConverter::getEncoding).collect(toImmutableList()),
                 ImmutableList.copyOf(columnDescriptor.getPath()),
                 compressionCodec.getParquetCompressionCodec(),
-                totalRows,
+                totalValues,
                 totalUnCompressedSize,
                 totalCompressedSize,
                 -1);
@@ -181,83 +150,11 @@ public class PrimitiveColumnWriter
         return columnMetaData;
     }
 
-    // page header
-    // repetition levels
-    // definition levels
-    // data
-    private void flushCurrentPageToBuffer()
-            throws IOException
-    {
-        ImmutableList.Builder<ParquetDataOutput> outputDataStreams = ImmutableList.builder();
-
-        BytesInput bytes = primitiveValueWriter.getBytes();
-        ParquetDataOutput repetitions = createDataOutput(copy(repetitionLevelEncoder.toBytes()));
-        ParquetDataOutput definitions = createDataOutput(copy(definitionLevelEncoder.toBytes()));
-
-        // Add encoding should be called after primitiveValueWriter.getBytes() and before primitiveValueWriter.reset()
-        encodings.add(primitiveValueWriter.getEncoding());
-
-        long uncompressedSize = bytes.size() + repetitions.size() + definitions.size();
-
-        ParquetDataOutput data;
-        long compressedSize;
-        if (compressor != null) {
-            data = compressor.compress(bytes);
-            compressedSize = data.size() + repetitions.size() + definitions.size();
-        }
-        else {
-            data = createDataOutput(copy(bytes));
-            compressedSize = uncompressedSize;
-        }
-
-        ByteArrayOutputStream pageHeaderOutputStream = new ByteArrayOutputStream();
-
-        Statistics<?> statistics = primitiveValueWriter.getStatistics();
-        statistics.incrementNumNulls(currentPageNullCounts);
-
-        columnStatistics.mergeStatistics(statistics);
-
-        parquetMetadataConverter.writeDataPageV2Header((int) uncompressedSize,
-                (int) compressedSize,
-                currentPageRows,
-                currentPageNullCounts,
-                currentPageRowCount,
-                statistics,
-                primitiveValueWriter.getEncoding(),
-                (int) repetitions.size(),
-                (int) definitions.size(),
-                pageHeaderOutputStream);
-
-        ParquetDataOutput pageHeader = createDataOutput(Slices.wrappedBuffer(pageHeaderOutputStream.toByteArray()));
-        outputDataStreams.add(pageHeader);
-        outputDataStreams.add(repetitions);
-        outputDataStreams.add(definitions);
-        outputDataStreams.add(data);
-
-        List<ParquetDataOutput> dataOutputs = outputDataStreams.build();
-
-        // update total stats
-        totalCompressedSize += pageHeader.size() + compressedSize;
-        totalUnCompressedSize += pageHeader.size() + uncompressedSize;
-        totalRows += currentPageRows;
-
-        pageBuffer.addAll(dataOutputs);
-
-        // reset page stats
-        currentPageRows = 0;
-        currentPageNullCounts = 0;
-        currentPageRowCount = 0;
-
-        definitionLevelEncoder.reset();
-        repetitionLevelEncoder.reset();
-        primitiveValueWriter.reset();
-    }
-
-    private List<ParquetDataOutput> getDataStreams()
+    protected List<ParquetDataOutput> getDataStreams()
             throws IOException
     {
         List<ParquetDataOutput> dictPage = new ArrayList<>();
-        if (currentPageRows > 0) {
+        if (valueCount > 0) {
             flushCurrentPageToBuffer();
         }
         // write dict page if possible
@@ -294,14 +191,7 @@ public class PrimitiveColumnWriter
                 .build();
     }
 
-    @Override
-    public long getBufferedBytes()
-    {
-        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() +
-                definitionLevelEncoder.getBufferedSize() +
-                repetitionLevelEncoder.getBufferedSize() +
-                primitiveValueWriter.getBufferedSize();
-    }
+    public abstract long getBufferedBytes();
 
     @Override
     public long getRetainedBytes()
@@ -318,10 +208,20 @@ public class PrimitiveColumnWriter
 
         totalCompressedSize = 0;
         totalUnCompressedSize = 0;
-        totalRows = 0;
+        totalValues = 0;
         encodings.clear();
         this.columnStatistics = Statistics.createStats(columnDescriptor.getPrimitiveType());
 
         getDataStreamsCalled = false;
     }
+
+    protected abstract void writeDefinitionAndRepetitionLevels(ColumnChunk current)
+            throws IOException;
+
+    // page header
+    // repetition levels
+    // definition levels
+    // data
+    protected abstract void flushCurrentPageToBuffer()
+            throws IOException;
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV1.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV1.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
+import com.facebook.presto.parquet.writer.valuewriter.PrimitiveValueWriter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.facebook.presto.parquet.writer.ParquetDataOutput.createDataOutput;
+import static com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables.getIterator;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.bytes.BytesInput.copy;
+
+public class PrimitiveColumnWriterV1
+        extends PrimitiveColumnWriter
+{
+    private final ValuesWriter definitionLevelWriter;
+    private final ValuesWriter repetitionLevelWriter;
+
+    public PrimitiveColumnWriterV1(Type type, ColumnDescriptor columnDescriptor, PrimitiveValueWriter primitiveValueWriter, ValuesWriter definitionLevelWriter, ValuesWriter repetitionLevelWriter, CompressionCodecName compressionCodecName, int pageSizeThreshold)
+    {
+        super(type, columnDescriptor, primitiveValueWriter, compressionCodecName, pageSizeThreshold);
+
+        this.definitionLevelWriter = requireNonNull(definitionLevelWriter, "definitionLevelWriter is null");
+        this.repetitionLevelWriter = requireNonNull(repetitionLevelWriter, "repetitionLevelWriter is null");
+    }
+
+    protected void writeDefinitionAndRepetitionLevels(ColumnChunk current)
+    {
+        // write definition levels
+        Iterator<Integer> defIterator = DefinitionLevelIterables.getIterator(current.getDefinitionLevelIterables());
+        while (defIterator.hasNext()) {
+            int next = defIterator.next();
+            definitionLevelWriter.writeInteger(next);
+            if (next != maxDefinitionLevel) {
+                currentPageNullCounts++;
+            }
+            valueCount++;
+        }
+
+        // write repetition levels
+        Iterator<Integer> repIterator = getIterator(current.getRepetitionLevelIterables());
+        while (repIterator.hasNext()) {
+            int next = repIterator.next();
+            repetitionLevelWriter.writeInteger(next);
+        }
+    }
+
+    @Override
+    public List<BufferData> getBuffer()
+            throws IOException
+    {
+        checkState(closed);
+        return ImmutableList.of(new BufferData(getDataStreams(), getColumnMetaData()));
+    }
+
+    // page header
+    // repetition levels
+    // definition levels
+    // data
+    protected void flushCurrentPageToBuffer()
+            throws IOException
+    {
+        ImmutableList.Builder<ParquetDataOutput> outputDataStreams = ImmutableList.builder();
+
+        BytesInput bytesInput = BytesInput.concat(copy(repetitionLevelWriter.getBytes()),
+                copy(definitionLevelWriter.getBytes()),
+                copy(primitiveValueWriter.getBytes()));
+        ParquetDataOutput pageData = (compressor != null) ? compressor.compress(bytesInput) : createDataOutput(bytesInput);
+        long uncompressedSize = bytesInput.size();
+        long compressedSize = pageData.size();
+
+        ByteArrayOutputStream pageHeaderOutputStream = new ByteArrayOutputStream();
+
+        Statistics<?> statistics = primitiveValueWriter.getStatistics();
+        statistics.incrementNumNulls(currentPageNullCounts);
+
+        columnStatistics.mergeStatistics(statistics);
+
+        parquetMetadataConverter.writeDataPageV1Header((int) uncompressedSize,
+                (int) compressedSize,
+                valueCount,
+                repetitionLevelWriter.getEncoding(),
+                definitionLevelWriter.getEncoding(),
+                primitiveValueWriter.getEncoding(),
+                pageHeaderOutputStream);
+
+        ParquetDataOutput pageHeader = createDataOutput(Slices.wrappedBuffer(pageHeaderOutputStream.toByteArray()));
+        outputDataStreams.add(pageHeader);
+        outputDataStreams.add(pageData);
+
+        List<ParquetDataOutput> dataOutputs = outputDataStreams.build();
+
+        // update total stats
+        totalUnCompressedSize += pageHeader.size() + uncompressedSize;
+        totalCompressedSize += pageHeader.size() + compressedSize;
+        totalValues += valueCount;
+
+        pageBuffer.addAll(dataOutputs);
+
+        // Add encoding should be called after ValuesWriter#getBytes() and before ValuesWriter#reset()
+        encodings.add(repetitionLevelWriter.getEncoding());
+        encodings.add(definitionLevelWriter.getEncoding());
+        encodings.add(primitiveValueWriter.getEncoding());
+
+        // reset page stats
+        valueCount = 0;
+        currentPageNullCounts = 0;
+
+        repetitionLevelWriter.reset();
+        definitionLevelWriter.reset();
+        primitiveValueWriter.reset();
+    }
+
+    @Override
+    public long getBufferedBytes()
+    {
+        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() +
+                definitionLevelWriter.getBufferedSize() +
+                repetitionLevelWriter.getBufferedSize() +
+                primitiveValueWriter.getBufferedSize();
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV2.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriterV2.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
+import com.facebook.presto.parquet.writer.valuewriter.PrimitiveValueWriter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.facebook.presto.parquet.writer.ParquetDataOutput.createDataOutput;
+import static com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables.getIterator;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.bytes.BytesInput.copy;
+
+public class PrimitiveColumnWriterV2
+        extends PrimitiveColumnWriter
+{
+    private final RunLengthBitPackingHybridEncoder definitionLevelEncoder;
+    private final RunLengthBitPackingHybridEncoder repetitionLevelEncoder;
+
+    // current page stats
+    private int currentPageRowCount;
+
+    public PrimitiveColumnWriterV2(Type type, ColumnDescriptor columnDescriptor, PrimitiveValueWriter primitiveValueWriter, RunLengthBitPackingHybridEncoder definitionLevelEncoder, RunLengthBitPackingHybridEncoder repetitionLevelEncoder, CompressionCodecName compressionCodecName, int pageSizeThreshold)
+    {
+        super(type, columnDescriptor, primitiveValueWriter, compressionCodecName, pageSizeThreshold);
+
+        this.definitionLevelEncoder = requireNonNull(definitionLevelEncoder, "definitionLevelEncoder is null");
+        this.repetitionLevelEncoder = requireNonNull(repetitionLevelEncoder, "repetitionLevelEncoder is null");
+    }
+
+    protected void writeDefinitionAndRepetitionLevels(ColumnChunk current)
+            throws IOException
+    {
+        // write definition levels
+        Iterator<Integer> defIterator = DefinitionLevelIterables.getIterator(current.getDefinitionLevelIterables());
+        while (defIterator.hasNext()) {
+            int next = defIterator.next();
+            definitionLevelEncoder.writeInt(next);
+            if (next != maxDefinitionLevel) {
+                currentPageNullCounts++;
+            }
+            valueCount++;
+        }
+
+        // write repetition levels
+        Iterator<Integer> repIterator = getIterator(current.getRepetitionLevelIterables());
+        while (repIterator.hasNext()) {
+            int next = repIterator.next();
+            repetitionLevelEncoder.writeInt(next);
+            if (next == 0) {
+                currentPageRowCount++;
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+    }
+
+    @Override
+    public List<BufferData> getBuffer()
+            throws IOException
+    {
+        checkState(closed);
+        return ImmutableList.of(new BufferData(getDataStreams(), getColumnMetaData()));
+    }
+
+    // page header
+    // repetition levels
+    // definition levels
+    // data
+    protected void flushCurrentPageToBuffer()
+            throws IOException
+    {
+        ImmutableList.Builder<ParquetDataOutput> outputDataStreams = ImmutableList.builder();
+
+        BytesInput bytes = primitiveValueWriter.getBytes();
+        ParquetDataOutput repetitions = createDataOutput(copy(repetitionLevelEncoder.toBytes()));
+        ParquetDataOutput definitions = createDataOutput(copy(definitionLevelEncoder.toBytes()));
+
+        // Add encoding should be called after primitiveValueWriter.getBytes() and before primitiveValueWriter.reset()
+        encodings.add(primitiveValueWriter.getEncoding());
+
+        long uncompressedSize = bytes.size() + repetitions.size() + definitions.size();
+
+        ParquetDataOutput data;
+        long compressedSize;
+        if (compressor != null) {
+            data = compressor.compress(bytes);
+            compressedSize = data.size() + repetitions.size() + definitions.size();
+        }
+        else {
+            data = createDataOutput(copy(bytes));
+            compressedSize = uncompressedSize;
+        }
+
+        ByteArrayOutputStream pageHeaderOutputStream = new ByteArrayOutputStream();
+
+        Statistics<?> statistics = primitiveValueWriter.getStatistics();
+        statistics.incrementNumNulls(currentPageNullCounts);
+
+        columnStatistics.mergeStatistics(statistics);
+
+        parquetMetadataConverter.writeDataPageV2Header((int) uncompressedSize,
+                (int) compressedSize,
+                valueCount,
+                currentPageNullCounts,
+                currentPageRowCount,
+                statistics,
+                primitiveValueWriter.getEncoding(),
+                (int) repetitions.size(),
+                (int) definitions.size(),
+                pageHeaderOutputStream);
+
+        ParquetDataOutput pageHeader = createDataOutput(Slices.wrappedBuffer(pageHeaderOutputStream.toByteArray()));
+        outputDataStreams.add(pageHeader);
+        outputDataStreams.add(repetitions);
+        outputDataStreams.add(definitions);
+        outputDataStreams.add(data);
+
+        List<ParquetDataOutput> dataOutputs = outputDataStreams.build();
+
+        // update total stats
+        totalCompressedSize += pageHeader.size() + compressedSize;
+        totalUnCompressedSize += pageHeader.size() + uncompressedSize;
+        totalValues += valueCount;
+
+        pageBuffer.addAll(dataOutputs);
+
+        // reset page stats
+        valueCount = 0;
+        currentPageNullCounts = 0;
+        currentPageRowCount = 0;
+
+        definitionLevelEncoder.reset();
+        repetitionLevelEncoder.reset();
+        primitiveValueWriter.reset();
+    }
+
+    @Override
+    public long getBufferedBytes()
+    {
+        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() +
+                definitionLevelEncoder.getBufferedSize() +
+                repetitionLevelEncoder.getBufferedSize() +
+                primitiveValueWriter.getBufferedSize();
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/9497 and https://github.com/trinodb/trino/pull/9611

## Description
Adds support for writing Parquet data versions V1 and V2 using a config and session property.

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/20926

## Impact
No external changes. Default Parquet version is set to V2 which is currently used in Presto.

## Test Plan
Amended the ParquetTester.java to run round trip tests for both writer versions.

```
== RELEASE NOTES ==

Hive Changes
* Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. It can be toggled using session property `parquet_writer_version` and config property `hive.parquet.writer.version`. Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0. E.g., set session parquet_writer_version=PARQUET_1_0 / hive.parquet.writer.version=PARQUET_1_0
```

