### PR TITLE
secrets management support in presto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
         <module>presto-open-telemetry</module>
         <module>redis-hbo-provider</module>
         <module>presto-singlestore</module>
+        <module>presto-vault</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-docs/src/main/sphinx/develop/secrets-manager.rst
+++ b/presto-docs/src/main/sphinx/develop/secrets-manager.rst
@@ -1,0 +1,40 @@
+=====================
+Secrets Manager
+=====================
+
+Presto supports Custom Secrets Manager Plugins to retrieve secrets from secrets manager implementations of users' choice.
+By default, Hashicorp Vault is integrated as part of presto-vault module. More implementations can be plugged into the framework by extending
+the Presto SPI.
+
+
+Implementation
+--------------
+
+``SecretsManagerFactory`` is responsible for creating a
+``SecretsManager`` instance. It also defines a ``SecretsManager``
+name which is used by the administrator in a Presto configuration.
+
+``SecretsManager`` implementations have the responsibility to:
+
+* Read relevant configurations for connecting to the secrets manager service.
+* Fetch the secrets for all catalogs that require secrets manager.
+
+The implementation of ``SecretsManager`` and ``SecretsManagerFactory``
+must be wrapped as a plugin and installed on the Presto cluster.
+
+Configuration
+-------------
+
+After a plugin that implements ``SecretsManager`` and
+``SecretsManagerFactory`` has been installed on the coordinator, it is
+configured using an ``etc/secrets-manager.properties`` file.
+
+The ``secrets-manager.name`` property is used by Presto to find a registered
+``SecretsManagerFactory`` based on the name returned by
+``SecretsManagerFactory.getName()``. Remaining configuration needed by the custom implementation should be loaded from plugin code itself.
+
+Example configuration file:
+
+.. code-block:: none
+
+    secrets-manager.name=custom-secrets-manager

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -50,7 +50,8 @@ plugin.bundles=\
   ../presto-node-ttl-fetchers/pom.xml,\
   ../presto-hive-function-namespace/pom.xml,\
   ../presto-delta/pom.xml,\
-  ../presto-hudi/pom.xml
+  ../presto-hudi/pom.xml,\
+  ../presto-vault/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-main/etc/secrets-manager.properties
+++ b/presto-main/etc/secrets-manager.properties
@@ -1,0 +1,1 @@
+secrets-manager.name=none

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.secretsManager.SecretsManagerHandler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -23,10 +24,12 @@ import com.google.common.io.Files;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.util.PropertiesUtil.loadProperties;
@@ -36,25 +39,31 @@ import static com.google.common.base.Preconditions.checkState;
 public class StaticCatalogStore
 {
     private static final Logger log = Logger.get(StaticCatalogStore.class);
+    public static final String SECRETS_MANAGER_ENABLED = "secretsManager.enabled";
+    public static final String CONNECTOR_NAME = "connector.name";
+    private static final Map<String, Map<String, String>> secrets = new ConcurrentHashMap<>();
+
     private final ConnectorManager connectorManager;
     private final File catalogConfigurationDir;
     private final Set<String> disabledCatalogs;
     private final AtomicBoolean catalogsLoading = new AtomicBoolean();
     private final AtomicBoolean catalogsLoaded = new AtomicBoolean();
+    private final SecretsManagerHandler secretsManagerHandler;
 
     @Inject
-    public StaticCatalogStore(ConnectorManager connectorManager, StaticCatalogStoreConfig config)
+    public StaticCatalogStore(ConnectorManager connectorManager, StaticCatalogStoreConfig config, SecretsManagerHandler secretsManagerHandler)
     {
         this(connectorManager,
                 config.getCatalogConfigurationDir(),
-                firstNonNull(config.getDisabledCatalogs(), ImmutableList.of()));
+                firstNonNull(config.getDisabledCatalogs(), ImmutableList.of()), secretsManagerHandler);
     }
 
-    public StaticCatalogStore(ConnectorManager connectorManager, File catalogConfigurationDir, List<String> disabledCatalogs)
+    public StaticCatalogStore(ConnectorManager connectorManager, File catalogConfigurationDir, List<String> disabledCatalogs, SecretsManagerHandler secretsManagerHandler)
     {
         this.connectorManager = connectorManager;
         this.catalogConfigurationDir = catalogConfigurationDir;
         this.disabledCatalogs = ImmutableSet.copyOf(disabledCatalogs);
+        this.secretsManagerHandler = secretsManagerHandler;
     }
 
     public boolean areCatalogsLoaded()
@@ -71,6 +80,11 @@ public class StaticCatalogStore
     public void loadCatalogs(Map<String, Map<String, String>> additionalCatalogs)
             throws Exception
     {
+        final String secretsManagerName = secretsManagerHandler.getSecretsManagerName();
+        if (secretsManagerName != null && !"none".equalsIgnoreCase(secretsManagerName)) {
+            log.info("-- Fetching secrets from  %s --", secretsManagerName);
+            secrets.putAll(secretsManagerHandler.loadSecrets(secretsManagerName));
+        }
         if (!catalogsLoading.compareAndSet(false, true)) {
             return;
         }
@@ -93,7 +107,7 @@ public class StaticCatalogStore
 
         log.info("-- Loading catalog properties %s --", file);
         Map<String, String> properties = loadProperties(file);
-        checkState(properties.containsKey("connector.name"), "Catalog configuration %s does not contain connector.name", file.getAbsoluteFile());
+        checkState(properties.containsKey(CONNECTOR_NAME), "Catalog configuration %s does not contain connector.name", file.getAbsoluteFile());
 
         loadCatalog(catalogName, properties);
     }
@@ -107,21 +121,36 @@ public class StaticCatalogStore
 
         log.info("-- Loading catalog %s --", catalogName);
 
+        Map<String, String> catalogSecrets = getSecretsForCatalog(properties, catalogName);
         String connectorName = null;
         ImmutableMap.Builder<String, String> connectorProperties = ImmutableMap.builder();
         for (Entry<String, String> entry : properties.entrySet()) {
-            if (entry.getKey().equals("connector.name")) {
+            if (entry.getKey().equals(CONNECTOR_NAME)) {
                 connectorName = entry.getValue();
             }
-            else {
+            else if (!entry.getKey().equals(SECRETS_MANAGER_ENABLED) && !catalogSecrets.containsKey(entry.getKey())) {
+                // Ignore the secrets manager properties & keys present in secrets to avoid unnecessary/duplicate binding later
                 connectorProperties.put(entry.getKey(), entry.getValue());
             }
         }
-
+        // Remove connector name from secrets if present
+        catalogSecrets.remove(CONNECTOR_NAME);
+        connectorProperties.putAll(catalogSecrets);
         checkState(connectorName != null, "Configuration for catalog %s does not contain connector.name", catalogName);
 
         connectorManager.createConnection(catalogName, connectorName, connectorProperties.build());
         log.info("-- Added catalog %s using connector %s --", catalogName, connectorName);
+    }
+
+    private Map<String, String> getSecretsForCatalog(Map<String, String> properties, String catalogName)
+    {
+        if (properties.containsKey(SECRETS_MANAGER_ENABLED) && "true".equalsIgnoreCase(properties.get(SECRETS_MANAGER_ENABLED))) {
+            if (secrets.containsKey(catalogName)) {
+                return secrets.get(catalogName);
+            }
+            log.warn("No secrets fetched for catalog %s. Check the Secrets Manager Configuration", catalogName);
+        }
+        return Collections.emptyMap();
     }
 
     private static List<File> listFiles(File installedPluginsDir)

--- a/presto-main/src/main/java/com/facebook/presto/secretsManager/SecretsManagerHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/secretsManager/SecretsManagerHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.secretsManager;
+
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class SecretsManagerHandler
+{
+    private final Map<String, SecretsManagerFactory> secretsManagerFactories = new ConcurrentHashMap<>();
+
+    private static final File SECRETS_MANAGER_CONFIGURATION = new File("etc/secrets-manager.properties");
+
+    private static final String SECRETS_MANAGER_PROPERTY_NAME = "secrets-manager.name";
+
+    private static final Map<String, String> secretsManagerProperties = new ConcurrentHashMap<>();
+
+    /**
+     * Add the secretsmanagerfactory object from plugin to the map
+     * @param secretsManagerFactory
+     */
+    public void addSecretsManagerFactory(SecretsManagerFactory secretsManagerFactory)
+    {
+        requireNonNull(secretsManagerFactory, "secretsManagerFactory is null");
+
+        if (secretsManagerFactories.putIfAbsent(secretsManagerFactory.getName(), secretsManagerFactory) != null) {
+            throw new IllegalArgumentException(format("SecretsManager implementation '%s' is already registered", secretsManagerFactory.getName()));
+        }
+    }
+
+    /**
+     * Creates an instance of configured secrets manager implementation and invokes the fetchSecrets()
+     * @param secretsManagerName
+     * @return Map of secretsId & secrets
+     * @throws IOException
+     */
+
+    public Map<String, Map<String, String>> loadSecrets(String secretsManagerName) throws IOException
+    {
+        requireNonNull(secretsManagerName, "secretsManagerName is null");
+        SecretsManagerFactory secretsManagerFactory = secretsManagerFactories.get(secretsManagerName);
+        checkArgument(secretsManagerFactory != null, "No factory for SecretsManager %s", secretsManagerName);
+        return secretsManagerFactory.create().fetchSecrets();
+    }
+
+    /**
+     * Loads the configuration for secrets manager
+     * @throws IOException
+     */
+    public void loadConfiguredSecretsManager() throws IOException
+    {
+        if (SECRETS_MANAGER_CONFIGURATION.exists()) {
+            secretsManagerProperties.putAll(loadProperties(SECRETS_MANAGER_CONFIGURATION));
+            checkArgument(
+                    !isNullOrEmpty(secretsManagerProperties.get(SECRETS_MANAGER_PROPERTY_NAME)),
+                    "Secrets Manager configuration %s does not contain %s",
+                    SECRETS_MANAGER_CONFIGURATION.getAbsoluteFile(),
+                    SECRETS_MANAGER_PROPERTY_NAME);
+        }
+    }
+
+    /**
+     * Return the loaded secrets manager implementation name
+     * @return
+     */
+    public String getSecretsManagerName()
+    {
+        return secretsManagerProperties.get(SECRETS_MANAGER_PROPERTY_NAME);
+    }
+
+    @VisibleForTesting
+    public void loadSecretsManagerConfiguration(Map<String, String> properties) throws IOException
+    {
+        secretsManagerProperties.putAll(properties);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/secretsManager/SecretsManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/secretsManager/SecretsManagerModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.secretsManager;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class SecretsManagerModule
+        implements Module
+{
+    /**
+     * Binds the Handler(Manager) Class
+     * @param binder
+     */
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(SecretsManagerHandler.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.secretsManager.SecretsManagerHandler;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.spi.Plugin;
@@ -36,6 +37,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
@@ -125,6 +127,7 @@ public class PluginManager
     private final TracerProviderManager tracerProviderManager;
     private final AnalyzerProviderManager analyzerProviderManager;
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
+    private final SecretsManagerHandler secretsManagerHandler;
 
     @Inject
     public PluginManager(
@@ -145,7 +148,8 @@ public class PluginManager
             ClusterTtlProviderManager clusterTtlProviderManager,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
             TracerProviderManager tracerProviderManager,
-            NodeStatusNotificationManager nodeStatusNotificationManager)
+            NodeStatusNotificationManager nodeStatusNotificationManager,
+            SecretsManagerHandler secretsManagerHandler)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -176,6 +180,7 @@ public class PluginManager
         this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
         this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
+        this.secretsManagerHandler = requireNonNull(secretsManagerHandler, "secretsManagerHandler is null");
     }
 
     public void loadPlugins()
@@ -325,6 +330,11 @@ public class PluginManager
         for (NodeStatusNotificationProviderFactory nodeStatusNotificationProviderFactory : plugin.getNodeStatusNotificationProviderFactory()) {
             log.info("Registering node status notification provider %s", nodeStatusNotificationProviderFactory.getName());
             nodeStatusNotificationManager.addNodeStatusNotificationProviderFactory(nodeStatusNotificationProviderFactory);
+        }
+
+        for (SecretsManagerFactory secretsManagerFactory : plugin.getSecretsManagerFactories()) {
+            log.info("Registering secretsManager factory %s", secretsManagerFactory.getName());
+            secretsManagerHandler.addSecretsManagerFactory(secretsManagerFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -41,6 +41,8 @@ import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
+import com.facebook.presto.secretsManager.SecretsManagerHandler;
+import com.facebook.presto.secretsManager.SecretsManagerModule;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
@@ -133,7 +135,8 @@ public class PrestoServer
                 new TempStorageModule(),
                 new QueryPrerequisitesManagerModule(),
                 new NodeTtlFetcherManagerModule(),
-                new ClusterTtlProviderManagerModule());
+                new ClusterTtlProviderManagerModule(),
+                new SecretsManagerModule());
 
         modules.addAll(getAdditionalModules());
 
@@ -146,6 +149,7 @@ public class PrestoServer
 
             ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
 
+            injector.getInstance(SecretsManagerHandler.class).loadConfiguredSecretsManager();
             if (!serverConfig.isResourceManager()) {
                 injector.getInstance(StaticCatalogStore.class).loadCatalogs();
             }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -133,6 +133,7 @@ import com.facebook.presto.resourcemanager.ResourceManagerClusterStatusSender;
 import com.facebook.presto.resourcemanager.ResourceManagerConfig;
 import com.facebook.presto.resourcemanager.ResourceManagerInconsistentException;
 import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
+import com.facebook.presto.secretsManager.SecretsManagerHandler;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
 import com.facebook.presto.server.thrift.ThriftServerInfoClient;
@@ -589,6 +590,9 @@ public class ServerMainModule
         // page sink provider
         binder.bind(PageSinkManager.class).in(Scopes.SINGLETON);
         binder.bind(PageSinkProvider.class).to(PageSinkManager.class).in(Scopes.SINGLETON);
+
+        // secrets manager handler
+        binder.bind(SecretsManagerHandler.class).in(Scopes.SINGLETON);
 
         // metadata
         binder.bind(StaticCatalogStore.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -118,6 +118,7 @@ import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.secretsManager.SecretsManagerHandler;
 import com.facebook.presto.server.ConnectorMetadataUpdateHandleJsonSerde;
 import com.facebook.presto.server.NodeStatusNotificationManager;
 import com.facebook.presto.server.PluginManager;
@@ -506,7 +507,8 @@ public class LocalQueryRunner
                 new ThrowingClusterTtlProviderManager(),
                 historyBasedPlanStatisticsManager,
                 new TracerProviderManager(new TracingConfig()),
-                new NodeStatusNotificationManager());
+                new NodeStatusNotificationManager(),
+                new SecretsManagerHandler());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main/src/test/java/com/facebook/presto/secretsManager/TestSecretsManagerHandler.java
+++ b/presto-main/src/test/java/com/facebook/presto/secretsManager/TestSecretsManagerHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.secretsManager;
+
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestSecretsManagerHandler
+{
+    public static final String INVALID = "invalid";
+    private SecretsManagerHandler testSecretsManagerHandler;
+
+    @BeforeClass
+    public void setup() throws IOException
+    {
+        testSecretsManagerHandler = new SecretsManagerHandler();
+        SecretsManagerFactory factory = new TestingSecretsManagerFactory();
+        testSecretsManagerHandler.addSecretsManagerFactory(factory);
+        testSecretsManagerHandler.loadSecretsManagerConfiguration(ImmutableMap.of("secrets-manager.name", "test-secrets-manager"));
+    }
+
+    @Test
+    public void testLoadSecrets() throws IOException
+    {
+        Map<String, Map<String, String>> secrets = testLoadSecrets(testSecretsManagerHandler.getSecretsManagerName());
+        assertEquals(secrets.size(), 1);
+    }
+    @Test
+    public void testInvalidSecretsManager() throws IOException
+    {
+        assertThrows(RuntimeException.class, () -> testLoadSecrets(INVALID));
+    }
+
+    @Test
+    public void testInvalidConfig() throws IOException
+    {
+        SecretsManagerFactory factory = new InvalidSecretsManagerFactory();
+        testSecretsManagerHandler.addSecretsManagerFactory(factory);
+        assertThrows(RuntimeException.class, () -> testLoadSecrets(INVALID));
+    }
+
+    private Map<String, Map<String, String>> testLoadSecrets(String secretsManager) throws IOException
+    {
+        return testSecretsManagerHandler.loadSecrets(secretsManager);
+    }
+
+    private class InvalidSecretsManagerFactory
+            implements SecretsManagerFactory
+    {
+        @Override
+        public String getName()
+        {
+            return INVALID;
+        }
+
+        @Override
+        public SecretsManager create()
+        {
+            return null;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/secretsManager/TestingSecretsManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/secretsManager/TestingSecretsManager.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.secretsManager;
+
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class TestingSecretsManager
+        implements SecretsManager
+{
+    public static final String TESTADM = "testadm";
+
+    @Override
+    public Map<String, Map<String, String>> fetchSecrets()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("test-username", TESTADM)
+                .put("test-password", TESTADM).build();
+
+        Map<String, Map<String, String>> secrets = ImmutableMap.of(UUID.randomUUID().toString(), properties);
+        return secrets;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/secretsManager/TestingSecretsManagerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/secretsManager/TestingSecretsManagerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.secretsManager;
+
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+
+public class TestingSecretsManagerFactory
+        implements SecretsManagerFactory
+{
+    @Override
+    public String getName()
+    {
+        return "test-secrets-manager";
+    }
+
+    @Override
+    public SecretsManager create()
+    {
+        return new TestingSecretsManager();
+    }
+}

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -372,6 +372,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-vault</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -212,5 +212,9 @@
             <directory>${project.build.directory}/dependency/presto-clickhouse-${project.version}</directory>
             <outputDirectory>plugin/clickhouse</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/presto-vault-${project.version}</directory>
+            <outputDirectory>plugin/vault</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
@@ -136,4 +137,9 @@ public interface Plugin
     {
         return emptyList();
     }
+
+    default Iterable<SecretsManagerFactory> getSecretsManagerFactories()
+    {
+        return emptyList();
+    };
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/secretsManager/SecretsManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/secretsManager/SecretsManager.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.secretsManager;
+
+import java.util.Map;
+
+public interface SecretsManager
+{
+    /**
+     * Fetches the secrets from the configured secrets manager
+     * @return Map of secretId & secrets
+     */
+    Map<String, Map<String, String>> fetchSecrets();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/secretsManager/SecretsManagerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/secretsManager/SecretsManagerFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.secretsManager;
+
+public interface SecretsManagerFactory
+{
+    /**
+     * Return the name of SecretsManagerFactory
+     * @return Name of Secretmanager implementation
+     */
+    String getName();
+
+    /**
+     * Create and return an instance of SecretsManager
+     * @return Instance of SecretsManager implementation
+     */
+    SecretsManager create();
+}

--- a/presto-vault/README.md
+++ b/presto-vault/README.md
@@ -1,0 +1,24 @@
+# Vault Secrets Manager Plugin for Presto
+
+This is an implementation for the Secrets Manager Plugin of Presto using the Hashicorp Vault.
+
+### Setting Secrets Manager Properties
+
+Update the etc/secrets-manager.properties, with below configuration.
+
+    secrets-manager.name=vault
+
+Set the below environment variables for the Vault Secrets Manager Plugin.
+
+    export VAULT_ADDR={Vault URL}
+    export VAULT_TOKEN={Root token to access Vault}
+    export VAULT_SECRET_KEYS={Comma seperated list of catalog names, for which secrets manager is enabled}
+
+### Configuring Secrets
+
+In the sample configuration above, we are specifying a list of secret keys aka catalog names for which secrets are to be fetched. The secrets for each catalog needs to be configured in the Vault as a Key-Value secret and the property secrets-manager.enabled should be set to true in the catalog property file.
+
+#### etc/catalog/[connector].properties
+
+    secretsManager.enabled=true
+    [Other connector specific properties if any]

--- a/presto-vault/pom.xml
+++ b/presto-vault/pom.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.285-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-vault</artifactId>
+    <description>Presto - IBM SecretManager Plugin</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.bettercloud</groupId>
+            <artifactId>vault-java-driver</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>testing-mysql-server-5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>testing-mysql-server-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override" />
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManager.java
+++ b/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManager.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.response.LogicalResponse;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class VaultSecretsManager
+        implements SecretsManager
+{
+    private static final Logger log = Logger.get(VaultSecretsManager.class);
+    private final VaultSecretsManagerConfig config;
+
+    @Inject
+    VaultSecretsManager(VaultSecretsManagerConfig config)
+    {
+        this.config = requireNonNull(config, "Required Configuration is null");
+    }
+
+    @Override
+    public Map<String, Map<String, String>> fetchSecrets()
+    {
+        checkArgument(config.getVaultAddress() != null, "Secrets Url not configured");
+        checkArgument(config.getVaultToken() != null, "Secrets access key not configured");
+        checkArgument(config.getSecretsKeys() != null, "Secrets ID not configured");
+
+        log.info("Loading Secrets from Vault");
+
+        final VaultConfig vaultConfig;
+        final Vault vault;
+        LogicalResponse response;
+        Map<String, Map<String, String>> finalMap = new HashMap<>();
+        try {
+            vaultConfig = new VaultConfig()
+                    .address(config.getVaultAddress())
+                    .token(config.getVaultToken())
+                    .build();
+
+            vault = new Vault(vaultConfig);
+            for (String secretID : config.getSecretsKeys().split(",")) {
+                response = vault.withRetries(5, 1000)
+                        .logical()
+                        .read("secret/" + secretID);
+                finalMap.put(secretID, response.getData());
+            }
+        }
+        catch (VaultException e) {
+            throw new RuntimeException(e);
+        }
+        return finalMap;
+    }
+}

--- a/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerConfig.java
+++ b/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.facebook.airlift.configuration.Config;
+
+public class VaultSecretsManagerConfig
+{
+    private String vaultAddress;
+    private String secretsKeys;
+    private String vaultToken;
+
+    @Config("vault_address")
+    public VaultSecretsManagerConfig setVaultAddress(String url)
+    {
+        this.vaultAddress = url;
+        return this;
+    }
+
+    public String getVaultAddress()
+    {
+        return vaultAddress;
+    }
+
+    @Config("vault_token")
+    public VaultSecretsManagerConfig setVaultToken(String secretsID)
+    {
+        this.vaultToken = secretsID;
+        return this;
+    }
+
+    public String getVaultToken()
+    {
+        return vaultToken;
+    }
+
+    @Config("vault_secret_keys")
+    public VaultSecretsManagerConfig setSecretsKeys(String secretsKeys)
+    {
+        this.secretsKeys = secretsKeys;
+        return this;
+    }
+
+    public String getSecretsKeys()
+    {
+        return secretsKeys;
+    }
+}

--- a/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerFactory.java
+++ b/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class VaultSecretsManagerFactory
+        implements SecretsManagerFactory
+{
+    private final String name;
+
+    private static final Logger log = Logger.get(VaultSecretsManagerFactory.class);
+
+    public VaultSecretsManagerFactory(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public SecretsManager create()
+    {
+        final Map<String, String> config = new HashMap<>();
+        try {
+            config.put("vault_address", Optional.ofNullable(System.getenv("VAULT_ADDR")).orElseThrow(
+                    () -> new Exception("vault_address is not set in the environment")));
+            config.put("vault_token", Optional.ofNullable(System.getenv("VAULT_TOKEN")).orElseThrow(
+                    () -> new Exception("vault_token is not set in the environment")));
+            config.put("vault_secret_keys", Optional.ofNullable(System.getenv("VAULT_SECRET_KEYS")).orElseThrow(
+                    () -> new Exception("vault_secret_keys is not set in the environment")));
+        }
+        catch (Exception e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        try {
+            Bootstrap app = new Bootstrap(
+                    binder -> {
+                        binder.bind(VaultSecretsManager.class).in(Scopes.SINGLETON);
+                        configBinder(binder).bindConfig(VaultSecretsManagerConfig.class);
+                    });
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .quiet() // Do not log configuration
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(VaultSecretsManager.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerPlugin.java
+++ b/presto-vault/src/main/java/com/facebook/presto/plugin/secretsManager/VaultSecretsManagerPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import com.google.common.collect.ImmutableList;
+
+public class VaultSecretsManagerPlugin
+        implements Plugin
+{
+    public static final String VAULT = "vault";
+
+    @Override
+    public Iterable<SecretsManagerFactory> getSecretsManagerFactories()
+    {
+        return ImmutableList.of(new VaultSecretsManagerFactory(VAULT));
+    }
+}

--- a/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerConfig.java
+++ b/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+
+public class TestVaultSecretsManagerConfig
+{
+    public static final String VAULT_ADDR = "test://vault-url";
+    public static final String VAULT_TOKEN = "test-vault-token";
+    public static final String VAULT_SECRET_KEYS = "testAccessKey";
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("vault_address", VAULT_ADDR)
+                .put("vault_token", VAULT_TOKEN)
+                .put("vault_secret_keys", VAULT_SECRET_KEYS).build();
+
+        VaultSecretsManagerConfig expected = new VaultSecretsManagerConfig()
+                .setSecretsKeys(VAULT_SECRET_KEYS)
+                .setVaultAddress(VAULT_ADDR)
+                .setVaultToken(VAULT_TOKEN);
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerIntegrationTest.java
+++ b/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.plugin.mysql.MySqlPlugin;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.secretsManager.SecretsManager;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.mysql.TestingMySqlServer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
+import static org.testng.Assert.assertThrows;
+
+@Test
+public class TestVaultSecretsManagerIntegrationTest
+{
+    private final SecretsManager secretsManager;
+
+    private static final String TEST_SCHEMA = "test_database";
+    private final TestingMySqlServer mysqlServer;
+    private final QueryRunner queryRunner;
+
+    TestVaultSecretsManagerIntegrationTest() throws Exception
+    {
+        Plugin plugin = new VaultSecretsManagerPlugin();
+        SecretsManagerFactory factory = getOnlyElement(plugin.getSecretsManagerFactories());
+        secretsManager = factory.create();
+        mysqlServer = new TestingMySqlServer("testuser", "testpass", TEST_SCHEMA);
+        queryRunner = createQueryRunner(mysqlServer, true);
+    }
+
+    @Test
+    public void testCatalogWithSecrets()
+    {
+        queryRunner.execute(getSession(mysqlServer), "CREATE TABLE test_create (a bigint, b double, c varchar)");
+    }
+
+    @Test
+    public void testCatalogWithoutSecrets() throws Exception
+    {
+        assertThrows(RuntimeException.class, () ->
+                createQueryRunner(mysqlServer, false).execute(getSession(mysqlServer), "CREATE TABLE test_create (a bigint, b double, c varchar)"));
+    }
+
+    private QueryRunner createQueryRunner(TestingMySqlServer mySqlServer, boolean appendSecrets)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+            queryRunner.installPlugin(new MySqlPlugin());
+
+            //Fetch secrets
+            final Map<String, Map<String, String>> secrets = secretsManager.fetchSecrets();
+            Map<String, String> properties = ImmutableMap.<String, String>builder()
+                    .put("connection-url", getConnectionUrl(mySqlServer))
+                    .putAll(appendSecrets ? getOnlyElement(secrets.values()) : Collections.emptyMap())
+                    .build();
+            queryRunner.createCatalog("mysql", "mysql", properties);
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner, mySqlServer);
+            throw e;
+        }
+    }
+
+    private static String getConnectionUrl(TestingMySqlServer mySqlServer)
+    {
+        return format("jdbc:mysql://localhost:%s?useSSL=false&allowPublicKeyRetrieval=true", mySqlServer.getPort());
+    }
+
+    private static Session getSession(TestingMySqlServer mySqlServer)
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of("mysql.user", mySqlServer.getUser(), "mysql.password", mySqlServer.getPassword());
+        return testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema(TEST_SCHEMA)
+                .setIdentity(new Identity(
+                        mySqlServer.getUser(),
+                        Optional.empty(),
+                        ImmutableMap.of(),
+                        extraCredentials,
+                        ImmutableMap.of(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .build();
+    }
+}

--- a/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerPlugin.java
+++ b/presto-vault/src/test/java/com/facebook/presto/plugin/secretsManager/TestVaultSecretsManagerPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.secretsManager;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.secretsManager.SecretsManagerFactory;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestVaultSecretsManagerPlugin
+{
+    @Test
+    public void testCreateConnector()
+    {
+        Plugin plugin = new VaultSecretsManagerPlugin();
+        SecretsManagerFactory factory = getOnlyElement(plugin.getSecretsManagerFactories());
+        factory.create();
+    }
+}


### PR DESCRIPTION
## Description

This brings in secrets management capability in Presto

A sample plugin - presto-vault is also provided

## Motivation and Context
https://github.com/prestodb/presto/issues/20486

Above issue can be resolved

As well as in future this can used any place in presto where secrets management is required

## Impact
None

## Test Plan
Enabled vault as the secrets manager

Loaded catalogs with encrypted values  from vault

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes

Presto support for Custom Secrets Manager Plugins to retrieve secrets from secrets manager implementations of users' choice is supported

By default, Hashicorp Vault is based implementation is provided as presto-vault module. More implementations can be plugged into the framework by extending


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

