### PR TITLE
Remove redundant cast to varchar in join clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -294,6 +294,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
     public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
     public static final String ENABLE_HISTORY_BASED_SCALED_WRITER = "enable_history_based_scaled_writer";
+    public static final String REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN = "remove_redundant_cast_to_varchar_in_join";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1769,6 +1770,11 @@ public final class SystemSessionProperties
                         ENABLE_HISTORY_BASED_SCALED_WRITER,
                         "Enable setting the initial number of tasks for scaled writers with HBO",
                         featuresConfig.isUseHBOForScaledWriters(),
+                        false),
+                booleanProperty(
+                        REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN,
+                        "If both left and right side of join clause are varchar cast from int/bigint, remove the cast here",
+                        featuresConfig.isRemoveRedundantCastToVarcharInJoin(),
                         false));
     }
 
@@ -2947,5 +2953,10 @@ public final class SystemSessionProperties
     public static boolean useHBOForScaledWriters(Session session)
     {
         return session.getSystemProperty(ENABLE_HISTORY_BASED_SCALED_WRITER, Boolean.class);
+    }
+
+    public static boolean isRemoveRedundantCastToVarcharInJoinEnabled(Session session)
+    {
+        return session.getSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -283,6 +283,8 @@ public class FeaturesConfig
     private boolean preProcessMetadataCalls;
     private boolean useHBOForScaledWriters;
 
+    private boolean removeRedundantCastToVarcharInJoin = true;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2814,6 +2816,19 @@ public class FeaturesConfig
     public FeaturesConfig setUseHBOForScaledWriters(boolean useHBOForScaledWriters)
     {
         this.useHBOForScaledWriters = useHBOForScaledWriters;
+        return this;
+    }
+
+    public boolean isRemoveRedundantCastToVarcharInJoin()
+    {
+        return removeRedundantCastToVarcharInJoin;
+    }
+
+    @Config("optimizer.remove-redundant-cast-to-varchar-in-join")
+    @ConfigDescription("If both left and right side of join clause are varchar cast from int/bigint, remove the cast")
+    public FeaturesConfig setRemoveRedundantCastToVarcharInJoin(boolean removeRedundantCastToVarcharInJoin)
+    {
+        this.removeRedundantCastToVarcharInJoin = removeRedundantCastToVarcharInJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -99,6 +99,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveIdentityProjectionsBelowProjection;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantAggregateDistinct;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantCastToVarcharInJoinClause;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
@@ -459,6 +460,12 @@ public class PlanOptimizers
                                 new RemoveRedundantIdentityProjections(),
                                 new TransformCorrelatedSingleRowSubqueryToProject())),
                 new CheckSubqueryNodesAreRewritten(),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new RemoveRedundantCastToVarcharInJoinClause(metadata.getFunctionAndTypeManager()))),
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantCastToVarcharInJoinClause.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantCastToVarcharInJoinClause.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.isRemoveRedundantCastToVarcharInJoinEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.relational.Expressions.castToBigInt;
+
+/**
+ * Remove redundant cast to varchar in join condition for queries like `select select * from orders o join customer c on cast(o.custkey as varchar) = cast(c.custkey as varchar)`
+ * Transform from
+ * <pre>
+ *     - Join
+ *          left_cast = right_cast
+ *          - Project
+ *              left_cast := cast(lkey as varchar)
+ *              - TableScan
+ *                  lkey BIGINT
+ *          - Project
+ *              right_cast := cast(rkey as varchar)
+ *              - TableScan
+ *                  rkey BIGINT
+ *
+ * </pre>
+ * into
+ * <pre>
+ *     - Join
+ *          new_lkey = new_rkey
+ *          - Project
+ *              left_cast := cast(lkey as varchar)
+ *              new_lkey := lkey
+ *              - TableScan
+ *                  lkey BIGINT
+ *          - Project
+ *              right_cast := cast(rkey as varchar)
+ *              new_rkey := rkey
+ *              - TableScan
+ *                  rkey BIGINT
+ * </pre>
+ * We will rely on optimizations later to remove unnecessary cast (if not used) and identity projection here.
+ * <p>
+ * Notice that we do not apply similar optimizations to queries with similar join condition like `cast(bigint as varchar) = varchar`. In general it can be converted to
+ * `bigint = try_cast(varchar as bigint)` as if the varchar here cannot be converted to bigint, try_cast will return null and will not match anyway. However, a special case is
+ * varchar begins with 0. `select cast(92 as varchar) = '092'` is false, but `select 92 = try_cast('092' as bigint)` returns true.
+ */
+public class RemoveRedundantCastToVarcharInJoinClause
+        implements Rule<JoinNode>
+{
+    private static final List<Type> TYPE_SUPPORTED = ImmutableList.of(INTEGER, BIGINT);
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final FunctionResolution functionResolution;
+
+    public RemoveRedundantCastToVarcharInJoinClause(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRemoveRedundantCastToVarcharInJoinEnabled(session);
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return join();
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        PlanNode leftInput = context.getLookup().resolve(node.getLeft());
+        PlanNode rightInput = context.getLookup().resolve(node.getRight());
+        if (!(leftInput instanceof ProjectNode) || !(rightInput instanceof ProjectNode)) {
+            return Result.empty();
+        }
+        ProjectNode leftProject = (ProjectNode) leftInput;
+        ProjectNode rightProject = (ProjectNode) rightInput;
+
+        ImmutableList.Builder<JoinNode.EquiJoinClause> joinClauseBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<VariableReferenceExpression, RowExpression> newLeftAssignmentsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<VariableReferenceExpression, RowExpression> newRightAssignmentsBuilder = ImmutableMap.builder();
+        boolean isChanged = false;
+        for (JoinNode.EquiJoinClause equiJoinClause : node.getCriteria()) {
+            RowExpression leftProjectAssignment = leftProject.getAssignments().getMap().get(equiJoinClause.getLeft());
+            RowExpression rightProjectAssignment = rightProject.getAssignments().getMap().get(equiJoinClause.getRight());
+            if (!isSupportedCast(leftProjectAssignment) || !isSupportedCast(rightProjectAssignment)) {
+                joinClauseBuilder.add(equiJoinClause);
+                continue;
+            }
+
+            RowExpression leftAssignment = ((CallExpression) leftProjectAssignment).getArguments().get(0);
+            RowExpression rightAssignment = ((CallExpression) rightProjectAssignment).getArguments().get(0);
+
+            if (!leftAssignment.getType().equals(rightAssignment.getType())) {
+                leftAssignment = castToBigInt(functionAndTypeManager, leftAssignment);
+                rightAssignment = castToBigInt(functionAndTypeManager, rightAssignment);
+            }
+
+            VariableReferenceExpression newLeft = context.getVariableAllocator().newVariable(leftAssignment);
+            newLeftAssignmentsBuilder.put(newLeft, leftAssignment);
+
+            VariableReferenceExpression newRight = context.getVariableAllocator().newVariable(rightAssignment);
+            newRightAssignmentsBuilder.put(newRight, rightAssignment);
+
+            joinClauseBuilder.add(new JoinNode.EquiJoinClause(newLeft, newRight));
+            isChanged = true;
+        }
+
+        if (!isChanged) {
+            return Result.empty();
+        }
+
+        newLeftAssignmentsBuilder.putAll(leftProject.getAssignments().getMap());
+        Map<VariableReferenceExpression, RowExpression> newLeftAssignments = newLeftAssignmentsBuilder.build();
+        newRightAssignmentsBuilder.putAll(rightProject.getAssignments().getMap());
+        Map<VariableReferenceExpression, RowExpression> newRightAssignments = newRightAssignmentsBuilder.build();
+
+        PlanNode newLeftProject = addProjections(leftProject.getSource(), context.getIdAllocator(), newLeftAssignments);
+        PlanNode newRightProject = addProjections(rightProject.getSource(), context.getIdAllocator(), newRightAssignments);
+
+        return Result.ofPlanNode(new JoinNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), node.getType(), newLeftProject, newRightProject, joinClauseBuilder.build(), node.getOutputVariables(), node.getFilter(), Optional.empty(), Optional.empty(), node.getDistributionType(), node.getDynamicFilters()));
+    }
+
+    private boolean isSupportedCast(RowExpression rowExpression)
+    {
+        if (rowExpression instanceof CallExpression && functionResolution.isCastFunction(((CallExpression) rowExpression).getFunctionHandle())) {
+            CallExpression cast = (CallExpression) rowExpression;
+            return TYPE_SUPPORTED.contains(cast.getArguments().get(0).getType()) && cast.getType() instanceof VarcharType;
+        }
+        return false;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
@@ -159,6 +161,14 @@ public final class Expressions
     {
         FunctionHandle functionHandle = functionAndTypeResolver.resolveOperator(operatorType, fromTypes(Arrays.stream(arguments).map(RowExpression::getType).collect(toImmutableList())));
         return call(operatorType.name(), functionHandle, returnType, arguments);
+    }
+
+    public static RowExpression castToBigInt(FunctionAndTypeManager functionAndTypeManager, RowExpression rowExpression)
+    {
+        if (rowExpression.getType().equals(BIGINT)) {
+            return rowExpression;
+        }
+        return call("CAST", functionAndTypeManager.lookupCast(CastType.CAST, rowExpression.getType(), BIGINT), BIGINT, rowExpression);
     }
 
     public static RowExpression searchedCaseExpression(List<RowExpression> whenClauses, Optional<RowExpression> defaultValue)

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.SystemSessionProperties.REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN;
 import static com.facebook.presto.testing.LocalQueryRunner.queryRunnerWithInitialTransaction;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -85,6 +86,7 @@ public class TestMemoryPools
                 .setCatalog("tpch")
                 .setSchema("tiny")
                 .setSystemProperty("task_default_concurrency", "1")
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "false")
                 .build();
 
         localQueryRunner = queryRunnerWithInitialTransaction(session);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -247,7 +247,8 @@ public class TestFeaturesConfig
                 .setInferInequalityPredicates(false)
                 .setPullUpExpressionFromLambdaEnabled(false)
                 .setRewriteConstantArrayContainsToInEnabled(false)
-                .setUseHBOForScaledWriters(false));
+                .setUseHBOForScaledWriters(false)
+                .setRemoveRedundantCastToVarcharInJoin(true));
     }
 
     @Test
@@ -443,6 +444,7 @@ public class TestFeaturesConfig
                 .put("optimizer.pull-up-expression-from-lambda", "true")
                 .put("optimizer.rewrite-constant-array-contains-to-in", "true")
                 .put("optimizer.use-hbo-for-scaled-writers", "true")
+                .put("optimizer.remove-redundant-cast-to-varchar-in-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -635,7 +637,8 @@ public class TestFeaturesConfig
                 .setInferInequalityPredicates(true)
                 .setPullUpExpressionFromLambdaEnabled(true)
                 .setRewriteConstantArrayContainsToInEnabled(true)
-                .setUseHBOForScaledWriters(true);
+                .setUseHBOForScaledWriters(true)
+                .setRemoveRedundantCastToVarcharInJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
@@ -107,9 +107,10 @@ public class ValuesMatcher
             return NO_MATCH;
         }
 
-        return match(SymbolAliases.builder()
+        MatchResult result = match(SymbolAliases.builder()
                 .putAll(Maps.transformValues(outputSymbolAliases, index -> createSymbolReference(valuesNode.getOutputVariables().get(index))))
                 .build());
+        return result;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveRedundantCastToVarcharInJoinClause.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveRedundantCastToVarcharInJoinClause.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestRemoveRedundantCastToVarcharInJoinClause
+        extends BaseRuleTest
+{
+    @Test
+    public void testCastBigIntToVarchar()
+    {
+        tester().assertThat(new RemoveRedundantCastToVarcharInJoinClause(getFunctionManager()))
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression leftBigint = p.variable("left_bigint");
+                    VariableReferenceExpression rightBigint = p.variable("right_bigint");
+                    VariableReferenceExpression leftCast = p.variable("left_cast", VARCHAR);
+                    VariableReferenceExpression rightCast = p.variable("right_cast", VARCHAR);
+                    return p.join(
+                            JoinNode.Type.INNER,
+                            p.project(assignment(leftCast, p.rowExpression("cast(left_bigint as varchar)")),
+                                    p.values(leftBigint)),
+                            p.project(assignment(rightCast, p.rowExpression("cast(right_bigint as varchar)")),
+                                    p.values(rightBigint)),
+                            new JoinNode.EquiJoinClause(leftCast, rightCast));
+                })
+                .matches(
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(equiJoinClause("new_left", "new_right")),
+                                project(
+                                        ImmutableMap.of("new_left", expression("left_bigint")),
+                                        values("left_bigint")),
+                                project(
+                                        ImmutableMap.of("new_right", expression("right_bigint")),
+                                        values("right_bigint"))));
+    }
+
+    @Test
+    public void testCastIntToBigint()
+    {
+        tester().assertThat(new RemoveRedundantCastToVarcharInJoinClause(getFunctionManager()))
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression leftBigint = p.variable("left_bigint", INTEGER);
+                    VariableReferenceExpression rightBigint = p.variable("right_bigint", SMALLINT);
+                    VariableReferenceExpression leftCast = p.variable("left_cast", BIGINT);
+                    VariableReferenceExpression rightCast = p.variable("right_cast", BIGINT);
+                    return p.join(
+                            JoinNode.Type.INNER,
+                            p.project(assignment(leftCast, p.rowExpression("cast(left_bigint as varchar)")),
+                                    p.values(leftBigint)),
+                            p.project(assignment(rightCast, p.rowExpression("cast(right_bigint as varchar)")),
+                                    p.values(rightBigint)),
+                            new JoinNode.EquiJoinClause(leftCast, rightCast));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testNoCast()
+    {
+        tester().assertThat(new RemoveRedundantCastToVarcharInJoinClause(getFunctionManager()))
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression rightBigint = p.variable("right_bigint");
+                    VariableReferenceExpression leftCast = p.variable("left_cast", VARCHAR);
+                    VariableReferenceExpression rightCast = p.variable("right_cast", VARCHAR);
+                    return p.join(
+                            JoinNode.Type.INNER,
+                            p.values(leftCast),
+                            p.project(assignment(rightCast, p.rowExpression("cast(right_bigint as varchar)")),
+                                    p.values(rightBigint)),
+                            new JoinNode.EquiJoinClause(leftCast, rightCast));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testCastDoubleToVarchar()
+    {
+        tester().assertThat(new RemoveRedundantCastToVarcharInJoinClause(getFunctionManager()))
+                .setSystemProperty(REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression leftBigint = p.variable("left_bigint", DOUBLE);
+                    VariableReferenceExpression rightBigint = p.variable("right_bigint", DOUBLE);
+                    VariableReferenceExpression leftCast = p.variable("left_cast", VARCHAR);
+                    VariableReferenceExpression rightCast = p.variable("right_cast", VARCHAR);
+                    return p.join(
+                            JoinNode.Type.INNER,
+                            p.project(assignment(leftCast, p.rowExpression("cast(left_bigint as varchar)")),
+                                    p.values(leftBigint)),
+                            p.project(assignment(rightCast, p.rowExpression("cast(right_bigint as varchar)")),
+                                    p.values(rightBigint)),
+                            new JoinNode.EquiJoinClause(leftCast, rightCast));
+                }).doesNotFire();
+    }
+}

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
@@ -200,6 +200,12 @@ public class TestSingleStoreDistributedQueries
         // no op -- test not supported due to lack of support for array types.
     }
 
+    @Test
+    public void testRemoveRedundantCastToVarcharInJoinClause()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+
     @Override
     public void testDelete()
     {


### PR DESCRIPTION
## Description
Rewrite query such as `select select * from orders o join customer c on cast(o.custkey as varchar) = cast(c.custkey as varchar)` to `select select * from orders o join customer c on o.custkey = c.custkey`

## Motivation and Context
Varchar is expensive to hash, and join with varchar keys can be expensive. For the cases above, removing the cast can reduce the cost of join operation.

## Impact
Test in production queries show it decrease both CPU and latency by half.

## Test Plan
Unit tests and [verifier run](https://www.internalfb.com/intern/presto/verifier/results/?test_id=141530)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an optimization, which removes the redundant cast to varchar expression in join condition. The optimizer is controlled by session property `remove_redundant_cast_to_varchar_in_join` and enabled by default.
```


