### PR TITLE
Introduce AWS Lake Formation Security Mapping

### DIFF
--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMapping.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMapping.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.aws.lakeformation;
+
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class LakeFormationSecurityMapping
+{
+    private final Predicate<String> user;
+    private final String iamRole;
+
+    @JsonCreator
+    public LakeFormationSecurityMapping(
+            @JsonProperty("user") Optional<Pattern> user,
+            @JsonProperty("iamRole") Optional<String> iamRole)
+    {
+        this.user = requireNonNull(user, "user is null")
+                .map(LakeFormationSecurityMapping::toPredicate)
+                .orElse(x -> true);
+        this.iamRole = requireNonNull(iamRole, "iamRole is null").orElse(null);
+
+        checkArgument(iamRole.isPresent(), "IAM Role must be provided");
+    }
+
+    public boolean matches(MetastoreContext metastoreContext)
+    {
+        return user.test(metastoreContext.getUsername());
+    }
+
+    public String getIamRole()
+    {
+        return iamRole;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("user", user)
+                .add("iamRole", iamRole)
+                .toString();
+    }
+
+    private static Predicate<String> toPredicate(Pattern pattern)
+    {
+        return value -> pattern.matcher(value).matches();
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMappingConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMappingConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.aws.lakeformation;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class LakeFormationSecurityMappingConfig
+{
+    private File configFile;
+    private Duration refreshPeriod = new Duration(30, SECONDS);
+
+    public Optional<File> getConfigFile()
+    {
+        if (configFile != null) {
+            checkArgument(configFile.exists() && configFile.isFile(), "AWS Lake Formation Security Mapping config file does not exist: %s", configFile);
+        }
+        return Optional.ofNullable(configFile);
+    }
+
+    @Config("hive.metastore.glue.lakeformation.security-mapping.config-file")
+    @ConfigDescription("JSON configuration file containing AWS Lake Formation security mappings")
+    public LakeFormationSecurityMappingConfig setConfigFile(File configFile)
+    {
+        this.configFile = configFile;
+        return this;
+    }
+
+    public Optional<Duration> getRefreshPeriod()
+    {
+        return Optional.ofNullable(refreshPeriod);
+    }
+
+    @MinDuration("0ms")
+    @Config("hive.metastore.glue.lakeformation.security-mapping.refresh-period")
+    @ConfigDescription("Time interval after which securing mapping configuration will be refreshed")
+    public LakeFormationSecurityMappingConfig setRefreshPeriod(Duration refreshPeriod)
+    {
+        this.refreshPeriod = refreshPeriod;
+        return this;
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMappings.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/aws/lakeformation/LakeFormationSecurityMappings.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.aws.lakeformation;
+
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class LakeFormationSecurityMappings
+{
+    private final List<LakeFormationSecurityMapping> mappings;
+
+    @JsonCreator
+    public LakeFormationSecurityMappings(@JsonProperty("mappings") List<LakeFormationSecurityMapping> mappings)
+    {
+        this.mappings = ImmutableList.copyOf(requireNonNull(mappings, "mappings is null"));
+    }
+
+    public Optional<LakeFormationSecurityMapping> getMapping(MetastoreContext metastoreContext)
+    {
+        return mappings.stream()
+                .filter(mapping -> (mapping.matches(metastoreContext) && !mapping.getIamRole().isEmpty()))
+                .findFirst();
+    }
+}

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/aws/lakeformation/TestLakeFormationSecurityMappingConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/aws/lakeformation/TestLakeFormationSecurityMappingConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.aws.lakeformation;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestLakeFormationSecurityMappingConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(LakeFormationSecurityMappingConfig.class)
+                .setConfigFile(null)
+                .setRefreshPeriod(Duration.valueOf("30s")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path securityMappingConfigFile = Files.createTempFile(null, null);
+
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.metastore.glue.lakeformation.security-mapping.config-file", securityMappingConfigFile.toString())
+                .put("hive.metastore.glue.lakeformation.security-mapping.refresh-period", "60s")
+                .build();
+
+        LakeFormationSecurityMappingConfig expected = new LakeFormationSecurityMappingConfig()
+                .setConfigFile(securityMappingConfigFile.toFile())
+                .setRefreshPeriod(Duration.valueOf("60s"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/aws/lakeformation/TestLakeFormationSecurityMappings.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/aws/lakeformation/TestLakeFormationSecurityMappings.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.aws.lakeformation;
+
+import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.spi.security.ConnectorIdentity;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.aws.lakeformation.TestLakeFormationSecurityMappings.MappingSelector.empty;
+import static com.facebook.presto.plugin.base.JsonUtils.parseJson;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestLakeFormationSecurityMappings
+{
+    private static final String DEFAULT_USER = "defaultUser";
+
+    @Test
+    public void testMapping()
+    {
+        String lakeFormationSecurityMappingConfigPath = this.getClass().getClassLoader().getResource("com.facebook.presto.hive.aws.lakeformation/lake-formation-security-mapping.json").getPath();
+
+        LakeFormationSecurityMappings mappings = parseJson(new File(lakeFormationSecurityMappingConfigPath).toPath(), LakeFormationSecurityMappings.class);
+
+        assertEquals(MappingResult.role("arn:aws:iam::123456789101:role/admin_role").getIamRole(),
+                mappings.getMapping(empty().withUser("admin").getMetastoreContext()).get().getIamRole());
+        assertEquals(MappingResult.role("arn:aws:iam::123456789101:role/analyst_role").getIamRole(),
+                mappings.getMapping(empty().withUser("analyst").getMetastoreContext()).get().getIamRole());
+        assertEquals(MappingResult.role("arn:aws:iam::123456789101:role/default_role").getIamRole(),
+                mappings.getMapping(empty().getMetastoreContext()).get().getIamRole());
+    }
+
+    public static class MappingSelector
+    {
+        public static MappingSelector empty()
+        {
+            return new MappingSelector(DEFAULT_USER);
+        }
+
+        private final String user;
+
+        public static final String PRESTO_QUERY_ID_NAME = "presto_query_id";
+
+        private MappingSelector(String user)
+        {
+            this.user = requireNonNull(user, "user is null");
+        }
+
+        public MappingSelector withUser(String user)
+        {
+            return new MappingSelector(user);
+        }
+
+        public MetastoreContext getMetastoreContext()
+        {
+            return new MetastoreContext(
+                    new ConnectorIdentity(
+                            user,
+                            Optional.empty(),
+                            Optional.empty(),
+                            Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            Optional.empty(),
+                            Optional.empty()),
+                    PRESTO_QUERY_ID_NAME,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    false,
+                    HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+        }
+    }
+
+    public static class MappingResult
+    {
+        public static MappingResult role(String role)
+        {
+            return new MappingResult(role);
+        }
+
+        private final String iamRole;
+
+        private MappingResult(String iamRole)
+        {
+            this.iamRole = requireNonNull(iamRole, "role is null");
+        }
+
+        public String getIamRole()
+        {
+            return iamRole;
+        }
+    }
+}

--- a/presto-hive-metastore/src/test/resources/com.facebook.presto.hive.aws.lakeformation/lake-formation-security-mapping.json
+++ b/presto-hive-metastore/src/test/resources/com.facebook.presto.hive.aws.lakeformation/lake-formation-security-mapping.json
@@ -1,0 +1,15 @@
+{
+  "mappings": [
+    {
+      "user": "admin",
+      "iamRole": "arn:aws:iam::123456789101:role/admin_role"
+    },
+    {
+      "user": "analyst",
+      "iamRole": "arn:aws:iam::123456789101:role/analyst_role"
+    },
+    {
+      "iamRole": "arn:aws:iam::123456789101:role/default_role"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This will allow flexible security mapping for AWS Glue, Lake Formation, and S3 API calls when AWS Lake Formation is enabled, allowing for separate IAM roles for specific users.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#20851 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```
