### PR TITLE
Flatten nested string concat

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlStringConcatBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlStringConcatBenchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlStringConcatBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlStringConcatBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 4, 5, query);
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlArrayConcatBenchmark(createLocalQueryRunner(), "SELECT CONCAT(a[random(x) % 5 + 1], CONCAT(a[2], CONCAT(CONCAT(a[3], concat(a[4], concat(a[5],a[6]))), a[7])), a[8]) FROM (select x, set_agg(name) a from nation CROSS JOIN UNNEST(SEQUENCE(1, 1000)) AS T(x) group by x)", "sql_concat_1k").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -1047,6 +1047,16 @@ public class TestStringFunctions
     }
 
     @Test
+    public void testNestedConcat()
+    {
+        assertFunction("CONCAT('a', CONCAT('b', CONCAT(CONCAT('c', 'd'), 'e')))", VARCHAR, "abcde");
+        assertFunction("CONCAT(concat('a', CONCAT('b', CONCAT('c', CONCAT('d', 'e')))), 'f')", VARCHAR, "abcdef");
+        assertFunction("CONCAT('a', CONCAT(cast(null as varchar), concat(concat('c', 'd'), 'e')))", VARCHAR, null);
+        // The following is a harness for if/when someone touches the concat flattening logic
+        assertFunction("cast(concat(cast('abcde' as char(10)), concat(cast('abc' as char(3)) , 'd')) AS VARCHAR)", VARCHAR, "abcde     abcd");
+    }
+
+    @Test
     public void testStartsWith()
     {
         assertFunction("starts_with('abcd', 'ab')", BOOLEAN, true);


### PR DESCRIPTION
## Description
We now flatten nested concat operations for performance

## Motivation and Context
It improves performance for a common pattern that many queries use.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Added tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

