### PR TITLE
[native] Fix "unknown pool name 'link_job_pool'" CMake error

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -76,8 +76,10 @@ target_link_libraries(
 # dependencies first followed by FBThrift.
 target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra
                       ${THRIFT_LIBRARY})
-
-set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK link_job_pool)
+message("Checking CMAKE_JOB_POOL_LINK: ${CMAKE_JOB_POOL_LINK}")
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 add_executable(presto_server PrestoMain.cpp)
 
@@ -97,7 +99,10 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
 
-set_property(TARGET presto_server PROPERTY JOB_POOL_LINK link_job_pool)
+message("Checking CMAKE_JOB_POOL_LINK: ${CMAKE_JOB_POOL_LINK}")
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_server PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(presto_exception Exception.cpp)
 add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
 
 target_link_libraries(presto_exception velox_exception)
-set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK link_job_pool)
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 target_link_libraries(presto_common velox_config velox_core velox_exception)
 

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -35,7 +35,9 @@ target_link_libraries(
   ${FMT}
   ${RE2})
 
-set_property(TARGET presto_http PROPERTY JOB_POOL_LINK link_job_pool)
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_http PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -46,7 +46,9 @@ target_link_libraries(
   gtest
   gtest_main)
 
-set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK link_job_pool)
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_executable(presto_server_remote_function_test

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -24,7 +24,9 @@ add_dependencies(presto_types presto_operators presto_type_converter velox_type
 target_link_libraries(presto_types presto_type_converter velox_type_fbhive
                       velox_hive_partition_function velox_tpch_gen)
 
-set_property(TARGET presto_types PROPERTY JOB_POOL_LINK link_job_pool)
+if("${CMAKE_JOB_POOL_LINK}")
+  set_property(TARGET presto_types PROPERTY JOB_POOL_LINK link_job_pool)
+endif()
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)


### PR DESCRIPTION
## Description
Velox creates link_job_pool only when MAX_LINK_JOBS is defined, but by default, this variable is not defined, and thus the CMake job pool was not created. However in presto_cpp, this job pool was used without checking its existence, and caused the "unknown pool name 'link_job_pool'" error while loading the CMake project. This commit fixes this problem by adding a check whether the job pool was created before using it.

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/21102

## Impact
NA

## Test Plan
The CMake project was able to be loaded successfully after this change.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

