### PR TITLE
Add session property to set input table matching threshold

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -254,6 +254,7 @@ public final class SystemSessionProperties
     public static final String HISTORY_CANONICAL_PLAN_NODE_LIMIT = "history_canonical_plan_node_limit";
     public static final String HISTORY_BASED_OPTIMIZER_TIMEOUT_LIMIT = "history_based_optimizer_timeout_limit";
     public static final String RESTRICT_HISTORY_BASED_OPTIMIZATION_TO_COMPLEX_QUERY = "restrict_history_based_optimization_to_complex_query";
+    public static final String HISTORY_INPUT_TABLE_STATISTICS_MATCHING_THRESHOLD = "history_input_table_statistics_matching_threshold";
     public static final String MAX_LEAF_NODES_IN_PLAN = "max_leaf_nodes_in_plan";
     public static final String LEAF_NODE_LIMIT_ENABLED = "leaf_node_limit_enabled";
     public static final String PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID = "push_remote_exchange_through_group_id";
@@ -1466,6 +1467,11 @@ public final class SystemSessionProperties
                         "Enable history based optimization only for complex queries, i.e. queries with join and aggregation",
                         true,
                         false),
+                doubleProperty(
+                        HISTORY_INPUT_TABLE_STATISTICS_MATCHING_THRESHOLD,
+                        "When the size difference between current table and history table exceed this threshold, do not match history statistics",
+                        0.0,
+                        true),
                 new PropertyMetadata<>(
                         MAX_LEAF_NODES_IN_PLAN,
                         "Maximum number of leaf nodes in the logical plan of SQL statement",
@@ -2760,6 +2766,11 @@ public final class SystemSessionProperties
     public static boolean restrictHistoryBasedOptimizationToComplexQuery(Session session)
     {
         return session.getSystemProperty(RESTRICT_HISTORY_BASED_OPTIMIZATION_TO_COMPLEX_QUERY, Boolean.class);
+    }
+
+    public static double getHistoryInputTableStatisticsMatchingThreshold(Session session)
+    {
+        return session.getSystemProperty(HISTORY_INPUT_TABLE_STATISTICS_MATCHING_THRESHOLD, Double.class);
     }
 
     public static boolean shouldPushRemoteExchangeThroughGroupId(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
@@ -34,14 +34,14 @@ public class HistoricalPlanStatisticsUtil
     public static PlanStatistics getPredictedPlanStatistics(
             HistoricalPlanStatistics historicalPlanStatistics,
             List<PlanStatistics> inputTableStatistics,
-            HistoryBasedOptimizationConfig config)
+            double historyMatchingThreshold)
     {
         List<HistoricalPlanStatisticsEntry> lastRunsStatistics = historicalPlanStatistics.getLastRunsStatistics();
         if (lastRunsStatistics.isEmpty()) {
             return PlanStatistics.empty();
         }
 
-        Optional<Integer> similarStatsIndex = getSimilarStatsIndex(historicalPlanStatistics, inputTableStatistics, config.getHistoryMatchingThreshold());
+        Optional<Integer> similarStatsIndex = getSimilarStatsIndex(historicalPlanStatistics, inputTableStatistics, historyMatchingThreshold);
 
         if (similarStatsIndex.isPresent()) {
             return lastRunsStatistics.get(similarStatsIndex.get()).getPlanStatistics();

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
@@ -105,6 +105,6 @@ public class TestHistoricalPlanStatistics
         return HistoricalPlanStatisticsUtil.getPredictedPlanStatistics(
                 historicalPlanStatistics,
                 inputTableStatistics,
-                new HistoryBasedOptimizationConfig());
+                0.1);
     }
 }


### PR DESCRIPTION
## Description
Add session property to set the threshold for input table stats matching in HBO

## Motivation and Context
In HBO, when we get statistics from history runs, we are to compare the input table statistics in history runs with the input table statistics in current runs. If the difference is larger than a threshold, HBO estimates will not be used.

However, in debug, I found that it's hard to debug and tune this threshold. Currently it's set in config and needs to restart the coordinator to make changes. This PR is to add a session property for it, it's mainly for debugging/tuning purpose and hidden from user.

## Impact
Make HBO debug and tune easier.

## Test Plan
Existing unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a session property `history_input_table_statistics_matching_threshold` to set the threshold for input statistics match in HBO.
```


