### PR TITLE
Fix RowExpressionTest to be forward compatible with variant.toJson 

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -479,7 +479,7 @@ TEST_F(RowExpressionTest, call) {
     {
       auto cexpr = std::static_pointer_cast<const ConstantTypedExpr>(iexpr[1]);
       ASSERT_EQ(cexpr->type()->toString(), "VARCHAR");
-      ASSERT_EQ(cexpr->value().toJson(), "\"foo\"");
+      ASSERT_EQ(cexpr->value().toJson(cexpr->type()), "\"foo\"");
     }
   }
 }
@@ -585,7 +585,7 @@ TEST_F(RowExpressionTest, special) {
       auto cexpr = std::static_pointer_cast<const ConstantTypedExpr>(
           arg0expr->inputs()[1]);
       ASSERT_EQ(cexpr->type()->toString(), "BIGINT");
-      ASSERT_EQ(cexpr->value().toJson(), "10");
+      ASSERT_EQ(cexpr->value().toJson(cexpr->type()), "10");
     }
   }
 
@@ -605,7 +605,7 @@ TEST_F(RowExpressionTest, special) {
       auto cexpr = std::static_pointer_cast<const ConstantTypedExpr>(
           arg1expr->inputs()[1]);
       ASSERT_EQ(cexpr->type()->toString(), "VARCHAR");
-      ASSERT_EQ(cexpr->value().toJson(), "\"foo\"");
+      ASSERT_EQ(cexpr->value().toJson(cexpr->type()), "\"foo\"");
     }
   }
 }


### PR DESCRIPTION
This is required so we can land https://github.com/facebookincubator/velox/pull/6216 . 

## Description
Makes a test forward compatible.

```
== NO RELEASE NOTE ==
```

