### PR TITLE
Support deleting whole partitions in Iceberg table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -511,6 +511,25 @@ dropping the table from the metadata catalog using ``TRUNCATE TABLE``.
     -----------+------+-----------+---------
     (0 rows)
 
+DELETE
+^^^^^^^^
+
+The iceberg connector can delete data in one or more entire partitions from tables by using ``DELETE FROM``. For example, to delete from the table ``lineitem``::
+
+     DELETE FROM lineitem;
+
+     DELETE FROM lineitem WHERE linenumber = 1;
+
+     DELETE FROM lineitem WHERE linenumber not in (1, 3, 5, 7) and linestatus in ('O', 'F');
+
+.. note::
+
+    Columns in the filter must all be identity transformed partition columns of the target table.
+
+    Filtered columns only support comparison operators, such as EQUALS, LESS THAN, or LESS THAN EQUALS.
+
+    Deletes must only occur on the latest snapshot.
+
 DROP TABLE
 ^^^^^^^^^^^
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -33,6 +33,7 @@ public class IcebergTableHandle
     private final TableType tableType;
     private final Optional<Long> snapshotId;
     private final TupleDomain<IcebergColumnHandle> predicate;
+    private final boolean snapshotSpecified;
 
     @JsonCreator
     public IcebergTableHandle(
@@ -40,12 +41,14 @@ public class IcebergTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableType") TableType tableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
+            @JsonProperty("snapshotSpecified") boolean snapshotSpecified,
             @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
+        this.snapshotSpecified = requireNonNull(snapshotSpecified, "specifiedSnapshot is null");
         this.predicate = requireNonNull(predicate, "predicate is null");
     }
 
@@ -71,6 +74,12 @@ public class IcebergTableHandle
     public Optional<Long> getSnapshotId()
     {
         return snapshotId;
+    }
+
+    @JsonProperty
+    public boolean isSnapshotSpecified()
+    {
+        return snapshotSpecified;
     }
 
     @JsonProperty
@@ -104,13 +113,14 @@ public class IcebergTableHandle
                 Objects.equals(tableName, that.tableName) &&
                 tableType == that.tableType &&
                 Objects.equals(snapshotId, that.snapshotId) &&
+                snapshotSpecified == that.snapshotSpecified &&
                 Objects.equals(predicate, that.predicate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tableType, snapshotId, predicate);
+        return Objects.hash(schemaName, tableName, tableType, snapshotId, snapshotSpecified, predicate);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
@@ -57,6 +58,7 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPS
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isMergeOnReadModeEnabled;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Lists.reverse;
@@ -85,6 +87,13 @@ public final class IcebergUtil
     public static boolean isIcebergTable(com.facebook.presto.hive.metastore.Table table)
     {
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_TYPE_PROP));
+    }
+
+    public static Table getIcebergTable(ConnectorMetadata metadata, ConnectorSession session, SchemaTableName table)
+    {
+        checkArgument(metadata instanceof IcebergAbstractMetadata, "metadata must be instance of IcebergAbstractMetadata!");
+        IcebergAbstractMetadata icebergMetadata = (IcebergAbstractMetadata) metadata;
+        return icebergMetadata.getIcebergTable(session, table);
     }
 
     public static Table getHiveIcebergTable(ExtendedHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, ConnectorSession session, SchemaTableName table)

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.MergeJoinNode;
+import com.facebook.presto.sql.planner.plan.MetadataDeleteNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
@@ -116,6 +117,7 @@ public final class GraphvizPrinter
         TABLE_WRITER,
         TABLE_WRITER_MERGE,
         TABLE_FINISH,
+        METADATA_DELETE,
         INDEX_SOURCE,
         UNNEST,
         ANALYZE_FINISH,
@@ -142,6 +144,7 @@ public final class GraphvizPrinter
             .put(NodeType.TABLE_WRITER, "cyan")
             .put(NodeType.TABLE_WRITER_MERGE, "cyan4")
             .put(NodeType.TABLE_FINISH, "hotpink")
+            .put(NodeType.METADATA_DELETE, "garnet")
             .put(NodeType.INDEX_SOURCE, "dodgerblue3")
             .put(NodeType.UNNEST, "crimson")
             .put(NodeType.SAMPLE, "goldenrod4")
@@ -298,6 +301,13 @@ public final class GraphvizPrinter
         {
             printNode(node, format("TableFinish[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.TABLE_FINISH));
             return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Void visitMetadataDelete(MetadataDeleteNode node, Void context)
+        {
+            printNode(node, format("MetadataDeleteNode[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.METADATA_DELETE));
+            return null;
         }
 
         @Override


### PR DESCRIPTION
## Description

We can use `delete from <table> [where <predicate>];` to delete one or more whole partitions or all data in Iceberg table when some conditions are met:
 - The predicate could be wholly pushed down and exactly enforced.
 - The predicate Indicated one or more whole partitions in Iceberg table.

## Motivation and Context

This PR allows deleting partition level data from Iceberg tables.


## Test Plan

 - Make sure filter push down optimization do not affect existing test cases in IcebergDistributedTestBase
 - Newly added test case in IcebergDistributedTestBase.testDelete()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* The Iceberg connector now supports `DELETE FROM <table> [where <filter>]` statements to delete one or more entire partitions
```

