### PR TITLE
Add validation that checks next URI host and port does not change during query execution

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -110,7 +110,8 @@ public class BenchmarkDriverOptions
                 clientRequestTimeout,
                 disableCompression,
                 ImmutableMap.of(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                false);
     }
 
     private static URI parseServer(String server)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -143,6 +143,9 @@ public class ClientOptions
     @Option(name = "--disable-compression", title = "disable response compression", description = "Disable compression of query results")
     public boolean disableCompression;
 
+    @Option(name = "--validate-nexturi-source", title = "validate nextUri source", description = "Validate nextUri server host and port does not change during query execution")
+    public boolean validateNextUriSource;
+
     public enum OutputFormat
     {
         ALIGNED,
@@ -176,7 +179,8 @@ public class ClientOptions
                 clientRequestTimeout,
                 disableCompression,
                 emptyMap(),
-                emptyMap());
+                emptyMap(),
+                validateNextUriSource);
     }
 
     public static URI parseServer(String server)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -84,7 +84,8 @@ public abstract class AbstractCliTest
                 new Duration(2, MINUTES),
                 true,
                 ImmutableMap.of(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                false);
     }
 
     protected QueryResults createMockQueryResults()

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -171,4 +171,12 @@ public class TestClientOptions
         ClientOptions options = console.clientOptions;
         options.toClientSession();
     }
+
+    @Test
+    public void testValidateNextUriSource()
+    {
+        Console console = singleCommand(Console.class).parse("--validate-nexturi-source");
+        assertTrue(console.clientOptions.validateNextUriSource);
+        assertTrue(console.clientOptions.toClientSession().validateNextUriSource());
+    }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -54,6 +54,7 @@ public class ClientSession
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
     private final Map<String, String> sessionFunctions;
+    private final boolean validateNextUriSource;
 
     public static Builder builder(ClientSession clientSession)
     {
@@ -87,7 +88,8 @@ public class ClientSession
             Duration clientRequestTimeout,
             boolean compressionDisabled,
             Map<String, String> sessionFunctions,
-            Map<String, String> customHeaders)
+            Map<String, String> customHeaders,
+            boolean validateNextUriSource)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = user;
@@ -109,6 +111,7 @@ public class ClientSession
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
         this.sessionFunctions = ImmutableMap.copyOf(requireNonNull(sessionFunctions, "sessionFunctions is null"));
+        this.validateNextUriSource = validateNextUriSource;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -255,6 +258,11 @@ public class ClientSession
         return sessionFunctions;
     }
 
+    public boolean validateNextUriSource()
+    {
+        return validateNextUriSource;
+    }
+
     @Override
     public String toString()
     {
@@ -296,6 +304,7 @@ public class ClientSession
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
         private Map<String, String> sessionFunctions;
+        private boolean validateNextUriSource;
 
         private Builder(ClientSession clientSession)
         {
@@ -320,6 +329,7 @@ public class ClientSession
             clientRequestTimeout = clientSession.getClientRequestTimeout();
             compressionDisabled = clientSession.isCompressionDisabled();
             sessionFunctions = clientSession.getSessionFunctions();
+            validateNextUriSource = clientSession.validateNextUriSource();
         }
 
         public Builder withCatalog(String catalog)
@@ -388,6 +398,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder withValidateNextUriSource(final boolean validateNextUriSource)
+        {
+            this.validateNextUriSource = validateNextUriSource;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -410,7 +426,8 @@ public class ClientSession
                     clientRequestTimeout,
                     compressionDisabled,
                     sessionFunctions,
-                    customHeaders);
+                    customHeaders,
+                    validateNextUriSource);
         }
     }
 }

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -119,4 +119,5 @@ Name                              Description
                                   customHeaders is a list of key-value pairs. Example:
                                   ``testHeaderKey:testHeaderValue`` will inject the header ``testHeaderKey``
                                   with value ``testHeaderValue``. Values should be percent encoded.
+``validateNextUriSource``         Validates that host and port in next URI does not change during query execution.
 ================================= =======================================================================

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -62,6 +62,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<List<Protocol>> HTTP_PROTOCOLS = new HttpProtocols();
     public static final ConnectionProperty<List<QueryInterceptor>> QUERY_INTERCEPTORS = new QueryInterceptors();
+    public static final ConnectionProperty<Boolean> VALIDATE_NEXTURI_SOURCE = new ValidateNextUriSource();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -89,6 +90,7 @@ final class ConnectionProperties
             .add(SESSION_PROPERTIES)
             .add(HTTP_PROTOCOLS)
             .add(QUERY_INTERCEPTORS)
+            .add(VALIDATE_NEXTURI_SOURCE)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -365,6 +367,15 @@ final class ConnectionProperties
         public QueryInterceptors()
         {
             super("queryInterceptors", NOT_REQUIRED, ALLOWED, CLASS_LIST_CONVERTER);
+        }
+    }
+
+    private static class ValidateNextUriSource
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public ValidateNextUriSource()
+        {
+            super("validateNextUriSource", Optional.of("false"), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -98,6 +98,7 @@ public class PrestoConnection
     private final QueryExecutor queryExecutor;
     private final WarningsManager warningsManager = new WarningsManager();
     private final List<QueryInterceptor> queryInterceptorInstances;
+    private final boolean validateNextUriSource;
 
     PrestoConnection(PrestoDriverUri uri, QueryExecutor queryExecutor)
             throws SQLException
@@ -116,6 +117,7 @@ public class PrestoConnection
         this.sessionProperties = new ConcurrentHashMap<>(uri.getSessionProperties());
         this.connectionProperties = uri.getProperties();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
+        this.validateNextUriSource = uri.validateNextUriSource();
         uri.getClientTags().ifPresent(tags -> clientInfo.put("ClientTags", tags));
 
         timeZoneId.set(uri.getTimeZoneId());
@@ -792,7 +794,8 @@ public class PrestoConnection
                 timeout,
                 compressionDisabled,
                 ImmutableMap.of(),
-                customHeaders);
+                customHeaders,
+                validateNextUriSource);
 
         return queryExecutor.startQuery(session, sql);
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASS
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
 import static com.facebook.presto.jdbc.ConnectionProperties.TIMEZONE_ID;
 import static com.facebook.presto.jdbc.ConnectionProperties.USER;
+import static com.facebook.presto.jdbc.ConnectionProperties.VALIDATE_NEXTURI_SOURCE;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -208,6 +209,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return HTTP_PROTOCOLS.getValue(properties);
+    }
+
+    public boolean validateNextUriSource()
+            throws SQLException
+    {
+        return VALIDATE_NEXTURI_SOURCE.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -33,8 +33,10 @@ import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static com.facebook.presto.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
+import static com.facebook.presto.jdbc.ConnectionProperties.VALIDATE_NEXTURI_SOURCE;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -317,6 +319,21 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?queryInterceptors=" + queryInterceptor);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(QUERY_INTERCEPTORS.getKey()), queryInterceptor);
+    }
+
+    @Test
+    public void testValidateNextUriSource()
+            throws SQLException
+    {
+        PrestoDriverUri defaultParams = createDriverUri("presto://localhost:8080/blackhole");
+        assertFalse(defaultParams.validateNextUriSource());
+        assertEquals(defaultParams.getProperties().getProperty(VALIDATE_NEXTURI_SOURCE.getKey()), "false");
+
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080/blackhole?validateNextUriSource=true");
+        assertTrue(parameters.validateNextUriSource());
+        assertEquals(parameters.getProperties().getProperty(VALIDATE_NEXTURI_SOURCE.getKey()), "true");
+
+        assertInvalid("presto://localhost:8080/blackhole?validateNextUriSource=ANOTHERVALUE", "Connection property 'validateNextUriSource' value is invalid: ANOTHERVALUE");
     }
 
     public static class TestForUriQueryInterceptor

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -172,7 +172,8 @@ public abstract class AbstractTestingPrestoClient<T>
                 clientRequestTimeout,
                 true,
                 serializedSessionFunctions,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                false);
     }
 
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -82,7 +82,8 @@ public class TestFinalQueryInfo
                     new Duration(2, MINUTES),
                     true,
                     ImmutableMap.of(),
-                    ImmutableMap.of());
+                    ImmutableMap.of(),
+                    false);
 
             // start query
             StatementClient client = newStatementClient(httpClient, clientSession, sql);


### PR DESCRIPTION

## Description
Presto client can attempt to follow a next URI from an untrusted source, adding option to validate that next URI host and port does not change during query execution.

## Motivation and Context
Presto clients can attempt to follow a next URI from an untrusted source, adding option to validate that the host and port are consistent during query execution as a security improvement.
Fixes advisory https://github.com/prestodb/presto/security/advisories/GHSA-86q5-qcjc-7pv4 

## Impact
Adding option to Presto Client to validate next URI during query execution. This is an opt in, by default the current client behavior does not change

## Test Plan
Tested locally with CLI and Presto Jdbc client by sending an invalid next URI host & port during a query execution, confirmed clients will not follow the invalid next URI if option to perform this validation is turned on.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add validation to check that next URI host and port does not change during query execution