### PR TITLE
[GH Actions] Clear unused disk space

### DIFF
--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           df -h
           sudo apt-get clean
+          rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -37,6 +37,12 @@ jobs:
       group: ${{ github.workflow }}-product-tests-specific-environment1-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Free Disk Space
+        run: |
+          df -h
+          sudo apt-get clean
+          rm -rf /opt/hostedtoolcache
+          df -h
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
@@ -79,6 +85,12 @@ jobs:
       group: ${{ github.workflow }}-product-tests-specific-environment2-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Free Disk Space
+        run: |
+          df -h
+          sudo apt-get clean
+          rm -rf /opt/hostedtoolcache
+          df -h
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
## Description

Free up some additional space on the runners before executing the product-tests suite. The `/opt/hostedtoolcache` folder is unnecessary and gives 10GB back in disk space after deleting it. The idea came from this thread: https://github.com/orgs/community/discussions/25678#discussioncomment-5242449. Previously the product test actions would fail with `no space left on device` when pulling the container images.

Below is the runner output from the `Free Disk Space` step:

```
df -h
  sudo apt-get clean
  rm -rf /opt/hostedtoolcache
  df -h
  shell: /usr/bin/bash -e {0}
  env:
    CONTINUOUS_INTEGRATION: true
    MAVEN_OPTS: -Xmx1024M -XX:+ExitOnOutOfMemoryError
    MAVEN_INSTALL_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
    MAVEN_FAST_INSTALL: -B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true
    RETRY: .github/bin/retry
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   64G   20G  77% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   53G   31G  63% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
```

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

