### PR TITLE
Bump org.apache.zookeeper:zookeeper from 3.4.14 to 3.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1888,7 +1888,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.14</version>
+                <version>3.7.2</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>jline</artifactId>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -244,6 +244,12 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -150,6 +150,12 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumping the version of a dependency like org.apache.zookeeper:zookeeper from 3.4.13 to 3.7.2 can bring several benefits:

Bug Fixes: Newer versions often come with fixes for bugs that were present in the older versions. This can help improve the stability and reliability of your project.

New Features: Upgrading to a newer version can provide access to features that were not available in the older version.

Performance Improvements: Newer versions can also come with optimizations that make your project run more efficiently.

Security Patches: This is one of the most important reasons to keep your dependencies up to date. Older versions of libraries can have known security vulnerabilities that are fixed in newer versions.

