### PR TITLE
[native] Fix GROUPING SETS with multiple aliased columns

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1921,19 +1921,19 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   //    and groupingColumns = [orderstatus$gid => orderstatus, orderpriority$gid
   //    => orderpriority]
 
-  // core::GroupIdNode.groupingSets is defined using input fields.
-  // core::GroupIdNode.outputGroupingKeyNames maps output name of a
+  // core::GroupIdNode.groupingSets is defined using output field names.
+  // core::GroupIdNode.groupingKeys maps output name of a
   // grouping key to the corresponding input field.
 
-  std::vector<std::vector<core::FieldAccessTypedExprPtr>> groupingSets;
+  std::vector<std::vector<std::string>> groupingSets;
   groupingSets.reserve(node->groupingSets.size());
   for (const auto& groupingSet : node->groupingSets) {
-    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    std::vector<std::string> groupingKeys;
     groupingKeys.reserve(groupingSet.size());
+    // Use the output key name in the GroupingSet as there could be
+    // multiple output keys mapping to the same input column.
     for (const auto& groupingKey : groupingSet) {
-      groupingKeys.emplace_back(std::make_shared<core::FieldAccessTypedExpr>(
-          stringToType(groupingKey.type),
-          node->groupingColumns.at(groupingKey).name));
+      groupingKeys.emplace_back(groupingKey.name);
     }
     groupingSets.emplace_back(std::move(groupingKeys));
   }


### PR DESCRIPTION
GROUPING SETS can be specified with multiple alias columns of the same input column. This is typically used to compute multiple mixed aggregations on the same key.

e.g. in queries
`select COUNT(orderkey), count(distinct orderkey) from orders;`

or

`SELECT lna, lnb, SUM(quantity) FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ()) 
`

Presto built plan fragments correctly specifying the output column name for such cases. But the Velox plan conversion always mapped to the input column losing the distinction of the output group keys. This change retains the output column name thus disambiguating aliased columns.

Fixes https://github.com/prestodb/presto/issues/20910

```
== NO RELEASE NOTE ==
```

