### PR TITLE
Update AWS SDK 1.12.261 to 1.12.560

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
-        <dep.aws-sdk.version>1.12.261</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.560</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>


### PR DESCRIPTION
Updating the AWS SDK from an older version to 1.12.493 can have several benefits:

Bug Fixes: Newer versions often come with fixes for bugs that were present in older versions. This can help improve the stability and reliability of your project.

New Features: Upgrading to a newer version can provide access to features that were not available in the older version. AWS SDKs are regularly updated with support for new services and features.

Performance Improvements: Newer versions can also come with optimizations that make your project run more efficiently.

Security Patches: This is one of the most important reasons to keep your dependencies up to date. Older versions of libraries can have known security vulnerabilities that are fixed in newer versions.

