### PR TITLE
[native] Use env variables else System properties for QueryRunner configuration

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -264,13 +264,19 @@ public class PrestoNativeQueryRunnerUtils
 
     public static NativeQueryRunnerParameters getNativeQueryRunnerParameters()
     {
-        Path prestoServerPath = Paths.get(Optional.ofNullable(System.getProperty("PRESTO_SERVER"))
-                        .orElse("_build/debug/presto_cpp/main/presto_server"))
+        Path prestoServerPath = Paths.get(Optional.ofNullable(System.getenv("PRESTO_SERVER"))
+                        .orElseGet(() -> Optional.ofNullable(System.getProperty("PRESTO_SERVER"))
+                                .orElse("_build/debug/presto_cpp/main/presto_server")))
                 .toAbsolutePath();
-        Path dataDirectory = Paths.get(Optional.ofNullable(System.getProperty("DATA_DIR"))
-                        .orElse("target/velox_data"))
+        Path dataDirectory = Paths.get(Optional.ofNullable(System.getenv("DATA_DIR"))
+                        .orElseGet(() -> Optional.ofNullable(System.getProperty("DATA_DIR"))
+                                .orElse("target/velox_data")))
                 .toAbsolutePath();
-        Optional<Integer> workerCount = Optional.ofNullable(System.getProperty("WORKER_COUNT")).map(Integer::parseInt);
+        Optional<String> workerProp = Optional.ofNullable(System.getenv("WORKER_COUNT"));
+        if (!workerProp.isPresent()) {
+            workerProp = Optional.ofNullable(System.getProperty("WORKER_COUNT"));
+        }
+        Optional<Integer> workerCount = workerProp.map(Integer::parseInt);
 
         assertTrue(Files.exists(prestoServerPath), format("Native worker binary at %s not found. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.", prestoServerPath));
         log.info("Using PRESTO_SERVER binary at %s", prestoServerPath);


### PR DESCRIPTION
## Description

Uses environment variables, then system properties as the query runner configuration source.

## Motivation and Context

See #21162 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

