### PR TITLE
Fix Iceberg table partitioned by columns of TimestampType

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -58,6 +58,11 @@ public final class TimestampType
         }
     }
 
+    public TimeUnit getPrecision()
+    {
+        return this.precision;
+    }
+
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeUtils;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -56,6 +57,8 @@ import static com.facebook.presto.iceberg.IcebergUtil.getIdentityPartitions;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
 public class PartitionTable
@@ -272,7 +275,7 @@ public class PartitionTable
         return Partition.toMap(idToTypeMapping, idToMetricMap);
     }
 
-    public static Object convert(Object value, Type type)
+    private Object convert(Object value, Type type)
     {
         if (value == null) {
             return null;
@@ -286,6 +289,12 @@ public class PartitionTable
         }
         if (type instanceof Types.FloatType) {
             return Float.floatToIntBits((Float) value);
+        }
+        if (type instanceof Types.TimestampType) {
+            com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
+                return MICROSECONDS.toMillis((long) value);
+            }
         }
         return value;
     }


### PR DESCRIPTION
## Description

In current implementation, when Iceberg table was partitioned by columns of TimestampType, we would meet some problems when insert, select, delete from it, or query system table "$partitions". Also see #20487 

The main reason is, Iceberg maintain data of TimestampType as long of microseconds, but presto by default handle data of TimestampType as long of milliseconds. This would introduce problems when iceberg use the long value to handle partitions.

This PR fix the problems when we use partition columns of TimestampType in IcebergTable.


## Test Plan

 - Make sure this fix do not affect existing test cases in IcebergDistributedTestBase
 - Newly added test case in IcebergDistributedTestBase.testPartitionedByTimestampType()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

