### PR TITLE
Track whether an optimization decision was cost-based

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
@@ -177,9 +177,12 @@ public class Optimizer
                 isTriggered ||
                 !optimizer.isEnabled(session) && isVerboseOptimizerInfoEnabled(session) &&
                         optimizer.isApplicable(oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+        boolean isCostBased = isTriggered && optimizer.isCostBased(session);
+        String statsSource = optimizer.getStatsSource();
 
-        if (isTriggered || isApplicable) {
-            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(optimizerName, isTriggered, Optional.of(isApplicable), Optional.empty()));
+        if (isTriggered || isApplicable || isCostBased) {
+            session.getOptimizerInformationCollector().addInformation(
+                    new PlanOptimizerInformation(optimizerName, isTriggered, Optional.of(isApplicable), Optional.empty(), Optional.of(isCostBased), statsSource == null ? Optional.empty() : Optional.of(statsSource)));
         }
 
         if (isTriggered && isVerboseOptimizerResults(session, optimizerName)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -39,6 +39,15 @@ public interface Rule<T>
     {
         return true;
     }
+    default boolean isCostBased(Session session)
+    {
+        return false;
+    }
+
+    default String getStatsSource()
+    {
+        return null;
+    }
 
     Result apply(T node, Captures captures, Context context);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -106,6 +106,7 @@ public class ReorderJoins
     private final Metadata metadata;
     private final FunctionResolution functionResolution;
     private final DeterminismEvaluator determinismEvaluator;
+    private String statsSource;
 
     public ReorderJoins(CostComparator costComparator, Metadata metadata)
     {
@@ -133,6 +134,18 @@ public class ReorderJoins
     }
 
     @Override
+    public boolean isCostBased(Session session)
+    {
+        // when enabled, join order is always cost-based
+        return isEnabled(session);
+    }
+
+    public String getStatsSource()
+    {
+        return statsSource;
+    }
+
+    @Override
     public Result apply(JoinNode joinNode, Captures captures, Context context)
     {
         MultiJoinNode multiJoinNode = toMultiJoinNode(joinNode, context.getLookup(), getMaxReorderedJoins(context.getSession()), functionResolution, determinismEvaluator);
@@ -147,6 +160,7 @@ public class ReorderJoins
         if (!result.getPlanNode().isPresent()) {
             return Result.empty();
         }
+        statsSource = context.getStatsProvider().getStats(joinNode).getSourceInfo().getSourceInfoName();
         return Result.ofPlanNode(result.getPlanNode().get());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -136,7 +136,8 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
 
     private void logOptimizerFailure(Session session)
     {
-        session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(HistoricalStatisticsEquivalentPlanMarkingOptimizer.class.getSimpleName(), false, Optional.empty(), Optional.of(true)));
+        session.getOptimizerInformationCollector().addInformation(
+                new PlanOptimizerInformation(HistoricalStatisticsEquivalentPlanMarkingOptimizer.class.getSimpleName(), false, Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty()));
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -238,7 +238,8 @@ public class MergePartialAggregationsWithFilter
             Map<VariableReferenceExpression, AggregationNode.Aggregation> newAggregations = node.getAggregations().entrySet().stream()
                     .filter(x -> !partialResultToMerge.contains(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
-            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(MergePartialAggregationsWithFilter.class.getSimpleName(), true, Optional.empty(), Optional.empty()));
+            session.getOptimizerInformationCollector().addInformation(
+                    new PlanOptimizerInformation(MergePartialAggregationsWithFilter.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.of(false), Optional.empty()));
 
             return new AggregationNode(
                     node.getSourceLocation(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -244,7 +244,8 @@ public class MetadataQueryOptimizer
             }
 
             // replace the tablescan node with a values node
-            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(MetadataQueryOptimizer.class.getSimpleName(), true, Optional.empty(), Optional.empty()));
+            session.getOptimizerInformationCollector().addInformation(
+                    new PlanOptimizerInformation(MetadataQueryOptimizer.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             return SimplePlanRewriter.rewriteWith(new Replacer(new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), inputs, rowsBuilder.build(), Optional.empty())), node);
         }
 
@@ -324,7 +325,8 @@ public class MetadataQueryOptimizer
                     return context.defaultRewrite(node);
                 }
             }
-            session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(MetadataQueryOptimizer.class.getSimpleName(), true, Optional.empty(), Optional.empty()));
+            session.getOptimizerInformationCollector().addInformation(
+                    new PlanOptimizerInformation(MetadataQueryOptimizer.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             Assignments assignments = assignmentsBuilder.build();
             ValuesNode valuesNode = new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(new ArrayList<>(assignments.getExpressions())), Optional.empty());
             return new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), valuesNode, assignments, LOCAL);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizerInformationCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizerInformationCollector.java
@@ -19,14 +19,14 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 
 @ThreadSafe
 public class OptimizerInformationCollector
 {
     @GuardedBy("this")
-    private final List<PlanOptimizerInformation> optimizationInfo = new LinkedList<>();
+    private final HashSet<PlanOptimizerInformation> optimizationInfo = new HashSet<>();
 
     public synchronized void addInformation(PlanOptimizerInformation optimizerInformation)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
@@ -34,6 +34,17 @@ public interface PlanOptimizer
         return true;
     }
 
+    default boolean isCostBased(Session session)
+    {
+        return false;
+    }
+
+    default String getStatsSource()
+    {
+        // source of statistics used for this optimizer: reimplement accordingly for each cost-based optimizer
+        return null;
+    }
+
     default void setEnabledForTesting(boolean isSet)
     {
         return;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -173,6 +173,12 @@ public class RandomizeNullKeyInOuterJoin
     }
 
     @Override
+    public boolean isCostBased(Session session)
+    {
+        return getRandomizeOuterJoinNullKeyStrategy(session).equals(COST_BASED);
+    }
+
+    @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
@@ -277,6 +283,10 @@ public class RandomizeNullKeyInOuterJoin
             PlanNodeStatsEstimate joinEstimate = statsProvider.getStats(joinNode);
             boolean enabledByCostModel = strategy.equals(COST_BASED) && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
                     && joinEstimate.getJoinNodeStatsEstimate().getNullJoinBuildKeyCount() / joinEstimate.getJoinNodeStatsEstimate().getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
+            String statsSource = null;
+            if (enabledByCostModel) {
+                statsSource = joinEstimate.getSourceInfo().getSourceInfoName();
+            }
             List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
                     .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
                     .filter(x -> enabledByCostModel || strategy.equals(ALWAYS) || enabledForJoinKeyFromOuterJoin(context.get(), x))
@@ -348,7 +358,13 @@ public class RandomizeNullKeyInOuterJoin
             joinOutputBuilder.addAll(joinNode.getOutputVariables().stream().filter(x -> newRight.getOutputVariables().contains(x)).collect(toImmutableList()));
 
             session.getOptimizerInformationCollector().addInformation(
-                    new PlanOptimizerInformation(RandomizeNullKeyInOuterJoin.class.getSimpleName(), true, Optional.empty(), Optional.empty()));
+                    new PlanOptimizerInformation(
+                            RandomizeNullKeyInOuterJoin.class.getSimpleName(),
+                            true,
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of(enabledByCostModel),
+                            statsSource == null ? Optional.empty() : Optional.of(statsSource)));
             JoinNode newJoinNode = new JoinNode(
                     joinNode.getSourceLocation(),
                     joinNode.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -123,7 +123,8 @@ public class SimplifyPlanWithEmptyInput
             Rewriter rewriter = new Rewriter(idAllocator);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(rewriter, plan);
             if (rewriter.isPlanChanged()) {
-                session.getOptimizerInformationCollector().addInformation(new PlanOptimizerInformation(SimplifyPlanWithEmptyInput.class.getSimpleName(), true, Optional.empty(), Optional.empty()));
+                session.getOptimizerInformationCollector().addInformation(
+                        new PlanOptimizerInformation(SimplifyPlanWithEmptyInput.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.of(false), Optional.empty()));
             }
             return rewrittenNode;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -300,18 +300,21 @@ public class TextRenderer
 
     private String optimizerInfoToText(List<PlanOptimizerInformation> planOptimizerInfo)
     {
-        List<String> applicableOptimizers = planOptimizerInfo.stream()
+        List<String> applicableOptimizerNames = planOptimizerInfo.stream()
                 .filter(x -> !x.getOptimizerTriggered() && x.getOptimizerApplicable().isPresent() && x.getOptimizerApplicable().get())
-                .map(x -> x.getOptimizerName()).collect(toList());
-        List<String> triggeredOptimizers = planOptimizerInfo.stream()
-                .filter(x -> x.getOptimizerTriggered())
-                .map(x -> x.getOptimizerName()).collect(toList());
+                .map(x -> x.getOptimizerName()).distinct().sorted().collect(toList());
+
+        List<String> triggeredOptimizerNames = planOptimizerInfo.stream().filter(x -> x.getOptimizerTriggered()).map(x -> x.getOptimizerName()).distinct().sorted().collect(toList());
+        List<String> costBasedOptimizerNames = planOptimizerInfo.stream().filter(x -> x.getIsCostBased().isPresent() && x.getIsCostBased().get()).map(x -> x.getOptimizerName() + "(" + x.getStatsSource().get() + ")").distinct().sorted().collect(toList());
 
         String triggered = "Triggered optimizers: [" +
-                String.join(", ", triggeredOptimizers) + "]\n";
+                String.join(", ", triggeredOptimizerNames) + "]\n";
         String applicable = "Applicable optimizers: [" +
-                String.join(", ", applicableOptimizers) + "]\n";
-        return triggered + applicable;
+                String.join(", ", applicableOptimizerNames) + "]\n";
+        String costBased = "Cost-based optimizers: [" +
+                String.join(", ", costBasedOptimizerNames) + "]\n";
+
+        return triggered + applicable + costBased;
     }
 
     private String cteInformationToText(List<CTEInformation> cteInformationList)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/PlanOptimizerInformation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/PlanOptimizerInformation.java
@@ -31,18 +31,24 @@ public class PlanOptimizerInformation
     private final Optional<Boolean> optimizerApplicable;
     // True if optimizer encounter failures (for example timeout etc.), false if no failures, empty if information not available.
     private final Optional<Boolean> optimizerFailure;
+    private final Optional<Boolean> isCostBased;
+    private final Optional<String> statsSource;
 
     @JsonCreator
     public PlanOptimizerInformation(
             @JsonProperty("optimizerName") String optimizerName,
             @JsonProperty("optimizerTriggered") boolean optimizerTriggered,
             @JsonProperty("optimizerApplicable") Optional<Boolean> optimizerApplicable,
-            @JsonProperty("optimizerFailure") Optional<Boolean> optimizerFailure)
+            @JsonProperty("optimizerFailure") Optional<Boolean> optimizerFailure,
+            @JsonProperty("isCostBased") Optional<Boolean> isCostBased,
+            @JsonProperty("statsSource") Optional<String> statsSource)
     {
         this.optimizerName = requireNonNull(optimizerName, "optimizerName is null");
         this.optimizerTriggered = requireNonNull(optimizerTriggered, "optimizerTriggered is null");
         this.optimizerApplicable = requireNonNull(optimizerApplicable, "optimizerApplicable is null");
         this.optimizerFailure = requireNonNull(optimizerFailure, "optimizerFailure is null");
+        this.isCostBased = requireNonNull(isCostBased, "isCostBased is null");
+        this.statsSource = requireNonNull(statsSource, "statsSource is null");
     }
 
     @JsonProperty
@@ -67,5 +73,17 @@ public class PlanOptimizerInformation
     public Optional<Boolean> getOptimizerFailure()
     {
         return optimizerFailure;
+    }
+
+    @JsonProperty
+    public Optional<Boolean> getIsCostBased()
+    {
+        return isCostBased;
+    }
+
+    @JsonProperty
+    public Optional<String> getStatsSource()
+    {
+        return statsSource;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/CostBasedSourceInfo.java
@@ -51,6 +51,12 @@ public class CostBasedSourceInfo
     }
 
     @Override
+    public String getSourceInfoName()
+    {
+        return "CBO";
+    }
+
+    @Override
     public boolean estimateSizeUsingVariables()
     {
         return true;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoryBasedSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/HistoryBasedSourceInfo.java
@@ -68,4 +68,10 @@ public class HistoryBasedSourceInfo
     {
         return true;
     }
+
+    @Override
+    public String getSourceInfoName()
+    {
+        return "HBO";
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RuntimeSourceInfo.java
@@ -46,6 +46,12 @@ public class RuntimeSourceInfo
     }
 
     @Override
+    public String getSourceInfoName()
+    {
+        return "Runtime";
+    }
+
+    @Override
     public boolean estimateSizeUsingVariables()
     {
         return false;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
@@ -29,4 +29,6 @@ public abstract class SourceInfo
     {
         return false;
     }
+
+    public abstract String getSourceInfoName();
 }


### PR DESCRIPTION
Some of Presto's optimizers are heuristic, while others are cost-based. This change allows tracking which optimizers were driven by a cost-based decision (independent of whether the cost was estimated or supplied by HBO). This information is added to PlanOptimizerInformation and can be seen in the explain plan when verbose_optimizer_info_enabled=true, for example:

```
presto:tpch> explain select lineitem.linenumber,count(*) from orders join lineitem on (lineitem.orderkey=orders.orderkey) group by linenumber;
                                                                                                                                                                                                                                        Query Plan
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[PlanNodeId 12][linenumber, _col1] => [linenumber:integer, count:bigint]
         _col1 := count (1:36)
...
 Triggered optimizers: [AddLocalExchanges, ApplyConnectorOptimization, HashGenerationOptimizer, PickTableLayoutWithoutPredicate, PruneJoinChildrenColumns, PruneJoinColumns, PruneProjectColumns, PruneTableScanColumns, PruneUnreferencedOutputs, PushPartialAggregationThroughExchange, RemoveRedundantDistinctAggregation, RemoveRedundantIdentityProjections, ReorderJoins, SetFlatteningOptimizer, SimplifyPlanWithEmptyInput, StatsRecordingPlanOptimizer, UnaliasSymbolReferences]
 Applicable optimizers: [AddNotNullFiltersToJoinNode, KeyBasedSampler, MergePartialAggregationsWithFilter, PushPartialAggregationThroughJoin]
 Cost-based optimizers: [PushPartialAggregationThroughExchange(CBO), ReorderJoins(CBO)]
```

Note: currently we don't track whether the cost came from HBO or through cost estimation, only that the decision was cost-driven. We already have a change that tracks what the source of the cost estimation is, so we can potentially intersect the two to find this information. I could potentially reconsider and track and log this information directly here.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Print information about cost-based optimizers and the source of stats they use (CBO/HBO) in explain plans when session property verbose_optimizer_info_enabled=true

```

