### PR TITLE
[native][circleci] Fix native build failure

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -207,4 +207,12 @@ if(PRESTO_ENABLE_JWT)
   add_compile_definitions(PRESTO_ENABLE_JWT)
 endif()
 
+if("${MAX_LINK_JOBS}")
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS
+                                      "presto_link_job_pool=${MAX_LINK_JOBS}")
+else()
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS "presto_link_job_pool=8")
+endif()
+set(CMAKE_JOB_POOL_LINK presto_link_job_pool)
+
 add_subdirectory(presto_cpp)

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -77,7 +77,8 @@ target_link_libraries(
 target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra
                       ${THRIFT_LIBRARY})
 
-set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK
+                                               presto_link_job_pool)
 
 add_executable(presto_server PrestoMain.cpp)
 
@@ -97,7 +98,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
 
-set_property(TARGET presto_server PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_server PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -14,9 +14,11 @@ add_library(presto_exception Exception.cpp)
 add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
 
 target_link_libraries(presto_exception velox_exception)
-set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK
+                                              presto_link_job_pool)
 
 target_link_libraries(presto_common velox_config velox_core velox_exception)
+set_property(TARGET presto_common PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -23,3 +23,6 @@ target_link_libraries(
   ${RE2}
   gtest
   gtest_main)
+
+set_property(TARGET presto_common_test PROPERTY JOB_POOL_LINK
+                                                presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(
   ${FMT}
   ${RE2})
 
-set_property(TARGET presto_http PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_http PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/http/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/tests/CMakeLists.txt
@@ -18,6 +18,9 @@ add_test(
 
 target_link_libraries(presto_http_test presto_http gtest gtest_main)
 
+set_property(TARGET presto_http_test PROPERTY JOB_POOL_LINK
+                                              presto_link_job_pool)
+
 if(PRESTO_ENABLE_JWT)
   add_executable(presto_http_jwt_test HttpJwtTest.cpp)
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -38,3 +38,6 @@ target_link_libraries(
   gtest
   ${ANTLR4_RUNTIME}
   gtest_main)
+
+set_property(TARGET presto_operators_test PROPERTY JOB_POOL_LINK
+                                                   presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -46,7 +46,8 @@ target_link_libraries(
   gtest
   gtest_main)
 
-set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK
+                                                presto_link_job_pool)
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_executable(presto_server_remote_function_test
@@ -83,3 +84,6 @@ target_link_libraries(
   ${ANTLR4_RUNTIME}
   velox_dwio_dwrf_writer
   velox_exec_test_lib)
+
+set_property(TARGET presto_query_runner_test PROPERTY JOB_POOL_LINK
+                                                      presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -24,7 +24,7 @@ add_dependencies(presto_types presto_operators presto_type_converter velox_type
 target_link_libraries(presto_types presto_type_converter velox_type_fbhive
                       velox_hive_partition_function velox_tpch_gen)
 
-set_property(TARGET presto_types PROPERTY JOB_POOL_LINK link_job_pool)
+set_property(TARGET presto_types PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -78,3 +78,6 @@ target_link_libraries(
   ${GLOG}
   ${GFLAGS_LIBRARIES}
   pthread)
+
+set_property(TARGET presto_expressions_test PROPERTY JOB_POOL_LINK
+                                                     presto_link_job_pool)


### PR DESCRIPTION
## Description
Even with previous PRs like https://github.com/prestodb/presto/pull/21093, the native ci jobs are still failing. So it looks like the previous changes do not work very well. A few more changes:
* change link_job_pool to presto_link_job_pool. link_job_pool is used by velox. Make the change to enable finer grained control from our side.
* add more targets to the job pool
* more testing to make sure the fix does work:
- compare results between 2 and 8 and 2 passes while fails which is expected
- try to disable ccache to see if jobs still pass. 

## Test Plan
Make sure all circle ci runs are green

```
== NO RELEASE NOTE ==
```

