### PR TITLE
Silently drop Iceberg tables with missing filesystem metadata

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -132,6 +132,9 @@ public abstract class IcebergAbstractMetadata
     @Override
     public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
     {
+        IcebergTableHandle tableHandle = ((IcebergTableLayoutHandle) handle).getTable();
+        Table table = getIcebergTable(session, tableHandle.getSchemaTableName());
+        validateTableMode(session, table);
         return new ConnectorTableLayout(handle);
     }
 
@@ -381,6 +384,7 @@ public abstract class IcebergAbstractMetadata
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        validateTableMode(session, icebergTable);
 
         return beginIcebergTableInsert(table, icebergTable);
     }
@@ -414,7 +418,6 @@ public abstract class IcebergAbstractMetadata
 
         // use a new schema table name that omits the table type
         Table table = getIcebergTable(session, new SchemaTableName(tableName.getSchemaName(), name.getTableName()));
-        validateTableMode(session, table);
 
         return new IcebergTableHandle(
                 tableName.getSchemaName(),


### PR DESCRIPTION

## Description
Adds two utility methods to bypass the previous "Table metadata is missing" error thrown when attempting to drop a Hive-backed table for which a metadata file or folder is missing from the underlying file system. The utility methods (accessed when attempting a fetch of the table properties or snapshotId) eat the `TableNotFoundException`, log a warning, and continue with the drop task. Other tasks like select and insert will still throw the error as expected.

## Motivation and Context
Fixes #20529 

## Impact
Logs a warning indicating property or snapshotId couldn't be fetched in lieu of throwing an exception

## Test Plan
Tested manually. One new test case is also added that deletes filesystem files and asserts that a drop task succeeds without throwing an error and drops the table from the expected schema. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTES ==
```

