### PR TITLE
Split product tests to avoid out of disk space issues

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -34,7 +34,7 @@ jobs:
     if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-product-tests-specific-environment1-${{ github.event.pull_request.number }}
+      group: ${{ github.workflow }}-product-tests-specific-environment-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
@@ -63,12 +63,6 @@ jobs:
       # temporarily disable this flaky run. see issue #20388 for details
       # - name: Product Tests Specific 1.3
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
-      - name: Product Tests Specific 1.4
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
-      - name: Product Tests Specific 1.5
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
-      - name: Product Tests Specific 1.6
-        run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
 
   product-tests-specific-environment2:
     runs-on: ubuntu-latest
@@ -76,7 +70,42 @@ jobs:
     if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-product-tests-specific-environment2-${{ github.event.pull_request.number }}
+      group: ${{ github.workflow }}-product-tests-specific-environment-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Mave install
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
+      - name: Product Tests Specific 1.4
+        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
+      - name: Product Tests Specific 1.5
+        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
+      - name: Product Tests Specific 1.6
+        run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
+
+  product-tests-specific-environment3:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
+    timeout-minutes: 60
+    concurrency:
+      group: ${{ github.workflow }}-product-tests-specific-environment-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
@@ -112,6 +141,35 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls -g smoke,cli,group-by,join,tls
       - name: Product Tests Specific 2.3
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
+
+  product-tests-specific-environment4:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.codechange == 'true'
+    timeout-minutes: 60
+    concurrency:
+      group: ${{ github.workflow }}-product-tests-specific-environment-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Maven install
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Product Tests Specific 2.4
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5


### PR DESCRIPTION
## Description
There are frequent CI issues as reported in #20984.  I am trying to mitigate the problem by splitting apart the product tests.

## Motivation and Context
Reduce flakiness in our CI.

## Impact
N/A

## Test Plan
Tests should be green

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

