### PR TITLE
Use LinkedBlockingQueue to queue requests when all threads are busy

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -57,7 +57,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -137,7 +137,7 @@ public class HivePartitionManager
         this.domainCompactionThreshold = domainCompactionThreshold;
         this.partitionFilteringFromMetastoreEnabled = partitionFilteringFromMetastoreEnabled;
         ExecutorService threadPoolExecutor = new ThreadPoolExecutor(0, maxParallelParsingConcurrency,
-                60L, TimeUnit.SECONDS, new SynchronousQueue<>(), daemonThreadsNamed("partition-value-parser-%s"));
+                60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), daemonThreadsNamed("partition-value-parser-%s"));
         this.executorService = listeningDecorator(threadPoolExecutor);
         this.executorServiceMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) threadPoolExecutor);
     }


### PR DESCRIPTION
## Description
We recently introduced a ThreadPoolExecutor to do parallel parsing of partition names. But since we used a SynchronousQueue while creating the executor, the requests are not getting queued and are being rejected when all the threads in the pool are busy when a new request comes in.
This PR changes that to use LinkedBlockingQueue(), so that we queue the requests when there are no free threads.

## Impact
None

## Test Plan
Tested by shadowing traffic 


## Release Notes

```
== NO RELEASE NOTE ==
```

