### PR TITLE
[native pos] Disable old task cleanup routine

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -86,7 +86,10 @@ void PeriodicTaskManager::start() {
 
   VELOX_CHECK_NOT_NULL(taskManager_);
   addTaskStatsTask();
-  addOldTaskCleanupTask();
+
+  if (SystemConfig::instance()->enableOldTaskCleanUp()) {
+    addOldTaskCleanupTask();
+  }
 
   if (memoryAllocator_ != nullptr) {
     addMemoryAllocatorStatsTask();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -187,6 +187,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
           BOOL_PROP(kIncludeNodeInSpillPath, false),
           NUM_PROP(kOldTaskCleanUpMs, 60'000),
+          BOOL_PROP(kEnableOldTaskCleanUp, true),
           STR_PROP(kInternalCommunicationJwtEnabled, "false"),
           STR_PROP(kInternalCommunicationSharedSecret, ""),
           NUM_PROP(kInternalCommunicationJwtExpirationSeconds, 300),
@@ -470,6 +471,10 @@ bool SystemConfig::includeNodeInSpillPath() const {
 
 int32_t SystemConfig::oldTaskCleanUpMs() const {
   return optionalProperty<int32_t>(kOldTaskCleanUpMs).value();
+}
+
+bool SystemConfig::enableOldTaskCleanUp() const {
+  return optionalProperty<bool>(kEnableOldTaskCleanUp).value();
 }
 
 // The next three toggles govern the use of JWT for authentication

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -273,6 +273,11 @@ class SystemConfig : public ConfigBase {
   /// cleanup.
   static constexpr std::string_view kOldTaskCleanUpMs{"old-task-cleanup-ms"};
 
+  /// Enable periodic old task clean up. Typically enabled for presto (default)
+  /// and disabled for presto-on-spark.
+  static constexpr std::string_view kEnableOldTaskCleanUp{
+      "enable-old-task-cleanup"};
+
   static constexpr std::string_view kAnnouncementMaxFrequencyMs{
       "announcement-max-frequency-ms"};
 
@@ -467,6 +472,8 @@ class SystemConfig : public ConfigBase {
   bool includeNodeInSpillPath() const;
 
   int32_t oldTaskCleanUpMs() const;
+
+  bool enableOldTaskCleanUp() const;
 
   bool internalCommunicationJwtEnabled() const;
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -91,6 +91,11 @@ public class NativeExecutionSystemConfig
     // Spilling related configs.
     private static final String SPILLER_SPILL_PATH = "experimental.spiller-spill-path";
     private static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
+    // Tasks are considered old, when they are in not-running state and it ended more than
+    // OLD_TASK_CLEANUP_MS ago or last heartbeat was more than OLD_TASK_CLEANUP_MS ago.
+    // For Presto-On-Spark, this is not relevant as it runs tasks serially, and spark's speculative
+    // execution takes care of zombie tasks.
+    private static final String ENABLE_OLD_TASK_CLEANUP = "enable-old-task-cleanup";
     // Name of exchange client to use
     private static final String SHUFFLE_NAME = "shuffle.name";
     // Feature flag for access log on presto-native http server
@@ -123,6 +128,7 @@ public class NativeExecutionSystemConfig
     private String spillerSpillPath = "";
     private int concurrentLifespansPerTask = 5;
     private int maxDriversPerTask = 15;
+    private boolean enableOldTaskCleanUp; // false;
     private String prestoVersion = "dummy.presto.version";
     private String shuffleName = "local";
     private boolean registerTestFunctions;
@@ -159,6 +165,7 @@ public class NativeExecutionSystemConfig
                 .put(MEMORY_POOL_TRANSFER_CAPACITY, String.valueOf(getMemoryPoolTransferCapacity()))
                 .put(SPILLER_SPILL_PATH, String.valueOf(getSpillerSpillPath()))
                 .put(TASK_MAX_DRIVERS_PER_TASK, String.valueOf(getMaxDriversPerTask()))
+                .put(ENABLE_OLD_TASK_CLEANUP, String.valueOf(getOldTaskCleanupMs()))
                 .put(SHUFFLE_NAME, getShuffleName())
                 .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
                 .build();
@@ -498,6 +505,18 @@ public class NativeExecutionSystemConfig
     public int getMaxDriversPerTask()
     {
         return maxDriversPerTask;
+    }
+
+    public boolean getOldTaskCleanupMs()
+    {
+        return enableOldTaskCleanUp;
+    }
+
+    @Config(ENABLE_OLD_TASK_CLEANUP)
+    public NativeExecutionSystemConfig setOldTaskCleanupMs(boolean enableOldTaskCleanUp)
+    {
+        this.enableOldTaskCleanUp = enableOldTaskCleanUp;
+        return this;
     }
 
     @Config(PRESTO_VERSION)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -86,6 +86,7 @@ public class TestNativeExecutionSystemConfig
                 .setSpillerSpillPath("")
                 .setConcurrentLifespansPerTask(5)
                 .setMaxDriversPerTask(15)
+                .setOldTaskCleanupMs(false)
                 .setPrestoVersion("dummy.presto.version")
                 .setShuffleName("local")
                 .setRegisterTestFunctions(false)
@@ -120,6 +121,7 @@ public class TestNativeExecutionSystemConfig
                 .setMemoryPoolTransferCapacity(1L << 30)
                 .setSpillerSpillPath("dummy.spill.path")
                 .setMaxDriversPerTask(30)
+                .setOldTaskCleanupMs(true)
                 .setShuffleName("custom")
                 .setRegisterTestFunctions(true)
                 .setEnableHttpServerAccessLog(false);


### PR DESCRIPTION
## Motivation and Context
PrestoServer contains oldTaskCleanup routine which cleans up tasks which are not running or have not recieved heart-beat in a long while. This is meant to detect zombie or stuck tasks, this is not relevant in Presto-On-Spark as Spark speculative execution takes care of it.


## Impact
In production we have seen legitimate tasks getting cleanup, especially jobs which are long running or have skew. Disabling old task cleanup fixes the problem.
When task cleanup routine takes effect, we see that JAVA keeps on pooling as the task has been removed from `TaskResource::taskMap_` thus making no progress.

## Test Plan
Verified on internal build on queries where we were seeing old task cleanup take action.


```
== NO RELEASE NOTE ==
```

