### PR TITLE
com.google.protobuf package update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.14.0</version>
+                <version>3.21.7</version>
             </dependency>
 
             <dependency>
@@ -1119,7 +1119,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.199</version>
+                <version>2.1.210</version>
             </dependency>
 
             <dependency>
@@ -1870,7 +1870,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.1</version>
+                <version>1.1.10.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Update com.google.protobuf and its dependencies to latest

## Description
1. com.google.protobuf » protobuf-java » 3.14.0
Direct vulnerabilities:
[CVE-2022-3510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510)
[CVE-2022-3509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509)
[CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)
[CVE-2021-22570](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22570)
[CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569)
Vulnerabilities from dependencies:
[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
2. com.h2database » h2 » 1.4.199
Direct vulnerabilities:
[CVE-2022-45868](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45868)
[CVE-2022-23221](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23221)
[CVE-2021-42392](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392)
[CVE-2021-23463](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23463)
3. org.xerial.snappy » snappy-java » 1.1.7.1
Direct vulnerabilities:
[CVE-2023-34455](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34455)
[CVE-2023-34454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34454)
[CVE-2023-34453](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34453)
Vulnerabilities from dependencies:
[CVE-2022-26612](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26612)
[CVE-2022-25168](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25168)
[CVE-2021-37404](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37404)
[CVE-2020-9492](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9492)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
[CVE-2017-7669](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7669)
[CVE-2016-6811](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6811)

## Motivation and Context
Many open CVEs that can be exploited and this is a simple fix.

## Impact
Several securities issues are fixed

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

