### PR TITLE
Add support for reading v2 row level deletes in Iceberg connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -211,10 +211,8 @@ Property Name                                      Description                  
                                                    improve performance for queries with highly skewed
                                                    aggregations or joins.
 
-``iceberg.enable-merge-on-read-mode``              Enable reading base tables that use merge-on-read for          ``false``
-                                                   updates. The Iceberg connector currently does not read
-                                                   delete lists, which means any updates will not be
-                                                   reflected in the table.
+``iceberg.enable-merge-on-read-mode``              Enable reading base tables that use merge-on-read for          ``true``
+                                                   updates.
 ================================================== ============================================================= ============
 
 Table Properties
@@ -817,8 +815,10 @@ In the following query, the expression CURRENT_TIMESTAMP returns the current tim
             30 | mexico        |         3 | comment
     (3 rows)
 
-Iceberg Connector Limitations
------------------------------
+Table with delete files
+-----------------------
 
-* The ``SELECT`` operations on Iceberg Tables with format version 2 do not read the delete files
-  and remove the deleted rows as of now (:issue:`20492`).
+Iceberg V2 tables support row-level deletion. For more information see
+`Row-level deletes <https://iceberg.apache.org/spec/#row-level-deletes>`_ in the Iceberg Table Spec.
+Presto supports reading delete files, including Position Delete Files and Equality Delete Files.
+When reading, Presto merges these delete files to read the latest results.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
+import com.facebook.presto.common.block.LongArrayBlock;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -34,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
@@ -42,6 +44,7 @@ import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class OrcBatchPageSource
@@ -66,6 +69,8 @@ public class OrcBatchPageSource
 
     private final RuntimeStats runtimeStats;
 
+    private final List<Boolean> isRowPositionList;
+
     public OrcBatchPageSource(
             OrcBatchRecordReader recordReader,
             OrcDataSource orcDataSource,
@@ -75,6 +80,19 @@ public class OrcBatchPageSource
             FileFormatDataSourceStats stats,
             RuntimeStats runtimeStats)
     {
+        this(recordReader, orcDataSource, columns, typeManager, systemMemoryContext, stats, runtimeStats, nCopies(columns.size(), false));
+    }
+
+    public OrcBatchPageSource(
+            OrcBatchRecordReader recordReader,
+            OrcDataSource orcDataSource,
+            List<HiveColumnHandle> columns,
+            TypeManager typeManager,
+            OrcAggregatedMemoryContext systemMemoryContext,
+            FileFormatDataSourceStats stats,
+            RuntimeStats runtimeStats,
+            List<Boolean> isRowPositionList)
+    {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
 
@@ -82,6 +100,7 @@ public class OrcBatchPageSource
 
         this.stats = requireNonNull(stats, "stats is null");
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.isRowPositionList = requireNonNull(isRowPositionList, "rowPosIndices is null");
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
@@ -155,11 +174,16 @@ public class OrcBatchPageSource
 
             Block[] blocks = new Block[hiveColumnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                if (constantBlocks[fieldId] != null) {
-                    blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
+                if (isRowPositionColumn(fieldId)) {
+                    blocks[fieldId] = getRowPosColumnBlock(recordReader.getFilePosition(), batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId]));
+                    if (constantBlocks[fieldId] != null) {
+                        blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
+                    }
+                    else {
+                        blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId]));
+                    }
                 }
             }
             return new Page(batchSize, blocks);
@@ -223,6 +247,20 @@ public class OrcBatchPageSource
                 throwable.addSuppressed(e);
             }
         }
+    }
+
+    private boolean isRowPositionColumn(int column)
+    {
+        return isRowPositionList.get(column);
+    }
+
+    private static Block getRowPosColumnBlock(long baseIndex, int size)
+    {
+        long[] rowPositions = new long[size];
+        for (int position = 0; position < size; position++) {
+            rowPositions[position] = baseIndex + position;
+        }
+        return new LongArrayBlock(size, Optional.empty(), rowPositions);
     }
 
     private final class OrcBlockLoader

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -414,6 +414,11 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.BaseHiveColumnHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
@@ -36,6 +37,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 
 public class IcebergColumnHandle
         implements BaseHiveColumnHandle
@@ -106,6 +108,12 @@ public class IcebergColumnHandle
     public List<Subfield> getRequiredSubfields()
     {
         return requiredSubfields;
+    }
+
+    @JsonIgnore
+    public boolean isRowPositionColumn()
+    {
+        return columnIdentity.getId() == ROW_POSITION.fieldId();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -43,7 +43,7 @@ public class IcebergConfig
     private List<String> hadoopConfigResources = ImmutableList.of();
     private double minimumAssignedSplitWeight = 0.05;
     private boolean parquetDereferencePushdownEnabled = true;
-    private boolean mergeOnReadModeEnabled;
+    private boolean mergeOnReadModeEnabled = true;
     private double statisticSnapshotRecordDifferenceWeight;
     private boolean pushdownFilterEnabled;
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -336,7 +336,7 @@ public class IcebergPageSink
         return ((Transform<Object, Object>) transform).bind(icebergType).apply(value);
     }
 
-    private static Object getIcebergValue(Block block, int position, Type type)
+    public static Object getIcebergValue(Block block, int position, Type type)
     {
         if (block.isNull(position)) {
             return null;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -16,7 +16,10 @@ package com.facebook.presto.iceberg;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.NullableValue;
+import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -35,6 +38,10 @@ import com.facebook.presto.hive.orc.HdfsOrcDataSource;
 import com.facebook.presto.hive.orc.OrcBatchPageSource;
 import com.facebook.presto.hive.orc.ProjectionBasedDwrfKeyProvider;
 import com.facebook.presto.hive.parquet.ParquetPageSource;
+import com.facebook.presto.iceberg.delete.DeleteFile;
+import com.facebook.presto.iceberg.delete.DeleteFilter;
+import com.facebook.presto.iceberg.delete.PositionDeleteFilter;
+import com.facebook.presto.iceberg.delete.RowPredicate;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
@@ -66,8 +73,12 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.base.Suppliers;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -75,6 +86,9 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.BlockMissingException;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.types.Conversions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.crypto.InternalFileDecryptor;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
@@ -84,18 +98,25 @@ import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.MessageType;
+import org.roaringbitmap.longlong.LongBitmapDataProvider;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
@@ -121,6 +142,8 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcBloomFil
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
+import static com.facebook.presto.iceberg.delete.EqualityDeleteFilter.readEqualityDeletes;
+import static com.facebook.presto.iceberg.delete.PositionDeleteFilter.readPositionDeletes;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
@@ -136,13 +159,21 @@ import static com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatc
 import static com.facebook.presto.parquet.reader.ColumnIndexFilterUtils.getColumnIndexStore;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.uniqueIndex;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.FileContent.EQUALITY_DELETES;
+import static org.apache.iceberg.FileContent.POSITION_DELETES;
+import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
+import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
+import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 import static org.apache.parquet.io.ColumnIOConverter.constructField;
 import static org.apache.parquet.io.ColumnIOConverter.findNestedColumnIO;
 
@@ -180,7 +211,7 @@ public class IcebergPageSourceProvider
         this.parquetMetadataSource = requireNonNull(parquetMetadataSource, "parquetMetadataSource is null");
     }
 
-    private static ConnectorPageSource createParquetPageSource(
+    private static ConnectorPageSourceWithRowPositions createParquetPageSource(
             HdfsEnvironment hdfsEnvironment,
             ConnectorSession session,
             Configuration configuration,
@@ -244,6 +275,11 @@ public class IcebergPageSourceProvider
             TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(descriptorsByPath, effectivePredicate);
             Predicate parquetPredicate = buildPredicate(requestedSchema, parquetTupleDomain, descriptorsByPath);
             final ParquetDataSource finalDataSource = dataSource;
+
+            long nextStart = 0;
+            Optional<Long> startRowPosition = Optional.empty();
+            Optional<Long> endRowPosition = Optional.empty();
+            ImmutableList.Builder<Long> blockStarts = ImmutableList.builder();
             List<BlockMetaData> blocks = new ArrayList<>();
             List<ColumnIndexStore> blockIndexStores = new ArrayList<>();
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
@@ -255,7 +291,13 @@ public class IcebergPageSourceProvider
                             predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndexStore, false, Optional.of(session.getWarningCollector()))) {
                         blocks.add(block);
                         blockIndexStores.add(columnIndexStore.orElse(null));
+                        blockStarts.add(nextStart);
+                        if (!startRowPosition.isPresent()) {
+                            startRowPosition = Optional.of(nextStart);
+                        }
+                        endRowPosition = Optional.of(nextStart + block.getRowCount());
                     }
+                    nextStart += block.getRowCount();
                 }
             }
 
@@ -263,7 +305,7 @@ public class IcebergPageSourceProvider
             ParquetReader parquetReader = new ParquetReader(
                     messageColumnIO,
                     blocks,
-                    Optional.empty(),
+                    Optional.of(blockStarts.build()),
                     dataSource,
                     systemMemoryContext,
                     getParquetMaxReadBlockSize(session),
@@ -277,6 +319,7 @@ public class IcebergPageSourceProvider
             ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> prestoTypes = ImmutableList.builder();
             ImmutableList.Builder<Optional<Field>> internalFields = ImmutableList.builder();
+            List<Boolean> isRowPositionList = new ArrayList<>();
             for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
                 IcebergColumnHandle column = regularColumns.get(columnIndex);
                 namesBuilder.add(column.getName());
@@ -305,9 +348,13 @@ public class IcebergPageSourceProvider
                         internalFields.add(constructField(column.getType(), messageColumnIO.getChild(parquetField.get().getName())));
                     }
                 }
+                isRowPositionList.add(column.isRowPositionColumn());
             }
 
-            return new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), namesBuilder.build(), new RuntimeStats());
+            return new ConnectorPageSourceWithRowPositions(
+                    new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), isRowPositionList, namesBuilder.build(), new RuntimeStats()),
+                    startRowPosition,
+                    endRowPosition);
         }
         catch (Exception e) {
             try {
@@ -382,7 +429,7 @@ public class IcebergPageSourceProvider
         return TupleDomain.withColumnDomains(predicate.build());
     }
 
-    private static ConnectorPageSource createBatchOrcPageSource(
+    private static ConnectorPageSourceWithRowPositions createBatchOrcPageSource(
             HdfsEnvironment hdfsEnvironment,
             String user,
             Configuration configuration,
@@ -462,6 +509,7 @@ public class IcebergPageSourceProvider
             Map<String, IcebergOrcColumn> fileOrcColumnsByName = uniqueIndex(fileOrcColumns, orcColumn -> orcColumn.getColumnName().toLowerCase(ENGLISH));
 
             int nextMissingColumnIndex = fileOrcColumnsByName.size();
+            List<Boolean> isRowPositionList = new ArrayList<>();
             for (IcebergColumnHandle column : regularColumns) {
                 IcebergOrcColumn icebergOrcColumn;
                 boolean isExcludeColumn = false;
@@ -509,6 +557,7 @@ public class IcebergPageSourceProvider
                             column.getRequiredSubfields(),
                             Optional.empty()));
                 }
+                isRowPositionList.add(column.isRowPositionColumn());
             }
 
             TupleDomain<HiveColumnHandle> hiveColumnHandleTupleDomain = effectivePredicate.transform(column -> {
@@ -547,14 +596,18 @@ public class IcebergPageSourceProvider
                     systemMemoryUsage,
                     INITIAL_BATCH_SIZE);
 
-            return new OrcBatchPageSource(
-                    recordReader,
-                    orcDataSource,
-                    physicalColumnHandles,
-                    typeManager,
-                    systemMemoryUsage,
-                    stats,
-                    runtimeStats);
+            return new ConnectorPageSourceWithRowPositions(
+                    new OrcBatchPageSource(
+                            recordReader,
+                            orcDataSource,
+                            physicalColumnHandles,
+                            typeManager,
+                            systemMemoryUsage,
+                            stats,
+                            runtimeStats,
+                            isRowPositionList),
+                    Optional.empty(),
+                    Optional.empty());
         }
         catch (Exception e) {
             if (orcDataSource != null) {
@@ -666,11 +719,20 @@ public class IcebergPageSourceProvider
         List<IcebergColumnHandle> regularColumns = columns.stream()
                 .map(IcebergColumnHandle.class::cast)
                 .filter(column -> !partitionKeys.containsKey(column.getId()))
-                .collect(toImmutableList());
+                .collect(Collectors.toList());
+
+        Optional<String> tableSchemaJson = table.getTableSchemaJson();
+        verify(tableSchemaJson.isPresent(), "tableSchemaJson is null");
+        Schema tableSchema = SchemaParser.fromJson(tableSchemaJson.get());
+        Set<IcebergColumnHandle> deleteFilterRequiredColumns = requiredColumnsForDeletes(tableSchema, split.getDeletes());
+
+        deleteFilterRequiredColumns.stream()
+                .filter(not(icebergColumns::contains))
+                .forEach(regularColumns::add);
 
         // TODO: pushdownFilter for icebergLayout
         HdfsContext hdfsContext = new HdfsContext(session, table.getSchemaName(), table.getTableName());
-        ConnectorPageSource dataPageSource = createDataPageSource(
+        ConnectorPageSourceWithRowPositions connectorPageSourceWithRowPositions = createDataPageSource(
                 session,
                 hdfsContext,
                 new Path(split.getPath()),
@@ -680,11 +742,135 @@ public class IcebergPageSourceProvider
                 regularColumns,
                 table.getPredicate(),
                 splitContext.isCacheable());
+        ConnectorPageSource dataPageSource = connectorPageSourceWithRowPositions.getConnectorPageSource();
 
-        return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource);
+        Supplier<Optional<RowPredicate>> deletePredicate = Suppliers.memoize(() -> {
+            List<DeleteFilter> deleteFilters = readDeletes(
+                    session,
+                    tableSchema,
+                    split.getPath(),
+                    split.getDeletes(),
+                    connectorPageSourceWithRowPositions.getStartRowPosition(),
+                    connectorPageSourceWithRowPositions.getEndRowPosition());
+            return deleteFilters.stream()
+                    .map(filter -> filter.createPredicate(regularColumns))
+                    .reduce(RowPredicate::and);
+        });
+
+        return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource, deletePredicate);
     }
 
-    private ConnectorPageSource createDataPageSource(
+    private Set<IcebergColumnHandle> requiredColumnsForDeletes(Schema schema, List<DeleteFile> deletes)
+    {
+        ImmutableSet.Builder<IcebergColumnHandle> requiredColumns = ImmutableSet.builder();
+        for (DeleteFile deleteFile : deletes) {
+            if (deleteFile.content() == POSITION_DELETES) {
+                requiredColumns.add(IcebergColumnHandle.create(ROW_POSITION, typeManager, IcebergColumnHandle.ColumnType.REGULAR));
+            }
+            else if (deleteFile.content() == EQUALITY_DELETES) {
+                deleteFile.equalityFieldIds().stream()
+                        .map(id -> IcebergColumnHandle.create(schema.findField(id), typeManager, IcebergColumnHandle.ColumnType.REGULAR))
+                        .forEach(requiredColumns::add);
+            }
+        }
+
+        return requiredColumns.build();
+    }
+
+    private List<DeleteFilter> readDeletes(
+            ConnectorSession session,
+            Schema schema,
+            String dataFilePath,
+            List<DeleteFile> deleteFiles,
+            Optional<Long> startRowPosition,
+            Optional<Long> endRowPosition)
+    {
+        verify(startRowPosition.isPresent() == endRowPosition.isPresent(), "startRowPosition and endRowPosition must be specified together");
+
+        Slice targetPath = utf8Slice(dataFilePath);
+        List<DeleteFilter> filters = new ArrayList<>();
+        LongBitmapDataProvider deletedRows = new Roaring64Bitmap();
+
+        IcebergColumnHandle deleteFilePath = IcebergColumnHandle.create(DELETE_FILE_PATH, typeManager, IcebergColumnHandle.ColumnType.REGULAR);
+        IcebergColumnHandle deleteFilePos = IcebergColumnHandle.create(DELETE_FILE_POS, typeManager, IcebergColumnHandle.ColumnType.REGULAR);
+        List<IcebergColumnHandle> deleteColumns = ImmutableList.of(deleteFilePath, deleteFilePos);
+        TupleDomain<IcebergColumnHandle> deleteDomain = TupleDomain.fromFixedValues(ImmutableMap.of(deleteFilePath, NullableValue.of(VARCHAR, targetPath)));
+        if (startRowPosition.isPresent()) {
+            Range positionRange = Range.range(deleteFilePos.getType(), startRowPosition.get(), true, endRowPosition.get(), true);
+            TupleDomain<IcebergColumnHandle> positionDomain = TupleDomain.withColumnDomains(ImmutableMap.of(deleteFilePos, Domain.create(ValueSet.ofRanges(positionRange), false)));
+            deleteDomain = deleteDomain.intersect(positionDomain);
+        }
+
+        for (DeleteFile delete : deleteFiles) {
+            if (delete.content() == POSITION_DELETES) {
+                if (startRowPosition.isPresent()) {
+                    byte[] lowerBoundBytes = delete.getLowerBounds().get(DELETE_FILE_POS.fieldId());
+                    Optional<Long> positionLowerBound = Optional.ofNullable(lowerBoundBytes)
+                            .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
+
+                    byte[] upperBoundBytes = delete.getUpperBounds().get(DELETE_FILE_POS.fieldId());
+                    Optional<Long> positionUpperBound = Optional.ofNullable(upperBoundBytes)
+                            .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
+
+                    if ((positionLowerBound.isPresent() && positionLowerBound.get() > endRowPosition.get()) ||
+                            (positionUpperBound.isPresent() && positionUpperBound.get() < startRowPosition.get())) {
+                        continue;
+                    }
+                }
+
+                try (ConnectorPageSource pageSource = openDeletes(session, delete, deleteColumns, deleteDomain)) {
+                    readPositionDeletes(pageSource, targetPath, deletedRows);
+                }
+                catch (IOException e) {
+                    throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, format("Cannot open Iceberg delete file: %s", delete.path()), e);
+                }
+            }
+            else if (delete.content() == EQUALITY_DELETES) {
+                List<Integer> fieldIds = delete.equalityFieldIds();
+                verify(!fieldIds.isEmpty(), "equality field IDs are missing");
+                List<IcebergColumnHandle> columns = fieldIds.stream()
+                        .map(id -> IcebergColumnHandle.create(schema.findField(id), typeManager, IcebergColumnHandle.ColumnType.REGULAR))
+                        .collect(toImmutableList());
+
+                try (ConnectorPageSource pageSource = openDeletes(session, delete, columns, TupleDomain.all())) {
+                    filters.add(readEqualityDeletes(pageSource, columns, schema));
+                }
+                catch (IOException e) {
+                    throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, format("Cannot open Iceberg delete file: %s", delete.path()), e);
+                }
+            }
+            else {
+                throw new VerifyException("Unknown delete content: " + delete.content());
+            }
+        }
+
+        if (!deletedRows.isEmpty()) {
+            filters.add(new PositionDeleteFilter(deletedRows));
+        }
+
+        return filters;
+    }
+
+    private ConnectorPageSource openDeletes(
+            ConnectorSession session,
+            DeleteFile delete,
+            List<IcebergColumnHandle> columns,
+            TupleDomain<IcebergColumnHandle> tupleDomain)
+    {
+        return createDataPageSource(
+                session,
+                new HdfsContext(session),
+                new Path(delete.path()),
+                0,
+                delete.fileSizeInBytes(),
+                delete.format(),
+                columns,
+                tupleDomain,
+                false)
+                .getConnectorPageSource();
+    }
+
+    private ConnectorPageSourceWithRowPositions createDataPageSource(
             ConnectorSession session,
             HdfsContext hdfsContext,
             Path path,
@@ -742,5 +928,37 @@ public class IcebergPageSourceProvider
                         dwrfEncryptionProvider);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
+    }
+
+    private static final class ConnectorPageSourceWithRowPositions
+    {
+        private final ConnectorPageSource connectorPageSource;
+        private final Optional<Long> startRowPosition;
+        private final Optional<Long> endRowPosition;
+
+        public ConnectorPageSourceWithRowPositions(
+                ConnectorPageSource connectorPageSource,
+                Optional<Long> startRowPosition,
+                Optional<Long> endRowPosition)
+        {
+            this.connectorPageSource = requireNonNull(connectorPageSource, "connectorPageSource is null");
+            this.startRowPosition = requireNonNull(startRowPosition, "startRowPosition is null");
+            this.endRowPosition = requireNonNull(endRowPosition, "endRowPosition is null");
+        }
+
+        public ConnectorPageSource getConnectorPageSource()
+        {
+            return connectorPageSource;
+        }
+
+        public Optional<Long> getStartRowPosition()
+        {
+            return startRowPosition;
+        }
+
+        public Optional<Long> getEndRowPosition()
+        {
+            return endRowPosition;
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -34,6 +34,7 @@ public class IcebergTableHandle
     private final Optional<Long> snapshotId;
     private final TupleDomain<IcebergColumnHandle> predicate;
     private final boolean snapshotSpecified;
+    private final Optional<String> tableSchemaJson;
 
     @JsonCreator
     public IcebergTableHandle(
@@ -42,7 +43,8 @@ public class IcebergTableHandle
             @JsonProperty("tableType") TableType tableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
             @JsonProperty("snapshotSpecified") boolean snapshotSpecified,
-            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate)
+            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate,
+            @JsonProperty("tableSchemaJson") Optional<String> tableSchemaJson)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -50,6 +52,7 @@ public class IcebergTableHandle
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
         this.snapshotSpecified = requireNonNull(snapshotSpecified, "specifiedSnapshot is null");
         this.predicate = requireNonNull(predicate, "predicate is null");
+        this.tableSchemaJson = requireNonNull(tableSchemaJson, "tableSchemaJson is null");
     }
 
     @JsonProperty
@@ -88,6 +91,12 @@ public class IcebergTableHandle
         return predicate;
     }
 
+    @JsonProperty
+    public Optional<String> getTableSchemaJson()
+    {
+        return tableSchemaJson;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -114,13 +123,14 @@ public class IcebergTableHandle
                 tableType == that.tableType &&
                 Objects.equals(snapshotId, that.snapshotId) &&
                 snapshotSpecified == that.snapshotSpecified &&
-                Objects.equals(predicate, that.predicate);
+                Objects.equals(predicate, that.predicate) &&
+                Objects.equals(tableSchemaJson, that.tableSchemaJson);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tableType, snapshotId, snapshotSpecified, predicate);
+        return Objects.hash(schemaName, tableName, tableType, snapshotId, snapshotSpecified, predicate, tableSchemaJson);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.delete;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 
@@ -24,9 +25,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
-public class DeleteFile
+public final class DeleteFile
 {
     private final FileContent content;
     private final String path;
@@ -34,11 +38,16 @@ public class DeleteFile
     private final long recordCount;
     private final long fileSizeInBytes;
     private final List<Integer> equalityFieldIds;
-    private final Map<Integer, ByteBuffer> lowerBounds;
-    private final Map<Integer, ByteBuffer> upperBounds;
+    private final Map<Integer, byte[]> lowerBounds;
+    private final Map<Integer, byte[]> upperBounds;
 
     public static DeleteFile fromIceberg(org.apache.iceberg.DeleteFile deleteFile)
     {
+        Map<Integer, byte[]> lowerBounds = firstNonNull(deleteFile.lowerBounds(), ImmutableMap.<Integer, ByteBuffer>of())
+                .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
+        Map<Integer, byte[]> upperBounds = firstNonNull(deleteFile.upperBounds(), ImmutableMap.<Integer, ByteBuffer>of())
+                .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
+
         return new DeleteFile(
                 deleteFile.content(),
                 deleteFile.path().toString(),
@@ -46,8 +55,8 @@ public class DeleteFile
                 deleteFile.recordCount(),
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
-                deleteFile.lowerBounds(),
-                deleteFile.upperBounds());
+                lowerBounds,
+                upperBounds);
     }
 
     @JsonCreator
@@ -58,8 +67,8 @@ public class DeleteFile
             long recordCount,
             long fileSizeInBytes,
             List<Integer> equalityFieldIds,
-            Map<Integer, ByteBuffer> lowerBounds,
-            Map<Integer, ByteBuffer> upperBounds)
+            Map<Integer, byte[]> lowerBounds,
+            Map<Integer, byte[]> upperBounds)
     {
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
@@ -67,8 +76,8 @@ public class DeleteFile
         this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
-        this.lowerBounds = requireNonNull(lowerBounds, "lowerBounds is null");
-        this.upperBounds = requireNonNull(upperBounds, "upperBounds is null");
+        this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
+        this.upperBounds = ImmutableMap.copyOf(requireNonNull(upperBounds, "upperBounds is null"));
     }
 
     @JsonProperty
@@ -108,14 +117,23 @@ public class DeleteFile
     }
 
     @JsonProperty
-    public Map<Integer, ByteBuffer> getLowerBounds()
+    public Map<Integer, byte[]> getLowerBounds()
     {
         return lowerBounds;
     }
 
     @JsonProperty
-    public Map<Integer, ByteBuffer> getUpperBounds()
+    public Map<Integer, byte[]> getUpperBounds()
     {
         return upperBounds;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(path)
+                .add("records", recordCount)
+                .toString();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFilter.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+
+import java.util.List;
+
+public interface DeleteFilter
+{
+    RowPredicate createPredicate(List<IcebergColumnHandle> columns);
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.StructLikeSet;
+import org.apache.iceberg.util.StructProjection;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.iceberg.IcebergUtil.schemaFromHandles;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public final class EqualityDeleteFilter
+        implements DeleteFilter
+{
+    private final Schema schema;
+    private final StructLikeSet deleteSet;
+
+    private EqualityDeleteFilter(Schema schema, StructLikeSet deleteSet)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        this.deleteSet = requireNonNull(deleteSet, "deleteSet is null");
+    }
+
+    @Override
+    public RowPredicate createPredicate(List<IcebergColumnHandle> columns)
+    {
+        Type[] types = columns.stream()
+                .map(IcebergColumnHandle::getType)
+                .toArray(Type[]::new);
+
+        Schema fileSchema = schemaFromHandles(columns);
+        StructProjection projection = StructProjection.create(fileSchema, schema);
+
+        return (page, position) -> {
+            StructLike row = new LazyStructLikeRow(types, page, position);
+            return !deleteSet.contains(projection.wrap(row));
+        };
+    }
+
+    public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Schema tableSchema)
+    {
+        Set<Integer> ids = columns.stream()
+                .map(IcebergColumnHandle::getId)
+                .collect(toImmutableSet());
+
+        Type[] types = columns.stream()
+                .map(IcebergColumnHandle::getType)
+                .toArray(Type[]::new);
+
+        Schema deleteSchema = TypeUtil.select(tableSchema, ids);
+        StructLikeSet deleteSet = StructLikeSet.create(deleteSchema.asStruct());
+
+        while (!pageSource.isFinished()) {
+            Page page = pageSource.getNextPage();
+            if (page == null) {
+                continue;
+            }
+
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                deleteSet.add(new StructLikeRow(types, page, position));
+            }
+        }
+
+        return new EqualityDeleteFilter(deleteSchema, deleteSet);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/LazyStructLikeRow.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/LazyStructLikeRow.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import org.apache.iceberg.StructLike;
+
+import static com.facebook.presto.iceberg.IcebergPageSink.getIcebergValue;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Lazy version of {@link StructLikeRow}.
+ */
+public class LazyStructLikeRow
+        implements StructLike
+{
+    private final Type[] types;
+    private final Page page;
+    private final int position;
+    private final Object[] values;
+
+    public LazyStructLikeRow(Type[] types, Page page, int position)
+    {
+        checkArgument(types.length == page.getChannelCount(), "mismatched types for page");
+        this.types = requireNonNull(types, "types is null");
+        this.page = requireNonNull(page, "page is null");
+        checkElementIndex(position, page.getPositionCount(), "page position");
+        this.position = position;
+        this.values = new Object[types.length];
+    }
+
+    @Override
+    public int size()
+    {
+        return page.getChannelCount();
+    }
+
+    @Override
+    public <T> T get(int i, Class<T> clazz)
+    {
+        return clazz.cast(get(i));
+    }
+
+    @Override
+    public <T> void set(int i, T t)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private Object get(int i)
+    {
+        Object value = values[i];
+        if (value != null) {
+            return value;
+        }
+
+        value = getIcebergValue(page.getBlock(i), position, types[i]);
+        values[i] = value;
+        return value;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/PositionDeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/PositionDeleteFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import io.airlift.slice.Slice;
+import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
+import org.roaringbitmap.longlong.LongBitmapDataProvider;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class PositionDeleteFilter
+        implements DeleteFilter
+{
+    private final ImmutableLongBitmapDataProvider deletedRows;
+
+    public PositionDeleteFilter(ImmutableLongBitmapDataProvider deletedRows)
+    {
+        this.deletedRows = requireNonNull(deletedRows, "deletedRows is null");
+    }
+
+    @Override
+    public RowPredicate createPredicate(List<IcebergColumnHandle> columns)
+    {
+        int filePosChannel = rowPositionChannel(columns);
+        return (page, position) -> {
+            long filePos = BIGINT.getLong(page.getBlock(filePosChannel), position);
+            return !deletedRows.contains(filePos);
+        };
+    }
+
+    private static int rowPositionChannel(List<IcebergColumnHandle> columns)
+    {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).isRowPositionColumn()) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("No row position column");
+    }
+
+    public static void readPositionDeletes(ConnectorPageSource pageSource, Slice targetPath, LongBitmapDataProvider deletedRows)
+    {
+        CachingVarcharComparator comparator = new CachingVarcharComparator(targetPath);
+
+        // Use a linear search since we expect most deletion files to only contain
+        // entries for a single path. The comparison cost is minimal if the
+        // path values are dictionary encoded, since we only do the comparison once.
+        while (!pageSource.isFinished()) {
+            Page page = pageSource.getNextPage();
+            if (page == null) {
+                continue;
+            }
+
+            Block pathBlock = page.getBlock(0);
+            Block posBlock = page.getBlock(1);
+
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                int result = comparator.compare(pathBlock, position);
+                if (result > 0) {
+                    // deletion files are sorted by path, so we're done
+                    return;
+                }
+                if (result == 0) {
+                    deletedRows.addLong(BIGINT.getLong(posBlock, position));
+                }
+            }
+        }
+    }
+
+    private static final class CachingVarcharComparator
+    {
+        private final Slice reference;
+        private int result;
+        private Slice value;
+
+        public CachingVarcharComparator(Slice reference)
+        {
+            this.reference = requireNonNull(reference, "reference is null");
+        }
+
+        @SuppressWarnings({"ObjectEquality", "ReferenceEquality"})
+        public int compare(Block block, int position)
+        {
+            checkArgument(!block.isNull(position), "position is null");
+            Slice next = VARCHAR.getSlice(block, position);
+            // The expected case is a dictionary block with many entries for the
+            // same path. Only perform a comparison if the object has changed.
+            if (value != next) {
+                value = next;
+                result = value.compareTo(reference);
+            }
+            return result;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/RowPredicate.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/RowPredicate.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.common.Page;
+
+import static java.util.Objects.requireNonNull;
+
+public interface RowPredicate
+{
+    boolean test(Page page, int position);
+
+    default RowPredicate and(RowPredicate other)
+    {
+        requireNonNull(other, "other is null");
+        return (page, position) -> test(page, position) && other.test(page, position);
+    }
+
+    default Page filterPage(Page page)
+    {
+        int positionCount = page.getPositionCount();
+        int[] retained = new int[positionCount];
+        int retainedCount = 0;
+        for (int position = 0; position < positionCount; position++) {
+            if (test(page, position)) {
+                retained[retainedCount] = position;
+                retainedCount++;
+            }
+        }
+        if (retainedCount == positionCount) {
+            return page;
+        }
+        return page.getPositions(retained, 0, retainedCount);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/StructLikeRow.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/StructLikeRow.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import org.apache.iceberg.StructLike;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.iceberg.IcebergPageSink.getIcebergValue;
+import static com.google.common.base.Preconditions.checkArgument;
+
+final class StructLikeRow
+        implements StructLike
+{
+    private final Object[] values;
+
+    public StructLikeRow(Type[] types, Page page, int position)
+    {
+        checkArgument(types.length == page.getChannelCount(), "mismatched types for page");
+        values = new Object[types.length];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = getIcebergValue(page.getBlock(i), position, types[i]);
+        }
+    }
+
+    @Override
+    public int size()
+    {
+        return values.length;
+    }
+
+    @Override
+    public <T> T get(int i, Class<T> clazz)
+    {
+        return clazz.cast(values[i]);
+    }
+
+    @Override
+    public <T> void set(int i, T t)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "StructLikeRow" + Arrays.toString(values);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -132,7 +132,8 @@ public class IcebergPlanOptimizer
                     oldTableHandle.getTableType(),
                     oldTableHandle.getSnapshotId(),
                     oldTableHandle.isSnapshotSpecified(),
-                    simplifiedColumnDomain);
+                    simplifiedColumnDomain,
+                    oldTableHandle.getTableSchemaJson());
             TableScanNode newTableScan = new TableScanNode(
                     tableScan.getSourceLocation(),
                     tableScan.getId(),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -914,9 +914,7 @@ public class IcebergDistributedSmokeTestBase
 
     protected void cleanupTableWithMergeOnRead(String tableName)
     {
-        Session session = Session.builder(getSession())
-                .setCatalogSessionProperty(ICEBERG_CATALOG, "merge_on_read_enabled", "true")
-                .build();
+        Session session = getSession();
         dropTable(session, tableName);
     }
 
@@ -925,9 +923,7 @@ public class IcebergDistributedSmokeTestBase
     {
         String tableName = "test_merge_on_read_enabled";
         try {
-            Session session = Session.builder(getSession())
-                    .setCatalogSessionProperty(ICEBERG_CATALOG, "merge_on_read_enabled", "true")
-                    .build();
+            Session session = getSession();
 
             createTableWithMergeOnRead(session, "tpch", tableName);
             assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, 1)", 1);
@@ -945,12 +941,14 @@ public class IcebergDistributedSmokeTestBase
         String tableName = "test_merge_on_read_disabled";
         @Language("RegExp") String errorMessage = "merge-on-read table mode not supported yet";
         try {
-            Session session = getSession();
+            Session session = Session.builder(getSession())
+                    .setCatalogSessionProperty(ICEBERG_CATALOG, "merge_on_read_enabled", "false")
+                    .build();
 
             createTableWithMergeOnRead(session, "tpch", tableName);
-            assertQueryFails("INSERT INTO " + tableName + " VALUES (1, 1)", errorMessage);
-            assertQueryFails("INSERT INTO " + tableName + " VALUES (2, 2)", errorMessage);
-            assertQueryFails("SELECT * FROM " + tableName, errorMessage);
+            assertQueryFails(session, "INSERT INTO " + tableName + " VALUES (1, 1)", errorMessage);
+            assertQueryFails(session, "INSERT INTO " + tableName + " VALUES (2, 2)", errorMessage);
+            assertQueryFails(session, "SELECT * FROM " + tableName, errorMessage);
         }
         finally {
             cleanupTableWithMergeOnRead(tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -16,8 +16,18 @@ package com.facebook.presto.iceberg;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
@@ -27,26 +37,65 @@ import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.util.TableScanUtil;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_CATALOG_DIRECTORY;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_DATA_DIRECTORY;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.STATISTIC_SNAPSHOT_RECORD_DIFFERENCE_WEIGHT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.FileContent.EQUALITY_DELETES;
+import static org.apache.iceberg.FileContent.POSITION_DELETES;
 import static org.testng.Assert.assertTrue;
 
 public class IcebergDistributedTestBase
@@ -678,5 +727,210 @@ public class IcebergDistributedTestBase
                 .map(Map.Entry::getValue)
                 .findFirst()
                 .get();
+    }
+
+    @DataProvider(name = "fileFormat")
+    public Object[][] getFileFormat()
+    {
+        return new Object[][] {{"PARQUET"}, {"ORC"}};
+    }
+
+    @Test(dataProvider = "fileFormat")
+    public void testTableWithPositionDelete(String fileFormat)
+            throws Exception
+    {
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 24");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE nationkey != 0");
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 8);
+        testCheckDeleteFiles(icebergTable, 2, ImmutableList.of(POSITION_DELETES, POSITION_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 23");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE nationkey not in (0 ,8)");
+    }
+
+    @Test(dataProvider = "fileFormat")
+    public void testTableWithEqualityDelete(String fileFormat)
+            throws Exception
+    {
+        String tableName = "test_v2_equality_delete" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(EQUALITY_DELETES));
+        assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey != 1");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1");
+    }
+
+    @Test(dataProvider = "fileFormat")
+    public void testTableWithPositionDeleteAndEqualityDelete(String fileFormat)
+            throws Exception
+    {
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 24");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE nationkey != 0");
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 2, ImmutableList.of(POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey != 1 AND nationkey != 0");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1 AND nationkey != 0");
+    }
+
+    @Test(dataProvider = "fileFormat")
+    public void testTableWithPositionDeletesAndEqualityDeletes(String fileFormat)
+            throws Exception
+    {
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 24");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE nationkey != 0");
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 2, ImmutableList.of(POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 19");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1 AND nationkey != 0");
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 7);
+        testCheckDeleteFiles(icebergTable, 3, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 18");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1 AND nationkey NOT IN (0, 7)");
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 2L));
+        testCheckDeleteFiles(icebergTable, 4, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 13");
+        assertQuery("SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey NOT IN (1, 2) AND nationkey NOT IN (0, 7)");
+    }
+
+    private void testCheckDeleteFiles(Table icebergTable, int expectedSize, List<FileContent> expectedFileContent)
+    {
+        // check delete file list
+        TableScan tableScan = icebergTable.newScan().useSnapshot(icebergTable.currentSnapshot().snapshotId());
+        Iterator<FileScanTask> iterator = TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize()).iterator();
+        List<DeleteFile> deleteFiles = new ArrayList<>();
+        while (iterator.hasNext()) {
+            FileScanTask task = iterator.next();
+            List<org.apache.iceberg.DeleteFile> deletes = task.deletes();
+            deletes.forEach(delete -> deleteFiles.add(DeleteFile.fromIceberg(delete)));
+        }
+
+        assertEquals(deleteFiles.size(), expectedSize);
+        List<FileContent> fileContents = deleteFiles.stream().map(DeleteFile::content).sorted().collect(Collectors.toList());
+        assertEquals(fileContents, expectedFileContent);
+    }
+
+    private void writePositionDeleteToNationTable(Table icebergTable, String dataFilePath, long deletePos)
+            throws IOException
+    {
+        File metastoreDir = getDistributedQueryRunner().getCoordinator().getDataDirectory().toFile();
+        org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(metastoreDir.toURI());
+        String deleteFileName = "delete_file_" + UUID.randomUUID();
+        FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
+        org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(metadataDir, deleteFileName);
+        PositionDeleteWriter<Record> writer = Parquet.writeDeletes(HadoopOutputFile.fromPath(path, fs))
+                .createWriterFunc(GenericParquetWriter::buildWriter)
+                .forTable(icebergTable)
+                .overwrite()
+                .rowSchema(icebergTable.schema())
+                .withSpec(PartitionSpec.unpartitioned())
+                .buildPositionWriter();
+
+        PositionDelete<Record> positionDelete = PositionDelete.create();
+        PositionDelete<Record> record = positionDelete.set(dataFilePath, deletePos, GenericRecord.create(icebergTable.schema()));
+        try (Closeable ignored = writer) {
+            writer.write(record);
+        }
+
+        icebergTable.newRowDelta().addDeletes(writer.toDeleteFile()).commit();
+    }
+
+    private void writeEqualityDeleteToNationTable(Table icebergTable, Map<String, Object> overwriteValues)
+            throws Exception
+    {
+        File metastoreDir = getDistributedQueryRunner().getCoordinator().getDataDirectory().toFile();
+        org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(metastoreDir.toURI());
+        String deleteFileName = "delete_file_" + UUID.randomUUID();
+        FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
+        Schema deleteRowSchema = icebergTable.schema().select("regionkey");
+        EqualityDeleteWriter<Record> writer = Parquet.writeDeletes(HadoopOutputFile.fromPath(new org.apache.hadoop.fs.Path(metadataDir, deleteFileName), fs))
+                .forTable(icebergTable)
+                .rowSchema(deleteRowSchema)
+                .createWriterFunc(GenericParquetWriter::buildWriter)
+                .equalityFieldIds(deleteRowSchema.findField("regionkey").fieldId())
+                .overwrite()
+                .buildEqualityWriter();
+
+        Record dataDelete = GenericRecord.create(deleteRowSchema);
+        try (Closeable ignored = writer) {
+            writer.write(dataDelete.copy(overwriteValues));
+        }
+        icebergTable.newRowDelta().addDeletes(writer.toDeleteFile()).commit();
+    }
+
+    protected static HdfsEnvironment getHdfsEnvironment()
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig),
+                ImmutableSet.of(),
+                hiveClientConfig);
+        return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
+    }
+
+    private Table updateTable(String tableName)
+    {
+        BaseTable table = (BaseTable) loadTable(tableName);
+        TableOperations operations = table.operations();
+        TableMetadata currentMetadata = operations.current();
+        operations.commit(currentMetadata, currentMetadata.upgradeToFormatVersion(2));
+
+        return table;
+    }
+
+    protected Table loadTable(String tableName)
+    {
+        Catalog catalog = CatalogUtil.loadCatalog(catalogType.getCatalogImpl(), "test-hive", getProperties(), new Configuration());
+        return catalog.loadTable(TableIdentifier.of("tpch", tableName));
+    }
+
+    protected Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toString());
+    }
+
+    protected File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        switch (catalogType) {
+            case HIVE:
+                return dataDirectory
+                        .resolve(TEST_DATA_DIRECTORY)
+                        .getParent()
+                        .resolve(TEST_CATALOG_DIRECTORY)
+                        .toFile();
+            case HADOOP:
+            case NESSIE:
+                return dataDirectory.toFile();
+        }
+
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported Presto Iceberg catalog type " + catalogType);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -47,7 +47,7 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(100)
                 .setMinimumAssignedSplitWeight(0.05)
                 .setParquetDereferencePushdownEnabled(true)
-                .setMergeOnReadModeEnabled(false)
+                .setMergeOnReadModeEnabled(true)
                 .setPushdownFilterEnabled(false));
     }
 
@@ -64,7 +64,7 @@ public class TestIcebergConfig
                 .put("iceberg.max-partitions-per-writer", "222")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .put("iceberg.enable-parquet-dereference-pushdown", "false")
-                .put("iceberg.enable-merge-on-read-mode", "true")
+                .put("iceberg.enable-merge-on-read-mode", "false")
                 .put("iceberg.statistic-snapshot-record-difference-weight", "1.0")
                 .put("iceberg.hive-statistics-merge-strategy", "USE_NDV")
                 .put("iceberg.pushdown-filter-enabled", "true")
@@ -81,7 +81,7 @@ public class TestIcebergConfig
                 .setMinimumAssignedSplitWeight(0.01)
                 .setStatisticSnapshotRecordDifferenceWeight(1.0)
                 .setParquetDereferencePushdownEnabled(false)
-                .setMergeOnReadModeEnabled(true)
+                .setMergeOnReadModeEnabled(false)
                 .setHiveStatisticsMergeStrategy(USE_NDV)
                 .setPushdownFilterEnabled(true);
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -131,7 +131,7 @@ public class TestIcebergMetadataListing
         }
         tableMetadataDir.delete();
 
-        assertQueryFails("SELECT * FROM iceberg.test_metadata_schema.iceberg_table1", "Table metadata is missing.");
+        assertQueryFails("SELECT * FROM iceberg.test_metadata_schema.iceberg_table1", "Could not read table schema");
         assertQuerySucceeds("DROP TABLE iceberg.test_metadata_schema.iceberg_table1");
         assertQuery("SHOW TABLES FROM iceberg.test_metadata_schema", "VALUES 'iceberg_table2'");
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
@@ -13,11 +13,20 @@
  */
 package com.facebook.presto.iceberg.hive;
 
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.Table;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.hive.metastore.CachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 
 @Test
 public class TestIcebergDistributedHive
@@ -38,5 +47,25 @@ public class TestIcebergDistributedHive
     public void testStatsByDistance()
     {
         // ignore because HMS doesn't support statistics versioning
+    }
+
+    @Override
+    protected Table loadTable(String tableName)
+    {
+        CatalogManager catalogManager = getDistributedQueryRunner().getCoordinator().getCatalogManager();
+        ConnectorId connectorId = catalogManager.getCatalog(ICEBERG_CATALOG).get().getConnectorId();
+
+        return IcebergUtil.getHiveIcebergTable(getFileHiveMetastore(),
+                getHdfsEnvironment(),
+                getQueryRunner().getDefaultSession().toConnectorSession(connectorId),
+                SchemaTableName.valueOf("tpch." + tableName));
+    }
+
+    protected ExtendedHiveMetastore getFileHiveMetastore()
+    {
+        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+                getCatalogDirectory().getPath(),
+                "test");
+        return memoizeMetastore(fileHiveMetastore, false, 1000, 0);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -22,6 +22,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.util.Map;
+
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 
@@ -40,6 +43,13 @@ public class TestIcebergDistributedNessie
     protected boolean supportsViews()
     {
         return false;
+    }
+
+    @Override
+    protected Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toString(), "uri", nessieContainer.getRestApiUri());
     }
 
     @BeforeClass


### PR DESCRIPTION
## Description
Add support for reading v2 row level deletes in Iceberg connector

Cherry-pick of https://github.com/trinodb/trino/pull/11642
Cherry-pick of https://github.com/trinodb/trino/pull/13219
Cherry-pick of https://github.com/trinodb/trino/pull/13395

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
* Add support for reading v2 row level deletes in Iceberg connector
```

