### PR TITLE
Fix memory accounting in InMemoryHashAggregationBuilder

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -575,7 +575,7 @@ public class HashAggregationOperator
                     maxPartialMemory,
                     joinCompiler,
                     true,
-                    useSystemMemory);
+                    useSystemMemory ? ReserveType.SYSTEM : ReserveType.USER);
         }
         else {
             verify(!useSystemMemory, "using system memory in spillable aggregations is not supported");
@@ -666,5 +666,12 @@ public class HashAggregationOperator
             }
         }
         return result;
+    }
+
+    public enum ReserveType
+    {
+        USER,
+        SYSTEM,
+        REVOCABLE
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.GroupByHash;
+import com.facebook.presto.operator.HashAggregationOperator.ReserveType;
 import com.facebook.presto.operator.HashCollisionsCounter;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.TransformWork;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.SystemSessionProperties.isDictionaryAggregationEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -61,7 +63,8 @@ public class InMemoryHashAggregationBuilder
     private final OptionalLong maxPartialMemory;
     private final LocalMemoryContext systemMemoryContext;
     private final LocalMemoryContext localUserMemoryContext;
-    private final boolean useSystemMemory;
+    private final ReserveType reserveType;
+    private final Consumer<Long> memoryConsumer;
 
     private boolean full;
 
@@ -76,7 +79,7 @@ public class InMemoryHashAggregationBuilder
             Optional<DataSize> maxPartialMemory,
             JoinCompiler joinCompiler,
             boolean yieldForMemoryReservation,
-            boolean useSystemMemory)
+            ReserveType reserveType)
     {
         this(accumulatorFactories,
                 step,
@@ -89,7 +92,36 @@ public class InMemoryHashAggregationBuilder
                 Optional.empty(),
                 joinCompiler,
                 yieldForMemoryReservation,
-                useSystemMemory);
+                reserveType,
+                Optional.empty());
+    }
+
+    public InMemoryHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            Optional<DataSize> maxPartialMemory,
+            JoinCompiler joinCompiler,
+            boolean yieldForMemoryReservation,
+            Optional<Consumer<Long>> memoryConsumer)
+    {
+        this(accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByChannels,
+                hashChannel,
+                operatorContext,
+                maxPartialMemory,
+                Optional.empty(),
+                joinCompiler,
+                yieldForMemoryReservation,
+                ReserveType.REVOCABLE,
+                memoryConsumer);
     }
 
     public InMemoryHashAggregationBuilder(
@@ -104,8 +136,24 @@ public class InMemoryHashAggregationBuilder
             Optional<Integer> overwriteIntermediateChannelOffset,
             JoinCompiler joinCompiler,
             boolean yieldForMemoryReservation,
-            boolean useSystemMemory)
+            ReserveType reserveType,
+            Optional<Consumer<Long>> memoryConsumer)
     {
+        // reserveType is REVOCABLE implies current InMemoryHashAggregationBuilder is built from SpillableHashAggregationBuilder
+        //  and it will accept a customized memoryConsumer for memory update
+        if (reserveType == ReserveType.REVOCABLE) {
+            checkArgument(memoryConsumer.isPresent(),
+                    "memoryConsumer must be present when reserve type is REVOCABLE");
+        }
+
+        this.reserveType = reserveType;
+        if (memoryConsumer.isPresent()) {
+            this.memoryConsumer = memoryConsumer.get();
+        }
+        else {
+            this.memoryConsumer = this::updateMemory;
+        }
+
         UpdateMemory updateMemory;
         if (yieldForMemoryReservation) {
             updateMemory = this::updateMemoryWithYieldInfo;
@@ -113,7 +161,6 @@ public class InMemoryHashAggregationBuilder
         else {
             // Report memory usage but do not yield for memory.
             // This is specially used for spillable hash aggregation operator.
-            // TODO: revisit this when spillable hash aggregation operator is turned on
             updateMemory = () -> {
                 updateMemoryWithYieldInfo();
                 return true;
@@ -132,7 +179,6 @@ public class InMemoryHashAggregationBuilder
         this.maxPartialMemory = maxPartialMemory.map(dataSize -> OptionalLong.of(dataSize.toBytes())).orElseGet(OptionalLong::empty);
         this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(InMemoryHashAggregationBuilder.class.getSimpleName());
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
-        this.useSystemMemory = useSystemMemory;
 
         // wrapper each function with an aggregator
         ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
@@ -151,7 +197,7 @@ public class InMemoryHashAggregationBuilder
     @Override
     public void close()
     {
-        updateMemory(0);
+        memoryConsumer.accept(0L);
     }
 
     @Override
@@ -326,24 +372,28 @@ public class InMemoryHashAggregationBuilder
     {
         long memorySize = getSizeInMemory();
         if (partial && maxPartialMemory.isPresent()) {
-            updateMemory(memorySize);
+            memoryConsumer.accept(memorySize);
             full = (memorySize > maxPartialMemory.getAsLong());
             return true;
         }
         // Operator/driver will be blocked on memory after we call setBytes.
         // If memory is not available, once we return, this operator will be blocked until memory is available.
-        updateMemory(memorySize);
+        memoryConsumer.accept(memorySize);
         // If memory is not available, inform the caller that we cannot proceed for allocation.
         return operatorContext.isWaitingForMemory().isDone();
     }
 
     private void updateMemory(long memorySize)
     {
-        if (useSystemMemory) {
-            systemMemoryContext.setBytes(memorySize);
-        }
-        else {
-            localUserMemoryContext.setBytes(memorySize);
+        switch (reserveType) {
+            case USER:
+                localUserMemoryContext.setBytes(memorySize);
+                break;
+            case SYSTEM:
+                systemMemoryContext.setBytes(memorySize);
+                break;
+            default:
+                throw new AssertionError("InMemoryHashAggregationBuilder do not support reserve type: " + reserveType);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.builder;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.operator.HashAggregationOperator.ReserveType;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.WorkProcessor;
 import com.facebook.presto.operator.WorkProcessor.Transformation;
@@ -150,6 +151,7 @@ public class MergingHashAggregationBuilder
                 Optional.of(overwriteIntermediateChannelOffset),
                 joinCompiler,
                 false,
-                false);
+                ReserveType.USER,
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -55,6 +55,15 @@ public final class TestingTaskContext
                 .build();
     }
 
+    public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService yieldExecutor, Session session,
+                                                DataSize maxMemory, DataSize maxTotalMemory)
+    {
+        return builder(notificationExecutor, yieldExecutor, session)
+                .setQueryMaxMemory(maxMemory)
+                .setQueryMaxTotalMemory(maxTotalMemory)
+                .build();
+    }
+
     public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService yieldExecutor, Session session, TaskStateMachine taskStateMachine)
     {
         return builder(notificationExecutor, yieldExecutor, session)


### PR DESCRIPTION
## Description
InMemoryHashAggregationBuilder when used by SpillableHashAggregationBuilder
while processing input should be spillable and part of revocable memory.

The same instance is used while producing output by spillable accumulators
like: DedupBasedSpillableDistinctGroupedAccumulator
(GenericAccumulatorFactory.java#L401). While producing the output, the memory
should be accounted as part of user memory and is non-revocable.


Stack trace:
```
java.lang.Throwable
        at com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.logMemory(InMemoryHashAggregationBuilder.java:506)
        at com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.updateMemoryWithYieldInfo(InMemoryHashAggregationBuilder.java:384)
        at com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.lambda$new$0(InMemoryHashAggregationBuilder.java:166)
        at com.facebook.presto.operator.aggregation.GenericAccumulatorFactory$DistinctingGroupedAccumulator.lambda$createMarkDistinctHash$0(GenericAccumulatorFactory.java:557)
        at com.facebook.presto.operator.MultiChannelGroupByHash.tryRehash(MultiChannelGroupByHash.java:449)
        at com.facebook.presto.operator.MultiChannelGroupByHash.addNewGroup(MultiChannelGroupByHash.java:362)
        at com.facebook.presto.operator.MultiChannelGroupByHash.putIfAbsent(MultiChannelGroupByHash.java:326)
        at com.facebook.presto.operator.MultiChannelGroupByHash.putIfAbsent(MultiChannelGroupByHash.java:298)
        at com.facebook.presto.operator.MultiChannelGroupByHash.access$200(MultiChannelGroupByHash.java:56)
        at com.facebook.presto.operator.MultiChannelGroupByHash$GetNonDictionaryGroupIdsWork.process(MultiChannelGroupByHash.java:757)
        at com.facebook.presto.operator.TransformWork.process(TransformWork.java:40)
        at com.facebook.presto.operator.aggregation.GenericAccumulatorFactory$DistinctingGroupedAccumulator.computeDistinctMask(GenericAccumulatorFactory.java:640)
        at com.facebook.presto.operator.aggregation.GenericAccumulatorFactory$DistinctingGroupedAccumulator.addInput(GenericAccumulatorFactory.java:584)
        at com.facebook.presto.operator.aggregation.GenericAccumulatorFactory$SpillableFinalOnlyGroupedAccumulator.prepareFinal(GenericAccumulatorFactory.java:1123)
        at com.facebook.presto.operator.aggregation.GenericAccumulatorFactory$DedupBasedSpillableDistinctGroupedAccumulator.prepareFinal(GenericAccumulatorFactory.java:1219)
        at com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder$Aggregator.prepareFinal(InMemoryHashAggregationBuilder.java:465)
        at com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.buildResult(InMemoryHashAggregationBuilder.java:302)
        at com.facebook.presto.operator.aggregation.builder.SpillableHashAggregationBuilder.buildResult(SpillableHashAggregationBuilder.java:225)
        at com.facebook.presto.operator.HashAggregationOperator.getOutput(HashAggregationOperator.java:460)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:428)
        at com.facebook.presto.operator.Driver.lambda$processFor$9(Driver.java:311)
        at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:732)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:304)
        at com.facebook.presto.spark.execution.task.PrestoSparkTaskExecution$DriverSplitRunner.processFor(PrestoSparkTaskExecution.java:480)
        at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
        at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:621)
        at com.facebook.presto.$gen.Presto_0_285_SNAPSHOT_afca768____20231012_170616_1.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```



See issue: #21134 

## Motivation and Context
In previous implementation, rehash in GroupByHash will cause all memory be 
accounted to user memory, including preallocatedMemoryInBytes for rehash.
It maybe lead some queries to fail, although they could exe successfully, 
especially in a low "query.max-memory-per-node" configuration environment.

```
== NO RELEASE NOTE ==
```

