### PR TITLE
Functions for extracting plan id information from json query plans

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -183,6 +183,7 @@ import com.facebook.presto.operator.scalar.UrlFunctions;
 import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.operator.scalar.WilsonInterval;
 import com.facebook.presto.operator.scalar.WordStemFunction;
+import com.facebook.presto.operator.scalar.queryplan.JsonPrestoQueryPlanFunctions;
 import com.facebook.presto.operator.scalar.sql.ArraySqlFunctions;
 import com.facebook.presto.operator.scalar.sql.MapNormalizeFunction;
 import com.facebook.presto.operator.scalar.sql.MapSqlFunctions;
@@ -729,6 +730,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalars(BitwiseFunctions.class)
                 .scalars(DateTimeFunctions.class)
                 .scalars(JsonFunctions.class)
+                .scalars(JsonPrestoQueryPlanFunctions.class)
                 .scalars(ColorFunctions.class)
                 .scalars(ColorOperators.class)
                 .scalars(GeoFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/queryplan/JsonPrestoQueryPlanFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/queryplan/JsonPrestoQueryPlanFunctions.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.queryplan;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.planPrinter.JsonRenderer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.planPrinter.JsonRenderer.JsonRenderedNode;
+import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_MANAGER;
+import static io.airlift.slice.Slices.utf8Slice;
+
+public final class JsonPrestoQueryPlanFunctions
+{
+    private JsonPrestoQueryPlanFunctions() {}
+
+    @Description("Get the plan ids of given plan node")
+    @ScalarFunction("json_presto_query_plan_ids")
+    @SqlType("ARRAY<VARCHAR>")
+    @SqlNullable
+    public static Block jsonPlanIds(@TypeParameter("ARRAY<VARCHAR>") ArrayType arrayType,
+            @SqlType(StandardTypes.JSON) Slice jsonPlan)
+    {
+        List<JsonRenderedNode> planFragments = parseJsonPlanFragmentsAsList(jsonPlan);
+
+        if (planFragments == null) {
+            return null;
+        }
+
+        Map<String, List<String>> planMap = extractPlanIds(planFragments);
+        return constructSqlArray(arrayType, planMap.keySet().stream().collect(Collectors.toList()));
+    }
+
+    @Description("Get the plan ids of given plan node")
+    @ScalarFunction("json_presto_query_plan_node_children")
+    @SqlType("ARRAY<VARCHAR>")
+    @SqlNullable
+    public static Block jsonPlanNodeChildren(@TypeParameter("ARRAY<VARCHAR>") ArrayType arrayType,
+            @SqlType(StandardTypes.JSON) Slice jsonPlan,
+            @SqlType(StandardTypes.VARCHAR) Slice planId)
+    {
+        List<JsonRenderedNode> planFragments = parseJsonPlanFragmentsAsList(jsonPlan);
+
+        if (planFragments == null) {
+            return null;
+        }
+
+        Map<String, List<String>> planMap = extractPlanIds(planFragments);
+        List<String> planChildren = planMap.get(planId.toStringUtf8());
+        if (planChildren == null) {
+            return null;
+        }
+        return constructSqlArray(arrayType, planChildren);
+    }
+
+    @Description("Scrub runtime information such as plan estimates and variable names from the query plan, leaving the structure of the plan intact")
+    @ScalarFunction("json_presto_query_plan_scrub")
+    @SqlType(StandardTypes.JSON)
+    @SqlNullable
+    public static Slice jsonScrubPlan(@SqlType(StandardTypes.JSON) Slice jsonPlan)
+    {
+        Map<PlanFragmentId, Map<String, JsonRenderedNode>> jsonRenderedNodeMap = parseJsonPlanFragments(jsonPlan);
+
+        if (jsonRenderedNodeMap == null) {
+            return null;
+        }
+
+        jsonRenderedNodeMap.forEach((key, planMap) ->
+        {
+            planMap.put("plan", scrubJsonPlan(planMap.get("plan")));
+        });
+
+        JsonCodec<Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>>> planMapCodec = constructJsonPlanMapCodec();
+        return utf8Slice(planMapCodec.toJson(jsonRenderedNodeMap));
+    }
+
+    private static Map<String, List<String>> extractPlanIds(List<JsonRenderedNode> jsonPlanFragments)
+    {
+        Map<String, List<String>> planMap = new HashMap<>();
+        jsonPlanFragments.stream().forEach(jsonPlanFragment -> addChildrenPlanIds(jsonPlanFragment, planMap));
+        return planMap;
+    }
+
+    private static List<JsonRenderedNode> parseJsonPlanFragmentsAsList(Slice jsonPlan)
+    {
+        Map<PlanFragmentId, Map<String, JsonRenderedNode>> jsonRenderedNodeMap = parseJsonPlanFragments(jsonPlan);
+
+        if (jsonRenderedNodeMap == null) {
+            return null;
+        }
+        List<JsonRenderedNode> planFragments = new ArrayList<>();
+        jsonRenderedNodeMap.values().forEach(map -> planFragments.addAll(map.values()));
+        return planFragments;
+    }
+
+    private static JsonCodec<Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>>> constructJsonPlanMapCodec()
+    {
+        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
+        provider.setJsonSerializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionSerializer()));
+        provider.setKeyDeserializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionDeserializer(FUNCTION_AND_TYPE_MANAGER)));
+        JsonCodecFactory codecFactory = new JsonCodecFactory(provider, true);
+
+        JsonCodec<Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>>> planMapCodec = codecFactory.mapJsonCodec(PlanFragmentId.class, mapJsonCodec(String.class, JsonRenderer.JsonRenderedNode.class));
+        return planMapCodec;
+    }
+
+    private static Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>> parseJsonPlanFragments(Slice jsonPlan)
+    {
+        JsonCodec<Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>>> planMapCodec = constructJsonPlanMapCodec();
+
+        try {
+            Map<PlanFragmentId, Map<String, JsonRenderer.JsonRenderedNode>> fragmentMap = planMapCodec.fromJson(jsonPlan.getBytes());
+            return fragmentMap;
+        }
+        catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private static JsonCodec<JsonRenderedNode> constructJsonCodec()
+    {
+        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
+        provider.setJsonSerializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionSerializer()));
+        provider.setKeyDeserializers(ImmutableMap.of(VariableReferenceExpression.class, new Serialization.VariableReferenceExpressionDeserializer(FUNCTION_AND_TYPE_MANAGER)));
+        JsonCodecFactory codecFactory = new JsonCodecFactory(provider, true);
+        JsonCodec<JsonRenderedNode> planCodec = codecFactory.jsonCodec(JsonRenderedNode.class);
+        return planCodec;
+    }
+
+    private static Block constructSqlArray(ArrayType arrayType, List<String> planIds)
+    {
+        Type valueType = new ArrayType(VARCHAR);
+
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, planIds.size());
+        BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
+        for (String planId : planIds) {
+            valueType.writeSlice(singleMapBlockBuilder, utf8Slice(planId));
+        }
+        blockBuilder.closeEntry();
+        return (Block) arrayType.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
+    }
+
+    private static void addChildrenPlanIds(JsonRenderedNode jsonRenderedNode, Map<String, List<String>> childrenMap)
+    {
+        String planId = jsonRenderedNode.getId();
+        List<String> children = jsonRenderedNode.getChildren().stream().map(x -> x.getId()).collect(Collectors.toList());
+        childrenMap.put(planId, children);
+        jsonRenderedNode.getChildren().stream().forEach(x -> addChildrenPlanIds(x, childrenMap));
+    }
+
+    private static JsonRenderedNode scrubJsonPlan(JsonRenderedNode node)
+    {
+        if (node == null) {
+            return null;
+        }
+
+        String newName = scrubName(node.getName());
+        String newIdentifier = scrubIdentifier(node.getIdentifier());
+        List<JsonRenderedNode> newChildren = node.getChildren().stream().map(x -> scrubJsonPlan(x)).collect(Collectors.toList());
+        String newDetails = scrubDetails(node.getDetails());
+
+        return new JsonRenderedNode(node.getSourceLocation(), "PLANID", newName, newIdentifier, newDetails, newChildren, node.getRemoteSources(), ImmutableList.of());
+    }
+
+    private static String scrubName(String name)
+    {
+        if (name.startsWith("Aggregate(PARTIAL)")) {
+            return "Aggregate(PARTIAL)";
+        }
+
+        if (name.startsWith("Aggregate(FINAL)")) {
+            return "Aggregate(FINAL)";
+        }
+
+        if (name.startsWith("Aggregate")) {
+            return "Aggregate";
+        }
+
+        return name;
+    }
+
+    private static String scrubIdentifier(String identifier)
+    {
+        if (identifier.startsWith("[table")) {
+            String pattern = "tableName=(\\w)";
+
+            Pattern r = Pattern.compile(pattern);
+
+            Matcher m = r.matcher(identifier);
+
+            if (m.find()) {
+                return "tableName=" + m.group(1);
+            }
+        }
+        return "IDENTIFIER";
+    }
+
+    private static String scrubDetails(String details)
+    {
+        return "DETAILS";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctionUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctionUtils.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.queryplan;
+
+public class TestJsonPrestoQueryPlanFunctionUtils
+{
+    private TestJsonPrestoQueryPlanFunctionUtils() {}
+
+    // explain (type distributed, format json) select * from r,s where r.a=s.a;
+    public static String joinPlan =
+            "{\n" +
+                    "   \"0\" : {\n" +
+                    "     \"plan\" : {\n" +
+                    "   \"id\" : \"8\",\n" +
+                    "   \"name\" : \"Output\",\n" +
+                    "   \"identifier\" : \"[a, b, a, b]\",\n" +
+                    "   \"details\" : \"b := b_1 (1:41)\\n\",\n" +
+                    "   \"children\" : [ {\n" +
+                    "     \"id\" : \"241\",\n" +
+                    "     \"name\" : \"RemoteSource\",\n" +
+                    "     \"identifier\" : \"[1]\",\n" +
+                    "     \"details\" : \"\",\n" +
+                    "     \"children\" : [ ],\n" +
+                    "     \"remoteSources\" : [ \"1\" ],\n" +
+                    "     \"estimates\" : [ ]\n" +
+                    "   } ],\n" +
+                    "   \"remoteSources\" : [ ],\n" +
+                    "   \"estimates\" : [ {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : \"NaN\",\n" +
+                    "     \"confident\" : false,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"a<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b_1<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   } ]\n" +
+                    " }\n" +
+                    "   },\n" +
+                    "   \"1\" : {\n" +
+                    "     \"plan\" : {\n" +
+                    "   \"id\" : \"218\",\n" +
+                    "   \"name\" : \"InnerJoin\",\n" +
+                    "   \"identifier\" : \"[(\\\"a\\\" = \\\"a_0\\\")][$hashvalue, $hashvalue_21]\",\n" +
+                    "   \"details\" : \"Distribution: PARTITIONED\\n\",\n" +
+                    "   \"children\" : [ {\n" +
+                    "     \"id\" : \"239\",\n" +
+                    "     \"name\" : \"RemoteSource\",\n" +
+                    "     \"identifier\" : \"[2]\",\n" +
+                    "     \"details\" : \"\",\n" +
+                    "     \"children\" : [ ],\n" +
+                    "     \"remoteSources\" : [ \"2\" ],\n" +
+                    "     \"estimates\" : [ ]\n" +
+                    "   }, {\n" +
+                    "     \"id\" : \"272\",\n" +
+                    "     \"name\" : \"LocalExchange\",\n" +
+                    "     \"identifier\" : \"[HASH][$hashvalue_21] (a_0)\",\n" +
+                    "     \"details\" : \"\",\n" +
+                    "     \"children\" : [ {\n" +
+                    "       \"id\" : \"240\",\n" +
+                    "       \"name\" : \"RemoteSource\",\n" +
+                    "       \"identifier\" : \"[3]\",\n" +
+                    "       \"details\" : \"\",\n" +
+                    "       \"children\" : [ ],\n" +
+                    "       \"remoteSources\" : [ \"3\" ],\n" +
+                    "       \"estimates\" : [ ]\n" +
+                    "     } ],\n" +
+                    "     \"remoteSources\" : [ ],\n" +
+                    "     \"estimates\" : [ {\n" +
+                    "       \"outputRowCount\" : 0.0,\n" +
+                    "       \"totalSize\" : \"NaN\",\n" +
+                    "       \"confident\" : true,\n" +
+                    "       \"variableStatistics\" : {\n" +
+                    "         \"$hashvalue_21<bigint>\" : {\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\",\n" +
+                    "           \"nullsFraction\" : 1.0,\n" +
+                    "           \"averageRowSize\" : 0.0,\n" +
+                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "         },\n" +
+                    "         \"a_0<integer>\" : {\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\",\n" +
+                    "           \"nullsFraction\" : 1.0,\n" +
+                    "           \"averageRowSize\" : 0.0,\n" +
+                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "         },\n" +
+                    "         \"b_1<integer>\" : {\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\",\n" +
+                    "           \"nullsFraction\" : 1.0,\n" +
+                    "           \"averageRowSize\" : 0.0,\n" +
+                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "         }\n" +
+                    "       },\n" +
+                    "       \"joinNodeStatsEstimate\" : {\n" +
+                    "         \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "         \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "       },\n" +
+                    "       \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "         \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "       }\n" +
+                    "     } ]\n" +
+                    "   } ],\n" +
+                    "   \"remoteSources\" : [ ],\n" +
+                    "   \"estimates\" : [ {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : \"NaN\",\n" +
+                    "     \"confident\" : false,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"a<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b_1<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   } ]\n" +
+                    " }\n" +
+                    "   },\n" +
+                    "   \"2\" : {\n" +
+                    "     \"plan\" : {\n" +
+                    "   \"id\" : \"301\",\n" +
+                    "   \"name\" : \"ScanProject\",\n" +
+                    "   \"identifier\" : \"[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=r, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.r{}]'}, projectLocality = LOCAL]\",\n" +
+                    "   \"details\" : \"$hashvalue_20 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(a), BIGINT'0')) (1:55)\\nLAYOUT: tpch.r{}\\na := a:int:0:REGULAR (1:55)\\nb := b:int:1:REGULAR (1:55)\\n\",\n" +
+                    "   \"children\" : [ ],\n" +
+                    "   \"remoteSources\" : [ ],\n" +
+                    "   \"estimates\" : [ {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : 0.0,\n" +
+                    "     \"confident\" : true,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"a<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   }, {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : \"NaN\",\n" +
+                    "     \"confident\" : true,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"$hashvalue_20<bigint>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"a<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   } ]\n" +
+                    " }\n" +
+                    "   },\n" +
+                    "   \"3\" : {\n" +
+                    "     \"plan\" : {\n" +
+                    "   \"id\" : \"302\",\n" +
+                    "   \"name\" : \"ScanProject\",\n" +
+                    "   \"identifier\" : \"[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=s, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.s{}]'}, projectLocality = LOCAL]\",\n" +
+                    "   \"details\" : \"$hashvalue_23 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(a_0), BIGINT'0')) (1:57)\\nLAYOUT: tpch.s{}\\nb_1 := b:int:1:REGULAR (1:57)\\na_0 := a:int:0:REGULAR (1:57)\\n\",\n" +
+                    "   \"children\" : [ ],\n" +
+                    "   \"remoteSources\" : [ ],\n" +
+                    "   \"estimates\" : [ {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : 0.0,\n" +
+                    "     \"confident\" : true,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"a_0<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b_1<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   }, {\n" +
+                    "     \"outputRowCount\" : 0.0,\n" +
+                    "     \"totalSize\" : \"NaN\",\n" +
+                    "     \"confident\" : true,\n" +
+                    "     \"variableStatistics\" : {\n" +
+                    "       \"$hashvalue_23<bigint>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"a_0<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       },\n" +
+                    "       \"b_1<integer>\" : {\n" +
+                    "         \"lowValue\" : \"NaN\",\n" +
+                    "         \"highValue\" : \"NaN\",\n" +
+                    "         \"nullsFraction\" : 1.0,\n" +
+                    "         \"averageRowSize\" : 0.0,\n" +
+                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "       }\n" +
+                    "     },\n" +
+                    "     \"joinNodeStatsEstimate\" : {\n" +
+                    "       \"nullJoinBuildKeyCount\" : \"NaN\",\n" +
+                    "       \"joinBuildKeyCount\" : \"NaN\"\n" +
+                    "     },\n" +
+                    "     \"tableWriterNodeStatsEstimate\" : {\n" +
+                    "       \"taskCountIfScaledWriter\" : \"NaN\"\n" +
+                    "     }\n" +
+                    "   } ]\n" +
+                    " }\n" +
+                    "   }\n" +
+                    " }";
+
+    public static final String scrubbedJoinPlan =
+            "{\n" +
+                    "  \"0\" : {\n" +
+                    "    \"plan\" : {\n" +
+                    "      \"id\" : \"PLANID\",\n" +
+                    "      \"name\" : \"Output\",\n" +
+                    "      \"identifier\" : \"IDENTIFIER\",\n" +
+                    "      \"details\" : \"DETAILS\",\n" +
+                    "      \"children\" : [ {\n" +
+                    "        \"id\" : \"PLANID\",\n" +
+                    "        \"name\" : \"RemoteSource\",\n" +
+                    "        \"identifier\" : \"IDENTIFIER\",\n" +
+                    "        \"details\" : \"DETAILS\",\n" +
+                    "        \"children\" : [ ],\n" +
+                    "        \"remoteSources\" : [ \"1\" ],\n" +
+                    "        \"estimates\" : [ ]\n" +
+                    "      } ],\n" +
+                    "      \"remoteSources\" : [ ],\n" +
+                    "      \"estimates\" : [ ]\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"1\" : {\n" +
+                    "    \"plan\" : {\n" +
+                    "      \"id\" : \"PLANID\",\n" +
+                    "      \"name\" : \"InnerJoin\",\n" +
+                    "      \"identifier\" : \"IDENTIFIER\",\n" +
+                    "      \"details\" : \"DETAILS\",\n" +
+                    "      \"children\" : [ {\n" +
+                    "        \"id\" : \"PLANID\",\n" +
+                    "        \"name\" : \"RemoteSource\",\n" +
+                    "        \"identifier\" : \"IDENTIFIER\",\n" +
+                    "        \"details\" : \"DETAILS\",\n" +
+                    "        \"children\" : [ ],\n" +
+                    "        \"remoteSources\" : [ \"2\" ],\n" +
+                    "        \"estimates\" : [ ]\n" +
+                    "      }, {\n" +
+                    "        \"id\" : \"PLANID\",\n" +
+                    "        \"name\" : \"LocalExchange\",\n" +
+                    "        \"identifier\" : \"IDENTIFIER\",\n" +
+                    "        \"details\" : \"DETAILS\",\n" +
+                    "        \"children\" : [ {\n" +
+                    "          \"id\" : \"PLANID\",\n" +
+                    "          \"name\" : \"RemoteSource\",\n" +
+                    "          \"identifier\" : \"IDENTIFIER\",\n" +
+                    "          \"details\" : \"DETAILS\",\n" +
+                    "          \"children\" : [ ],\n" +
+                    "          \"remoteSources\" : [ \"3\" ],\n" +
+                    "          \"estimates\" : [ ]\n" +
+                    "        } ],\n" +
+                    "        \"remoteSources\" : [ ],\n" +
+                    "        \"estimates\" : [ ]\n" +
+                    "      } ],\n" +
+                    "      \"remoteSources\" : [ ],\n" +
+                    "      \"estimates\" : [ ]\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"2\" : {\n" +
+                    "    \"plan\" : {\n" +
+                    "      \"id\" : \"PLANID\",\n" +
+                    "      \"name\" : \"ScanProject\",\n" +
+                    "      \"identifier\" : \"tableName=r\",\n" +
+                    "      \"details\" : \"DETAILS\",\n" +
+                    "      \"children\" : [ ],\n" +
+                    "      \"remoteSources\" : [ ],\n" +
+                    "      \"estimates\" : [ ]\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"3\" : {\n" +
+                    "    \"plan\" : {\n" +
+                    "      \"id\" : \"PLANID\",\n" +
+                    "      \"name\" : \"ScanProject\",\n" +
+                    "      \"identifier\" : \"tableName=s\",\n" +
+                    "      \"details\" : \"DETAILS\",\n" +
+                    "      \"children\" : [ ],\n" +
+                    "      \"remoteSources\" : [ ],\n" +
+                    "      \"estimates\" : [ ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}";
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctions.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.queryplan;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestJsonPrestoQueryPlanFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testJsonPlanIds()
+    {
+        assertFunction("json_presto_query_plan_ids(null)", new ArrayType(VARCHAR), null);
+
+        assertFunction("json_presto_query_plan_ids(json '" +
+                        TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "')",
+                new ArrayType(VARCHAR), ImmutableList.of("301", "302", "8", "239", "218", "272", "240", "241"));
+    }
+
+    @Test
+    public void testJsonPlanNodeChildren()
+    {
+        assertFunction("json_presto_query_plan_node_children(null, null)", new ArrayType(VARCHAR), null);
+        assertFunction("json_presto_query_plan_node_children(null, '1')", new ArrayType(VARCHAR), null);
+
+        assertFunction("json_presto_query_plan_node_children(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "', '301')",
+                new ArrayType(VARCHAR), ImmutableList.of());
+
+        assertFunction("json_presto_query_plan_node_children(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "', '218')",
+                new ArrayType(VARCHAR), ImmutableList.of("239", "272"));
+
+        assertFunction("json_presto_query_plan_node_children(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "', 'nonkey')",
+                new ArrayType(VARCHAR), null);
+    }
+
+    @Test
+    public void testJsonScrubPlan()
+    {
+        assertFunction("json_presto_query_plan_scrub(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "')", JSON,
+                TestJsonPrestoQueryPlanFunctionUtils.scrubbedJoinPlan);
+    }
+
+    @Test
+    public void testJsonFunctionsInvalidPlans()
+    {
+        // failures to parse json string result in null
+        String invalidJsonPlan = "{   \"id\" : \"9\",   \"name\" : \"Output\"}";
+
+        assertFunction("json_presto_query_plan_ids(json '" + invalidJsonPlan.replaceAll("'", "''") + "')",
+                new ArrayType(VARCHAR), null);
+
+        assertFunction("json_presto_query_plan_node_children(json '" + invalidJsonPlan.replaceAll("'", "''") + "', 'nonkey')",
+                new ArrayType(VARCHAR), null);
+    }
+}


### PR DESCRIPTION
Adding the following three functions for manipulating json query plans:

```
json_presto_query_plan_ids(json jsonPlan)
json_presto_query_plan_node_children(json jsonPlan, varchar planId)
json_presto_query_plan_scrub(json jsonPlan)
```

These fill be helpful when searching for patterns in collections of query plans.
json_plan_scrub can also be used to remove noise when diffing query plans and help when investigating regressions.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Introduces new functions for manipulating Presto json query plans: json_presto_query_plan_ids, json_presto_query_plan_node_children, json_presto_query_plan_scrub
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

