### PR TITLE
Upgrade libthrift version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1270,7 +1270,7 @@
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.9.3</version>
+                <version>0.15.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -19,6 +19,16 @@
         <dep.reload4j.version>1.2.18.3</dep.reload4j.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>0.9.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -165,6 +165,8 @@
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <scope>test</scope>
+            <!-- libthrift >= 0.14.0 not compatible with cassandra-server 2.x -->
+            <version>0.9.3</version>
         </dependency>
 
         <dependency>

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
 import com.google.common.net.HostAndPort;
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -212,6 +213,35 @@ public final class Transport
         {
             try {
                 transport.flush();
+            }
+            catch (TTransportException e) {
+                throw rewriteException(e, address);
+            }
+        }
+
+        @Override
+        public TConfiguration getConfiguration()
+        {
+            return transport.getConfiguration();
+        }
+
+        @Override
+        public void updateKnownMessageSize(long size)
+                throws TTransportException
+        {
+            try {
+                transport.updateKnownMessageSize(size);
+            }
+            catch (TTransportException e) {
+                throw rewriteException(e, address);
+            }
+        }
+        @Override
+        public void checkReadBytesAvailable(long numBytes)
+                throws TTransportException
+        {
+            try {
+                transport.checkReadBytesAvailable(numBytes);
             }
             catch (TTransportException e) {
                 throw rewriteException(e, address);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 
 import javax.inject.Inject;
 import javax.security.auth.callback.Callback;
@@ -97,6 +98,9 @@ public class KerberosHiveMetastoreAuthentication
         }
         catch (IOException ex) {
             throw new UncheckedIOException(ex);
+        }
+        catch (TTransportException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -174,6 +178,9 @@ public class KerberosHiveMetastoreAuthentication
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+        catch (TTransportException e) {
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Fix CVE-2018-1320, CVE-2019-0205, CVE-2019-0210 and CVE-2020-13949

## Description
The PR upgrades libthrift version version to address known CVEs.

Exception made for Accumulo connector, since is not compatible with newer versions of libthrift.

## Motivation and Context
Dependency org.apache.thrift:libthrift:0.9.3 has four HIGH vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2018-1320
https://nvd.nist.gov/vuln/detail/CVE-2019-0205
https://nvd.nist.gov/vuln/detail/CVE-2019-0210
https://nvd.nist.gov/vuln/detail/CVE-2020-13949

The following issue should be closed after merge:

CVE-2020-13949 libthrift #18026

## Impact
None

## Test Plan
Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade libthrift version to 0.15.0



