### PR TITLE
Support implicit mapping of Presto datatype Char to Iceberg datatype String

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -161,6 +161,9 @@ public final class TypeConverter
         if (type instanceof VarcharType) {
             return Types.StringType.get();
         }
+        if (type instanceof CharType) {
+            return Types.StringType.get();
+        }
         if (type instanceof VarbinaryType) {
             return Types.BinaryType.get();
         }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -987,4 +987,14 @@ public class IcebergDistributedSmokeTestBase
                         "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL)");
         dropTable(session, tableName);
     }
+
+    @Test
+    public void testCharTable()
+    {
+        String tableName = "test_char_table";
+        assertUpdate(format("CREATE TABLE %s (char_column CHAR(5))", tableName));
+        assertUpdate(format("INSERT INTO %s VALUES ('abcde'), ('12345')", tableName), 2);
+        assertQuery(format("SELECT * FROM %s", tableName), "VALUES ('abcde'), ('12345')");
+        dropTable(getSession(), tableName);
+    }
 }


### PR DESCRIPTION
## Description
This PR addresses the `Type not supported for Iceberg: char(3)` error which is getting thrown when creating an Iceberg table using the "Create Table As Select" (CTAS) operation, when the source table contains character columns. 
This fix supports the mapping of Presto datatype Char to the equivalent datatype String in Iceberg. 

## Motivation and Context
Creating an Iceberg table using CTAS fails when the source table has character columns. It is unable to create table as the query throws error `Type not supported for Iceberg: char(3)`. The expected behaviour should be that CHAR fields in the source table should be implicitly mapped to String when used in a CTAS for an Iceberg table. Without the implicit mapping of Char to String the process of using CTAS when the source table has character columns, becomes very cumbersome with the need to specify and cast each individual column. With this fix, the CHAR fields in the source table can be implicitly mapped to the String data type in the Iceberg table. 

## Impact
The fix supports the implicit mapping of Char data type to String data type, when creating CTAS table containing character columns in the source table.

## Test Plan
Tested the fix by creating a table in DB2 having column where the data type is CHAR.
Tried creating an Iceberg table using CTAS, selecting from the created DB2 table. Successfully executed the query. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

