### PR TITLE
Document null handling for SET_AGG and SET_UNION 

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -145,11 +145,16 @@ General Aggregate Functions
 
 .. function:: set_agg(x) -> array<[same as input]>
 
-        Returns an array created from the distinct input ``x`` elements.
+    Returns an array created from the distinct input ``x`` elements.
+
+    If the input includes ``NULL``, ``NULL`` will be included in the returned array.
 
 .. function:: set_union(array(T)) -> array(T)
 
-    Returns an array of all the distinct values contained in each array of the input
+    Returns an array of all the distinct values contained in each array of the input.
+
+    When all inputs are ``NULL``, this function returns an empty array. If ``NULL`` is
+    an element of one of the input arrays, ``NULL`` will be included in the returned array.
 
     Example::
 


### PR DESCRIPTION
## Description
Null handling behavior of SET_AGG and SET_UNION can be confusing. This change improves documentation to clarify the behavior. 

Part of https://github.com/prestodb/presto/issues/20955

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

