### PR TITLE
Add time travel syntax support for iceberg tables (VERSION and TIMESTAMP).

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
@@ -96,6 +97,12 @@ public abstract class DelegatingMetadataManager
     public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
     {
         return delegate.getSystemTable(session, tableName);
+    }
+
+    @Override
+    public Optional<TableHandle> getHandleVersion(Session session, QualifiedObjectName tableName, Optional<Block> tableVersionBlock)
+    {
+        return delegate.getHandleVersion(session, tableName, tableVersionBlock);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
@@ -72,6 +73,11 @@ public interface Metadata
     List<String> listSchemaNames(Session session, String catalogName);
 
     Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName);
+
+    /**
+     * Returns a table handle for time travel expression
+     */
+    Optional<TableHandle> getHandleVersion(Session session, QualifiedObjectName tableName, Optional<Block> tableVersionBlock);
 
     Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -20,6 +20,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.function.OperatorType;
@@ -324,6 +325,12 @@ public class MetadataManager
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<TableHandle> getHandleVersion(Session session, QualifiedObjectName tableName, Optional<Block> tableVersionBlock)
+    {
+        return getOptionalTableHandle(session, transactionManager, tableName, tableVersionBlock);
     }
 
     @Override
@@ -1010,7 +1017,7 @@ public class MetadataManager
 
     private MaterializedViewStatus getMaterializedViewStatus(Session session, QualifiedObjectName materializedViewName, TupleDomain<String> baseQueryDomain)
     {
-        Optional<TableHandle> materializedViewHandle = getOptionalTableHandle(session, transactionManager, materializedViewName);
+        Optional<TableHandle> materializedViewHandle = getOptionalTableHandle(session, transactionManager, materializedViewName, Optional.empty());
 
         ConnectorId connectorId = materializedViewHandle.get().getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
@@ -1322,13 +1329,13 @@ public class MetadataManager
             @Override
             public boolean tableExists(QualifiedObjectName tableName)
             {
-                return getOptionalTableHandle(session, transactionManager, tableName).isPresent();
+                return getOptionalTableHandle(session, transactionManager, tableName, Optional.empty()).isPresent();
             }
 
             @Override
             public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
             {
-                return getOptionalTableHandle(session, transactionManager, tableName);
+                return getOptionalTableHandle(session, transactionManager, tableName, Optional.empty());
             }
 
             @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -18,14 +18,18 @@ import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.OperatorNotFoundException;
@@ -147,6 +151,7 @@ import com.facebook.presto.sql.tree.StartTransaction;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
+import com.facebook.presto.sql.tree.TableVersionExpression;
 import com.facebook.presto.sql.tree.TruncateTable;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
@@ -188,10 +193,12 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
@@ -268,6 +275,8 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.FOLLOWING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.PRECEDING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionType.TIMESTAMP;
+import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionType.VERSION;
 import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
 import static com.facebook.presto.util.MetadataUtils.getMaterializedViewDefinition;
 import static com.facebook.presto.util.MetadataUtils.getTableColumnsMetadata;
@@ -1280,7 +1289,7 @@ class StatementAnalyzer
             }
 
             TableColumnMetadata tableColumnsMetadata = getTableColumnsMetadata(session, metadataResolver, analysis.getMetadataHandle(), name);
-            Optional<TableHandle> tableHandle = tableColumnsMetadata.getTableHandle();
+            Optional<TableHandle> tableHandle = getTableHandle(tableColumnsMetadata, table, name, scope);
 
             Map<String, ColumnHandle> columnHandles = tableColumnsMetadata.getColumnHandles();
 
@@ -1319,6 +1328,51 @@ class StatementAnalyzer
             }
 
             return createAndAssignScope(table, scope, fields.build());
+        }
+
+        private Optional<TableHandle> getTableHandle(TableColumnMetadata tableColumnsMetadata, Table table, QualifiedObjectName name, Optional<Scope> scope)
+        {
+            // Process table version AS OF expression
+            if (table.getTableVersionExpression().isPresent()) {
+                return processTableVersion(table, name, scope);
+            }
+            else {
+                return tableColumnsMetadata.getTableHandle();
+            }
+        }
+        private Optional<TableHandle> processTableVersion(Table table, QualifiedObjectName name, Optional<Scope> scope)
+        {
+            Expression asOfExpr = table.getTableVersionExpression().get().getAsOfExpression();
+            TableVersionExpression.TableVersionType tableVersionType = table.getTableVersionExpression().get().getTableVersionType();
+            ExpressionAnalysis expressionAnalysis = analyzeExpression(asOfExpr, scope.get());
+            analysis.recordSubqueries(table, expressionAnalysis);
+            Type asOfExprType = expressionAnalysis.getType(asOfExpr);
+            if (asOfExprType == UNKNOWN) {
+                throw new PrestoException(INVALID_ARGUMENTS, format("Table version AS OF expression cannot be NULL for %s", name.toString()));
+            }
+            Object evalAsOfExpr = evaluateConstantExpression(asOfExpr, asOfExprType, metadata, session, analysis.getParameters());
+            if (tableVersionType == TIMESTAMP) {
+                if (!(asOfExprType instanceof TimestampWithTimeZoneType)) {
+                    throw new SemanticException(TYPE_MISMATCH, asOfExpr,
+                            "Type %s is invalid. Supported table version AS OF expression type is Timestamp with Time Zone.",
+                            asOfExprType.getDisplayName());
+                }
+            }
+            if (tableVersionType == VERSION) {
+                if (!(asOfExprType instanceof BigintType)) {
+                    throw new SemanticException(TYPE_MISMATCH, asOfExpr,
+                            "Type %s is invalid. Supported table version AS OF expression type is BIGINT",
+                            asOfExprType.getDisplayName());
+                }
+            }
+
+            // Two block entries for table version type and expression.
+            BlockBuilder blockBuilder = asOfExprType.createBlockBuilder(null, 2);
+            writeNativeValue(asOfExprType, blockBuilder, tableVersionType.ordinal());
+            writeNativeValue(asOfExprType, blockBuilder, evalAsOfExpr);
+            Block block = blockBuilder.build();
+
+            return metadata.getHandleVersion(session, name, Optional.of(block));
         }
 
         private Scope getScopeFromTable(Table table, Optional<Scope> scope)

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
@@ -139,6 +140,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getHandleVersion(Session session, QualifiedObjectName tableName, Optional<Block> tableVersionBlock)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -324,7 +324,7 @@ columnAliases
     ;
 
 relationPrimary
-    : qualifiedName                                                   #tableName
+    : qualifiedName tableVersionExpression?                             #tableName
     | '(' query ')'                                                   #subqueryRelation
     | UNNEST '(' expression (',' expression)* ')' (WITH ORDINALITY)?  #unnest
     | LATERAL '(' query ')'                                           #lateral
@@ -531,6 +531,10 @@ qualifiedName
     : identifier ('.' identifier)*
     ;
 
+tableVersionExpression
+    : FOR tableVersionType=(SYSTEM_TIME | SYSTEM_VERSION | TIMESTAMP | VERSION) AS OF valueExpression          #tableVersion
+    ;
+
 grantor
     : CURRENT_USER          #currentUserGrantor
     | CURRENT_ROLE          #currentRoleGrantor
@@ -576,14 +580,14 @@ nonReserved
     | LANGUAGE | LAST | LATERAL | LEVEL | LIMIT | LOGICAL
     | MAP | MATERIALIZED | MINUTE | MONTH
     | NAME | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
-    | OFFSET | ONLY | OPTION | ORDINALITY | OUTPUT | OVER
+    | OF | OFFSET | ONLY | OPTION | ORDINALITY | OUTPUT | OVER
     | PARTITION | PARTITIONS | POSITION | PRECEDING | PRIVILEGES | PROPERTIES
     | RANGE | READ | REFRESH | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | RETURN | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SERIALIZABLE | SESSION | SET | SETS | SQL
-    | SHOW | SOME | START | STATS | SUBSTRING | SYSTEM
+    | SHOW | SOME | START | STATS | SUBSTRING | SYSTEM | SYSTEM_TIME | SYSTEM_VERSION
     | TABLES | TABLESAMPLE | TEMPORARY | TEXT | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | USE | USER
-    | VALIDATE | VERBOSE | VIEW
+    | VALIDATE | VERBOSE | VERSION | VIEW
     | WORK | WRITE
     | YEAR
     | ZONE
@@ -709,6 +713,7 @@ NOT: 'NOT';
 NULL: 'NULL';
 NULLIF: 'NULLIF';
 NULLS: 'NULLS';
+OF: 'OF';
 OFFSET: 'OFFSET';
 ON: 'ON';
 ONLY: 'ONLY';
@@ -762,6 +767,8 @@ START: 'START';
 STATS: 'STATS';
 SUBSTRING: 'SUBSTRING';
 SYSTEM: 'SYSTEM';
+SYSTEM_TIME: 'SYSTEM_TIME';
+SYSTEM_VERSION: 'SYSTEM_VERSION';
 TABLE: 'TABLE';
 TABLES: 'TABLES';
 TABLESAMPLE: 'TABLESAMPLE';
@@ -787,6 +794,7 @@ USING: 'USING';
 VALIDATE: 'VALIDATE';
 VALUES: 'VALUES';
 VERBOSE: 'VERBOSE';
+VERSION: 'VERSION';
 VIEW: 'VIEW';
 WHEN: 'WHEN';
 WHERE: 'WHERE';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -73,6 +73,7 @@ import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.TableVersionExpression;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TryExpression;
@@ -688,6 +689,11 @@ public final class ExpressionFormatter
             return Joiner.on(", ").join(expressions.stream()
                     .map((e) -> process(e, null))
                     .iterator());
+        }
+
+        protected String visitTableVersion(TableVersionExpression node, Void context)
+        {
+            return "FOR " + node.getTableVersionType().name() + " AS OF " + process(node.getAsOfExpression(), context) + " ";
         }
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -401,6 +401,10 @@ public final class SqlFormatter
         protected Void visitTable(Table node, Integer indent)
         {
             builder.append(formatName(node.getName()));
+            if (node.getTableVersionExpression().isPresent()) {
+                builder.append(' ');
+                process(node.getTableVersionExpression().get(), indent);
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -164,6 +164,7 @@ import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.sql.tree.TableSubquery;
+import com.facebook.presto.sql.tree.TableVersionExpression;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
@@ -199,6 +200,8 @@ import static com.facebook.presto.sql.tree.RoutineCharacteristics.Determinism.NO
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.sql.tree.TableVersionExpression.timestampExpression;
+import static com.facebook.presto.sql.tree.TableVersionExpression.versionExpression;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
@@ -1296,6 +1299,10 @@ class AstBuilder
     @Override
     public Node visitTableName(SqlBaseParser.TableNameContext context)
     {
+        if (context.tableVersionExpression() != null) {
+            return new Table(getLocation(context), getQualifiedName(context.qualifiedName()), (TableVersionExpression) visit(context.tableVersionExpression()));
+        }
+
         return new Table(getLocation(context), getQualifiedName(context.qualifiedName()));
     }
 
@@ -1453,6 +1460,23 @@ class AstBuilder
     }
 
     // ************** value expressions **************
+
+    @Override
+    public Node visitTableVersion(SqlBaseParser.TableVersionContext context)
+    {
+        Expression child = (Expression) visit(context.valueExpression());
+
+        switch (context.tableVersionType.getType()) {
+            case SqlBaseLexer.SYSTEM_TIME:
+            case SqlBaseLexer.TIMESTAMP:
+                return timestampExpression(getLocation(context), child);
+            case SqlBaseLexer.SYSTEM_VERSION:
+            case SqlBaseLexer.VERSION:
+                return versionExpression(getLocation(context), child);
+            default:
+                throw new UnsupportedOperationException("Unsupported Type: " + context.tableVersionType.getText());
+        }
+    }
 
     @Override
     public Node visitArithmeticUnary(SqlBaseParser.ArithmeticUnaryContext context)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -352,6 +352,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitTableVersion(TableVersionExpression node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitNotExpression(NotExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Table.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Table.java
@@ -25,21 +25,28 @@ public class Table
         extends QueryBody
 {
     private final QualifiedName name;
+    private final Optional<TableVersionExpression> tableVersionExpression;
 
     public Table(QualifiedName name)
     {
-        this(Optional.empty(), name);
+        this(Optional.empty(), name, Optional.empty());
     }
 
     public Table(NodeLocation location, QualifiedName name)
     {
-        this(Optional.of(location), name);
+        this(Optional.of(location), name, Optional.empty());
     }
 
-    private Table(Optional<NodeLocation> location, QualifiedName name)
+    public Table(NodeLocation location, QualifiedName name, TableVersionExpression tableVersionExpression)
+    {
+        this(Optional.of(location), name, Optional.of(tableVersionExpression));
+    }
+
+    private Table(Optional<NodeLocation> location, QualifiedName name, Optional<TableVersionExpression> tableVersionExpression)
     {
         super(location);
         this.name = name;
+        this.tableVersionExpression = tableVersionExpression;
     }
 
     public QualifiedName getName()
@@ -56,6 +63,9 @@ public class Table
     @Override
     public List<Node> getChildren()
     {
+        if (tableVersionExpression.isPresent()) {
+            return ImmutableList.of(tableVersionExpression.get());
+        }
         return ImmutableList.of();
     }
 
@@ -64,6 +74,7 @@ public class Table
     {
         return toStringHelper(this)
                 .addValue(name)
+                .addValue(tableVersionExpression)
                 .toString();
     }
 
@@ -78,12 +89,17 @@ public class Table
         }
 
         Table table = (Table) o;
-        return Objects.equals(name, table.name);
+        return Objects.equals(name, table.name) && Objects.equals(tableVersionExpression, table.getTableVersionExpression());
     }
 
     @Override
     public int hashCode()
     {
         return name.hashCode();
+    }
+
+    public Optional<TableVersionExpression> getTableVersionExpression()
+    {
+        return tableVersionExpression;
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableVersionExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableVersionExpression.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableVersionExpression
+        extends Expression
+{
+    public enum TableVersionType
+    {
+        TIMESTAMP,
+        VERSION
+    }
+
+    private final Expression asOfExpression;
+    private final TableVersionType type;
+
+    public TableVersionExpression(TableVersionType type, Expression value)
+    {
+        this(Optional.empty(), type, value);
+    }
+
+    public TableVersionExpression(NodeLocation location, TableVersionType type, Expression value)
+    {
+        this(Optional.of(location), type, value);
+    }
+
+    private TableVersionExpression(Optional<NodeLocation> location, TableVersionType type, Expression value)
+    {
+        super(location);
+        requireNonNull(value, "value is null");
+        requireNonNull(type, "type is null");
+
+        this.asOfExpression = value;
+        this.type = type;
+    }
+
+    public static TableVersionExpression timestampExpression(NodeLocation location, Expression value)
+    {
+        return new TableVersionExpression(Optional.of(location), TableVersionType.TIMESTAMP, value);
+    }
+
+    public static TableVersionExpression versionExpression(NodeLocation location, Expression value)
+    {
+        return new TableVersionExpression(Optional.of(location), TableVersionType.VERSION, value);
+    }
+
+    public static TableVersionExpression timestampExpression(Expression value)
+    {
+        return new TableVersionExpression(Optional.empty(), TableVersionType.TIMESTAMP, value);
+    }
+
+    public static TableVersionExpression versionExpression(Expression value)
+    {
+        return new TableVersionExpression(Optional.empty(), TableVersionType.VERSION, value);
+    }
+
+    public Expression getAsOfExpression()
+    {
+        return asOfExpression;
+    }
+
+    public TableVersionType getTableVersionType()
+    {
+        return type;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTableVersion(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of(asOfExpression);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TableVersionExpression that = (TableVersionExpression) o;
+        return Objects.equals(asOfExpression, that.asOfExpression) &&
+                (type == that.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(asOfExpression, type);
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParserErrorHandling.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParserErrorHandling.java
@@ -49,8 +49,7 @@ public class TestSqlParserErrorHandling
                 {"select * from 'oops",
                  "line 1:15: mismatched input '''. Expecting: '(', 'LATERAL', 'UNNEST', <identifier>"},
                 {"select *\nfrom x\nfrom",
-                 "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', 'NATURAL', 'OFFSET', " +
-                         "'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', <EOF>, <identifier>"},
+                 "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FOR', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', <EOF>, <identifier>"},
                 {"select *\nfrom x\nwhere from",
                  "line 3:7: mismatched input 'from'. Expecting: <expression>"},
                 {"select * from",
@@ -88,7 +87,7 @@ public class TestSqlParserErrorHandling
                 {"SELECT grouping(a+2) FROM (VALUES (1)) AS t (a) GROUP BY a+2",
                  "line 1:18: mismatched input '+'. Expecting: ')', ','"},
                 {"SELECT x() over (ROWS select) FROM t",
-                 "line 1:23: mismatched input 'select'. Expecting: 'BETWEEN', 'CURRENT', 'UNBOUNDED', <expression>"},
+                 "line 1:17: mismatched input '('. Expecting: ',', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'ORDER', 'UNION', 'WHERE', <EOF>"},
                 {"SELECT X() OVER (ROWS UNBOUNDED) FROM T",
                  "line 1:32: mismatched input ')'. Expecting: 'FOLLOWING', 'PRECEDING'"},
                 {"SELECT a FROM x ORDER BY (SELECT b FROM t WHERE ",
@@ -110,7 +109,7 @@ public class TestSqlParserErrorHandling
                 {"SELECT CAST(a AS decimal()",
                  "line 1:26: mismatched input ')'. Expecting: <integer>, <type>"},
                 {"SELECT foo(*) filter (",
-                 "line 1:23: mismatched input '<EOF>'. Expecting: 'WHERE'"},
+                 "line 1:22: mismatched input '('. Expecting: ',', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'ORDER', 'UNION', 'WHERE', <EOF>"},
                 {"SELECT * FROM t t x",
                  "line 1:19: mismatched input 'x'. Expecting: '(', ',', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', 'NATURAL', 'OFFSET', 'ORDER', " +
                          "'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', <EOF>"},

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
@@ -84,6 +85,14 @@ public interface ConnectorMetadata
      * Returns a table handle for the specified table name, or null if the connector does not contain the table.
      */
     ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName);
+
+    /**
+     * Returns an error for connectors which do not support table version AS OF expression.
+     */
+    default ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<Block> tableVersionBlock)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support table version AS OF expression");
+    }
 
     /**
      * Returns a table handle for the specified table name, or null if the connector does not contain the table.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector.classloader;
 
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
@@ -218,6 +219,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableHandle(session, tableName);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<Block> tableVersionBlock)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableHandle(session, tableName, tableVersionBlock);
         }
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Presto issue : https://github.com/prestodb/presto/issues/20495

Note - This PR has syntax and engine side changes. For iceberg connector changes, test and doc, a new PR will be created.

This feature will allow iceberg connector to query historical data using `AS OF` syntax on a table. 
Time travel version option will read bigint snapshot id value for the table. Time travel timestamp option will read
timestamp-with-time-zone value for the table. 
examples :
```
select * from tab1 FOR VERSION AS OF 8772871542276440693;
select * from tab1 FOR TIMESTAMP AS OF TIMESTAMP '2023-08-17 13:29:46.822 America/Los_Angeles';
```
Note - SYSTEM_TIME and SYSTEM_VERSION are the alias names for TIMESTAMP and VERSION respectively
```
select * from tab1 FOR SYSTEM_VERSION AS OF 8772871542276440693;
select * from tab1 FOR SYSTEM_TIME AS OF TIMESTAMP '2023-08-17 13:29:46.822 America/Los_Angeles';
```

Design description : 
Parser
- support point in time query with `AS OF` syntax on table reference 
```
select * from tab1 FOR VERSION AS OF  < bigint type >
select * from tab1 FOR TIMESTAMP AS OF <timestamp with time zone type>
```
- In parser tree, create a new class to hold time travel expression (extend Expression) 
- SqlFormatter & AstBuilder code for time travel expression 
- Parser table tree change to include time travel expression 
- New file for TableVersionExpression class to hold TableVersionType and AS-OF expression 
- Add SYSTEM_TIME as alias for TIMESTAMP and SYSTEM_VERSION for VERSION. 
 
Semantic Analyzer
- Changed VisitTable() to process table version expression and type
- In statement analyzer, Add a new function processTableVersion() to combine all semantic error handling and time travel expression evaluation 
- TIMESTAMP clause can accept any expression that will return timestamp-with-time-zone type
- New function getTableHandle to extract table version expression and type 
- Return table snapshot id based on Metadata functions 
- Add visitTableVersion() in ExpressionFormatter

Metadata 
- Add getHandleVersion() method to return optional table handle 
- Changed getTableHandle() to pass tableVersionType and tableVersionExpression expression object to connector and iceberg code 

Limitations : 
- VERSION syntax can only accept Bigint value or Bigint expression/cast
- TIMESTAMP syntax can only accept timestamp-with-time-zone value or timestamp-with-time-zone value expression/cast

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Right now, [we only support time travel via system tables and system procedures.](https://prestodb.io/docs/current/connector/iceberg.html#time-travel)

The current support does not include a convenient way to select a particular snapshot or the ability to select a snapshot as of a particular timestamp. Using system tables and system procedures to do this is not convenient, and it also is not safe per-user, since the system table alters the table for everyone, not just the current user.

[See Trino implementation,](https://trino.io/docs/current/connector/iceberg.html#time-travel-queries) which has syntax level support for going back to a particular snapshot via `FOR VERSION AS OF`, and to go back to a period in time without having to first fetch a snapshot id via `FOR TIMESTAMP AS OF`. We should consider a similar feature for convenience of time travel.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- A new table level option to return specific snapshot for iceberg connector 

## Test Plan
-manual testing 
- new iceberg PR will have time travel tests 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

Note - Iceberg PR will have release notes and doc section 

