### PR TITLE
Improve layout of table for SHOW STATS in docs

### DIFF
--- a/presto-docs/src/main/sphinx/sql/show-stats.rst
+++ b/presto-docs/src/main/sphinx/sql/show-stats.rst
@@ -14,19 +14,49 @@ Synopsis
 Description
 -----------
 
-Returns approximated statistics for the named table or for the results of a (limited) query.
+``SHOW STATS FOR table``: Show statistics for a specific table.
+It provides information about the number of rows, number of nulls, minimum and maximum values,
+number of distinct values, and average length for each column in the table.
 
-Statistics are returned for the specified columns, along with a summary row.
-(column_name will be ``NULL`` for the summary row).
+``SHOW STATS FOR ( query )``: Show statistics for the result of a specific query.
+It provides the same information as ``SHOW STATS FOR table``, but for the result set of the query instead
+of a single table.
 
-=====================   ============
-Column                  Description
-=====================   ============
-column_name             The name of the column
-data_size               The total size in bytes of all of the values in the column
-distinct_values_count   The number of distinct values in the column
-nulls_fractions         The portion of the values in the column that are ``NULL``
-row_count               The number of rows (only returned for the summary row)
-low_value               The lowest value found in this column (only for some types)
-high_value              The highest value found in this column (only for some types)
-=====================   ============
+Any statistics that are not populated or unavailable on the data source are returned as ``NULL``. Any additional
+statistics collected on the data source other than those listed below are not included in the output of the
+``SHOW STATS`` command.
+
+The summary row does not correspond to any specific column so the ``column_name`` value for the summary row is ``NULL``.
+
+The following table lists the returned columns and what statistics they represent.
+
+.. list-table:: Statistics
+  :widths: 20, 40, 40
+  :header-rows: 1
+
+  * - Column
+    - Description
+    - Notes
+  * - ``column_name``
+    - The name of the column
+    - ``NULL`` in the table summary row.
+  * - ``data_size``
+    - The total size in bytes of all of the values in the column
+    - ``NULL`` in the table summary row. Available for columns of string data types with variable widths.
+  * - ``distinct_values_count``
+    - The estimated number of distinct values in the column
+    - ``NULL`` in the table summary row.
+  * - ``nulls_fractions``
+    - The portion of the values in the column that are ``NULL``
+    - ``NULL`` in the table summary row.
+  * - ``row_count``
+    - The estimated number of rows in the table
+    - ``NULL`` in column statistic rows.
+  * - ``low_value``
+    - The lowest value found in this column
+    - ``NULL`` in the table summary row. Available for columns of DATE, integer, floating-point, and fixed-precision
+      data types.
+  * - ``high_value``
+    - The highest value found in this column
+    - ``NULL`` in the table summary row. Available for columns of DATE, integer, floating-point, and fixed-precision
+      data types.


### PR DESCRIPTION

<img width="787" alt="Screenshot 2023-10-11 at 6 35 25 PM" src="https://github.com/prestodb/presto/assets/89628774/983b1de3-d7be-446e-9b77-aa605492f5a7">

<img width="787" alt="Screenshot 2023-10-11 at 6 30 13 PM" src="https://github.com/prestodb/presto/assets/89628774/6a4f41db-9d88-4c60-a53b-b86c4299368a">
