### PR TITLE
Simplify union node with empty input

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -530,10 +530,10 @@ public class TestHiveMaterializedViewLogicalPlanner
             MaterializedResult baseTable = computeActual(baseQuery);
             assertEquals(viewTable, baseTable);
 
-            assertPlan(getSession(), viewQuery, anyTree(values("ds", "orderkey"), anyTree(
+            assertPlan(getSession(), viewQuery, anyTree(
                     constrainedTableScan(table2,
                             ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2019-01-02")))),
-                    constrainedTableScan(view, ImmutableMap.of()))));
+                    constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -71,7 +72,7 @@ import static java.util.function.Function.identity;
  * <pre>
  *     - Empty Values
  * </pre>
- *
+ * <p>
  * For outer join: replace with empty values if outer side is empty and project node if inner side is empty
  * For example:
  * <pre>
@@ -87,7 +88,7 @@ import static java.util.function.Function.identity;
  *          assignments := NULL if output not in Scan, otherwise identity projection
  *          - Scan
  * </pre>
- *
+ * <p>
  * For aggregation: if it has default output for empty input, stop and do not simplify, otherwise convert to empty values node
  * <pre>
  *     - Aggregation
@@ -95,8 +96,9 @@ import static java.util.function.Function.identity;
  *          - Empty Values
  * </pre>
  * No change for this query plan
- *
- * For Union node: if it has only one non-empty input, convert to a project node. If all inputs are empty, convert to empty values node
+ * <p>
+ * For Union node: if it has only one non-empty input, convert to a project node. If all inputs are empty, convert to empty values node. If more than one input is non-empty,
+ * remove the empty inputs and keep the union node and the non-empty inputs.
  */
 
 public class SimplifyPlanWithEmptyInput
@@ -222,6 +224,13 @@ public class SimplifyPlanWithEmptyInput
                 Assignments.Builder builder = Assignments.builder();
                 builder.putAll(node.getVariableMapping().entrySet().stream().collect(toImmutableMap(entry -> entry.getKey(), entry -> entry.getValue().get(index))));
                 return new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenChildren.get(index), builder.build(), LOCAL);
+            }
+            else if (nonEmptyChildIndex.size() < node.getSources().size()) {
+                this.planChanged = true;
+                List<PlanNode> nonEmptyInput = nonEmptyChildIndex.stream().map(x -> node.getSources().get(x)).collect(toImmutableList());
+                Map<VariableReferenceExpression, List<VariableReferenceExpression>> newOutputToInputs = node.getVariableMapping().entrySet().stream()
+                        .collect(toImmutableMap(Map.Entry::getKey, entry -> nonEmptyChildIndex.stream().map(idx -> entry.getValue().get(idx)).collect(toImmutableList())));
+                return new UnionNode(node.getSourceLocation(), idAllocator.getNextId(), nonEmptyInput, node.getOutputVariables(), newOutputToInputs);
             }
             return node.replaceChildren(rewrittenChildren);
         }


### PR DESCRIPTION
## Description
Simplify a union node when it has at least one empty input but more than one non-empty input

## Motivation and Context
Current optimization rule only simplify the union node when all input is empty or only one input is non-empty. This PR will simplify for the case where it has at least one empty input but more than one non-empty input.

## Impact
Simplify for more query plans.

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix the simplify plan with empty input rule to also work for union node with empty input but more than one non-empty input.
```

