### PR TITLE
Disable timestamp with time zone type for ddl

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
@@ -125,6 +125,10 @@ public class ColumnIdentity
         String name = column.name();
         org.apache.iceberg.types.Type fieldType = column.type();
 
+        if (fieldType.equals(Types.TimestampType.withZone())) {
+            throw new UnsupportedOperationException(format("Iceberg column type %s is not supported", fieldType));
+        }
+
         if (!fieldType.isNestedType()) {
             return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of());
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -348,9 +348,16 @@ public abstract class IcebergAbstractMetadata
         if (!column.isNullable()) {
             throw new PrestoException(NOT_SUPPORTED, "This connector does not support add column with non null");
         }
+
+        org.apache.iceberg.types.Type columnType = toIcebergType(column.getType());
+
+        if (columnType.equals(Types.TimestampType.withZone())) {
+            throw new PrestoException(NOT_SUPPORTED, format("Iceberg column type %s is not supported", columnType));
+        }
+
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
-        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();
+        icebergTable.updateSchema().addColumn(column.getName(), columnType, column.getComment()).commit();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -77,6 +77,15 @@ public class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testTimestampWithTimeZone()
+    {
+        assertQueryFails("CREATE TABLE test_timestamp_with_timezone (x timestamp with time zone)", "Iceberg column type timestamptz is not supported");
+        assertUpdate("CREATE TABLE test_timestamp_with_timezone (x timestamp)");
+        assertQueryFails("ALTER TABLE test_timestamp_with_timezone ADD COLUMN y timestamp with time zone", "Iceberg column type timestamptz is not supported");
+        dropTable(getSession(), "test_timestamp_with_timezone");
+    }
+
+    @Test
     @Override
     public void testDescribeTable()
     {


### PR DESCRIPTION

## Description
Presto issue https://github.com/prestodb/presto/issues/17891

## Motivation and Context

When "timestamp with time zone" type used in create statement for iceberg tables, it maps data type to "timestamp". In this case, data insert and query returns misleading/errors based on timestamp type. 
In createColumnIdentity(), iceberg data type for "timestamptz" is retuned as timestamp and then in toPrestoType(), it maps to TIMESTAMP.
Similar issue exists with ALTER TABLE ADD COLUMN case. 

`presto:test> alter table tab2 add column c1 timestamp with time zone;`

 Presto should disallow create table and alter table cases. Following column description is misleading to the create statement type. 

```
presto:test> CREATE TABLE tab1 (a timestamp with time zone, b integer);
CREATE TABLE
presto:test> show columns from tab1;


 Column |   Type    | Extra | Comment 
--------+-----------+-------+---------
 a      | timestamp |       |         
 b      | integer   |       |         
(2 rows)
```

## Impact
create table & alter table statement having "timestamp with time zone" will return error for iceberg tables. 
`Iceberg column type timestamptz is not supported`

## Test Plan
- Add a new test in IcebergDistributedSmokeTestBase
- Manual testing 
```
presto:test> create table tab1 (a timestamp with time zone, b integer);
Query 20231010_190153_00002_tjs3h failed: Iceberg column type timestamptz is not supported

presto:test> create table tab2 (a integer, b integer);
CREATE TABLE
presto:test> alter table tab2 add column c timestamp with time zone;
Query 20231011_185736_00005_ae5bc failed: Iceberg column type timestamptz is not supported
```


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
* Timestamp with time zone data type is not allowed in create table and alter table statements. 


```

