### PR TITLE
[Docs] Fix content of Hive security configuration page

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -7,65 +7,6 @@ Hive Security Configuration
     :backlinks: none
     :depth: 1
 
-Authorization
-=============
-
-You can enable authorization checks for the :doc:`/connector/hive` by setting
-the ``hive.security`` property in the Hive catalog properties file. This
-property must be one of the following values:
-
-================================================== ============================================================
-Property Value                                     Description
-================================================== ============================================================
-``legacy`` (default value)                         Few authorization checks are enforced, thus allowing most
-                                                   operations. The config properties ``hive.allow-drop-table``,
-                                                   ``hive.allow-rename-table``, ``hive.allow-add-column``,
-                                                   ``hive.allow-drop-column`` and
-                                                   ``hive.allow-rename-column`` are used.
-
-``read-only``                                      Operations that read data or metadata, such as ``SELECT``,
-                                                   are permitted, but none of the operations that write data or
-                                                   metadata, such as ``CREATE``, ``INSERT`` or ``DELETE``, are
-                                                   allowed.
-
-``file``                                           Authorization checks are enforced using a config file specified
-                                                   by the Hive configuration property ``security.config-file``.
-                                                   See :ref:`hive-file-based-authorization` for details.
-
-``sql-standard``                                   Users are permitted to perform the operations as long as
-                                                   they have the required privileges as per the SQL standard.
-                                                   In this mode, Presto enforces the authorization checks for
-                                                   queries based on the privileges defined in Hive metastore.
-                                                   To alter these privileges, use the :doc:`/sql/grant` and
-                                                   :doc:`/sql/revoke` commands.
-                                                   See :ref:`hive-sql-standard-based-authorization` for details.
-
-``ranger``                                         Users are permitted to perform the operations as per the
-                                                   authorization policies configured in Ranger Hive service.
-                                                   See :ref:`hive-ranger-based-authorization` for details.
-================================================== ============================================================
-
-.. _hive-sql-standard-based-authorization:
-
-SQL Standard Based Authorization
---------------------------------
-
-When ``sql-standard`` security is enabled, Presto enforces the same SQL
-standard based authorization as Hive does.
-
-Since Presto's ``ROLE`` syntax support matches the SQL standard, and
-Hive does not exactly follow the SQL standard, there are the following
-limitations and differences:
-
-* ``CREATE ROLE role WITH ADMIN`` is not supported.
-* The ``admin`` role must be enabled to execute ``CREATE ROLE`` or ``DROP ROLE``.
-* ``GRANT role TO user GRANTED BY someone`` is not supported.
-* ``REVOKE role FROM user GRANTED BY someone`` is not supported.
-* By default, all a user's roles except ``admin`` are enabled in a new user session.
-* One particular role can be selected by executing ``SET ROLE role``.
-* ``SET ROLE ALL`` enables all of a user's roles except ``admin``.
-* The ``admin`` role must be enabled explicitly by executing ``SET ROLE admin``.
-
 Authentication
 ==============
 
@@ -334,6 +275,24 @@ Keytab files must be distributed to every node in the cluster that runs Presto.
 
 :ref:`Additional Information About Keytab Files.<hive-security-additional-keytab>`
 
+HDFS wire encryption
+--------------------
+
+In a Kerberized Hadoop cluster with enabled HDFS wire encryption you can enable
+Presto to access HDFS by using the ``hive.hdfs.wire-encryption.enabled`` property.
+
+===================================== ==========================================
+Property Name                         Description
+===================================== ==========================================
+``hive.hdfs.wire-encryption.enabled`` Enables HDFS wire encryption.
+                                      Possible values are ``true`` or ``false``.
+===================================== ==========================================
+
+.. note::
+
+    Depending on Presto installation configuration, using wire encryption may
+    impact query execution performance.
+
 .. _hive-security-impersonation:
 
 End User Impersonation
@@ -432,10 +391,69 @@ node.
 You should ensure that the keytab files have the correct permissions on every
 node after distributing them.
 
+Authorization
+=============
+
+Enable authorization checks for the :doc:`/connector/hive` by setting
+the ``hive.security`` property in the Hive catalog properties file. This
+property must be one of the following values:
+
+================================================== ============================================================
+Property Value                                     Description
+================================================== ============================================================
+``legacy`` (default value)                         Few authorization checks are enforced, thus allowing most
+                                                   operations. The config properties ``hive.allow-drop-table``,
+                                                   ``hive.allow-rename-table``, ``hive.allow-add-column``,
+                                                   ``hive.allow-drop-column`` and
+                                                   ``hive.allow-rename-column`` are used.
+
+``read-only``                                      Operations that read data or metadata, such as ``SELECT``,
+                                                   are permitted, but none of the operations that write data or
+                                                   metadata, such as ``CREATE``, ``INSERT`` or ``DELETE``, are
+                                                   allowed.
+
+``file``                                           Authorization checks are enforced using a config file specified
+                                                   by the Hive configuration property ``security.config-file``.
+                                                   See :ref:`hive-file-based-authorization` for details.
+
+``sql-standard``                                   Users are permitted to perform the operations as long as
+                                                   they have the required privileges as per the SQL standard.
+                                                   In this mode, Presto enforces the authorization checks for
+                                                   queries based on the privileges defined in Hive metastore.
+                                                   To alter these privileges, use the :doc:`/sql/grant` and
+                                                   :doc:`/sql/revoke` commands.
+                                                   See :ref:`hive-sql-standard-based-authorization` for details.
+
+``ranger``                                         Users are permitted to perform the operations as per the
+                                                   authorization policies configured in Ranger Hive service.
+                                                   See :ref:`hive-ranger-based-authorization` for details.
+================================================== ============================================================
+
+.. _hive-sql-standard-based-authorization:
+
+SQL Standard Based Authorization
+--------------------------------
+
+When ``sql-standard`` security is enabled, Presto enforces the same SQL
+standard based authorization as Hive does.
+
+Because Presto's ``ROLE`` syntax support matches the SQL standard, and
+Hive does not exactly follow the SQL standard, there are the following
+limitations and differences:
+
+* ``CREATE ROLE role WITH ADMIN`` is not supported.
+* The ``admin`` role must be enabled to execute ``CREATE ROLE`` or ``DROP ROLE``.
+* ``GRANT role TO user GRANTED BY someone`` is not supported.
+* ``REVOKE role FROM user GRANTED BY someone`` is not supported.
+* By default, all a user's roles except ``admin`` are enabled in a new user session.
+* One particular role can be selected by executing ``SET ROLE role``.
+* ``SET ROLE ALL`` enables all of a user's roles except ``admin``.
+* The ``admin`` role must be enabled explicitly by executing ``SET ROLE admin``.
+
 .. _hive-file-based-authorization:
 
 File Based Authorization
-========================
+------------------------
 
 The config file is specified using JSON and is composed of three sections,
 each of which is a list of rules that are matched in the order specified
@@ -443,7 +461,7 @@ in the config file. The user is granted the privileges from the first
 matching rule. All regexes default to ``.*`` if not specified.
 
 Schema Rules
-------------
+^^^^^^^^^^^^
 
 These rules govern who is considered an owner of a schema.
 
@@ -454,7 +472,7 @@ These rules govern who is considered an owner of a schema.
 * ``owner`` (required): boolean indicating ownership.
 
 Table Rules
------------
+^^^^^^^^^^^
 
 These rules govern the privileges granted on specific tables.
 
@@ -468,7 +486,7 @@ These rules govern the privileges granted on specific tables.
   ``DELETE``, ``OWNERSHIP``, ``GRANT_SELECT``.
 
 Session Property Rules
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 These rules govern who may set session properties.
 
@@ -529,7 +547,7 @@ See below for an example.
 .. _hive-ranger-based-authorization:
 
 Ranger Based Authorization
-==========================
+--------------------------
 
 Apache Ranger is a widely used framework for providing centralized security
 administration and management.
@@ -553,7 +571,7 @@ Ranger uses the authenticated user and user groups to associate with the
 policy definition.
 
 Requirements
-------------
+^^^^^^^^^^^^
 
 Before you configure Presto for any integration with Apache Ranger,
 verify the following prerequisites:
@@ -564,21 +582,21 @@ communicate with the Ranger service. Typically this is port 6080.
 Apache Ranger 2.1.0 or higher must be used
 
 Policies
---------
+^^^^^^^^
 
 A policy is a combination of set of resources and the associated privileges.
 Ranger provides a user interface, or optionally a REST API, to create
 and manage these access control policies.
 
 Users, groups, and roles
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Apache Ranger has UserGroups sync mechanism by which Users, groups, and
 roles are sourced from your configured authentication system with Apache
 Ranger.
 
 Supported authorizations
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Ranger Hive service allows to configure privileges at schema, table, column
 level. Note to restrict access to specific user and groups ranger policies
@@ -588,7 +606,7 @@ Access for listing schema, show tables metadata & configuring session
 properties are enabled by default.
 
 Configuration properties
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 ================================================== ============================================================ ============
 Property Name                                      Description                                                  Default
@@ -617,21 +635,3 @@ Property Name                                      Description                  
 ``ranger.http-client.trust-store-password``        Ranger SSL configuration - client trust-store password
 
 ================================================== ============================================================ ============
-
-HDFS wire encryption
---------------------
-
-In a Kerberized Hadoop cluster with enabled HDFS wire encryption you can enable
-Presto to access HDFS by using below property.
-
-===================================== ==========================================
-Property Name                         Description
-===================================== ==========================================
-``hive.hdfs.wire-encryption.enabled`` Enables HDFS wire encryption.
-                                      Possible values are ``true`` or ``false``.
-===================================== ==========================================
-
-.. note::
-
-    Depending on Presto installation configuration, using wire encryption may
-    impact query execution performance.


### PR DESCRIPTION
## Description
The sub-topics of Authorization and Authentication are all mixed up currently on hive-security.rst page. This PR aims to fix the same.

## Motivation and Context
This PR makes it easier to go over the hive security page, making the content more structured and ordered.

## Impact
NA

## Test Plan
NA

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

