### PR TITLE
[native] Fix Timestamp construction for negative timestamps

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
@@ -137,8 +137,7 @@ velox::VectorPtr readScalarBlock(
           velox::AlignedBuffer::allocate<velox::Timestamp>(positionCount, pool);
       auto* rawTimestamps = timestamps->asMutable<velox::Timestamp>();
       for (auto i = 0; i < positionCount; i++) {
-        rawTimestamps[i] = velox::Timestamp(
-            rawBuffer[i] / 1000, (rawBuffer[i] % 1000) * 1000000);
+        rawTimestamps[i] = velox::Timestamp::fromMillis(rawBuffer[i]);
       }
       return std::make_shared<velox::FlatVector<velox::Timestamp>>(
           pool,


### PR DESCRIPTION
In Velox, `Timestamp::seconds_` is the starting point of one second,
and `Timestamp::nanos_` is the offset from the starting point (in
nanoseconds). So when converting milliseconds to seconds, we should
always round down, including negative values. This means that it is
wrong to use division and modulo directly. For example, for `-400ms`,
it should be converted into `(-1, 6 * 10^8)` instead of
`(0, -4 * 10^8)`.

`velox::Timestamp::fromMillis()` utility function can be used to
achieve this.

```
== NO RELEASE NOTE ==
```