### PR TITLE
Build catalog-specific properties for IcebergQueryRunner w static method

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
@@ -13,25 +13,10 @@
  */
 package com.facebook.presto.iceberg.hadoop;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
-import com.facebook.presto.iceberg.IcebergPlugin;
-import com.facebook.presto.testing.QueryRunner;
-import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
-import com.google.common.collect.ImmutableMap;
-import io.airlift.tpch.TpchTable;
 import org.testng.annotations.Test;
 
-import java.nio.file.Path;
-import java.util.Map;
-
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
-import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 @Test
 public class TestIcebergDistributedHadoop
@@ -40,37 +25,6 @@ public class TestIcebergDistributedHadoop
     public TestIcebergDistributedHadoop()
     {
         super(HADOOP);
-    }
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema("tpch")
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-
-        queryRunner.installPlugin(new IcebergPlugin());
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(ImmutableMap.of("iceberg.catalog.type", HADOOP.name()))
-                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        queryRunner.execute("CREATE SCHEMA tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
-
-        return queryRunner;
     }
 
     protected boolean supportsViews()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
@@ -13,35 +13,25 @@
  */
 package com.facebook.presto.iceberg.hadoop;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
-import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.iceberg.nessie.NessieConfig;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
-import com.google.common.collect.ImmutableMap;
-import io.airlift.tpch.TpchTable;
 import org.apache.iceberg.Table;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
-import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.lang.String.format;
 
 @Test
@@ -58,37 +48,6 @@ public class TestIcebergSmokeHadoop
     {
         File tempLocation = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().toFile();
         return format("%s%s/%s", tempLocation.toURI(), schema, table);
-    }
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema("tpch")
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-
-        queryRunner.installPlugin(new IcebergPlugin());
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(ImmutableMap.of("iceberg.catalog.type", HADOOP.name()))
-                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        queryRunner.execute("CREATE SCHEMA tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
-
-        return queryRunner;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -13,29 +13,17 @@
  */
 package com.facebook.presto.iceberg.nessie;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
-import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
-import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.nio.file.Path;
-import java.util.Map;
-
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
-import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 @Test
 public class TestIcebergDistributedNessie
@@ -76,30 +64,6 @@ public class TestIcebergDistributedNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema("tpch")
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-
-        queryRunner.installPlugin(new IcebergPlugin());
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
-                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        queryRunner.execute("CREATE SCHEMA tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
-
-        return queryRunner;
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -13,13 +13,12 @@
  */
 package com.facebook.presto.iceberg.nessie;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
-import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
@@ -27,26 +26,19 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.tpch.TpchTable;
 import org.apache.iceberg.Table;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
-import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -98,31 +90,7 @@ public class TestIcebergSmokeNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema("tpch")
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-
-        queryRunner.installPlugin(new IcebergPlugin());
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
-                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        queryRunner.execute("CREATE SCHEMA tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
-
-        return queryRunner;
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -14,16 +14,12 @@
 package com.facebook.presto.iceberg.nessie;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.iceberg.IcebergConfig;
-import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.tpch.TpchTable;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
@@ -37,17 +33,11 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
-import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
-import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
@@ -97,31 +87,7 @@ public class TestNessieMultiBranching
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema("tpch")
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data");
-
-        queryRunner.installPlugin(new IcebergPlugin());
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
-                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
-                .put("iceberg.catalog.warehouse", dataDirectory.getParent().toFile().toURI().toString())
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        queryRunner.execute("CREATE SCHEMA tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
-
-        return queryRunner;
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
     }
 
     @Test


### PR DESCRIPTION
## Description
Implements a static method to construct catalog-specific properties (Hive vs. Hadoop/Nessie) to pass to the query runner during Iceberg catalog creation.

## Motivation and Context
Reduce duplication in native  Iceberg tests introduced by #20912 

## Impact
Not user facing

## Test Plan
Tests passing

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

