### PR TITLE
[native] Allow exchange payload copy to happen in driver thread

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -215,6 +215,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const uint16_t port_;
   const std::string clientCertAndKeyPath_;
   const std::string ciphers_;
+  const bool immediateBufferTransfer_;
 
   folly::CPUThreadPoolExecutor* const driverExecutor_;
   folly::IOThreadPoolExecutor* const httpExecutor_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -184,6 +184,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kHeartbeatFrequencyMs, 0),
           STR_PROP(kExchangeMaxErrorDuration, "30s"),
           STR_PROP(kExchangeRequestTimeout, "10s"),
+          BOOL_PROP(kExchangeImmediateBufferTransfer, true),
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
           BOOL_PROP(kIncludeNodeInSpillPath, false),
           NUM_PROP(kOldTaskCleanUpMs, 60'000),
@@ -458,6 +459,10 @@ std::chrono::duration<double> SystemConfig::exchangeMaxErrorDuration() const {
 std::chrono::duration<double> SystemConfig::exchangeRequestTimeout() const {
   return velox::core::toDuration(
       optionalProperty(kExchangeRequestTimeout).value());
+}
+
+bool SystemConfig::exchangeImmediateBufferTransfer() const {
+  return optionalProperty<bool>(kExchangeImmediateBufferTransfer).value();
 }
 
 int32_t SystemConfig::taskRunTimeSliceMicros() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -284,6 +284,12 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
+  /// Enable to make immediate buffer memory transfer in the handling IO threads
+  /// as soon as exchange gets its response back. Otherwise the memory transfer
+  /// will happen later in driver thread pool.
+  static constexpr std::string_view kExchangeImmediateBufferTransfer{
+      "exchange.immediate-buffer-transfer"};
+
   static constexpr std::string_view kExchangeRequestTimeout{
       "exchange.http-client.request-timeout"};
 
@@ -461,6 +467,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> exchangeMaxErrorDuration() const;
 
   std::chrono::duration<double> exchangeRequestTimeout() const;
+
+  bool exchangeImmediateBufferTransfer() const;
 
   int32_t taskRunTimeSliceMicros() const;
 


### PR DESCRIPTION
Add option to allow the exchange response payload copy and memory allocation to happen in driver thread to reduce load in IO thread pool. This feature is configurable via system config property exchange.immediate-buffer-transfer
```
== NO RELEASE NOTE ==
```

