### PR TITLE
[native] Use QueryConfig's default value for base default

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -702,7 +702,7 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
           BOOL_PROP(
               QueryConfig::kAggregationSpillEnabled,
               c.aggregationSpillEnabled()),
-          BOOL_PROP(QueryConfig::kAggregationSpillAll, true),
+          BOOL_PROP(QueryConfig::kAggregationSpillAll, c.aggregationSpillAll()),
           BOOL_PROP(QueryConfig::kJoinSpillEnabled, c.joinSpillEnabled()),
           BOOL_PROP(QueryConfig::kOrderBySpillEnabled, c.orderBySpillEnabled()),
           NUM_PROP(


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

