### PR TITLE
[native]Improve spill directory failure handling

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
   velox_aggregates
   velox_hive_partition_function
   ${RE2}
+  Folly::folly
   gmock
   gtest
   gtest_main)


### PR DESCRIPTION
There are three problems found in Meta internal arbitration and spilling test about
task spilling directory setup:
(1) velox task creation failure handle path doesn't clear velox task before allowing
create the next velox task which can lead to the second velox task creation (retry)
fail with unrelated errors;
(2) set spilling path before the spill path creation succeed. The better is to create the
spilling directory and then set it task to avoid another exception on task destruction
which removes a non-exist spill directory/

This PR fixes this issue with unit test. Note the spill directory setup could fail because
of transient remote storage error as we found in Meta internal testing.

```
== NO RELEASE NOTE ==
```

