### PR TITLE
Fix NullPointerException for HiveExternalWorkerQueryRunner

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -77,12 +77,14 @@ import io.airlift.slice.Slice;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.json.smile.SmileCodec.smileCodec;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.hive.HiveDwrfEncryptionProvider.NO_ENCRYPTION;
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 public final class HiveTestUtils
@@ -266,5 +268,29 @@ public final class HiveTestUtils
     public static Slice longDecimal(String value)
     {
         return encodeScaledValue(new BigDecimal(value));
+    }
+
+    public static Optional<String> getProperty(String name)
+    {
+        String systemPropertyValue = System.getProperty(name);
+        String environmentVariableValue = System.getenv(name);
+        if (systemPropertyValue == null) {
+            if (environmentVariableValue == null) {
+                return Optional.empty();
+            }
+            else {
+                return Optional.of(environmentVariableValue);
+            }
+        }
+        else {
+            if (environmentVariableValue != null && !systemPropertyValue.equals(environmentVariableValue)) {
+                throw new IllegalArgumentException(format("%s is set in both Java system property and environment variable, but their values are different. The Java system property value is %s, while the" +
+                                " environment variable value is %s. Please use only one value.",
+                        name,
+                        systemPropertyValue,
+                        environmentVariableValue));
+            }
+            return Optional.of(systemPropertyValue);
+        }
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeRemoteFunctions.java
@@ -18,12 +18,12 @@ import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.hive.HiveTestUtils.getProperty;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_CATALOG_NAME;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.REMOTE_FUNCTION_JSON_SIGNATURES;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.setupJsonFunctionNamespaceManager;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.startRemoteFunctionServer;
-import static java.util.Objects.requireNonNull;
 
 @Test(groups = "remote-function")
 public abstract class AbstractTestNativeRemoteFunctions
@@ -49,12 +49,8 @@ public abstract class AbstractTestNativeRemoteFunctions
     {
         // Initialize the remote function thrift server process.
         String propertyName = "REMOTE_FUNCTION_SERVER";
-        remoteFunctionServerBinaryPath = System.getenv(propertyName);
-        if (remoteFunctionServerBinaryPath == null) {
-            remoteFunctionServerBinaryPath = System.getProperty(propertyName);
-        }
-
-        requireNonNull(remoteFunctionServerBinaryPath, "Remote function server path missing. Add -DREMOTE_FUNCTION_SERVER=<path/to/binary> to your JVM arguments.");
+        remoteFunctionServerBinaryPath = getProperty(propertyName).orElseThrow(() -> new NullPointerException("Remote function server path missing. Add -DREMOTE_FUNCTION_SERVER=<path/to/binary>" +
+                " to your JVM arguments, or create an environment variable REMOTE_FUNCTION_SERVER with value <path/to/binary>."));
         remoteFunctionServerUds = startRemoteFunctionServer(remoteFunctionServerBinaryPath);
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.airlift.log.Level.WARN;
+import static com.facebook.presto.hive.HiveTestUtils.getProperty;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerHiveProperties;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerSystemProperties;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.getNativeQueryRunnerParameters;
@@ -207,8 +208,9 @@ public class PrestoSparkNativeQueryRunnerUtils
         if (dataDirectory.isPresent()) {
             return dataDirectory.get();
         }
-        String dataDirectoryStr = System.getProperty("DATA_DIR");
-        if (dataDirectoryStr == null || dataDirectoryStr.isEmpty()) {
+
+        Optional<String> dataDirectoryStr = getProperty("DATA_DIR");
+        if (!dataDirectoryStr.isPresent()) {
             try {
                 dataDirectory = Optional.of(createTempDirectory("PrestoTest").toAbsolutePath());
             }


### PR DESCRIPTION
Resolves https://github.com/prestodb/presto/issues/21086

## Description
The documentation https://github.com/prestodb/presto/tree/master/presto
-native-execution#development says the DATA_DIR needs to be set as an
environment variable, however, the dataDirectory in createJavaQueryRunner()
was assigned to System.getProperty("DATA_DIR"), which gets null and causes
NullPointerException. Furthermore, System.getProperty() and System.getenv()
were used randomly in the native worker query runners. This is confusing
and could cause more future issues. System.getProperty() reads the Java
system properties that are passed in using -Dkey=value, while System.getenv()
reads environment variables. They cannot be used interchangably and would
return null if the corresponding values are not set. While the documentation
uses environment variables, CircleCI jobs rely on system variables. In order
to make the query runners more robust, it's better to support both of them.
This commit introduces HiveTestUtils.getProperty() static method to read
both. If both system property and environment variable are not set, an
exception would be thrown. If both of them are set but the values are
different, an exception would also be thrown.

## Motivation and Context
HiveExternalWorkerQueryRunner was unable to start

## Impact
none

## Test Plan
HiveExternalWorkerQueryRunner was able start after change

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

