### PR TITLE
Add release notes for 0.284

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.284
     Release-0.283 [2023-08-08] <release/release-0.283>
     release/release-0.282
     release/release-0.281

--- a/presto-docs/src/main/sphinx/release/release-0.284.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.284.rst
@@ -1,0 +1,60 @@
+=============
+Release 0.284
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix correctness bug in the optimizer when ``randomize_outer_join_null_key`` is enabled.
+* Fix bug in array ``CONTAINS`` expression rewrite rule.
+* Fix bugs parsing lambda expressions.  The bugs may cause compile exception with message "Can not compile special form: WHEN" and lead to runtime exception of array out of bound access.
+* Fix :func:`min` and :func:`max` to verify second argument is unique.
+* Fix access control checks for ``IS NULL`` and ``IS NOT NULL``.
+* Improve cache efficiency of history-based optimizer.
+* Improve cost-based optimizer to work with complex equi-join predicates.
+* Improve performance of outer join when nulls are present. It can be enabled by setting ``randomize_outer_join_null_key_strategy`` to be ``cost_based``. The trigger condition can be set by session properties ``randomize_outer_join_null_key_null_count_threshold`` and ``randomize_outer_join_null_key_null_ratio_threshold``.
+* Add field names when casting row to JSON.
+* Add :func:`array_top_n` to return an array of top ``N`` elements of a given array.
+* Add :func:`bitwise_xor_agg` function.
+* Add :func:`NOISY_COUNT_GAUSSIAN`.
+* Add :func:`NOISY_SUM_GAUSSIAN`.
+* Add :func:`NOISY_AVG_GAUSSIAN`.
+* Add session property ``restrict_history_based_optimization_to_complex_query``. When set to ``TRUE``, only queries with join or aggregation will try to use HBO. The default value is ``TRUE``.
+* Add session property ``pull_expression_from_lambda_enabled`` to optimize lambda functions which have expressions not referring to arguments of the lambda function.  The default state is enabled using the value ``TRUE``.
+* Add ``rewrite_constant_array_contains_to_in_expression`` session property to improve the performance of ``CONTAINS`` expressions.  The default state is enabled using the value ``TRUE``.
+* Add function :func:`trail`.
+* Add session property ``optimizers_to_enable_verbose_runtime_stats`` to enable runtime tracking for a set of optimizers.
+* Add support for ``EXPLAIN (TYPE VALIDATE)`` of ``EXPLAIN`` queries. Previously such queries would fail with an error.
+* Improve performance of cluster statistics reporting in the Presto coordinator by adding the configuration property ``cluster-stats-cache-expiration-duration``. The property is ``0`` (disabled) by default.
+* Add support for serializing nested data structures via server-side configuration properties using the configuration property ``nested-data-serialization-enabled``. The property is enabled by default with the value ``TRUE``.
+* Add a Redis-based historical statistics provider.  For more information, see :doc:`Redis HBO Provider </plugin/redis-hbo-provider>`.
+* Add principal name support in the resource group selection criteria.
+* Add ``noisy_count_if_gaussian(condition, noiseScale[, randomSeed])`` aggregation which calculates the number of ``TRUE`` input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true count. Optional ``randomSeed`` is used to get a fixed value of noise, often for reproducibility purposes. If ``randomSeed`` is omitted, ``SecureRandom`` is used. If ``randomSeed`` is provided, ``Random`` is used.
+
+Hive Connector Changes
+____________
+* Fix directory listing over directories with content-type ``application/octet-stream`` (:issue:`20310`).
+* Add DWRF filetype to min, max filtering for special column types such as tinyint, varbinary and timestamp.
+
+Iceberg Connector Changes
+_______________
+* Add Iceberg table location property in ``SHOW CREATE TABLE``.
+* Add validation for copy-on-write mode for Iceberg tables. This can be disabled with the ``merge_on_read_enabled`` session property or the ``iceberg.enable-merge-on-read-mode`` configuration property.
+* Add support for ``TRUNCATE TABLE <table>``.
+* Remove support for specifying ``NOT NULL`` constraint when adding a new column in ``ALTER TABLE`` statement.
+* Upgrade Iceberg from 1.3.0 to 1.3.1.
+
+PostgreSQL Connector Changes
+____________________________
+* Upgrade JDBC driver version to 42.6.0.
+
+Presto Verifier Changes
+_______________________
+* Add support for Presto Verifier to run in query-bank mode and save query results as a snapshot. (See :doc:`Presto Verifier </admin/verifier>`.)
+
+**Credits**
+===========
+
+8dukongjian, Ajay George, Ajay Gupte, Alex Perez, Amit Dutta, Amit Patil, Anant Aneja, Ann Rose Benny, Arjun Gupta, Arun D Panicker, Ashwin Krishna Kumar, Avinash Jain, Beinan, Chengcheng Jin, Christian Zentgraf, Chunxu Tang, Darren Fu, Deepak Majeti, Dongsheng Wang, Eduard Tudenhoefner, Efrat Levitan, Facebook Community Bot, Gary Ho, Ge Gao, Haritha K, Ivan Millan, Jalpreet Singh Nanda (:imjalpreet), James Petty, James Xu, Jialiang Tan, JiamingMai, Jimmy Lu, Jobbine, Jon Janzen, Karteekmurthys, Ke, Kevin Wilfong, Kien Nguyen, Krishna-Prasad-P-V, Lyublena Antova, Mahadevuni Naveen Kumar, Masha Basmanova, Melissa Guo, Michael Shang, Nikhil Collooru, Patrick Stuedi, Pedro Pedreira, Pramod, Pranjal Shankhdhar, Pratik Joseph Dabre, Pratyush Verma, Rebecca Schlussel, Reetika Agrawal, Rohan Pednekar, Rohit Jain, Sagar Sumit, SeanIFitch, Sergey Pershin, Sergii Druzkin, Setyven Lnu, Shrinidhi Joshi, Shubham Chaurasia, Sreeni Viswanadha, Steve Burnett, Sudheesh, Swapnil Tailor, Timothy Meehan, Vivek, Yihong Wang, Ying, Zac, Zac Blanco, abhiseksaikia, adamzwakk, aditi-pandit, dnskr, feilong-liu, gopukrishnasIBM, guhanjie, jaystarshot, kedia,Akanksha, kiersten-stokes, lingbin, mayunlei, oyeliseiev, pratyakshsharma, prithvip, rrando901, s-akhtar-baig, v-jizhang, wangd, xiaoxmeng, xpengahana


### PR DESCRIPTION
# Missing Release Notes
## Ajay Gupte
- [ ] https://github.com/prestodb/presto/pull/20464 Fix NaN/Infinity value for double/float partition columns (Merged by: Timothy Meehan)

## Alex Perez
- [ ] https://github.com/prestodb/presto/pull/20520 add merge_tdigest function (Merged by: Timothy Meehan)

## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/20928 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20915 [native] Fix build regarding to bitwise and boolean operation. (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/20905 [native] Use presto_native as prefix for spill path. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20891 [native] Cancel function before adding once in PeriodicTaskManager. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20890 [native] Minor refactor in PeriodicTaskManager (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20870 [native] Add a function to schedule task once in PeriodicTaskManager. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20866 [native] Re-factor in PeriodicTaskManager. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20849 [native] Allow updating spill directory in TaskManager. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20838 [native] Remove unnecessary velox check. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20819 [native] Log spill stats when available. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20755 [native] Remove spill console logging in periodic task manager. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20804 [native] Support host or Ip in exchange client. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20779 [native] Skip redundant Ip object to string conversion. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20754 [native] Fix announcment retry. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20757 [native] Fix exchange client creation. (Merged by: Michael Shang)
- [ ] https://github.com/prestodb/presto/pull/20749 [native] Change nlohmann json location as done in PR 20619 (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20736 [native] Print velox user error log upon failure during start up. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20735 [native] Add virtual destructor for PeriodicServiceInventoryManager (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/20429 [native] Add e2e tests for global aggregate with no grouping keys and no aggregates. (Merged by: Michael Shang)

## Anant Aneja
- [ ] https://github.com/prestodb/presto/pull/20943 Revert "Enhance join reordering to work with non-simple equi-join clauses" (Merged by: Ajay George)

## Arun D Panicker
- [ ] https://github.com/prestodb/presto/pull/20600 [native] Add e2e test for gamma_cdf function (Merged by: Aditi Pandit)

## Avinash Jain
- [ ] https://github.com/prestodb/presto/pull/20435 Add support for replace_first function (Merged by: Nikhil Collooru)

## Facebook Community Bot
- [ ] https://github.com/prestodb/presto/pull/20467 Automated submodule update: velox (Merged by: Amit Dutta)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/20394 [native] Combine MemoryManagerOptions with Arbitrator::Config (#5802) (Merged by: tanjialiang)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/20479 [native] Add plan node type in file format error (Merged by: Maria Basmanova)

## Jon Janzen
- [ ] https://github.com/prestodb/presto/pull/20670 Revert D48578640: [presto][diff_train] [native] Change json location for reuse with other third parties (Merged by: Facebook Community Bot)

## Karteekmurthys
- [ ] https://github.com/prestodb/presto/pull/20381 [native] Add support for LEFT, RIGHT and FULL joins with no equi clause (Merged by: Maria Basmanova)

## Ke
- [ ] https://github.com/prestodb/presto/pull/20845 [native] Set compression type to ZSTD by default for Native Query Runner (Merged by: Ke)

## Kevin Wilfong
- [ ] https://github.com/prestodb/presto/pull/20797 [native] Move testDereference to a general native test (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/20727 [native] Map Presto DereferenceExpr to Velox DereferenceTypedExpr  (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/20728 Advance Velox (Merged by: Xiaoxuan)

## Lyublena Antova
- [ ] https://github.com/prestodb/presto/pull/20705 Rewrite CROSS JOIN with array not contains predicate into an anti join (Merged by: Lyublena Antova)

## Patrick Stuedi
- [ ] https://github.com/prestodb/presto/pull/20798 [native] Add support for background CPU time stats in Shuffle operators (Merged by: Maria Basmanova)

## Pedro Pedreira
- [ ] https://github.com/prestodb/presto/pull/20335 [native] Adding RemoteFunctionRegisterer (Merged by: Zac)

## Pranjal Shankhdhar
- [ ] https://github.com/prestodb/presto/pull/20470 [presto][native] Add memory cache hit bytes metric (Merged by: Pranjal Shankhdhar)

## Rohan Pednekar
- [ ] https://github.com/prestodb/presto/pull/20267 Update PR template (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20270 Configure issues templates for Presto repository (Merged by: Timothy Meehan)

## Timothy Meehan
- [ ] https://github.com/prestodb/presto/pull/18647 Update README.md to redirect to Slack (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20412 Fix typo in config.yml (Merged by: Timothy Meehan)

## adamzwakk
- [ ] https://github.com/prestodb/presto/pull/20017 Fixed bigquery table not found error (Merged by: Timothy Meehan)

## jaystarshot
- [ ] https://github.com/prestodb/presto/pull/20471 Use track statistics flag to control hbo stats update (Merged by: Pranjal Shankhdhar)

## kedia,Akanksha
- [ ] https://github.com/prestodb/presto/pull/20994 Improve MakeSetDigest function Generic Parameter (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20995 Typo in bitwise_right_shift documentation (value, shift, digits) (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20685 Add support for generic parameters in make_set_digest function (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20823 Improve Document types.html setdigest Function (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20761 Improve Comparison Operator and function Document for IN operator (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20676 Document Set Digest functions (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20686 Remove overload version for hash_counts of Return type varchar (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20638 Exclude new time zones from TestTimeZoneUtils (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20569 Fix CVE-2022-42889: Upgrade org.apache.commons:commons-text to 1.10.0 (Merged by: Timothy Meehan)

## oyeliseiev
- [ ] https://github.com/prestodb/presto/pull/20781 Add SingleStore connector (Merged by: Timothy Meehan)

## rrando901
- [ ] https://github.com/prestodb/presto/pull/20344 [Native] Add e2e cast int/float to decimal tests (Merged by: Aditi Pandit)

# Extracted Release Notes
- #19253 (Author: v-jizhang): Add snapshot to presto-verifier
  - Add support for Verifier to run in query-bank mode and save query results as a snapshot.
- #19513 (Author: Amit Patil): Better JSON Casting for Rows
  - Improved row to json cast by including field names in the resulting json by making it a map instead of an array.
- #19884 (Author: Jalpreet Singh Nanda (:imjalpreet)): Add Iceberg table location property in SHOW CREATE TABLE
  - Add Iceberg table location property in SHOW CREATE TABLE.
- #20333 (Author: Eduard Tudenhoefner): Bump Iceberg from 1.3.0 to 1.3.1
  - Update Iceberg from 1.3.0 to 1.3.1.
- #20358 (Author: guhanjie): Reduce dns lookup overhead on NodeScheduler
  - Reduce dns lookup overhead on NodeScheduler. This can avoid unnecessary dns lookup for HostAddress has port, while previous would incurred additional overhead when dns too slow on some host environment.
- #20391 (Author: Dongsheng Wang): Change ResourceGroup refresh executor thread name
  - Change InternalResourceGroupManager refresh executor's thread name for easier read.
- #20413 (Author: Anant Aneja): Fix join reordering for non-trivial equi join conditions
  - Enhance join-reordering to work with non-simple equi-join predicates.
- #20415 (Author: Dongsheng Wang): Reducing lock contention on 'SqlStageExecution'
  - Optimize  `SqlStageExecution.checkAllTaskFinal` call.
  - Reduce number of call to  `SqlStageExecution.checkAllTaskFinal`.
- #20418 (Author: Ivan Millan): Enable presto connection session reuse at PrestoConnection creation time
  - Add static method ``newConnectionWithSessionProperties`` to PrestoConnection to enable presto connection session properties reuse at PrestoConnection creation time. (:pr:`20418`).
- #20455 (Author: jaystarshot): Adding OSS Redis based Historical Statistics Provider
  - Adding an open source redis based historical statistics provider.
- #20475 (Author: feilong-liu): Pull expressions in lambda out
  - Add an optimization for lambda functions which has expression not referring to arguments of the lambda function. Controlled by session parameter `pull_expression_from_lambda_enabled` and default to enabled.
- #20526 (Author: Setyven Lnu): Add array_top_n function
  - Add :func:`array_top_n` to return an array of top N elements of a given array.
- #20576 (Author: Ivan Millan): Refactor PrestoConnection newConnectionWithSessionProperties
  - Add static method ``copySessionProperties`` to PrestoConnection to enable the copy of presto connection session properties from one connection to another. (:pr:`20418`).
- #20601 (Author: feilong-liu): Rewrite array contains to in expression
  - Add an optimizer to rewrite contains(constant_array, col) to IN expression. It's controlled by session `rewrite_constant_array_contains_to_in_expression` and default to enabled.
- #20603 (Author: Jalpreet Singh Nanda (:imjalpreet)): Handle empty directories with content-type application/octet-stream also as directories
  - Handle empty directories with content-type application/octet-stream also as directories (:issue:`20310`).
- #20606 (Author: feilong-liu): Refactor logging for HBO
  - Add a session property ``restrict_history_based_optimization_to_complex_query``. When set to true, only queries with join or aggregation will try to use HBO. The default value is true.
- #20607 (Author: feilong-liu): Add session property to pick optimizers to enable runtime stats
  - Add session property `optimizers_to_enable_verbose_runtime_stats` to enable runtime track for a set of optimizers.
- #20616 (Author: Rebecca Schlussel): Fix EXPLAIN(TYPE VALIDATE) of EXPLAIN queries
  - Add support for ``EXPLAIN (TYPE VALIDATE)`` of ``EXPLAIN`` queries. Previously such queries would fail with an error.
- #20631 (Author: Nikhil Collooru): Add support for memoizing the cluster stats
  - Add support for memoizing in cluster stats endpoint. This can be enabled by setting `cluster-stats-cache-expiration-duration` to a non-zero duration.
- #20633 (Author: Ajay George): Add DWRF to min, max filtering for special column types
  - Add DWRF filetype to min, max filtering for special column types such as tinyint, varbinary and timestamp.
- #20650 (Author: Mahadevuni Naveen Kumar): [native] Add node.internal-address to support hostname and FQDN
  - Node config property `node.ip` is now a legacy config. It is replaced with `node.internal-address` to support hostname/FQDN too.
- #20669 (Author: Melissa Guo): Add support for TRAIL() function
  - Add function :func:`trail`.
- #20677 (Author: dnskr): Upgrade PostgreSQL JDBC driver version
  - Upgrade JDBC driver version to 42.6.0.
- #20691 (Author: Ajay Gupte): Disallow alter add column with not null constraint in iceberg
  - Disallow specifying `NOT NULL` constraint when adding a new column in `ALTER TABLE` statement.
- #20692 (Author: Rebecca Schlussel): Skip access check for is null arguments
  - Skip access control checks for IS NULL and IS NOT NULL.
- #20703 (Author: Kien Nguyen): Add NOISY_COUNT_GAUSSIAN aggregation
  - Adds NOISY_COUNT_GAUSSIAN aggregation that counts the non-null values and then add Gaussian noise to the true count. The noisy count is post-processed to be non-negative and rounded to bigint. Noise is from a secure random. When there are no input rows, this function returns ``NULL``. Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes. If randomSeed is omitted, SecureRandom is used; otherwise, Random is used.
- #20708 (Author: feilong-liu): Turn off PullUpExpressionInLambdaRules
  - Disable the optimizer PullUpExpressionInLambdaRules which can lead to query failures. The failure happens when a "CASE" expression is in a lambda expression and not using the lambda arguments. The error message will be "Can not compile special form: WHEN".
- #20733 (Author: feilong-liu): Fix exception when array is NULL for array contains to In expression rewrite rule
  - Fix bug in array contains to In expression rewrite rule. It will throw exception for expression `contains(null, col)`, now it will be skipped and not throwing exceptions.
- #20745 (Author: feilong-liu): Fix bug in randomize null key in outer join optimizer for varchar type
  - Fix a bug in `RandomizeNullKeyInOuterJoin` optimizer. It produced incorrect results when the join key are of type varchar, and has value like 'r0', 'r11' etc in left side and NULL in the right side or value like 'l1', 'l12' on the right side and NULL in the left side.
- #20746 (Author: feilong-liu): Enable outer join null salt by cost model
  - Add an option to make `RandomizeNullKeyInOuterJoin` cost based. It can be enabled by setting `randomize_outer_join_null_key_strategy` to be `cost_based`. The trigger condition can be set by session properties `randomize_outer_join_null_key_null_count_threshold` and `randomize_outer_join_null_key_null_ratio_threshold`.
- #20748 (Author: Nikhil Collooru): Add support for parallel parsing of partition values
  - Add support for parallelizing the partition value parsing using threadpool. This feature can be enabled by setting configuration parameter ``hive.parallel-parsing-of-partition-values-enabled=true``. The maximum size of the thread pool can also be configured by setting ``hive.max-parallel-parsing-concurrency`` to required value.
- #20774 (Author: Swapnil Tailor): Adding Principal name in resource group selector criteria
  - Adding principal name support in the resource group selection criteria.
- #20776 (Author: Zac Blanco): [Iceberg] Add support for TRUNCATE
  - The Iceberg connector now supports `TRUNCATE TABLE <table>` statements.
- #20783 (Author: feilong-liu): Fix bug in pull up expression in lambda rule
  - Fix bugs in PullUpExpressionInLambdaRules. The bugs may cause compile exception with message "Can not compile special form: WHEN" and lead to runtime exception of array out of bound access.
- #20810 (Author: Kien Nguyen): Add noisy_sum_gaussian function
  - Adds `NOISY_SUM_GAUSSIAN(col, noiseScale[, lower, upper][, randomSeed])` aggregation which calculates the sum over the input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true sum. This also provides options to clip values to a range `[lower, upper]` and a random seed for reproducibility. All values are converted to `DOUBLE` before being added to the sum, and the return type is `DOUBLE`. When there are no input rows, this function returns ``NULL``. When generating noise, if randomSeed is omitted, SecureRandom is used; otherwise, Random is used.
- #20811 (Author: s-akhtar-baig): Enforce copy-on-write mode for Iceberg Tables V2 or higher
  - Enforce copy-on-write mode for Iceberg tables. This can disabled with the ``merge_on_read_enabled`` session property or the ``iceberg.enable-merge-on-read-mode``configuration property.
- #20853 (Author: feilong-liu): Optimize latency for HBO optimizer
  - Fix the cache usage in HBO optimization. This will reduce the number of access to meta data for input table statistics.
- #20865 (Author: Kien Nguyen): Add noisy_avg_gaussian aggregation
  - Adds `noisy_avg_gaussian(col, noiseScale[, lower, upper][, randomSeed])` aggregation which calculates the average (arithmetic mean) of all over the input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true avg. This also provides options to clip values to a range `[lower, upper]` and a random seed for reproducibility. All values are converted to `double` before being added to the sum, which which is used to compute the avg, and the return type is `double`. When there are no input rows, this function returns ``NULL``. When generating noise, if randomSeed is omitted, SecureRandom is used; otherwise, Random is used.
- #20908 (Author: James Xu): Fix #20906: make sure the value of param N of minN/maxN is unique
  - MinN/maxN's second argument is now checked to be unique.
- #20913 (Author: Kien Nguyen): Add noisy_count_if_gaussian aggregation
  - This commit adds `noisy_count_if_gaussian(condition, noiseScale[, randomSeed])` aggregation which calculates the number of `TRUE` input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true count. Optional randomSeed is used to get a fixed value of noise, often for reproducibility purposes. If randomSeed is omitted, SecureRandom is used. If randomSeed is provided, Random is used.
- #20939 (Author: James Xu): Add aggregate function bitwise_xor_agg
  - Add aggregate function: bitwise_xor_agg.
- #20949 (Author: Gary Ho): Make parseToJson optional
  - Add support for serializing nested data structures via server-side configuration properties. The new pre-serialization feature can be disabled server-wide by using the configuration property: ``nested-data-serialization-enabled``.

# All Commits
- 5433c2cf8e72e152d11b1a8853ccdbda4c780076 Fix prune output optimizer and table writer merge node for HBO (feilong-liu)
- 987f81d2ce8b59fd45ed4e80cb90f73056eb3585 [native] Fix Timestamp construction for negative timestamps (lingbin)
- 567af0fd2b51b40d748770e48d1e9a386d5af2bd Remove duplicate code in IcebergNativeMetadata (wangd)
- 7b95c5bfab92c9321f319de0cdc74dfd3a80506f Fix bug in maxExecutors config tuning in AQE codepath (Arjun Gupta)
- 57a783e3fad984ac5edb1ccaf786a0ec40ea0db5 Improve MakeSetDigest function Generic Parameter (kedia,Akanksha)
- a635c34f3b83487640644ff8bd1d63e1d0875c4d Optimize DiscoveryNodeManager.refreshNodeInternal (mayunlei)
- 93ac3463a12e684a3e6d6204dacc5ae4eb66a2e7 upgrade org.xerial.snappy:snappy-java to 1.1.10.1 (Sudheesh)
- 67b1efe87269fce55f67d50478ecb00423be47a5 Correct the counting for resource group's running tasks (wangd)
- 666b2980f6eb5807d297159aea97502fc71852c7 Typo in bitwise_right_shift documentation (value, shift, digits) (kedia,Akanksha)
- 1e133ec62443c4619803dc4f5ae65fa06743e7c3 Add unit test for row group level flush between columnWriter fallbacks (wangd)
- 42883dba101f8745c543eddc8e35d4bf3cf97f13 Reset primitive writer on row group level flush (wangd)
- 469c234c9421d38b72be941d7b933e9828dd04d7 Update protobuf (Sudheesh)
- 69f08b17e075dc9cdc123e0801f5f296ee8e557d [native]Advance velox version and update memory config code (xiaoxmeng)
- 92928a98b876985c816afd08ba5fc475a91026cd Improve documentation for SET_AGG and SET_UNION as it relates to null handling (prithvip)
- 1c351b714efe02b501ea5e241e35ec7ad2d8c5cc Update DROP TABLE in Iceberg document (Reetika Agrawal)
- 49a6c23973c220643bc5b44dd9572d408168f2d4 Truncate Iceberg tables (Zac Blanco)
- 597272cea3eb39c35ed40ffc100f830dd4ab055c [native] Add retry for abort results (Pranjal Shankhdhar)
- 0a5b5261cb0a3f676e5773f53ae5646e5fd3617b [GH Actions] Attempt to clear unused disk space (Zac Blanco)
- fa194e616c5a39404eab79da830b60732fb3a3cd Change to USER_ERROR when table name is empty (Ke)
- 1e1a489793869e36969386068181ea17075bef93 Fix build failing due to unable to find sodium library (Arjun Gupta)
- 470b53229c5a4a5c8db96b944fe75621b718b14b Implement join sharding for skew mitigation (Lyublena Antova)
- c6e2893bf1a111fb29ad2b6c52d87812a6532ce0 Add FunctionCall expression rewriter to presto.verifier (Ge Gao)
- 114cc20268312f6845a8ebd24ce80b03064a7705 Add google sheet connector document to connector list (Reetika Agrawal)
- 704497d849e438695a69628a7b131096f208c6a6 Add SingleStore workflow and docs (oyeliseiev)
- cab7808d6569e2f0efff83139c117183c73845a1 Added SingleStore connector (oyeliseiev)
- 5a247d80bd9f5deb8c075d8c1e254d769a30373c [native] Pass cpu thread pool to PrestoExchangeSource for post-processing (Jialiang Tan)
- 2122929e9700fbc4560a434ff50f2c788c9bfbe6 Avoid the last unnecessary loop when positionCount is an integer multiple of positionsInStep. (wangd)
- 5dd916d7fef419671e146ec6948310d932381e57 Check uniqueness for param N of minN/maxN (James Xu)
- 48b754e9b61d0c4b4fec416bbe9476f78dba9e9d Make parseToJson optional (Gary Ho)
- 7fd7645fc7dadb5f9e4f29718b85f3fe9b06f906 [native]Add memory arbitration state check (xiaoxmeng)
- b5668436d81768f2a81ce24e639f810d32a9abf5 Add noisy_count_if_gaussian aggregation (Kien Nguyen)
- d7d6167555367a70cfb6361d7ac181ba73a4564e Rewrite CROSS JOIN with array not contains predicate into an anti join (Lyublena Antova)
- 9d1a8ae1d79172de1a50eaed0de2d2cd1460ec52 [native] Pass table parameters to Velox (Zac)
- c2a7cf51d842e6113ea88796db53e75e0bd0262f [native] Advance Velox version (Zac)
- c8533819805193560a5a63a9ca73942b4138106f fix `Splits` page and improve its layout (Yihong Wang)
- 081f215c8ef488f9036886810b40bc9b0ef45eaa Add support for generic parameters in make_set_digest function. (kedia,Akanksha)
- 0dde0a27677c106d1469b57f1211b03191ec2181 Add remote-function in the excludedGroups in all-non-parquet-tests profile (Michael Shang)
- 8ca58cfef6a5222ab6a73527efd38e8998a7463e Remove excludedGroups from pom.xml in presto-native-execution (Michael Shang)
- 316cd508646695b0b0b30891295c25f117b990b2 [native-pos]Improve velox memory init and cache stats logging (xiaoxmeng)
- f73f883b3c3d6c69023be1a3893f09541a757f77 [native] Advance velox. (Amit Dutta)
- f0291b113705b753f171c2d39aee6a1d54611e95 [native] Tighten decimal signature check in TypeSignatureTest.cpp (Chengcheng Jin)
- 55cc36f416ce35fd3cfef033b0292aad880f95ee Revert "Enhance join reordering to work with non-simple equi-join clauses" (Anant Aneja)
- da04baca61d79bc46afb4648f9daae86c7186784 Allow Presto clients to receive query results in binary format (Masha Basmanova)
- 9ed0fc2c89c851836560a172e5b816ac3c38932a Document DICTIONARY AND RLE encodings in SerializedPage Wire Format (Masha Basmanova)
- 6eef062bdd3777936fa29127e728edde86a681d4 Enforce JWT authentication without bearer token for internal endpoints (Mahadevuni Naveen Kumar)
- 17b4b95ef7448ceb319d41eb3158da5b32643a51 Add aggregate function bitwise_xor_agg (James Xu)
- 80c7f3e729af690fc92838dcb621ec0782f944a2 Remove requirement on metastore uri when using native Iceberg catalog (kiersten-stokes)
- dd5b168ff5bdf306de70be19cc37c9797ca00981 Add documentation for JDBC driver disableCompression (James Petty)
- 2888cc3a7f07f109b95d934416eec33747c403b2 Document set of whitespace characters recognized in trim functions (Masha Basmanova)
- 0ab7d55d04296999e2e4ccaee424b720d576dd59 Modify the config properties for fragment cache (JiamingMai)
- 1f688e712313ee6b46a6daf43069e7180e3a6a8e Add support for TRAIL() function (Melissa Guo)
- b916ad3045a3eb473509dd880b34f78dea3d738a Refactor ConnectorNodePartitioningProvider for readability (Ajay George)
- ed9eef04d87a102b8d7ad7fc16d59c54edf5a24a [native pos] Fix BroadcastWrite (Masha Basmanova)
- 3bc633f767809b51c5d8ec27386ea2c59624b0c7 Add array_top_n function (Setyven Lnu)
- 85c76607ebf27622c3a2cf423d9c1d92fbd68ed4 Update CONTRIBUTING.md (Timothy Meehan)
- 9adc716a9963539627912fd4fd6a0531ab36a72b Reduce code duplication in Iceberg metadata (Zac Blanco)
- 4fee2501436d10c751ca7899e41a7dcdbda64d88 [native] Fix build regarding to bitwise and boolean operation. (Amit Dutta)
- 566ec0ad2533a75ebd14e773b4e6f961785018b4 Add PartitionSkippabilityChecker to check if partition can be skipped (Nikhil Collooru)
- 92f51c047876444065e68061ed1927bee1fe2124 Add noisy_avg_gaussian aggregation (Kien Nguyen)
- 1bf8afe884a830c2f61051c5e9b5ef7fcc7fa1c6 [native]Move proxygen session pool destruction to run at the background (xiaoxmeng)
- 84509c219a997807563944accafbd6885131ed65 [native] Add ALPHA format translation (Jialiang Tan)
- cd3fae31579b4f1257930ff8e3fb68b2968d5e04 [native] Use presto_native as prefix for spill path. (Amit Dutta)
- 21d8e97660e6d4d9349861e75e70caf6ee105e85 [native] Add support for LEFT, RIGHT and FULL joins with no equi clause (Karteekmurthys)
- 75c9289e744d3102be90323e59d74dca204d61b0 Fix a binding issue in presto-verifier (v-jizhang)
- c30f8a1a6670ae660a62f8620d17d0b81a3f9d22 Fix failing tests (Pranjal Shankhdhar)
- 5acf8486d1aca030d30614f215f343555f2dc032 [native] Add e2e tests for to_iee754_64 Presto scalar function (Pratik Joseph Dabre)
- 911d8e0106be6559ac567855a8948543df0ba9df [native] Add remote function server end to end tests (Pedro Pedreira)
- 291548eb57e9c8e4454d67dcc4d87cff5d009080 [native] Add ALPHA format to protocol (Jialiang Tan)
- 494d5c8f17f1ee19d328535cbfa78914923fc177 Enforce copy-on-write mode for Iceberg tables (s-akhtar-baig)
- 009c06bfcd7e7b54c8b15fab5eb60e2b34f79d9f Enhance join reordering to work with non-simple equi-join clauses (Anant Aneja)
- 1e7bb750c86fc7417fe30faafb0fb9fc5cc26506 Improve Document types.html setdigest Function (kedia,Akanksha)
- 923b9735b18fdf33c81e4c552bf513778d2d4b2f [native] Cancel function before adding once in PeriodicTaskManager. (Amit Dutta)
- f223eaf1b7d42ab1e212b9ffce18c530ae5b08dd [native]Fix spilling memory usage log (xiaoxmeng)
- 50fbc07111ecca60a1a5e62755f095fa204120d0 [native] Minor refactor. (Amit Dutta)
- f74e37473866c358648cd3f54dbaf0bea9dd08f1 add E2E tests for poisson_cdf (Ann Rose Benny)
- 9f083b378f8853381d4c8f652b3a66b417c57a2b [native] Fold background CPU time into finish CPU time (Patrick Stuedi)
- 1fe7a1c088853677ad50cb6c027b46d98bcd0817 [native pos] Collect background CPU time in shuffle operators (Patrick Stuedi)
- 88acefc87bb37fbeda46e8f06724637b7ddf22ec [Native] Turn on support for bucketed sorted writer (Ke)
- 5b604194c8908aeb0244771536a786351e81a991 [native]Add spilling memory usage monitoring and logs improvement (xiaoxmeng)
- 5032044527bbf62c9ea779407ec94f6f78d059a3 [native] Add e2e test for timestamp with time zone cast (Zac)
- 9c22beb0b374bf08ecf9dc217ee02fa2c1264139 Clear HBO stats cache after the query completes when HBO write not enabled (feilong-liu)
- 629070d7eed3a479119136d252b6e35d440ca450 [native] Add test for reduce_agg (Masha Basmanova)
- 0fce67fb3106f9876545b5588640ea7a6edfe5a2 [native] Advance velox version (Patrick Stuedi)
- 9216655301232b72fc55e0ebbf54891494857b0f [native] Add a function to schedule task once in PeriodicTaskManager. (Amit Dutta)
- 4dc69b2d9510c428804167015d393c72fbb9d66a Refactor statistics structure for HBO (feilong-liu)
- bdc499090148c3ee9572d21b63360b310ce63fb9 Add optimizer information to QueryInfo for Presto On Spark (feilong-liu)
- f1f29e8dfa734e2beb5f5f9c2c79db887d90f9fe [native] Re-factor in PeriodicTaskManager. (Amit Dutta)
- 1cfda1927bb3d775aa94811fbf91d547276151ab Add noisy_sum_gaussian function (Kien Nguyen)
- a6eb6bc263f99311a5c63ff59e1db611e805010f Revert "Rewrite CROSS JOIN with array not contains predicate into an anti join" (Lyublena Antova)
- 42b5ee1170390878aceb10c632b9c5a162dba53d Optimize latency for HBO optimizer (feilong-liu)
- e383e7efbf29ac2bddd62bf9b469a0894bce564a [Native] Advance Velox version (Karteekmurthys)
- d83e6fb07ff115541fd2f89a7e02487fd5747958 [native] Allow updating spill directory in TaskManager. (Amit Dutta)
- 42a273e5018299aca9589d3f3da1cc948ec0ef53 Enable outer join null salt by cost (feilong-liu)
- c4a506e8bda8093a5770be8c5f4de1830132cee5 Free disk space on Ubuntu Github runner (Anant Aneja)
- 2800fe80bb014b0abb3e215d1c09ccf15521d67e Fix broken event listener test (Anant Aneja)
- cf4e7578aa5d4ef40b38c11b81585babc618b622 Alignment corrections (gopukrishnasIBM)
- 2e39678a395a9272b703b5dc60980c71f5901551 Added e2e test for timezone_hour and timezone_minute (GOPU-Krishna-S)
- 118c2bee2b49d34c392fbc5dacde611b152e7f97 [native] Modify testScaleWriters() so it does not write DATE column. (Sergey Pershin)
- 0535cfbca930bf16ea7d1a13d9d5115a1db953b0 Set compression type to ZSTD by default for Native Query Runner (Ke)
- b7c49f6dee574a3226400118fac5df7e48f4e1b7 [native] Remove unnecessary velox check. (Amit Dutta)
- 27b887de86fa9991932fac16f2e68cb97e725c4e Log error stacktrace when parallel parsing of partition values fails (Nikhil Collooru)
- 49885f29924ccc54c10dfbf8841c1c56eee38fb9 [native] Fix conversion of constant expressions (Masha Basmanova)
- 852bbfafeefc51b8476deaa8d5aee0c8a29bee57 [native]Advance velox version (xiaoxmeng)
- 255e2fa189ad31892056a79187d5cf29b9d6e6e7 Track information about named common table expressions in the query (Lyublena Antova)
- 7550889bd51ae5e3ebf7e38ef1df825ea870bead Add unit test for memory limit in spillable hash aggregation operator when trigger rehash. (wangd)
- d79e4adf91278dce293bc597ef15f615f386310a Fix memory reservation accounting problem about InMemoryHashAggregationBuilder inside SpillableHashAggregationBuilder. (wangd)
- 16ff15f7584bfe980a8c673b37f3e9c3d89bf248 Fix structural type rendering issue (Gary Ho)
- 6c3e43cd5ec0f5bd537d8052a9df12a43dd36612 fix a bug when use parquet column index filter (8dukongjian)
- cecd33bbfafd126b3ce3ed61f80b6019662517da [native] Log spill stats when available. (Amit Dutta)
- d877e7c58b715d56821d53572d667bf09390e7ba Rewrite CROSS JOIN with array not contains predicate into an anti join (Lyublena Antova)
- 8520615cfd0535b7e563bf04dfe891664d7bd8c9 Add support for parallel parsing of partition values (Nikhil Collooru)
- 86f6a64911f72abc6e1e9b8812d7cc686c9f63f2 dashboard: update webpack to v5 (Yihong Wang)
- e83393c31015f71e91a0bfc71b03bdd1af8269b8 Add unit test for query stats calculation about input and output. (wangd)
- 581152020ee549d405f11977e3eaa5c36703f67f Fix rawInputPositions in DriverStats. (wangd)
- 274c3a6a484217cd90bd7584ce770956abb2e7f3 Refactor query stats calculation about processedInputDataSize and processedInputPositions. (wangd)
- 232bc97c4b6461c33f8b121c38a9d7368d935c1e [native] Add e2e tests for accessing fields of a struct type (Pratik Joseph Dabre)
- f0f3f34f3663a10bf907a4bfaa3813b56a6eb852 [native] Fix plan conversion for IN (<complex type values>) (Masha Basmanova)
- c21fc28846252cd910d90f046514bf586d7bb5c6 [native] Remove spill console logging in periodic task manager. (Amit Dutta)
- 0faa3522416b950cdbbade73a1b95b2025948b14 Improve docs for iceberg nessie catalog (pratyakshsharma)
- 4dd461ff29c2ddda3e29a8a0dc3a4df5ec1bdf73 Add DeleteFile in IcebergSplit for execution with Velox (Reetika Agrawal)
- 77cfe0443a12fdb43463129859388379295c130a Addional parameters in IcebergSplit for execution with Velox (Reetika Agrawal)
- b0428058e4932a97e8ba43f02f44c8a20d78e829 [native] Add doc link to prestissimo page on develop ToC (Christian Zentgraf)
- 197db06fb8d5dad4f01ec23fbe062a6400fc3489 [native] Support host or Ip in exchange client.. (Amit Dutta)
- 98011c37bb93e93fe63d44dea470931b26af5007 Fix bug in pull up expression in lambda rule (feilong-liu)
- e2e81df608e6f3bf342e6608999f7ee6fc2238ae [native] Upgrade PrestoExchangeSource to report number of bytes received (Masha Basmanova)
- 89c15fc626d4b30a24e1eee037665007b7dd6125 [native]Advance velox version (xiaoxmeng)
- ec46076d0823b809304ad52210123adffb1cf096 Add snapshot to presto-verifier (v-jizhang)
- 0ef294e39791e262eb4db591b96912ef5c65e4c1 [native] Move testDereference to a general native test (Kevin Wilfong)
- a1517ad46ed99d3ea9f3fb9f335d44d6de446968 Fix a bug in randomize null varchar join key for outer join optimization (feilong-liu)
- 3d3b1d00bfeefeb845c6d3c86b5dd23098e39864 Improve Comparison Operator and function Document for IN operator (kedia,Akanksha)
- 13b2f5c6928167450768bda01e62caf9003ba4ce [native] Fix path to json in protocol template and update generated files (Christian Zentgraf)
- 96b96a82096ea26d4156f6f777ee628d0c828d4b Expose stripe footers in OrcReader (Sergii Druzkin)
- 9c7c230453e86ea1f7a62d184c5d05c9fa49248a Adding Principal name in resource group selector criteria (Swapnil Tailor)
- 0419278f8737e48da0b7875be9d9f1373eaa24fb [native] Skip redundant Ip object to string conversion. (Amit Dutta)
- 5ec2f3908ca4f7ac17b70137f91726193963b9eb CLA sign (Jobbine)
- a4d14b79fef13b7b5f4344bb238cd1e20c110a5b [native] Pass serde parameters to Velox split (Zac)
- b955d5a8ff8289843417c44f49419a51574dd924 [native] Treat http 204 as announcement success (Pranjal Shankhdhar)
- 6d701f3e42d32cd4895194c3fe5504b1a00875f6 [native] Advance Velox version (Zac)
- 4fb518d4fa29c1a58b70b21a1aa1a1029ab48ec6 [native] Use Velox DereferenceTypedExpr (Kevin Wilfong)
- 0edf92498e885c61cee073a5f55d0114444cb213 Disable flaky TestHiveDistributedQueriesWithOptimizedRepartitioning.testRunawayRegexAnalyzerTimeout (Masha Basmanova)
- ab55dd5bc7cd6a7b7a537e654d4e8d7c3d62afcc Disable flaky TestHiveRecoverableExecution.testCreateBucketedTable (Masha Basmanova)
- 8ba30d1101b7a0f3128eb89a79e4814ac31c4149 [native] Remove unused PrestoExchangeSource::supportsFlowControl API (Masha Basmanova)
- 82a89471dd7907ff43c0c3983bafbd598c88d03f [native] Fix announcment retry. (Amit Dutta)
- 6ca76cc32bf002cea3e1e5863089197cae37f06b [native] Fix e2e testing for normal_cdf (rrando901)
- e8872fb7d4e7e2b8174c0b747fa0d1b0443cc133 [native] Fix exchange client creation. (Amit Dutta)
- 417d3219eee9ac4c4d44f70f43ee432229763406 [native] Change nlohmann json location as done in PR 20619 (Amit Dutta)
- ea74ad495a399004b4beb904ce6ab3869919de1e [native] Print velox user error log upon failure during start up. (Amit Dutta)
- cfa66fcb4ecfed738707cf7cfe031ee4779c1a5a Add plan node hash to query complete event (feilong-liu)
- b27e1ace8cde2d78f0c1a6426ed4de4533374491 Revert "Track information about named common table expressions in the query" (Lyublena Antova)
- 9baeaf6379d3ab4368913b7b80569150fced1a12 Enlarge timeout value of testQueryOutputSizeExceeded test (feilong-liu)
- ad2d7596e0cbf17ce1ffba714e56b68467bdce43 [native] Fix E2E test framework for CDF functions (Ashwin Krishna Kumar)
- 565445bbc7ec3b38fb9dcc92050ce69a1f92e59b Document Set Digest functions (kedia,Akanksha)
- 26bd4a0e24762eb61b1e43a1a1ce903b54e5e5a7 [native] Advance velox version (Karteekmurthys)
- 2a882606ba0ce84d7ecbf9c957acb4cf31e1af8b [native] Future-proof TypeSignatureTest.cpp (Chengcheng Jin)
- f639d9870307edf6319f6b06abb58e7a7614b315 Remove overload version for hash_counts of Return type varchar (kedia,Akanksha)
- 4bf05e5b5cec5fc903ea51f55c7ac7e7351c71e6 Update README.md (Timothy Meehan)
- 950696ed1f4446a422926f10bd3f5550fc91ad2f [native] add E2E test for wilson_interval_* functions (Ashwin Krishna Kumar)
- b02dcaaec12480e7e1afcc1f700a4e29bdc2e1b8 [native] Add virtual destructor for PeriodicServiceInventoryManager (Amit Dutta)
- 79fc33cf5907efae18eef1953418e496bc26e598 Fix exception when array is NULL for RewriteConstantArrayContainsToInExpression rule (feilong-liu)
- 06603d9e659f24ee10e05551646a14590a23171f advance velox (Kevin Wilfong)
- c20175eb4c693337e0bdf1670c851114fa85f66c Add NOISY_COUNT_GAUSSIAN aggregation (Kien Nguyen)
- 4ad7dd71dec88116893a4fa4a9f31612cb6b0454 Fix Redis Hbo Provider docs (jaystarshot)
- 7bc90c68fe716658fdd7dba7fa38100444a2af54 [native]Avoid potential deadlock by moving presto task deletion out of task map lock (xiaoxmeng)
- 833ecd0c62d3fdcd4be90620edd2d18dbda41eb9 Add plan node id to query plan output (feilong-liu)
- c7afae9fa0973b8f2d642685742fb9ed4880e7ed [native] Add memory arbitrator metrics (Jialiang Tan)
- b825e03b931955d7d871cf9e7b58d98002a017bc [native pos] Add spilling logs for monitoring (xiaoxmeng)
- 4e51d8fc549867dc5ce596d4b80bc17706072564 Advance Velox (Jialiang Tan)
- 708dcd54276c00104c1d3cad262ab783b513c9cf [pos] Fix invalid argument exception in PhysicalResourceCalculator (Pratyush Verma)
- 08c67c919a921d630c7daed43490d23f7d116d30 Fix missing equals and hashCode in ORC BinaryStatistics (Sergii Druzkin)
- 3260288fbf9a4f8954ad9fdd06b41f36371b919a Add raw and storage sizes to DWRF ColumnStatistics (Sergii Druzkin)
- 10a4cb9bf981900013b127cdfdb14f35dffbd162 Exclude new time zone from TestTimeZoneUtils (kedia,Akanksha)
- 2735b57de097aa4f2394acb1a0b4ab30a6921de5 [native] Log connector config on worker startup (Pratyush Verma)
- c7d257fda6e9e2db2dc3b925fefe5683b049b324 Turn off PullUpExpressionInLambdaRules (feilong-liu)
- 01293f696c9aed537ce68672e22575a631fdd1fa Infer transitive inequality predicates in joins (Vivek)
- 3a0bcf2474724edb2e7a832c6be33f349a0fd71f Include ADD and MULTIPLY as commutative rewrites in ExpressionEquivalence (Vivek)
- c3b5ab5815efd53cf92fd7d451e5ce025c816adc Upgrade PostgreSQL JDBC driver version (dnskr)
- 3145f4e9ec2568c56c2af2217d14f0d29b44f8bf Add heartbeat manager (Pranjal Shankhdhar)
- 20090bc9bc714aeb28c3ffa7f3ff53ea09e46fae Skip access check for is null arguments (Rebecca Schlussel)
- 5514d25d0fd25a3cdfc913cb53b4c19434ee1835 Fix min max partial aggregation pushdown logic (Ajay George)
- c98aeedeff59d0b9c495ee9aabc876155d4145c7 Add general properties to jdbc based connectors (Reetika Agrawal)
- 8b2ae7676bd8ba783373aa2e742bdef278e0154b Return an error for presto iceberg connector for adding non-null column in alter table. (Ajay Gupte)
- 1309de02ace3c85952811084a22fe1282d4e589d Add decompression tests for LZ4 compressed parquet (Shubham Chaurasia)
- 57f6db9ad3e0a344629dd4ff9ef398eac2c6f830 Fix decompression for LZ4 compressed parquet (Shubham Chaurasia)
- b31bf182249715c8b73563af438e567a8e40f651 [native] Add node.internal-address to support hostname and FQDN (Mahadevuni Naveen Kumar)
- fc399fc09d74f28c77f2844a7b1aef92bca3e1e7 [native pos] Update ExchangeSources to use the new request API (Masha Basmanova)
- 5207f260c88902c033f9308d4200968fbe395a02 Add raw size to ORC column stats in simple column writers (Sergii Druzkin)
- ec25503d41dcf04869ae8ffbd1686b6721f3241d [native-pos]Fix memory config integer overflow and update the configs (xiaoxmeng)
- c914346ea546771a7378fc5e06b3faa628fdf06a [native] Fix spilling counter comments and remove unnecessary includes. (Amit Dutta)
- 0df463e2cc633be3fe59c906471626f26fad18a8 Revert D48578640: [presto][diff_train] [native] Change json location for reuse with other third parties (Jon Janzen)
- f31d65d452c3556d776bc5d8dc53e210340d26f9 Add support for memoizing the cluster stats (Nikhil Collooru)
- a4a7db81be7fcd85f87831d6e4b9fdfe754b4d0c Add storage size and raw size to ORC stats builders (Sergii Druzkin)
- 922468c7d92b155c3949c487ec9eeb811e1bb25c [Native] Add e2e for normal_cdf function (rrando901)
- 26935779bc50f3a9f2cf5df6f5b0cf4ecf3eae43 [native] Improve TaskManagerTest (Deepak Majeti)
- 3aa85ea3cfa8c1a9e717e786575ab491b07668e1 Track information about named common table expressions in the query (Lyublena Antova)
- a6fbf4d47ed8404c4d5a382586acb1417023793a Add testPartialAggregatePushdownDWRF integration test (Ajay George)
- 7e6113d2ae52a74123e56ef2546a87078c2ca81f Add DWRF to min, max filtering for special column types (Ajay George)
- d195d476431af3fc885881af37ad35cc31e508c1 [native] Add more logging in toJsonString() (Pranjal Shankhdhar)
- f0c79c3962387682671186320c90e3a3a73de9a8 Add e2e test for merge on empty Hyperloglog (Pramod)
- a3b6f0fe992f43491ee505e895d3e9c5c8cde4a4 Changes after addressing Review comments (Haritha K)
- fe63fa1306e87015ae92504ecfa4beae62c6b980 Enable ORC flat map writer by default (Sergii Druzkin)
- 80b4a06fbea130ab7274409851c526caf5af646d [Native] Add e2e for inverse_beta_cdf function (rrando901)
- 3ffb027999197165cde90393b57b01c63112f8ee fixed bigquery table not found error (adamzwakk)
- 1cdc23d94ce3c7da3b2cd0994b1624cf2d4f048d [native]Add to configure total query meomry usage enforced by arbitrator (xiaoxmeng)
- 354426df1f3a7ffc19148c61b2843eef5f043d2f [native] Fix type signature parser to allow numeric struct names (Masha Basmanova)
- 522593083a91bffd3e26dd50778b7eda5f9094f2 Add HTTP endpoint for node heartbeat (Pranjal Shankhdhar)
- ea40d8bc5711d31cc6d5002c788bebf11ea7ff8d [native]advance velox version (xiaoxmeng)
- 80b559f2e09d16e5115b50f8a49228a06e9c5f7e Rewrite array contains to in expression (feilong-liu)
- d2975047eb6f83817e808b122da0ead4c63c1beb Upgrade Prometheus JMX Exporter to 0.20.0 (dnskr)
- af12cfe223fc5ebcb98d60c8bc851867e73a2549 General clean up of the redis-hbo-provider tests (jaystarshot)
- 2e1dede32ce709e9ef15f764aa4f4776cb45a40e Fix TestHistoricalStatisticsSerde flaky test (jaystarshot)
- 7006abd9ae08c99142587a4bf06d779deb94b74f Fix #20310: Recognise empty directories with content-type octet-stream (Jalpreet Singh Nanda (:imjalpreet))
- 117562503611a4f325335b5bdd56df5f0a82f45b [native] Don't aquire taskMap lock when operting on prestoTask (Jialiang Tan)
- 3f1836e8118c42edaf00fb4b82eeb5eff52d22e7 [native] Change json location for reuse with other third parties (Christian Zentgraf)
- dfe245004163f018cee94420e4ca581b9e6ea883 Refactor logging for HBO (feilong-liu)
- 330e55e7132acfd4ea5424d79193537b45e92a6d Add session property to pick optimizers to enable runtime stats (feilong-liu)
- 1fda1368b1f16dc5e05f79640cc9ce837caf077d Support notification for host shutting down (abhiseksaikia)
- 7edd2c2366edf0867491ad1b6237066ac0fd3e4d Fix EXPLAIN(TYPE VALIDATE) of EXPLAIN queries (Rebecca Schlussel)
- 8499cd35657930a71d891eb0a5ef0d5917735ba1 docs deploy presto on Mac with Homebrew (Steve Burnett)
- 7743de07ea01634c125b19deffe2dab6aad1c4e9 Use track statistics flag to control hbo stats update (jaystarshot)
- fea80c96ddfe4dc42f79c3cff9294b88595275ce Refactor existing & add new details in Iceberg document (Reetika Agrawal)
- d40cd49e7f5be749f5bac1b0244c01a83713e8a7 [native] Add http endpoint latency filter (Jialiang Tan)
- 815bf40d7a18949c59eee7edf0d718ea86f9f21f [native]Add spill stats utilities and advance velox version (xiaoxmeng)
- 0155458f7b7dcff4e75b978d6245cdfa0cab9993 Added e2e test for gamma_cdf (Arun D Panicker)
- 93a29d362e9f15117b44ebac8bc2c52ea4f53246 Update q02.sql (xpengahana)
- 09a732df017d80a03cf738193c73e1fc1311f6a2 Add support for replace_first function (Avinash Jain)
- d878344d2badb888eb30e11734fc453179d1a82c [native] Add back cache counters (Pranjal Shankhdhar)
- cf3bfc08e1021b0af59d6148bf48737bfb15f9ec [Native] Advance Velox version (Karteekmurthys)
- ade693a73c09c8755284faef3da275b95579dd73 Pull expressions in lambda out (feilong-liu)
- 13be22d6e11a2d3c1388163ac751ff9adcfd9af4 [native] Make old_task_ms GFlag a config property. (Amit Dutta)
- 8dd969b32dbb33260cae9cdd3003ef8ddd697e68 [native]Remove old memory arbitrator config (xiaoxmeng)
- 0a09a99ab80ad03f520cad665fcba21993492275 [native-pos]Update memory arbitrator config (xiaoxmeng)
- ef930afa09fab46f793dd83fc9a4f37b887b526e [native] Generate timestamp filter based on plan (Zac)
- 7b10ab130f394fbe465685d8901a1ed18d3deea7 Added E2E testing for chi_squared_cdf() function (Krishna-Prasad-P-V)
- 6089f78c21053d94d24b0ae8bfd436c2cf076104 [native] Add function to get base spill directory. (Amit Dutta)
- 3362b7e7d1c05017832282251897adf7d565187f Fix CVE-2022-42889: Upgrade org.apache.commons:commons-text to 1.10.0 (kedia,Akanksha)
- 3013420793611470a2d73dafddc852be0ab369a2 Change ResourceGroup refresh executor thread name (Dongsheng Wang)
- 8bc6ece2079a0927f3044d317d76ec03083ecf80 Refactor PrestoConnection newConnectionWithSessionProperties (Ivan Millan)
- 6c2287d3f28b0354ef4066fe49dce7fd9735a58d Add iceberg table location property in SHOW CREATE TABLE (Jalpreet Singh Nanda (:imjalpreet))
- b3a6dc482b661950139b71940bf626d1a292d4fd [native] Add remote-function-server.catalog-name config parameter (Pedro Pedreira)
- 64ae83a708d31465767ddc53f93cd301c18edf4b Add number of NULL elements in hash table in operator stats (feilong-liu)
- 0785bc32e69d980bbd3722c0587924fb3fdbcf09 Fix a bug in the preprocess metadata (Rohit Jain)
- 20e31b24c17418ada6c5317660a8b4c389c272b1 [native]Advance velox version (xiaoxmeng)
- e2f35f8b77683f6681cd57fc3d0c61e8a7e34f0d Reduce locking contention on SqlStageExecution. (Dongsheng Wang)
- 1753d68eb75605c4a33f0cce9e417d05c412b01c [native] Add Prestissimo documentation page to Developer Guide (Pedro Pedreira)
- 6f332a3d4e701b5eb40e34ecfe600c6ea3b21b04 [Native] Add e2e testing for Decimal conversion (rrando901)
- 1d6a0bd1295cc9d56fb0e3397a374046c37ff626 Add cause to SemanticException when rethrowing (Rebecca Schlussel)
- c8ff68eefe44f1b1a340856a0368b9dac301f19e [native pos] Fix NPE in PrestoSparkQueryRunner (Shrinidhi Joshi)
- ee0e81dae84279f27679d46f2301b36fdb082138 [native] Support prefix and schema name when parsing json signatures (Pedro Pedreira)
- 45bf80a240af029d8a134be2c6222a696e3a7888 [native] Advance velox (Pedro Pedreira)
- bb977d912d03a0dba36b0d33b4c93edb0a685ec8 [native] Fix task delete remote source endpoint (Jialiang Tan)
- e04c9a8b12f6714e090f797986f7be83b49c3aaf [native] Add config parameters for remote function execution (Pedro Pedreira)
- d0905b26083660821c92db94b32a344fc9bda74f [native] Refactor setupJsonFunctionNamespaceManager (Pedro Pedreira)
- 0fa2debf5926c59a910aabf774cc14d1c7d05d3a doc: Add GitHub links in the localtoc (Yihong Wang)
- 9d24d67573dd061cb5b5d7f6d4f3b8e9a7bc257f Add operator estimated output to operator statistics (feilong-liu)
- 57a67468f8dfa3b3f9352b529e02555996e0e3cf Fix inappropriately set attribute of ParquetWriterOptions by IcebergFileWriterFactory. (wangd)
- 198c506c3e65f4f73ccc33cb9e49e21dfd0727b4 Add Redis HBO provider plugin (jaystarshot)
- 6465ee8a6b57e653606dca6ca433db54e3f1dc53 Update memory arbitrator config and advance velox version (xiaoxmeng)
- 15759827d992f174695f4ba3d646ff1659050679 Use Iceberg Metadata table's API for snapshot metadata table (Ajay Gupte)
- acdec1200c0baf8b1098aea5c63df364db59dac0 Remove title prefixes from issue template (Tim Meehan)
- 6ff4c539357f049a373eed82d95441721679be6d [native] Advance Velox version (Zac)
- c4b2e271b94a1bde14d3aeba58a561721dd13dc3 Support for better JSON casting (Amit Patil)
- ed010bc01cb7a5819872833ea033fcd0ad7bbd69 Add Thrift support for for SqlInvokedFunction and SqlFunctionId (SeanIFitch)
- 2e89ec77cb82506ac6d68ac122dfd053eaabecd8 Allow a custom metrics collector in s3FileSystem (Efrat Levitan)
- 9985b951b75bdfa4049d9e2dda0881995d5e8e20 add arraymerge tdigest function (Alex Perez)
- 76f45ee05f2d04537a8ac53a349b0d7458914d3a docs install Presto on Intel Mac using Homebrew (Steve Burnett)
- 459a8b0e87e22707720d1e3b0a884fd30eab36bd Fix ARRAY_SORT to use the correct API to read value for RealType (Sreeni Viswanadha)
- 3e6c87565127e7d27691f89db09d3c4509a693dc Allow null constantValues for OrcSelectiveRecordReader (#20542) (Darren Fu)
- 657a599f0d87e0e0ce8bd4414e43542fdf34beac [Native] Add e2e testing for f_cdf function (rrando901)
- 87cf51d6c432a4cf1bc58922ebcf125d94c7828c ci: fix matrix.modules case (Yihong Wang)
- 1c1855d02222e99f569742b827e6d805f2a8e62b [native] Add support for flow control to PrestoExchangeSource (Masha Basmanova)
- ccc8b134aaa526f768a060f0ddc2042e23446736 [native] Speed up PrestoExchangeSourceTestSuite::retryState and failedProducer (Masha Basmanova)
- e7589c2f88cad3e9fd05d5483002d9ad1dcdb7e6 [native] Extract helper function to setup mutable configs (Masha Basmanova)
- 603be39838189ad0a6554c9f7dd753adf30412d0 [native] Fix error message in exchange (Deepak Majeti)
- dc3b36279784ac3732a7076ff6de295a73c5c411 [native] Advance Velox (Masha Basmanova)
- 21b2f9028c239dec63fea38b58f230bab9c328e3 Upgrade hudi-presto-bundle (Sagar Sumit)
- 33bcfaf78d7392d53e4deaddf68e8fe7e70c31b4 Add committers as codeowners where missing (Rebecca Schlussel)
- 1df7df144e41337d5cf7b60fbdf29dc43259fae3 [native]Improve task manager shutdown logging (xiaoxmeng)
- 4ada10bbb765021c4daa8229d6b7878ebbee60d5 ci: fix typo for the presto-docs (Yihong Wang)
- 99576a98a857ab4d21b846b43a26a24278f2d6d4 Fix codenotify to work for PRs coming from forks (Rebecca Schlussel)
- cea8ab195d67cc798a0405b6c7a21edcd4aa9722 [native] Remove legacy task id parsing and tests. (Amit Dutta)
- 0ddccd7ba37c60305f181ff9f084d5cf4079509b ci: use jobs.<job_id>.if (Yihong Wang)
- db1732671b6880a940bb1d05eec444fb00615634 [native] Fix In predicate construction for DATE types (aditi-pandit)
- 77d259100306e750cc521ca64fd03602981b855f fix a typo in LocalExceptionPlanner (Yihong Wang)
- adbeef75524db87284413d44b7965d58bfa7b761 Split Iceberg tests from test-other-modules.yml (Tim Meehan)
- 2a54d1254b3d44728ee0ead02412d19368b5b504 Fix some incorrectness in comment. (wangd)
- 221c5cd732ee477bf088d137c4b99f53115f544e Remove useless code in LocalExecutionPlanner. (wangd)
- 095499c4837376db85349582111c92db4ef7a33f Add CODENOTIFY file for document changes (Tim Meehan)
- 7805bf0d451fe336afa77827e0697ab7ac2353ee Pass in Aggregation Node for Table Merge (Ke)
- c516ffa1a88b98b5a99369a1394b875b360ffe04 Advance velox version (Ke)
- c1c5f96cced2dea97799639990baeb89a6192f48 Make TestFileMergeCacheManager single threaded (Tim Meehan)
- 14811165a28b49e54ecbf09ff042103f28e42892 ci: simplify GH actions for doc change (Yihong Wang)
- 4bf581fbd1cfba830f92f1a4509dfb39745a7ee3 [native] Drop cast to CodePoints (Masha Basmanova)
- 8a9e1b6feae2d6caea3d2723c5d6a129448052bb Automated submodule update: velox (Facebook Community Bot)
- 5dfc8a0c6f165ab78bde27bb03f108df2977a354 [native] Re-factor cache initialization logging. (Amit Dutta)
- 7db13977e8c4c033f94f4954de096bf4d29e7dca docker command line install on OS X (Steve Burnett)
- cd6936961cdbb5ecce34f29854794379ed119dae [native] Enable remote function compilation and test on CI (Pedro Pedreira)
- 832a5c1e1c19204168960c6f1b6b0d590b2b231b Added new file for CDF functions (GOPU-Krishna-S)
- e2940203bead63da6c659483caa0d0295776b380 Added e2e test for binomial_cdf and cauchy_cdf (GOPU-Krishna-S)
- 81c4819c1b42a4fa16205e2af5a3e841c82e99ce Document 2-arg versions of trim functions (Masha Basmanova)
- 9a1e6acc520e0d3a754f2826644dcadb56fb6bab [native] Add link to wiki for troubleshooting (Christian Zentgraf)
- d4bc6c523c0b282bb7bbc21213d44e194f54e23e Fix infinity value for double/float partition columns (Ajay Gupte)
- dab79a9bedbdc74d3ffad6af7f2e474278629b35 Fix NaN value for double/float partition columns (Ajay Gupte)
- c73efd7977b1f413004d4be06e6a2ef4a92529d3 Remove useless code. (wangd)
- dd58b9243df331000c9deb52b4d36062c5a614b1 [native] Add plan node type in file format error (Jimmy Lu)
- 6306290fb92223c51185efdc694f7dcaeb9ff020 Use updated testcontainers dependency across all modules (Zac Blanco)
- 0f20bc1aee4a7c4a224f66a7c89d5d511ae1a9e5 [native]Fix async data cache shutdown (xiaoxmeng)
- a44e96e8037038482dffc1c2272c743e823b6e87 [native] Advance Velox and fixes for API changes (Pedro Pedreira)
- f43d0883de5cf97b1f442f4f1ae21e54d13a595d [Native] Some cleanup of cache stats reporting (Ge Gao)
- a2a906a452870a6f7a6ce788eb45289e608abe97 [presto][native] Add memory cache hit bytes metric (Pranjal Shankhdhar)
- 6685283d909d97967d1b928b5c5b99be4f2398c0 Revert "Update Drift dependency to use Header transport by default" (Shrinidhi Joshi)
- 0a7d31ad0afd46c2ee5bf87df29e613b9711efdb [native] Track process-wide CPU usage for the native process (Masha Basmanova)
- 7773b136522491471fc92de657cd75187122640e [native pos] Track process-wide CPU usage for the JVM process (Masha Basmanova)
- ba54169d4d911273add314fd25a7814fe48fa9d5 Refactor UseTask for readability (Ajay George)
- 9ee54a348538fd9bc2cb88bd886fed5cbf044986 Refactor SessionTransactionControlTask for readability (Ajay George)
- 95fd2687388bfc3ffcceb4beb8d124b0c6bdfdca Refactor StateMachine to remove redundant wording (Ajay George)
- 464b210c8c92f13d04d5995ee21b95966a523ced [native] Remove Protobuf dependency (Deepak Majeti)
- b9326a2b71537c3b2174c5df08e34992369f820e [native] Add e2e test for timestamp cast (Zac)
- 0515f186a8d3bf3412dfef4335a707ad2f9b0f57 [native]Advance velox version and update spill configs (xiaoxmeng)
- f9738334a4178b50e3780df0de84135599ac9bfe Optimize simple prefix and suffix LIKE expressions (Sreeni Viswanadha)
- a9ea75e3c4111306c8f51391ec343b154ee6e00a [native pos] Preserve plan node IDs for shuffle nodes (Masha Basmanova)
- 3b4cc9153a12dc87f34087a2a49829b072529554 Add newConnectionWithSessionProperties method (Ivan Millan)
- a18b153b67900c1351ef76aae562a844306ef1de Disable flaky memory.TestMemoryManager#testOutOfMemoryKillerMultiCoordinator (Masha Basmanova)
- d1b17dd303f1f753a885352c1c0b45cbeafb41df [native] Prepare for changes in ExchangeQueue::dequeueLocked (Masha Basmanova)
- 7b9e8fb4e6d74553cb91bbcf45a4090ad3b259dc Disable flaky tests.TestQueryManager#testQueryCountMetrics (Masha Basmanova)
- a76ec1e5426a30ac0b54eda1182683dd373ee13b [native] Add support for multimap_agg function (Masha Basmanova)
- 8f004ad5db97902edd141c358e4ffba2a5f0bcf8 [native] Add e2e tests for min(x, n) and max(x, n) functions (Masha Basmanova)
- 17904bd516d242d14a5bac6cb428fcd82b2a0ac6 Update Iceberg Tranform API calls (s-akhtar-baig)
- fb5afdc532f3248b49302a4bdf0dbe406903882b Add a standard pull request template (Rohan Pednekar)
- 18b5fec0edbd4fbac0d75dfc396427053cf04743 [native] Adding RemoteFunctionRegisterer (#20335) (Pedro Eugenio Rocha Pedreira)
- f909f303d55abf6050825df5c2b97346ebf20cd0 Add available table properties to Iceberg Connector Documentation (imjalpreet)
- c1dd4b5b0e679c58e31f969c71be2095609aa18d Reduce dns lookup overhead on NodeScheduler (guhanjie)
- d3cd54a0e9dd6bfcc608ca29c4905a6f43b9be31 Specialize ARRAY_SORT for simple types (Sreeni Viswanadha)
- c1110995594b7c31f35131e389c4d622b4c16cc1 [Native] Pass CompressionKind in HiveInsertTableHandle (Ke)
- 9ddcb22ef0f8f3d946cfa056c9c730ae6f754821 [native pos] revert taskmetrics update to end of task (Shrinidhi Joshi)
- 1989029f09d18cf08249c3d33dfa0278a99ac6b6 [native] Add e2e tests for global aggregate with no grouping keys and no aggregates. (Amit Dutta)
- 279b448d65eeaed5a4dea19e08aed15f1e341104 update docs for presto cli (Steve Burnett)
- 848229e10d715bc7ba686181b7e60234772eb56f [native pos] Add arbitration and disk spilling related configs (xiaoxmeng)
- 4975aaf49d0e85668ca08ca0507f23162560f6d3 Fix typo in config.yml (Timothy Meehan)
- 5ede06f8f65bc1ac0cd5b41d426c14c0e67379e4 [native] Advance Velox Version (Jialiang Tan)
- 35303b10ecbcb442e80ea57f366e87a3a134e957 Combine MemoryManagerOptions with Arbitrator::Config (#5802) (Deepak Majeti)
- c094a43763640aeae81cdc6cfcc80ec1d4cb6223 Fixing query failure due to selector missing (Swapnil Tailor)
- a7ad2d7e6f7dbe5d66ab75884f63c01e6c3c277a [native] Populate async data cache counters (Pranjal Shankhdhar)
- abf17bce799d8a940e98a521a90d483ad1795bdb [Native] Remove incorrect updating of outputBufferUtilization (Ke)
- a2757827e3748fa92cb6ccfcad458b50ac9ba366 Bump Iceberg from 1.3.0 to 1.3.1 (Eduard Tudenhoefner)
- 771598dc0c0266d8a1c197704a2294f7cd2dbd57 update issue_template files (Rohan Pednekar)
- 2085484d8ca7341118b1df8d94b3862f6b2be516 [native] Fix and re-enable testRowNumberWithFilter test (Christian Zentgraf)
- b518c030b76c8dee7570bfe2afe33cf1565e5079 Revert "Upgrade Alluxio to 2.9.3" (Zac)
- 3a5f84c5732da0023eb91f92879f01279f99ee9a Fix flaky test (Swapnil Tailor)
- 6bfc49b76f21ad4b657d1eff5c211d4c22675146 [native] Advance Velox version (Jialiang Tan)
- d9c0383059ca3db41ed93cba974068e85bdccf6d [native] Add e2e test for array_union function (Zac)