### PR TITLE
[Native] Avoid building samples and examples for Prestissimo dependencies

### DIFF
--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ function install_folly {
 function install_fizz {
   github_checkout facebookincubator/fizz "${FB_OS_VERSION}"
   OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF -S fizz
+    cmake_install -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -S fizz
 }
 
 function install_wangle {
@@ -52,7 +52,7 @@ function install_fbthrift {
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
   OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF
+    cmake_install -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF
 }
 
 function install_antlr {


### PR DESCRIPTION
## Description

Avoid unnecessary transitive dependency related issues

## Motivation and Context

On macos build of some of the fuzz and proxigen samples fails with missing SSL related dependencies. 

## Impact

N/A

## Test Plan

Run ./scripts/setup-macos.sh

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

