### PR TITLE
Revert "Fix memory reservation accounting problem about InMemoryHashAggregationBuilder inside SpillableHashAggregationBuilder."

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -575,7 +575,7 @@ public class HashAggregationOperator
                     maxPartialMemory,
                     joinCompiler,
                     true,
-                    useSystemMemory ? ReserveType.SYSTEM : ReserveType.USER);
+                    useSystemMemory);
         }
         else {
             verify(!useSystemMemory, "using system memory in spillable aggregations is not supported");
@@ -666,12 +666,5 @@ public class HashAggregationOperator
             }
         }
         return result;
-    }
-
-    public enum ReserveType
-    {
-        USER,
-        SYSTEM,
-        REVOCABLE
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation.builder;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.LocalMemoryContext;
-import com.facebook.presto.operator.HashAggregationOperator.ReserveType;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.WorkProcessor;
 import com.facebook.presto.operator.WorkProcessor.Transformation;
@@ -151,7 +150,6 @@ public class MergingHashAggregationBuilder
                 Optional.of(overwriteIntermediateChannelOffset),
                 joinCompiler,
                 false,
-                ReserveType.USER,
-                Optional.empty());
+                false);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -335,7 +335,7 @@ public class SpillableHashAggregationBuilder
                 Optional.of(DataSize.succinctBytes(0)),
                 joinCompiler,
                 false,
-                Optional.of((memorySize) -> localRevocableMemoryContext.setBytes(memorySize)));
+                false);
         emptyHashAggregationBuilderSize = hashAggregationBuilder.getSizeInMemory();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -55,15 +55,6 @@ public final class TestingTaskContext
                 .build();
     }
 
-    public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService yieldExecutor, Session session,
-                                                DataSize maxMemory, DataSize maxTotalMemory)
-    {
-        return builder(notificationExecutor, yieldExecutor, session)
-                .setQueryMaxMemory(maxMemory)
-                .setQueryMaxTotalMemory(maxTotalMemory)
-                .build();
-    }
-
     public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService yieldExecutor, Session session, TaskStateMachine taskStateMachine)
     {
         return builder(notificationExecutor, yieldExecutor, session)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -621,54 +621,6 @@ public class TestHashAggregationOperator
     }
 
     @Test
-    public void testMemoryLimitInSpillWhenTriggerRehash()
-    {
-        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(BIGINT);
-
-        int smallPagesSpillThresholdSize = 100000;
-
-        List<Page> input = rowPagesBuilder
-                .addSequencePage(smallPagesSpillThresholdSize, 0)
-                .addSequencePage(smallPagesSpillThresholdSize, smallPagesSpillThresholdSize)
-                .addSequencePage(smallPagesSpillThresholdSize, 2 * smallPagesSpillThresholdSize)
-                .addSequencePage(smallPagesSpillThresholdSize, 3 * smallPagesSpillThresholdSize)
-                .build();
-
-        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
-                0,
-                new PlanNodeId("test"),
-                ImmutableList.of(BIGINT),
-                ImmutableList.of(0),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                Step.SINGLE,
-                false,
-                ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
-                rowPagesBuilder.getHashChannel(),
-                Optional.empty(),
-                1,
-                Optional.of(new DataSize(16, MEGABYTE)),
-                true,
-                new DataSize(smallPagesSpillThresholdSize, Unit.BYTE),
-                succinctBytes(Integer.MAX_VALUE),
-                spillerFactory,
-                joinCompiler,
-                false);
-
-        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION,
-                new DataSize(10, MEGABYTE), new DataSize(20, MEGABYTE));
-        DriverContext driverContext = taskContext
-                .addPipelineContext(0, true, true, false)
-                .addDriverContext();
-
-        MaterializedResult.Builder resultBuilder = resultBuilder(driverContext.getSession(), BIGINT, BIGINT);
-        for (int i = 0; i < 4 * smallPagesSpillThresholdSize; ++i) {
-            resultBuilder.row((long) i, (long) i);
-        }
-        assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, resultBuilder.build());
-    }
-
-    @Test
     public void testSpillerFailure()
     {
         JavaAggregationFunctionImplementation maxVarcharColumn = getAggregation("max", VARCHAR);


### PR DESCRIPTION
We are seeing assertion failure in Presto-On-Spark and has been blocking internal release.

Meanwhile, I am working on reproducing the issue and a test case to support the case.

Reverts prestodb/presto#20360

Tracking issue: https://github.com/prestodb/presto/issues/21134