### PR TITLE
Correct the counting for resource group's running tasks

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -316,6 +316,11 @@ public class LocalDispatchQuery
                 .orElse(new DataSize(0, BYTE));
     }
 
+    public int getRunningTaskCount()
+    {
+        return stateMachine.getCurrentRunningTaskCount();
+    }
+
     @Override
     public BasicQueryInfo getBasicQueryInfo()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
@@ -48,6 +48,11 @@ public interface ManagedQueryExecution
 
     BasicQueryInfo getBasicQueryInfo();
 
+    default int getRunningTaskCount()
+    {
+        return 0;
+    }
+
     void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits);
 
     boolean isDone();

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution.resourceGroups;
 
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.execution.ManagedQueryExecution;
-import com.facebook.presto.execution.SqlQueryExecution;
 import com.facebook.presto.execution.resourceGroups.WeightedFairQueue.Usage;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.server.QueryStateInfo;
@@ -687,8 +686,7 @@ public class InternalResourceGroup
     {
         if (subGroups().isEmpty()) {
             return runningQueries.stream()
-                    .filter(SqlQueryExecution.class::isInstance)
-                    .mapToInt(query -> ((SqlQueryExecution) query).getRunningTaskCount())
+                    .mapToInt(query -> query.getRunningTaskCount())
                     .sum();
         }
 


### PR DESCRIPTION
## Description

Fix the counting for resource group's running tasks. Previously it will always be 0, and that would cause resource group manager's "max-total-running-task-count-to-not-execute-new-query" not working.

## Test Plan

. Renovate test case TestQueryTaskLimit.testQueuingWhenTaskLimitExceeds()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

