### PR TITLE
[native] Expose stats on 'Tasks with a stuck operator'.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -69,6 +69,7 @@ struct PrestoTask {
   const PrestoTaskId id;
   const long startProcessCpuTime;
   std::shared_ptr<velox::exec::Task> task;
+  std::atomic_bool hasStuckOperator{false};
 
   // Has the task been normally created and started.
   // When you create task with error - it has never been started.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -71,6 +71,8 @@ void registerPrestoCppCounters() {
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumZombiePrestoTasks, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterNumTasksWithStuckOperator, facebook::velox::StatType::AVG);
+  REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumRunningDrivers, facebook::velox::StatType::AVG);
   REPORT_ADD_STAT_EXPORT_TYPE(
       kCounterNumBlockedDrivers, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -66,6 +66,8 @@ constexpr folly::StringPiece kCounterNumZombieVeloxTasks{
     "presto_cpp.num_zombie_velox_tasks"};
 constexpr folly::StringPiece kCounterNumZombiePrestoTasks{
     "presto_cpp.num_zombie_presto_tasks"};
+constexpr folly::StringPiece kCounterNumTasksWithStuckOperator{
+    "presto_cpp.num_tasks_with_stuck_operator"};
 constexpr folly::StringPiece kCounterNumRunningDrivers{
     "presto_cpp.num_running_drivers"};
 constexpr folly::StringPiece kCounterNumBlockedDrivers{


### PR DESCRIPTION
## Description
Expose stats on 'Tasks with a stuck operator':
- As a metric in the Task.
- As a counter.

```
== NO RELEASE NOTE ==
```

