### PR TITLE
Make the data directory used by QueryRunners in sync

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
@@ -29,12 +29,12 @@ public class HiveExternalWorkerQueryRunner
         Logging.initialize();
 
         // Create tables before launching distributed runner.
-        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(false);
         NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner();
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false);
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -162,7 +162,7 @@ public class PrestoSparkNativeQueryRunnerUtils
     public static QueryRunner createJavaQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner(Optional.of(getBaseDataPath()), "legacy", DEFAULT_STORAGE_FORMAT);
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner(Optional.of(getBaseDataPath()), "legacy", DEFAULT_STORAGE_FORMAT, true);
     }
 
     public static void assertShuffleMetadata()


### PR DESCRIPTION
Partially resolves https://github.com/prestodb/presto/issues/21168

## Description
HiveExternalWorkerQueryRunner and HiveQueryRunner originally can access
    the data created by each other. However this useful property was lost
    some time ago, due to a storage format string added in the middle of the
    path. e.g. If the user pass "/Users/yingsu" as the DATA_DIR,
    HiveQueryRunner creates the data at "/Users/yingsu/hive_data", but
    HiveExternalWorkerQueryRunner creates the data at "/Users/yingsu/DWRF/
    hive_data". This commit adds a "addStorageFormatToPath" flag to the
    HiveExternalWorkerQueryRunner and set it to false. Other tests still
    add it to the path for backward compatibility.

## Motivation and Context
https://github.com/prestodb/presto/issues/21168

## Impact
Running standalone HiveExternalWorkerQueryRunner now create data at DATA_DIR/hive_data

## Test Plan
Before the change
```
presto:tpch> show schemas;
        Schema
----------------------
 __temporary_tables__
 information_schema
 tpcds
 tpcds_bucketed
 tpch
 tpch_bucketed
(6 rows)
```
After change
```
presto:tpch> show schemas;
           Schema
-----------------------------
 __temporary_tables__
 information_schema
 swiftly
 temp
 test
 test1
 tmp
 tpcds
 tpcds_1g_varchar
 tpcds_bucketed
 tpch
 tpch10g
 tpch1_dwrf
 tpch1_dwrf_partitioned
 tpch1g
 tpch_10
 tpch_100_dwrf
 tpch_100_parquet
 tpch_100_parquet_compressed
 tpch_10_parquet
 tpch_1_parquet
 tpch_1_parquet_partitioned
 tpch_1_parquet_smallfiles
 tpch_1_partitioned
 tpch_bucketed
 tpch_bucketed_tinytiny
 tpch_tiny
 tpch_tiny_bucketed
 tpch_tiny_parquet
 tpch_tiny_parquet_plain
 tpch_tinytiny
(31 rows)
```
The other schemas were created using HiveQueryRunner before.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

