### PR TITLE
[native][circleci] Add link targets to link_job_pool with a lower number of max concurrent jobs

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -112,8 +112,9 @@ jobs:
               -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
               -DPRESTO_ENABLE_JWT=ON \
               -DCMAKE_PREFIX_PATH=/usr/local \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            ninja -C _build/debug -j 7
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DMAX_LINK_JOBS=2
+            ninja -C _build/debug -j 8
             ccache -s
       - save_cache:
           name: "Save CCache cache"
@@ -124,7 +125,7 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             cd presto-native-execution/_build/debug
-            ctest -j 8 -VV --output-on-failure --exclude-regex velox.*
+            ctest -j 10 -VV --output-on-failure --exclude-regex velox.*
       - persist_to_workspace:
           root: presto-native-execution
           paths:
@@ -244,7 +245,8 @@ jobs:
               -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
               -DPRESTO_ENABLE_JWT=ON \
               -DCMAKE_PREFIX_PATH=/usr/local \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DMAX_LINK_JOBS=2
             ninja -C _build/release -j 8
 
   format-check:

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -77,6 +77,8 @@ target_link_libraries(
 target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra
                       ${THRIFT_LIBRARY})
 
+set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK link_job_pool)
+
 add_executable(presto_server PrestoMain.cpp)
 
 # Moving velox_hive_connector and velox_tpch_connector to presto_server_lib
@@ -94,6 +96,8 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
                         velox_functions_remote ${FOLLY_WITH_DEPENDENCIES})
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
+
+set_property(TARGET presto_server PROPERTY JOB_POOL_LINK link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(presto_exception Exception.cpp)
 add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
 
 target_link_libraries(presto_exception velox_exception)
+set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK link_job_pool)
+
 target_link_libraries(presto_common velox_config velox_core velox_exception)
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(
   ${FMT}
   ${RE2})
 
+set_property(TARGET presto_http PROPERTY JOB_POOL_LINK link_job_pool)
+
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ target_link_libraries(
   gtest
   gtest_main)
 
+set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK link_job_pool)
+
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_executable(presto_server_remote_function_test
                  JsonSignatureParserTest.cpp RemoteFunctionRegistererTest.cpp)

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -24,6 +24,8 @@ add_dependencies(presto_types presto_operators presto_type_converter velox_type
 target_link_libraries(presto_types presto_type_converter velox_type_fbhive
                       velox_hive_partition_function velox_tpch_gen)
 
+set_property(TARGET presto_types PROPERTY JOB_POOL_LINK link_job_pool)
+
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
We have several resource-intensive link target which will cause the ld get killed due to low memory. Instead of lowering the parallelism of the entire build (using -j) we put those jobs into a job pool (link_job_pool) a set a lower upper bound of max job. This will fix the previous build failures with "collect2: fatal error: ld terminated with signal 9 [Killed]”

Test Plans:
Make sure all circle ci runs are green

```
== NO RELEASE NOTE ==
```

