### PR TITLE
Fix bug in maxExecutors config tuning in AQE codepath

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
@@ -68,7 +68,6 @@ import java.util.concurrent.TimeoutException;
 import static com.facebook.presto.execution.QueryState.PLANNING;
 import static com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.createQueryInfo;
 import static com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.createStageInfo;
-import static com.facebook.presto.spark.PrestoSparkSettingsRequirements.SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS_CONFIG;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textDistributedPlan;
@@ -161,14 +160,6 @@ public class PrestoSparkStaticQueryExecution
             throws SparkException, TimeoutException
     {
         SubPlan rootFragmentedPlan = createFragmentedPlan();
-
-        // executor allocation is currently only supported at root level of the plan
-        // in future this could be extended to fragment level configuration
-        if (planAndMore.getPhysicalResourceSettings().getMaxExecutorCount().isPresent()) {
-            sparkContext.sc().conf().set(SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS_CONFIG,
-                    Integer.toString(planAndMore.getPhysicalResourceSettings().getMaxExecutorCount().getAsInt()));
-        }
-
         setFinalFragmentedPlan(rootFragmentedPlan);
         TableWriteInfo tableWriteInfo = getTableWriteInfo(session, rootFragmentedPlan);
         PlanFragment rootFragment = rootFragmentedPlan.getFragment();


### PR DESCRIPTION
maxExecutors config tuning currently only works for non-AQE execution path.
Moving it at common place so that it works for both AQE and non-AQE 
execution mode

```
== NO RELEASE NOTE ==
```

