### PR TITLE
Fix merge conflict in TestHiveTypeWidening

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeWidening.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeWidening.java
@@ -27,7 +27,6 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
@@ -45,6 +44,8 @@ import java.util.Map;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -122,7 +123,8 @@ public class TestHiveTypeWidening
                 Collections.singletonList("field"),
                 new Iterable[] {Collections.singletonList(getExpectedValueForType(baseType))},
                 1,
-                CompressionCodecName.GZIP);
+                GZIP,
+                PARQUET_2_0);
         logger.info("First file written");
         File secondParquetFile = new File(temporaryDirectory, randomUUID().toString());
         ParquetTester.writeParquetFileFromPresto(secondParquetFile,
@@ -130,7 +132,8 @@ public class TestHiveTypeWidening
                 Collections.singletonList("field"),
                 new Iterable[] {Collections.singletonList(getExpectedValueForType(widenedType))},
                 1,
-                CompressionCodecName.GZIP);
+                GZIP,
+                PARQUET_2_0);
         logger.info("Second file written");
         return temporaryDirectory;
     }


### PR DESCRIPTION
## Description
#20957 and #19983 were merged at similar times, and when taken together broke the build (as changes required by #20957 aren't present in #19983).

## Motivation and Context
Fix the build

## Impact
Fix the build

## Test Plan
CI tests pass

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

