### PR TITLE
Introduce Rolling forward to snapshot with Presto Procedure on Iceberg table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
@@ -91,6 +91,6 @@ public class RollbackToSnapshotProcedure
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) metadata).getMetastore();
             icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
         }
-        icebergTable.manageSnapshots().rollbackTo(snapshotId).commit();
+        icebergTable.manageSnapshots().setCurrentSnapshot(snapshotId).commit();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -441,6 +441,7 @@ public class IcebergDistributedSmokeTestBase
         long afterFirstInsertId = getLatestSnapshotId();
 
         assertUpdate(session, "INSERT INTO test_rollback (col0, col1) VALUES (456, CAST(654 AS BIGINT))", 1);
+        long latestSnapshotId = getLatestSnapshotId();
         assertQuery(session, "SELECT * FROM test_rollback ORDER BY col0",
                 "VALUES (123, CAST(987 AS BIGINT)), (456, CAST(654 AS BIGINT)), (123, CAST(321 AS BIGINT))");
 
@@ -450,6 +451,9 @@ public class IcebergDistributedSmokeTestBase
 
         assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterCreateTableId));
         assertEquals((long) computeActual(session, "SELECT COUNT(*) FROM test_rollback").getOnlyValue(), 1);
+
+        assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", latestSnapshotId));
+        assertEquals((long) computeActual(session, "SELECT COUNT(*) FROM test_rollback").getOnlyValue(), 3);
 
         dropTable(session, "test_rollback");
     }


### PR DESCRIPTION
## Description
The current existing pedicure rollback_to_snapshot (https://prestodb.io/docs/current/connector/iceberg.html#id2) in the Iceberg connector allows only rolling forward to an old snapshot but we can't roll forward to a different snapshot of ta Iceberg Table. Update the API to support roll-forward as well.
Related issue: https://github.com/prestodb/presto/issues/20881

## Test Plan
update IcebergDistributedSmokeTestBase.testRollbackSnapshot()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
*Rolling forward to snapshot with Presto Procedure on Iceberg table

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

