### PR TITLE
[pinot connector] Fix pinot single quote literal push down issue

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
@@ -286,7 +286,7 @@ public class PinotPushdownUtils
             return decodeDecimal(decodeUnscaledValue(value), decimalType).toString();
         }
         if (type instanceof VarcharType || type instanceof CharType) {
-            return "'" + ((Slice) node.getValue()).toStringUtf8() + "'";
+            return "'" + ((Slice) node.getValue()).toStringUtf8().replace("'", "''") + "'";
         }
         if (type instanceof TimestampType || type instanceof DateType) {
             return node.getValue().toString();

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
@@ -123,7 +123,7 @@ public class TestPinotExpressionConverters
         // in, not in
         testFilter("regionid in (20, 30, 40)", "(\"regionId\" IN (20, 30, 40))", sessionHolder);
         testFilter("regionid not in (20, 30, 40)", "(\"regionId\" NOT IN (20, 30, 40))", sessionHolder);
-        testFilter("city in ('San Jose', 'Campbell', 'Union City')", "(\"city\" IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
+        testFilter("city in ('San Jose', 'Campbell', 'Union City', 'L''Aquila')", "(\"city\" IN ('San Jose', 'Campbell', 'Union City', 'L''Aquila'))", sessionHolder);
         testFilter("city not in ('San Jose', 'Campbell', 'Union City')", "(\"city\" NOT IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
         testFilterUnsupported("secondssinceepoch + 1 in (234, 24324)", sessionHolder);
         testFilterUnsupported("NOT (secondssinceepoch = 2323)", sessionHolder);


### PR DESCRIPTION
## Description
When pushing down literal expression to pinot, single quote is not escaped.
Fix the issue by replacing single quote to two single quotes in a query.

## Test Plan
Unit test with predicate


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Pinot Changes
*  Fix pinot single quote literal push down issue
```
