### PR TITLE
Add null stats for join probe

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -148,10 +148,12 @@ public class HistoryBasedPlanStatisticsTracker
                 double outputBytes = adjustedOutputBytes(planNode, planNodeStats);
                 double nullJoinBuildKeyCount = planNodeStats.getPlanNodeNullJoinBuildKeyCount();
                 double joinBuildKeyCount = planNodeStats.getPlanNodeJoinBuildKeyCount();
+                double nullJoinProbeKeyCount = planNodeStats.getPlanNodeNullJoinProbeKeyCount();
+                double joinProbeKeyCount = planNodeStats.getPlanNodeJoinProbeKeyCount();
 
                 JoinNodeStatistics joinNodeStatistics = JoinNodeStatistics.empty();
                 if (planNode instanceof JoinNode) {
-                    joinNodeStatistics = new JoinNodeStatistics(Estimate.of(nullJoinBuildKeyCount), Estimate.of(joinBuildKeyCount));
+                    joinNodeStatistics = new JoinNodeStatistics(Estimate.of(nullJoinBuildKeyCount), Estimate.of(joinBuildKeyCount), Estimate.of(nullJoinProbeKeyCount), Estimate.of(joinProbeKeyCount));
                 }
 
                 TableWriterNodeStatistics tableWriterNodeStatistics = TableWriterNodeStatistics.empty();

--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinNodeStatsEstimate.java
@@ -23,16 +23,24 @@ import static java.lang.Double.NaN;
 
 public class JoinNodeStatsEstimate
 {
-    private static final JoinNodeStatsEstimate UNKNOWN = new JoinNodeStatsEstimate(NaN, NaN);
+    private static final JoinNodeStatsEstimate UNKNOWN = new JoinNodeStatsEstimate(NaN, NaN, NaN, NaN);
 
     private final double nullJoinBuildKeyCount;
     private final double joinBuildKeyCount;
+    private final double nullJoinProbeKeyCount;
+    private final double joinProbeKeyCount;
 
     @JsonCreator
-    public JoinNodeStatsEstimate(@JsonProperty("nullJoinBuildKeyCount") double nullJoinBuildKeyCount, @JsonProperty("joinBuildKeyCount") double joinBuildKeyCount)
+    public JoinNodeStatsEstimate(
+            @JsonProperty("nullJoinBuildKeyCount") double nullJoinBuildKeyCount,
+            @JsonProperty("joinBuildKeyCount") double joinBuildKeyCount,
+            @JsonProperty("nullJoinProbeKeyCount") double nullJoinProbeKeyCount,
+            @JsonProperty("joinProbeKeyCount") double joinProbeKeyCount)
     {
         this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
         this.joinBuildKeyCount = joinBuildKeyCount;
+        this.nullJoinProbeKeyCount = nullJoinProbeKeyCount;
+        this.joinProbeKeyCount = joinProbeKeyCount;
     }
 
     public static JoinNodeStatsEstimate unknown()
@@ -52,12 +60,26 @@ public class JoinNodeStatsEstimate
         return joinBuildKeyCount;
     }
 
+    @JsonProperty
+    public double getNullJoinProbeKeyCount()
+    {
+        return nullJoinProbeKeyCount;
+    }
+
+    @JsonProperty
+    public double getJoinProbeKeyCount()
+    {
+        return joinProbeKeyCount;
+    }
+
     @Override
     public String toString()
     {
         return toStringHelper(this)
                 .add("nullJoinBuildKeyCount", nullJoinBuildKeyCount)
                 .add("joinBuildKeyCount", joinBuildKeyCount)
+                .add("nullJoinProbeKeyCount", nullJoinProbeKeyCount)
+                .add("joinProbeKeyCount", joinProbeKeyCount)
                 .toString();
     }
 
@@ -72,12 +94,14 @@ public class JoinNodeStatsEstimate
         }
         JoinNodeStatsEstimate that = (JoinNodeStatsEstimate) o;
         return Double.compare(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) == 0 &&
-                Double.compare(joinBuildKeyCount, that.joinBuildKeyCount) == 0;
+                Double.compare(joinBuildKeyCount, that.joinBuildKeyCount) == 0 &&
+                Double.compare(nullJoinProbeKeyCount, that.nullJoinProbeKeyCount) == 0 &&
+                Double.compare(joinProbeKeyCount, that.joinProbeKeyCount) == 0;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount, nullJoinProbeKeyCount, joinProbeKeyCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -257,7 +257,9 @@ public class PlanNodeStatsEstimate
                     planStatistics.getJoinNodeStatistics().isEmpty() ? getJoinNodeStatsEstimate() :
                             new JoinNodeStatsEstimate(
                                     planStatistics.getJoinNodeStatistics().getNullJoinBuildKeyCount().getValue(),
-                                    planStatistics.getJoinNodeStatistics().getJoinBuildKeyCount().getValue()),
+                                    planStatistics.getJoinNodeStatistics().getJoinBuildKeyCount().getValue(),
+                                    planStatistics.getJoinNodeStatistics().getNullJoinProbeKeyCount().getValue(),
+                                    planStatistics.getJoinNodeStatistics().getJoinProbeKeyCount().getValue()),
                     planStatistics.getTableWriterNodeStatistics().isEmpty() ? getTableWriterNodeStatsEstimate() :
                             new TableWriterNodeStatsEstimate(planStatistics.getTableWriterNodeStatistics().getTaskCountIfScaledWriter().getValue()));
         }
@@ -309,7 +311,9 @@ public class PlanNodeStatsEstimate
                         sourceInfo.isConfident() ? 1 : 0,
                         new JoinNodeStatistics(
                                 Estimate.estimateFromDouble(joinNodeStatsEstimate.getNullJoinBuildKeyCount()),
-                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getJoinBuildKeyCount())),
+                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getJoinBuildKeyCount()),
+                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getNullJoinProbeKeyCount()),
+                                Estimate.estimateFromDouble(joinNodeStatsEstimate.getJoinProbeKeyCount())),
                         new TableWriterNodeStatistics(Estimate.estimateFromDouble(tableWriterNodeStatsEstimate.getTaskCountIfScaledWriter()))),
                 sourceInfo);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
@@ -55,6 +55,7 @@ public class JoinProbe
     private final boolean probeMayHaveNull;
 
     private int position = -1;
+    private int nullRowCount;
 
     private JoinProbe(int[] probeOutputChannels, Page page, Page probePage, @Nullable Block probeHashBlock)
     {
@@ -79,6 +80,7 @@ public class JoinProbe
     public long getCurrentJoinPosition(LookupSource lookupSource)
     {
         if (probeMayHaveNull && currentRowContainsNull()) {
+            ++nullRowCount;
             return -1;
         }
         if (probeHashBlock != null) {
@@ -116,5 +118,15 @@ public class JoinProbe
             }
         }
         return false;
+    }
+
+    public int getNullRowCount()
+    {
+        return nullRowCount;
+    }
+
+    public int getPositionCount()
+    {
+        return positionCount;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -77,6 +77,10 @@ public class OperatorContext
     private final AtomicLong nullJoinBuildKeyCount = new AtomicLong();
     // Number of elements in hash table for join operator
     private final AtomicLong joinBuildKeyCount = new AtomicLong();
+    // Number of NULL probe rows for join operator
+    private final AtomicLong nullJoinProbeKeyCount = new AtomicLong();
+    // Number of probe rows for join operator
+    private final AtomicLong joinProbeKeyCount = new AtomicLong();
 
     private final AtomicLong additionalCpuNanos = new AtomicLong();
 
@@ -234,6 +238,16 @@ public class OperatorContext
     public void recordJoinBuildKeyCount(long positions)
     {
         joinBuildKeyCount.getAndAdd(positions);
+    }
+
+    public void recordNullJoinProbeKeyCount(long positions)
+    {
+        nullJoinProbeKeyCount.getAndAdd(positions);
+    }
+
+    public void recordJoinProbeKeyCount(long positions)
+    {
+        joinProbeKeyCount.getAndAdd(positions);
     }
 
     public void recordPhysicalWrittenData(long sizeInBytes)
@@ -562,7 +576,9 @@ public class OperatorContext
                 info,
                 runtimeStats,
                 nullJoinBuildKeyCount.get(),
-                joinBuildKeyCount.get());
+                joinBuildKeyCount.get(),
+                nullJoinProbeKeyCount.get(),
+                joinProbeKeyCount.get());
     }
 
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -97,6 +97,8 @@ public class OperatorStats
 
     private final long nullJoinBuildKeyCount;
     private final long joinBuildKeyCount;
+    private final long nullJoinProbeKeyCount;
+    private final long joinProbeKeyCount;
 
     @JsonCreator
     public OperatorStats(
@@ -151,7 +153,9 @@ public class OperatorStats
             @JsonProperty("info") OperatorInfo info,
             @JsonProperty("runtimeStats") RuntimeStats runtimeStats,
             @JsonProperty("nullJoinBuildKeyCount") long nullJoinBuildKeyCount,
-            @JsonProperty("joinBuildKeyCount") long joinBuildKeyCount)
+            @JsonProperty("joinBuildKeyCount") long joinBuildKeyCount,
+            @JsonProperty("nullJoinProbeKeyCount") long nullJoinProbeKeyCount,
+            @JsonProperty("joinProbeKeyCount") long joinProbeKeyCount)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -211,6 +215,8 @@ public class OperatorStats
         this.infoUnion = null;
         this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
         this.joinBuildKeyCount = joinBuildKeyCount;
+        this.nullJoinProbeKeyCount = nullJoinProbeKeyCount;
+        this.joinProbeKeyCount = joinProbeKeyCount;
     }
 
     @ThriftConstructor
@@ -266,7 +272,9 @@ public class OperatorStats
             @Nullable
             OperatorInfoUnion infoUnion,
             long nullJoinBuildKeyCount,
-            long joinBuildKeyCount)
+            long joinBuildKeyCount,
+            long nullJoinProbeKeyCount,
+            long joinProbeKeyCount)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -326,6 +334,8 @@ public class OperatorStats
         this.info = null;
         this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
         this.joinBuildKeyCount = joinBuildKeyCount;
+        this.nullJoinProbeKeyCount = nullJoinProbeKeyCount;
+        this.joinProbeKeyCount = joinProbeKeyCount;
     }
 
     @JsonProperty
@@ -623,6 +633,20 @@ public class OperatorStats
         return joinBuildKeyCount;
     }
 
+    @JsonProperty
+    @ThriftField(42)
+    public long getNullJoinProbeKeyCount()
+    {
+        return nullJoinProbeKeyCount;
+    }
+
+    @JsonProperty
+    @ThriftField(43)
+    public long getJoinProbeKeyCount()
+    {
+        return joinProbeKeyCount;
+    }
+
     public OperatorStats add(OperatorStats operatorStats)
     {
         return add(ImmutableList.of(operatorStats));
@@ -674,6 +698,8 @@ public class OperatorStats
 
         long nullJoinBuildKeyCount = this.nullJoinBuildKeyCount;
         long joinBuildKeyCount = this.joinBuildKeyCount;
+        long nullJoinProbeKeyCount = this.nullJoinProbeKeyCount;
+        long joinProbeKeyCount = this.joinProbeKeyCount;
 
         Mergeable<OperatorInfo> base = getMergeableInfoOrNull(info);
         for (OperatorStats operator : operators) {
@@ -731,6 +757,8 @@ public class OperatorStats
 
             nullJoinBuildKeyCount += operator.getNullJoinBuildKeyCount();
             joinBuildKeyCount += operator.getJoinBuildKeyCount();
+            nullJoinProbeKeyCount += operator.getNullJoinProbeKeyCount();
+            joinProbeKeyCount += operator.getJoinProbeKeyCount();
         }
 
         return new OperatorStats(
@@ -784,7 +812,9 @@ public class OperatorStats
                 (OperatorInfo) base,
                 runtimeStats,
                 nullJoinBuildKeyCount,
-                joinBuildKeyCount);
+                joinBuildKeyCount,
+                nullJoinProbeKeyCount,
+                joinProbeKeyCount);
     }
 
     @SuppressWarnings("unchecked")
@@ -850,6 +880,8 @@ public class OperatorStats
                 info,
                 runtimeStats,
                 nullJoinBuildKeyCount,
-                joinBuildKeyCount);
+                joinBuildKeyCount,
+                nullJoinProbeKeyCount,
+                joinProbeKeyCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
@@ -250,7 +250,9 @@ public class TaskResourceUtils
                 operatorStats.getRuntimeStats(),
                 convertToOperatorInfoUnion(operatorStats.getInfo()),
                 operatorStats.getNullJoinBuildKeyCount(),
-                operatorStats.getJoinBuildKeyCount());
+                operatorStats.getJoinBuildKeyCount(),
+                operatorStats.getNullJoinProbeKeyCount(),
+                operatorStats.getJoinProbeKeyCount());
     }
 
     private static MetadataUpdates convertToThriftMetadataUpdates(
@@ -482,7 +484,9 @@ public class TaskResourceUtils
                 convertToOperatorInfo(thriftOperatorStats.getInfoUnion()),
                 thriftOperatorStats.getRuntimeStats(),
                 thriftOperatorStats.getNullJoinBuildKeyCount(),
-                thriftOperatorStats.getJoinBuildKeyCount());
+                thriftOperatorStats.getJoinBuildKeyCount(),
+                thriftOperatorStats.getNullJoinProbeKeyCount(),
+                thriftOperatorStats.getJoinProbeKeyCount());
     }
 
     private static MetadataUpdates convertFromThriftMetadataUpdates(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
@@ -43,10 +43,12 @@ public class HashCollisionPlanNodeStats
             Map<String, OperatorInputStats> operatorInputStats,
             long planNodeNullJoinBuildKeyCount,
             long planNodeJoinBuildKeyCount,
+            long planNodeNullJoinProbeKeyCount,
+            long planNodeJoinProbeKeyCount,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
         super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount);
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -104,6 +106,8 @@ public class HashCollisionPlanNodeStats
                 merged.operatorInputStats,
                 merged.getPlanNodeNullJoinBuildKeyCount(),
                 merged.getPlanNodeJoinBuildKeyCount(),
+                merged.getPlanNodeNullJoinProbeKeyCount(),
+                merged.getPlanNodeJoinProbeKeyCount(),
                 operatorHashCollisionsStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -47,6 +47,8 @@ public class PlanNodeStats
     protected final Map<String, OperatorInputStats> operatorInputStats;
     private final long planNodeNullJoinBuildKeyCount;
     private final long planNodeJoinBuildKeyCount;
+    private final long planNodeNullJoinProbeKeyCount;
+    private final long planNodeJoinProbeKeyCount;
 
     PlanNodeStats(
             PlanNodeId planNodeId,
@@ -60,7 +62,9 @@ public class PlanNodeStats
             DataSize planNodeOutputDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
             long planNodeNullJoinBuildKeyCount,
-            long planNodeJoinBuildKeyCount)
+            long planNodeJoinBuildKeyCount,
+            long planNodeNullJoinProbeKeyCount,
+            long planNodeJoinProbeKeyCount)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
@@ -76,6 +80,8 @@ public class PlanNodeStats
         this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
         this.planNodeNullJoinBuildKeyCount = planNodeNullJoinBuildKeyCount;
         this.planNodeJoinBuildKeyCount = planNodeJoinBuildKeyCount;
+        this.planNodeNullJoinProbeKeyCount = planNodeNullJoinProbeKeyCount;
+        this.planNodeJoinProbeKeyCount = planNodeJoinProbeKeyCount;
     }
 
     private static double computedStdDev(double sumSquared, double sum, long n)
@@ -165,6 +171,16 @@ public class PlanNodeStats
         return planNodeJoinBuildKeyCount;
     }
 
+    public long getPlanNodeNullJoinProbeKeyCount()
+    {
+        return planNodeNullJoinProbeKeyCount;
+    }
+
+    public long getPlanNodeJoinProbeKeyCount()
+    {
+        return planNodeJoinProbeKeyCount;
+    }
+
     @Override
     public PlanNodeStats mergeWith(PlanNodeStats other)
     {
@@ -180,6 +196,8 @@ public class PlanNodeStats
         Map<String, OperatorInputStats> operatorInputStats = mergeMaps(this.operatorInputStats, other.operatorInputStats, OperatorInputStats::merge);
         long planNodeNullJoinBuildKeyCount = this.planNodeNullJoinBuildKeyCount + other.planNodeNullJoinBuildKeyCount;
         long planNodeJoinBuildKeyCount = this.planNodeJoinBuildKeyCount + other.planNodeJoinBuildKeyCount;
+        long planNodeNullJoinProbeKeyCount = this.planNodeNullJoinProbeKeyCount + other.planNodeNullJoinProbeKeyCount;
+        long planNodeJoinProbeKeyCount = this.planNodeJoinProbeKeyCount + other.planNodeJoinProbeKeyCount;
 
         return new PlanNodeStats(
                 planNodeId,
@@ -190,6 +208,8 @@ public class PlanNodeStats
                 planNodeOutputPositions, planNodeOutputDataSize,
                 operatorInputStats,
                 planNodeNullJoinBuildKeyCount,
-                planNodeJoinBuildKeyCount);
+                planNodeJoinBuildKeyCount,
+                planNodeNullJoinProbeKeyCount,
+                planNodeJoinProbeKeyCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -82,6 +82,8 @@ public class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeCpuMillis = new HashMap<>();
         Map<PlanNodeId, Long> planNodeNullJoinBuildKeyCount = new HashMap<>();
         Map<PlanNodeId, Long> planNodeJoinBuildKeyCount = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeNullJoinProbeKeyCount = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeJoinProbeKeyCount = new HashMap<>();
 
         Map<PlanNodeId, Map<String, OperatorInputStats>> operatorInputStats = new HashMap<>();
         Map<PlanNodeId, Map<String, OperatorHashCollisionsStats>> operatorHashCollisionsStats = new HashMap<>();
@@ -153,6 +155,8 @@ public class PlanNodeStatsSummarizer
 
                 planNodeNullJoinBuildKeyCount.merge(planNodeId, operatorStats.getNullJoinBuildKeyCount(), Long::sum);
                 planNodeJoinBuildKeyCount.merge(planNodeId, operatorStats.getJoinBuildKeyCount(), Long::sum);
+                planNodeNullJoinProbeKeyCount.merge(planNodeId, operatorStats.getNullJoinProbeKeyCount(), Long::sum);
+                planNodeJoinProbeKeyCount.merge(planNodeId, operatorStats.getJoinProbeKeyCount(), Long::sum);
 
                 processedNodes.add(planNodeId);
             }
@@ -212,6 +216,8 @@ public class PlanNodeStatsSummarizer
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),
+                        planNodeNullJoinProbeKeyCount.get(planNodeId),
+                        planNodeJoinProbeKeyCount.get(planNodeId),
                         operatorHashCollisionsStats.get(planNodeId));
             }
             else if (windowNodeStats.containsKey(planNodeId)) {
@@ -228,6 +234,8 @@ public class PlanNodeStatsSummarizer
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),
+                        planNodeNullJoinProbeKeyCount.get(planNodeId),
+                        planNodeJoinProbeKeyCount.get(planNodeId),
                         windowNodeStats.get(planNodeId));
             }
             else {
@@ -243,7 +251,9 @@ public class PlanNodeStatsSummarizer
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
-                        planNodeJoinBuildKeyCount.get(planNodeId));
+                        planNodeJoinBuildKeyCount.get(planNodeId),
+                        planNodeNullJoinProbeKeyCount.get(planNodeId),
+                        planNodeJoinProbeKeyCount.get(planNodeId));
             }
 
             stats.add(nodeStats);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
@@ -39,10 +39,12 @@ public class WindowPlanNodeStats
             Map<String, OperatorInputStats> operatorInputStats,
             long planNodeNullJoinBuildKeyCount,
             long planNodeJoinBuildKeyCount,
+            long planNodeNullJoinProbeKeyCount,
+            long planNodeJoinProbeKeyCount,
             WindowOperatorStats windowOperatorStats)
     {
         super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount);
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -70,6 +72,8 @@ public class WindowPlanNodeStats
                 merged.operatorInputStats,
                 merged.getPlanNodeNullJoinBuildKeyCount(),
                 merged.getPlanNodeJoinBuildKeyCount(),
+                merged.getPlanNodeNullJoinProbeKeyCount(),
+                merged.getPlanNodeJoinProbeKeyCount(),
                 windowOperatorStats);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -99,6 +99,8 @@ public class TestQueryStats
                     null,
                     new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))),
                     0,
+                    0,
+                    0,
                     0),
             new OperatorStats(
                     20,
@@ -141,6 +143,8 @@ public class TestQueryStats
                     null,
                     new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))),
                     0,
+                    0,
+                    0,
                     0),
             new OperatorStats(
                     30,
@@ -182,6 +186,8 @@ public class TestQueryStats
                     Optional.empty(),
                     null,
                     new RuntimeStats(),
+                    0,
+                    0,
                     0,
                     0));
 
@@ -544,6 +550,8 @@ public class TestQueryStats
                 Optional.empty(),
                 null,
                 new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))),
+                0,
+                0,
                 0,
                 0);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -89,6 +89,8 @@ public class TestOperatorStats
             NON_MERGEABLE_INFO,
             new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))),
             0,
+            0,
+            0,
             0);
 
     public static final OperatorStats MERGEABLE = new OperatorStats(
@@ -138,6 +140,8 @@ public class TestOperatorStats
             Optional.empty(),
             MERGEABLE_INFO,
             new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))),
+            0,
+            0,
             0,
             0);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -761,9 +761,9 @@ public final class PlanMatchPattern
         return this;
     }
 
-    public PlanMatchPattern withJoinBuildKeyStatistics(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount)
+    public PlanMatchPattern withJoinStatistics(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount, double expectedJoinProbeKeyCount, double expectedNullJoinProbeKeyCount)
     {
-        matchers.add(new StatsJoinBuildKeyCountMatcher(expectedJoinBuildKeyCount, expectedNullJoinBuildKeyCount));
+        matchers.add(new StatsJoinKeyCountMatcher(expectedJoinBuildKeyCount, expectedNullJoinBuildKeyCount, expectedJoinProbeKeyCount, expectedNullJoinProbeKeyCount));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinKeyCountMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsJoinKeyCountMatcher.java
@@ -18,16 +18,20 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.PlanNode;
 
-public class StatsJoinBuildKeyCountMatcher
+public class StatsJoinKeyCountMatcher
         implements Matcher
 {
     private final double expectedJoinBuildKeyCount;
     private final double expectedNullJoinBuildKeyCount;
+    private final double expectedJoinProbeKeyCount;
+    private final double expectedNullJoinProbeKeyCount;
 
-    StatsJoinBuildKeyCountMatcher(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount)
+    StatsJoinKeyCountMatcher(double expectedJoinBuildKeyCount, double expectedNullJoinBuildKeyCount, double expectedJoinProbeKeyCount, double expectedNullJoinProbeKeyCount)
     {
         this.expectedJoinBuildKeyCount = expectedJoinBuildKeyCount;
         this.expectedNullJoinBuildKeyCount = expectedNullJoinBuildKeyCount;
+        this.expectedJoinProbeKeyCount = expectedJoinProbeKeyCount;
+        this.expectedNullJoinProbeKeyCount = expectedNullJoinProbeKeyCount;
     }
 
     @Override
@@ -40,12 +44,15 @@ public class StatsJoinBuildKeyCountMatcher
     public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         return new MatchResult(Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getJoinBuildKeyCount(), expectedJoinBuildKeyCount) == 0
-                && Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getNullJoinBuildKeyCount(), expectedNullJoinBuildKeyCount) == 0);
+                && Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getNullJoinBuildKeyCount(), expectedNullJoinBuildKeyCount) == 0
+                && Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getJoinProbeKeyCount(), expectedJoinProbeKeyCount) == 0
+                && Double.compare(stats.getStats(node).getJoinNodeStatsEstimate().getNullJoinProbeKeyCount(), expectedNullJoinProbeKeyCount) == 0);
     }
 
     @Override
     public String toString()
     {
-        return "expectedJoinBuildKeyCount(" + expectedJoinBuildKeyCount + ")" + " expectedNullJoinBuildKeyCount(" + expectedNullJoinBuildKeyCount + ")";
+        return "expectedJoinBuildKeyCount(" + expectedJoinBuildKeyCount + ")" + " expectedNullJoinBuildKeyCount(" + expectedNullJoinBuildKeyCount + ")"
+                + " expectedNullJoinProbeKeyCount(" + expectedNullJoinProbeKeyCount + ")" + " expectedNullJoinProbeKeyCount(" + expectedNullJoinProbeKeyCount + ")";
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/JoinNodeStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/JoinNodeStatistics.java
@@ -26,20 +26,28 @@ import static java.util.Objects.requireNonNull;
 @ThriftStruct
 public class JoinNodeStatistics
 {
-    private static final JoinNodeStatistics EMPTY = new JoinNodeStatistics(Estimate.unknown(), Estimate.unknown());
+    private static final JoinNodeStatistics EMPTY = new JoinNodeStatistics(Estimate.unknown(), Estimate.unknown(), Estimate.unknown(), Estimate.unknown());
     // Number of input rows from build side of a join which has at least one join column to be NULL
     private final Estimate nullJoinBuildKeyCount;
     // Number of input rows from build side of a join
     private final Estimate joinBuildKeyCount;
+    // Number of input rows from probe side of a join which has at least one join column to be NULL
+    private final Estimate nullJoinProbeKeyCount;
+    // Number of input rows from probe side of a join
+    private final Estimate joinProbeKeyCount;
 
     @JsonCreator
     @ThriftConstructor
     public JoinNodeStatistics(
             @JsonProperty("nullJoinBuildKeyCount") Estimate nullJoinBuildKeyCount,
-            @JsonProperty("joinBuildKeyCount") Estimate joinBuildKeyCount)
+            @JsonProperty("joinBuildKeyCount") Estimate joinBuildKeyCount,
+            @JsonProperty("nullJoinProbeKeyCount") Estimate nullJoinProbeKeyCount,
+            @JsonProperty("joinProbeKeyCount") Estimate joinProbeKeyCount)
     {
         this.nullJoinBuildKeyCount = requireNonNull(nullJoinBuildKeyCount, "nullJoinBuildKeyCount is null");
         this.joinBuildKeyCount = requireNonNull(joinBuildKeyCount, "joinBuildKeyCount is null");
+        this.nullJoinProbeKeyCount = requireNonNull(nullJoinProbeKeyCount, "nullJoinProbeKeyCount is null");
+        this.joinProbeKeyCount = requireNonNull(joinProbeKeyCount, "joinProbeKeyCount is null");
     }
 
     public static JoinNodeStatistics empty()
@@ -66,6 +74,20 @@ public class JoinNodeStatistics
         return joinBuildKeyCount;
     }
 
+    @JsonProperty
+    @ThriftField(3)
+    public Estimate getNullJoinProbeKeyCount()
+    {
+        return nullJoinProbeKeyCount;
+    }
+
+    @JsonProperty
+    @ThriftField(4)
+    public Estimate getJoinProbeKeyCount()
+    {
+        return joinProbeKeyCount;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -76,13 +98,14 @@ public class JoinNodeStatistics
             return false;
         }
         JoinNodeStatistics that = (JoinNodeStatistics) o;
-        return Objects.equals(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) && Objects.equals(joinBuildKeyCount, that.joinBuildKeyCount);
+        return Objects.equals(nullJoinBuildKeyCount, that.nullJoinBuildKeyCount) && Objects.equals(joinBuildKeyCount, that.joinBuildKeyCount)
+                && Objects.equals(nullJoinProbeKeyCount, that.nullJoinProbeKeyCount) && Objects.equals(joinProbeKeyCount, that.joinProbeKeyCount);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount);
+        return Objects.hash(nullJoinBuildKeyCount, joinBuildKeyCount, nullJoinProbeKeyCount, joinProbeKeyCount);
     }
 
     @Override
@@ -91,6 +114,8 @@ public class JoinNodeStatistics
         return "JoinNodeStatistics{" +
                 "nullJoinBuildKeyCount=" + nullJoinBuildKeyCount +
                 ", joinBuildKeyCount=" + joinBuildKeyCount +
+                ", nullJoinProbeKeyCount=" + nullJoinProbeKeyCount +
+                ", joinProbeKeyCount=" + joinProbeKeyCount +
                 '}';
     }
 }


### PR DESCRIPTION
## Description
Part of https://github.com/prestodb/presto/issues/20355

Track number of probe keys and number of null probe keys in HBO, and use it to enable outer join null salt.

## Motivation and Context
Currently HBO only records the null key stats for join build side, and use it to enable null salt in HBO. This PR also add probe side information and use it to enable null salt in HBO too.

## Impact
Resolve the probe side skew in null join.

## Test Plan
Add unit test
And [end to end test on tracking](https://fburl.com/scuba/presto_query_plan_stats_inc_archive/onrle7dz)

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Track null probe keys in join and use it to enable outer join null salt in history based optimization.
```


