### PR TITLE
[native] Set sane defaults for PRESTO_SERVER and DATA_DIR for NativeQueryRunner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -41,9 +41,9 @@ import java.util.Set;
 import static com.facebook.airlift.log.Level.WARN;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerHiveProperties;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerSystemProperties;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.getNativeQueryRunnerParameters;
 import static com.facebook.presto.spark.PrestoSparkQueryRunner.METASTORE_CONTEXT;
 import static java.nio.file.Files.createTempDirectory;
-import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -94,10 +94,7 @@ public class PrestoSparkNativeQueryRunnerUtils
                 .put("spark.partition-count-auto-tune-enabled", "false");
 
         if (System.getProperty("NATIVE_PORT") == null) {
-            String path = requireNonNull(System.getProperty("PRESTO_SERVER"),
-                    "Native worker binary path is missing. " +
-                            "Add -DPRESTO_SERVER=/path/to/native/process/bin to your JVM arguments.");
-            builder.put("native-execution-executable-path", path);
+            builder.put("native-execution-executable-path", getNativeQueryRunnerParameters().serverBinary.toString());
         }
 
         try {
@@ -211,7 +208,7 @@ public class PrestoSparkNativeQueryRunnerUtils
             return dataDirectory.get();
         }
         String dataDirectoryStr = System.getProperty("DATA_DIR");
-        if (dataDirectoryStr.isEmpty()) {
+        if (dataDirectoryStr == null || dataDirectoryStr.isEmpty()) {
             try {
                 dataDirectory = Optional.of(createTempDirectory("PrestoTest").toAbsolutePath());
             }
@@ -220,7 +217,7 @@ public class PrestoSparkNativeQueryRunnerUtils
             }
         }
         else {
-            dataDirectory = Optional.of(Paths.get(dataDirectoryStr));
+            dataDirectory = Optional.of(getNativeQueryRunnerParameters().dataDirectory);
         }
         return dataDirectory.get();
     }


### PR DESCRIPTION
## Description

Previously, these would always be required to be set to run a test. This change introduces some default values to search for the server binary as well as the data directory

## Motivation and Context

I got tired of having to set these manually in my IntelliJ run configurations

## Impact

Limited. Log messages now indicate the detected path of both binary and data directory. Users may need to verify through the log messages that the binary used is in-fact the desired one, such as if another IDE (e.g. CLion) might use a directory other than `_build` for binaries by default.

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

