### PR TITLE
Update the Version of Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1119,7 +1119,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.199</version>
+                <version>2.2.220</version>
             </dependency>
 
             <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -207,8 +207,9 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.9.2</version>
+            <version>1.11.0</version>
         </dependency>
+
 
         <!-- Presto SPI -->
         <dependency>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -30,6 +30,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.10.4</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <scala.version>2.12.2</scala.version>
-        <dep.avro.version>1.9.0</dep.avro.version>
+        <dep.avro.version>1.11.0</dep.avro.version>
     </properties>
 
     <dependencies>
@@ -42,6 +42,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-record-decoder</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -54,13 +54,19 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.1</version>
+            <version>1.11.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
+            <version>1.1.10.4</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/avro/TestAvroDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/avro/TestAvroDecoder.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -81,35 +80,55 @@ public class TestAvroDecoder
     private static final Type DOUBLE_MAP_TYPE = FUNCTION_AND_TYPE_MANAGER.getType(parseTypeSignature("map<varchar,double>"));
     private static final Type REAL_MAP_TYPE = FUNCTION_AND_TYPE_MANAGER.getType(parseTypeSignature("map<varchar,real>"));
 
-    private static String getAvroSchema(String name, String dataType)
+    private static Schema getAvroSchema(String name, String dataType)
     {
         return getAvroSchema(ImmutableMap.of(name, dataType));
     }
 
-    private static String getAvroSchema(Map<String, String> fields)
+    private static Schema getAvroSchema(Map<String, String> fields)
     {
-        String fieldSchema = fields.entrySet().stream()
-                .map(entry -> "{\"name\": \"" + entry.getKey() + "\",\"type\": " + entry.getValue() + ",\"default\": null}")
-                .collect(Collectors.joining(","));
-
-        return "{\"type\" : \"record\"," +
-                "  \"name\" : \"test_schema\"," +
-                "  \"namespace\" : \"com.facebook.presto.decoder.avro\"," +
-                "  \"fields\" :" +
-                "  [" +
-                fieldSchema +
-                "  ]}";
+        Schema.Parser parser = new Schema.Parser();
+        SchemaBuilder.FieldAssembler<Schema> fieldAssembler = getFieldBuilder();
+        for (Map.Entry<String, String> field : fields.entrySet()) {
+            SchemaBuilder.FieldBuilder<Schema> fieldBuilder = fieldAssembler.name(field.getKey());
+            Schema fieldSchema = parser.parse(field.getValue());
+            SchemaBuilder.GenericDefault<Schema> genericDefault = fieldBuilder.type(fieldSchema);
+            switch (fieldSchema.getType()) {
+                case ARRAY:
+                    genericDefault.withDefault(ImmutableList.of());
+                    break;
+                case MAP:
+                    genericDefault.withDefault(ImmutableMap.of());
+                    break;
+                case UNION:
+                    if (fieldSchema.getTypes().stream()
+                            .map(Schema::getType)
+                            .anyMatch(Schema.Type.NULL::equals)) {
+                        genericDefault.withDefault(null);
+                    }
+                    else {
+                        genericDefault.noDefault();
+                    }
+                    break;
+                case NULL:
+                    genericDefault.withDefault(null);
+                    break;
+                default:
+                    genericDefault.noDefault();
+            }
+        }
+        return fieldAssembler.endRecord();
     }
 
     private Map<DecoderColumnHandle, FieldValueProvider> buildAndDecodeColumns(Set<DecoderColumnHandle> columns, Map<String, String> fieldSchema, Map<String, Object> fieldValue)
     {
-        String schema = getAvroSchema(fieldSchema);
-        byte[] avroData = buildAvroData(new Schema.Parser().parse(schema), fieldValue);
+        Schema schema = getAvroSchema(fieldSchema);
+        byte[] avroData = buildAvroData(schema, fieldValue);
 
         return decodeRow(
                 avroData,
                 columns,
-                ImmutableMap.of(DATA_SCHEMA, schema));
+                ImmutableMap.of(DATA_SCHEMA, schema.toString()));
     }
 
     private Map<DecoderColumnHandle, FieldValueProvider> buildAndDecodeColumn(DecoderTestColumnHandle column, String columnName, String columnType, Object actualValue)
@@ -146,12 +165,9 @@ public class TestAvroDecoder
     {
         GenericData.Record record = new GenericData.Record(schema);
         values.forEach(record::put);
-        try {
-            DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<>(schema));
-
+        try (DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<>(schema))) {
             dataFileWriter.create(schema, outputStream);
             dataFileWriter.append(record);
-            dataFileWriter.close();
         }
         catch (IOException e) {
             throw new RuntimeException("Failed to convert to Avro.", e);
@@ -177,12 +193,14 @@ public class TestAvroDecoder
         DecoderTestColumnHandle newlyAddedColumn = new DecoderTestColumnHandle(1, "row1", VARCHAR, "string_field_added", null, null, false, false, false);
 
         // the decoded avro data file does not have string_field_added
-        byte[] originalData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema("string_field", "\"string\"")),
+        byte[] originalData = buildAvroData(getFieldBuilder()
+                        .name("string_field").type().stringType().noDefault()
+                        .endRecord(),
                 "string_field", "string_field_value");
-        String addedColumnSchema = getAvroSchema(ImmutableMap.of(
-                "string_field", "\"string\"",
-                "string_field_added", "[\"null\", \"string\"]"));
+        String addedColumnSchema = getFieldBuilder()
+                .name("string_field").type().stringType().noDefault()
+                .name("string_field_added").type().optional().stringType()
+                .endRecord().toString();
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = decodeRow(
                 originalData,
                 ImmutableSet.of(originalColumn, newlyAddedColumn),
@@ -216,12 +234,16 @@ public class TestAvroDecoder
     public void testSchemaEvolutionRenamingColumn()
             throws Exception
     {
-        byte[] originalData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema("string_field", "\"string\"")),
+        byte[] originalData = buildAvroData(getFieldBuilder()
+                        .name("string_field").type().stringType().noDefault()
+                        .endRecord(),
                 "string_field", "string_field_value");
 
         DecoderTestColumnHandle renamedColumn = new DecoderTestColumnHandle(0, "row0", VARCHAR, "string_field_renamed", null, null, false, false, false);
-        String renamedColumnSchema = getAvroSchema("string_field_renamed", "[\"null\", \"string\"]");
+        String renamedColumnSchema = getFieldBuilder()
+                .name("string_field_renamed").type().optional().stringType()
+                .endRecord()
+                .toString();
         Map<DecoderColumnHandle, FieldValueProvider> decodedEvolvedRow = decodeRow(
                 originalData,
                 ImmutableSet.of(renamedColumn),
@@ -235,16 +257,19 @@ public class TestAvroDecoder
     public void testSchemaEvolutionRemovingColumn()
             throws Exception
     {
-        byte[] originalData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema(ImmutableMap.of(
-                        "string_field", "\"string\"",
-                        "string_field_to_be_removed", "[\"null\", \"string\"]"))),
+        byte[] originalData = buildAvroData(getFieldBuilder()
+                        .name("string_field").type().stringType().noDefault()
+                        .name("string_field_to_be_removed").type().optional().stringType()
+                        .endRecord(),
                 ImmutableMap.of(
                         "string_field", "string_field_value",
                         "string_field_to_be_removed", "removed_field_value"));
 
         DecoderTestColumnHandle evolvedColumn = new DecoderTestColumnHandle(0, "row0", VARCHAR, "string_field", null, null, false, false, false);
-        String removedColumnSchema = getAvroSchema("string_field", "\"string\"");
+        String removedColumnSchema = getFieldBuilder()
+                .name("string_field").type().stringType().noDefault()
+                .endRecord()
+                .toString();
         Map<DecoderColumnHandle, FieldValueProvider> decodedEvolvedRow = decodeRow(
                 originalData,
                 ImmutableSet.of(evolvedColumn),
@@ -258,12 +283,16 @@ public class TestAvroDecoder
     public void testSchemaEvolutionIntToLong()
             throws Exception
     {
-        byte[] originalIntData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema("int_to_long_field", "\"int\"")),
+        byte[] originalIntData = buildAvroData(getFieldBuilder()
+                        .name("int_to_long_field").type().intType().noDefault()
+                        .endRecord(),
                 "int_to_long_field", 100);
 
         DecoderTestColumnHandle longColumnReadingIntData = new DecoderTestColumnHandle(0, "row0", BIGINT, "int_to_long_field", null, null, false, false, false);
-        String changedTypeSchema = getAvroSchema("int_to_long_field", "\"long\"");
+        String changedTypeSchema = getFieldBuilder()
+                .name("int_to_long_field").type().longType().noDefault()
+                .endRecord()
+                .toString();
         Map<DecoderColumnHandle, FieldValueProvider> decodedEvolvedRow = decodeRow(
                 originalIntData,
                 ImmutableSet.of(longColumnReadingIntData),
@@ -277,12 +306,16 @@ public class TestAvroDecoder
     public void testSchemaEvolutionIntToDouble()
             throws Exception
     {
-        byte[] originalIntData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema("int_to_double_field", "\"int\"")),
+        byte[] originalIntData = buildAvroData(getFieldBuilder()
+                        .name("int_to_double_field").type().intType().noDefault()
+                        .endRecord(),
                 "int_to_double_field", 100);
 
         DecoderTestColumnHandle doubleColumnReadingIntData = new DecoderTestColumnHandle(0, "row0", DOUBLE, "int_to_double_field", null, null, false, false, false);
-        String changedTypeSchema = getAvroSchema("int_to_double_field", "\"double\"");
+        String changedTypeSchema = getFieldBuilder()
+                .name("int_to_double_field").type().doubleType().noDefault()
+                .endRecord()
+                .toString();
         Map<DecoderColumnHandle, FieldValueProvider> decodedEvolvedRow = decodeRow(
                 originalIntData,
                 ImmutableSet.of(doubleColumnReadingIntData),
@@ -296,12 +329,16 @@ public class TestAvroDecoder
     public void testSchemaEvolutionToIncompatibleType()
             throws Exception
     {
-        byte[] originalIntData = buildAvroData(new Schema.Parser().parse(
-                getAvroSchema("int_to_string_field", "\"int\"")),
+        byte[] originalIntData = buildAvroData(getFieldBuilder()
+                        .name("int_to_string_field").type().intType().noDefault()
+                        .endRecord(),
                 "int_to_string_field", 100);
 
         DecoderTestColumnHandle stringColumnReadingIntData = new DecoderTestColumnHandle(0, "row0", VARCHAR, "int_to_string_field", null, null, false, false, false);
-        String changedTypeSchema = getAvroSchema("int_to_string_field", "\"string\"");
+        String changedTypeSchema = getFieldBuilder()
+                .name("int_to_string_field").type().stringType().noDefault()
+                .endRecord()
+                .toString();
 
         assertThatThrownBy(() -> decodeRow(originalIntData, ImmutableSet.of(stringColumnReadingIntData), ImmutableMap.of(DATA_SCHEMA, changedTypeSchema)))
                 .isInstanceOf(PrestoException.class)
@@ -467,7 +504,6 @@ public class TestAvroDecoder
 
     @Test
     public void testNonExistentFieldsAreNull()
-            throws Exception
     {
         DecoderTestColumnHandle row1 = new DecoderTestColumnHandle(0, "row1", createVarcharType(100), "very/deep/varchar", null, null, false, false, false);
         DecoderTestColumnHandle row2 = new DecoderTestColumnHandle(1, "row2", BIGINT, "no_bigint", null, null, false, false, false);
@@ -632,15 +668,28 @@ public class TestAvroDecoder
                 .hasMessageMatching("Unsupported column type .* for column .*");
     }
 
+    private static SchemaBuilder.FieldAssembler<Schema> getFieldBuilder()
+    {
+        return SchemaBuilder.record("test_schema")
+                .namespace("com.facebook.presto.decoder.avro")
+                .fields();
+    }
+
     private void singleColumnDecoder(Type columnType)
     {
-        String someSchema = getAvroSchema("dummy", "\"long\"");
+        String someSchema = getFieldBuilder()
+                .name("dummy").type().longType().noDefault()
+                .endRecord()
+                .toString();
         DECODER_FACTORY.create(ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, "0", null, null, false, false, false)));
     }
 
     private void singleColumnDecoder(Type columnType, String mapping, String dataFormat, String formatHint, boolean keyDecoder, boolean hidden, boolean internal)
     {
-        String someSchema = getAvroSchema("dummy", "\"long\"");
+        String someSchema = getFieldBuilder()
+                .name("dummy").type().longType().noDefault()
+                .endRecord()
+                .toString();
         DECODER_FACTORY.create(ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
     }
 }

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -40,6 +40,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-record-decoder</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
org.xerial.snappy:snappy-java vulnerabilities
org.apache.avro:avro vulnerabilities Upgrade to 1.11.0.
CVE-2022-45868: com.h2database 1.4.199 to 2.2.220

com.h2database : h2 : 2.2.220 -> The current version doesn't cause Release failure
org.apache.avro : avro :  Upgrade to 1.11.0
org.xerial.snappy : snappy-java : Upgrade to 1.1.10.4