### PR TITLE
Load error messages from resource bundles

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
@@ -99,8 +99,8 @@ public class DeltaClient
         Metadata metadata = snapshot.getMetadata();
         String format = metadata.getFormat().getProvider();
         if (!PARQUET.name().equalsIgnoreCase(format)) {
-            throw new PrestoException(DELTA_UNSUPPORTED_DATA_FORMAT,
-                    format("Delta table %s has unsupported data format: %s. Currently only Parquet data format is supported", schemaTableName, format));
+            throw new PrestoException("DELTA_UNSUPPORTED_DATA_FORMAT_1",
+                    DELTA_UNSUPPORTED_DATA_FORMAT, schemaTableName, format);
         }
 
         return Optional.of(new DeltaTable(

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaTableName.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaTableName.java
@@ -107,10 +107,7 @@ public class DeltaTableName
     {
         Matcher match = TABLE_PATTERN.matcher(tableName);
         if (!match.matches()) {
-            throw new PrestoException(NOT_SUPPORTED, "Invalid Delta table name: " + tableName +
-                    ", Expected table name form 'tableName[@v<snapshotId>][@t<snapshotAsOfTimestamp>]'. " +
-                    "The table can have either a particular snapshot identifier or a timestamp of the snapshot. " +
-                    "If timestamp is given the latest snapshot of the table that was generated at or before the given timestamp is read");
+            throw new PrestoException("NOT_SUPPORTED_26", NOT_SUPPORTED, tableName);
         }
 
         String tableNameOrPath = match.group(TABLE_GROUP_NAME);

--- a/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaTableName.java
+++ b/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaTableName.java
@@ -14,11 +14,13 @@
 package com.facebook.presto.delta;
 
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.util.Failures;
 import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
@@ -89,6 +91,7 @@ public class TestDeltaTableName
             fail("expected the above call to fail");
         }
         catch (PrestoException exception) {
+            exception = (PrestoException) Failures.toLocalisedPrestoException(exception, Locale.US);
             assertTrue(exception.getMessage().contains(expErrorMessage), exception.getMessage());
         }
     }

--- a/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaTypeUtils.java
+++ b/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaTypeUtils.java
@@ -15,10 +15,12 @@ package com.facebook.presto.delta;
 
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.util.Failures;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.math.BigInteger;
+import java.util.Locale;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -76,6 +78,7 @@ public class TestDeltaTypeUtils
             fail("expected to fail");
         }
         catch (PrestoException e) {
+            e = (PrestoException) Failures.toLocalisedPrestoException(e, Locale.US);
             assertEquals(e.getErrorCode(), DELTA_INVALID_PARTITION_VALUE.toErrorCode());
             assertTrue(e.getMessage().matches("Can not parse partition value .* of type .* for partition column 'p1'"));
         }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidExpressionConverters.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidExpressionConverters.java
@@ -16,8 +16,10 @@ package com.facebook.presto.druid;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.util.Failures;
 import org.testng.annotations.Test;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static com.facebook.presto.druid.DruidErrorCode.DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION;
@@ -99,6 +101,7 @@ public class TestDruidExpressionConverters
             fail("expected to not reach here: Generated " + actualDruidExpression);
         }
         catch (PrestoException e) {
+            e = (PrestoException) Failures.toLocalisedPrestoException(e, Locale.US);
             assertEquals(e.getErrorCode(), DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION.toErrorCode());
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisites;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
+import com.facebook.presto.util.Failures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
@@ -113,6 +114,8 @@ public class LocalDispatchQuery
         this.queryPrerequisites = requireNonNull(queryPrerequisites, "queryPrerequisites is null");
         this.warningCollector = requireNonNull(stateMachine.getWarningCollector(), "warningCollector is null");
         addExceptionCallback(queryExecutionFuture, throwable -> {
+            throwable = Failures.toLocalisedPrestoException(throwable, getSession().getLocale());
+
             if (stateMachine.transitionToFailed(throwable)) {
                 queryMonitor.queryImmediateFailureEvent(stateMachine.getBasicQueryInfo(Optional.empty()), toFailure(throwable));
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.util.Failures;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -256,6 +257,7 @@ public abstract class DataDefinitionExecution<T extends Statement>
     @Override
     public void fail(Throwable cause)
     {
+        cause = Failures.toLocalisedPrestoException(cause, getSession().getLocale());
         stateMachine.transitionToFailed(cause);
         stateMachine.updateQueryInfo(Optional.empty());
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.security.SelectedRole;
 import com.facebook.presto.sql.planner.CanonicalPlanWithInfo;
 import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.util.Failures;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -839,6 +840,7 @@ public class QueryStateMachine
                 @Override
                 public void onFailure(Throwable throwable)
                 {
+                    throwable = Failures.toLocalisedPrestoException(throwable, getSession().getLocale());
                     transitionToFailed(throwable, currentState -> !currentState.isDone());
                 }
             }, directExecutor());

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -63,6 +63,7 @@ import com.facebook.presto.sql.planner.SplitSourceFactory;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
+import com.facebook.presto.util.Failures;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -715,6 +716,7 @@ public class SqlQueryExecution
     {
         requireNonNull(cause, "cause is null");
 
+        cause = Failures.toLocalisedPrestoException(cause, getSession().getLocale());
         stateMachine.transitionToFailed(cause);
 
         // acquire reference to scheduler before checking finalQueryInfo, because

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -144,7 +144,7 @@ public final class MetadataUtil
         requireNonNull(session, "session is null");
         requireNonNull(name, "name is null");
         if (name.getParts().size() > 3) {
-            throw new PrestoException(SYNTAX_ERROR, format("Too many dots in table name: %s", name));
+            throw new PrestoException("SYNTAX_ERROR_2", SYNTAX_ERROR, name);
         }
 
         List<String> parts = Lists.reverse(name.getParts());

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -45,6 +45,7 @@ import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
+import com.facebook.presto.spi.error.ErrorRetriever;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.storage.TempStorageManager;
@@ -177,6 +178,9 @@ public class PrestoServer
             injector.getInstance(TracerProviderManager.class).loadTracerProvider();
             injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
+
+            ErrorRetriever.preloadErrorBundles(serverConfig.isErrorI18nEnabled());
+
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -40,6 +40,7 @@ public class ServerConfig
     private NodePoolType poolType = DEFAULT;
     private Duration clusterStatsExpirationDuration = new Duration(0, MILLISECONDS);
     private boolean nestedDataSerializationEnabled = true;
+    private boolean isErrorI18nEnabled = false;
 
     public boolean isResourceManager()
     {
@@ -212,6 +213,18 @@ public class ServerConfig
     public ServerConfig setNestedDataSerializationEnabled(boolean nestedDataSerializationEnabled)
     {
         this.nestedDataSerializationEnabled = nestedDataSerializationEnabled;
+        return this;
+    }
+
+    public boolean isErrorI18nEnabled()
+    {
+        return this.isErrorI18nEnabled;
+    }
+
+    @Config("error.i18n.enabled")
+    public ServerConfig setErrorI18nEnabled(boolean value)
+    {
+        this.isErrorI18nEnabled = value;
         return this;
     }
 }

--- a/presto-main/src/main/resources/Messages.properties
+++ b/presto-main/src/main/resources/Messages.properties
@@ -1,0 +1,1856 @@
+GENERIC_USER_ERROR_1=Catalog %s does not support functions implemented in language %s
+GENERIC_USER_ERROR_2=.*Function 'unittest.memory.power_tower\\(double\\)' already exists
+GENERIC_USER_ERROR_3=Error fetching function metadata
+GENERIC_USER_ERROR_4=Error fetching functions
+GENERIC_USER_ERROR_5=Function '%s' is missing from cache
+GENERIC_USER_ERROR_6=Function '%s' already exists
+GENERIC_USER_ERROR_7=Function has more than %s parameters: %s
+GENERIC_USER_ERROR_8=%s exceeds max length of %s: %s
+GENERIC_USER_ERROR_9=%s compression is not supported with %s
+GENERIC_USER_ERROR_10=%s compression is not supported for %s
+GENERIC_USER_ERROR_11=Table property %s is only allowed if there is also %s
+GENERIC_USER_ERROR_12=Missing table property %s
+GENERIC_USER_ERROR_13=Creating schema in Kudu connector not allowed if schema emulation is disabled.
+GENERIC_USER_ERROR_14=Deleting default schema not allowed.
+GENERIC_USER_ERROR_15=Table name conflicts with schema emulation settings. No '.' allowed for tables in schema 'default'.
+GENERIC_USER_ERROR_16=Table name conflicts with schema emulation settings. Table name must not start with %s .
+GENERIC_USER_ERROR_17=Cannot create function in built-in function namespace: %s
+GENERIC_USER_ERROR_18=Cannot alter function in built-in function namespace: %s
+GENERIC_USER_ERROR_19=Cannot drop function in built-in function namespace: %s
+GENERIC_USER_ERROR_20=Cannot create function in function namespace: %s
+GENERIC_USER_ERROR_21=Regexp matching interrupted
+GENERIC_USER_ERROR_22=n must be greater than or equal to 0
+GENERIC_USER_ERROR_23=%s' is not a valid timestamp literal
+GENERIC_USER_ERROR_24=Remote functions are not enabled
+GENERIC_USER_ERROR_25=SHOW CREATE FUNCTION is only supported for SQL functions
+GENERIC_USER_ERROR_26=invalid joda pattern '%s' passed as format hint for column '%s'
+GENERIC_USER_ERROR_27=mock exception
+
+SYNTAX_ERROR_1=Cannot rename tables across catalogs
+SYNTAX_ERROR_2=Too many dots in table name: %s
+
+ABANDONED_QUERY_1=something went wrong
+ABANDONED_QUERY_2=foo
+ABANDONED_QUERY_3=Query %s has not been accessed since %s: currentTime %s
+
+USER_CANCELED_1=Query was canceled
+USER_CANCELED_2=canceled
+
+PERMISSION_DENIED_1=DROP TABLE is disabled in this catalog
+PERMISSION_DENIED_2=DROP TABLE is disabled in this Cassandra catalog
+PERMISSION_DENIED_3=DROP TABLE is disabled in this catalog
+PERMISSION_DENIED_4=User does not have access to encryption key for encrypted column = %s. If returning 'null' for encrypted columns is acceptable to your query, please add 'set session hive.read_null_masked_parquet_encrypted_value_enabled=true' before your query
+PERMISSION_DENIED_5=Governance Exception : %s
+PERMISSION_DENIED_6=Access Denied: %s
+
+NOT_FOUND_1=Failed to find source column %s to rename to %s
+NOT_FOUND_2=Failed to factory serializer class.  Is it on the classpath?
+NOT_FOUND_3=Configured serializer class not found
+NOT_FOUND_4=No column with name %s
+NOT_FOUND_5=Prepared statement not found: %s
+NOT_FOUND_6=Schema not found: %s
+NOT_FOUND_7=Schema schema1 not found
+NOT_FOUND_8=Delta table (%s.%s) no longer exists.
+NOT_FOUND_9=Snapshot version %d does not exist in Delta table '%s'.
+NOT_FOUND_10=There is no snapshot exists in Delta table '%s' that is created on or before '%s'
+NOT_FOUND_11=type not found
+NOT_FOUND_12=Type %s not found
+NOT_FOUND_13=Function namespace not found: %s
+NOT_FOUND_14=Function not found: %s%s
+NOT_FOUND_15=Hive table handle not found
+NOT_FOUND_16=Table %s.%s does not have columns %s
+NOT_FOUND_17=Missing entry for all databases
+NOT_FOUND_18=Missing entry for roles
+NOT_FOUND_19=Missing entry found for key: %s
+NOT_FOUND_20=Session property catalog does not exist: %s
+NOT_FOUND_21=Catalog does not exist: %s
+NOT_FOUND_22=Target query not found: %s
+NOT_FOUND_23=Table %s not found
+NOT_FOUND_24=Session function %s not found
+NOT_FOUND_25=Prepared statement not found: my_query
+NOT_FOUND_26=Catalog not found: %s
+NOT_FOUND_27=Catalog '%s' does not exist
+NOT_FOUND_28=Schema [%s] does not exist
+NOT_FOUND_29=Schema test1 not found
+NOT_FOUND_30=Schema test2 not found
+NOT_FOUND_31=Schema test3 not found
+
+FUNCTION_NOT_FOUND_1=Function %s not registered
+FUNCTION_NOT_FOUND_2=Function not found: %s
+FUNCTION_NOT_FOUND_3=Functions that are not temporary or builtin must be referenced by 'catalog.schema.function_name', found: %s
+FUNCTION_NOT_FOUND_4=Dependent function implementation (%s) with convention (%s) is not available
+FUNCTION_NOT_FOUND_5=Sampling function: %s not cannot be resolved
+FUNCTION_NOT_FOUND_6=Function not found: %s%s
+
+INVALID_FUNCTION_ARGUMENT_1=Column mapped as the Accumulo row ID cannot be null
+INVALID_FUNCTION_ARGUMENT_2="Number of split tokens is not equal to schema length. Expected %s received %s. Schema: %s, fields {%s}, delimiter %s"
+INVALID_FUNCTION_ARGUMENT_3=Invalid GeoJSON: %s
+INVALID_FUNCTION_ARGUMENT_4=Invalid WKT: %s
+INVALID_FUNCTION_ARGUMENT_5=Geometry type not valid
+INVALID_FUNCTION_ARGUMENT_6=Unknown geometry type: %s
+INVALID_FUNCTION_ARGUMENT_7=Latitude must be between -90 and 90
+INVALID_FUNCTION_ARGUMENT_8=Longitude must be between -180 and 180
+INVALID_FUNCTION_ARGUMENT_9=When applied to SphericalGeography inputs, %s only supports %s. Input type is: %s
+INVALID_FUNCTION_ARGUMENT_10=map key cannot be null
+INVALID_FUNCTION_ARGUMENT_11=Invalid QuadKey digit sequence: %s
+INVALID_FUNCTION_ARGUMENT_12=Invalid input to %s: null at index %s
+INVALID_FUNCTION_ARGUMENT_13=Invalid input to %s: geometry is not a point: %s at index %s
+INVALID_FUNCTION_ARGUMENT_14=Invalid input to %s: empty point at index %s
+INVALID_FUNCTION_ARGUMENT_15=Invalid input to %s: consecutive duplicate points at index %s
+INVALID_FUNCTION_ARGUMENT_16=Invalid geometry: %s
+INVALID_FUNCTION_ARGUMENT_17=distance is NaN
+INVALID_FUNCTION_ARGUMENT_18=distance is negative
+INVALID_FUNCTION_ARGUMENT_19=Invalid type for isClosed: %s
+INVALID_FUNCTION_ARGUMENT_20=First argument to line_locate_point must be a LineString or a MultiLineString. Got: %s
+INVALID_FUNCTION_ARGUMENT_21=Second argument to line_locate_point must be a Point. Got: %s
+INVALID_FUNCTION_ARGUMENT_22=line_interpolate_point: Fraction must be between 0 and 1, but is %s
+INVALID_FUNCTION_ARGUMENT_23=distanceTolerance is NaN
+INVALID_FUNCTION_ARGUMENT_24=distanceTolerance is negative
+INVALID_FUNCTION_ARGUMENT_25=expand_envelope: distance is NaN
+INVALID_FUNCTION_ARGUMENT_26=expand_envelope: distance %s is negative
+INVALID_FUNCTION_ARGUMENT_27=distance is infinite
+INVALID_FUNCTION_ARGUMENT_28=Invalid WKB
+INVALID_FUNCTION_ARGUMENT_29=%s only applies to %s. Input type is: %s
+INVALID_FUNCTION_ARGUMENT_30=No rows supplied to spatial partition.
+INVALID_FUNCTION_ARGUMENT_31=Cannot convert 3D geometry to a spherical geography
+INVALID_FUNCTION_ARGUMENT_32=Cannot convert geometry of this type to spherical geography: %s
+INVALID_FUNCTION_ARGUMENT_33=Unexpected error. Average vector length adds to zero (%f, %f, %f)
+INVALID_FUNCTION_ARGUMENT_34=Polygon is not valid: a loop contains less then 3 vertices.
+INVALID_FUNCTION_ARGUMENT_35=Polygon is not valid: it has two identical consecutive vertices
+INVALID_FUNCTION_ARGUMENT_36=Invalid WKT: Invalid number of points in LineString (found 1 - must be 0 or >= 2)
+INVALID_FUNCTION_ARGUMENT_37=Invalid WKT: Expected number but found ')' (line 1)
+INVALID_FUNCTION_ARGUMENT_38=Invalid WKT: Points of LinearRing do not form a closed linestring
+INVALID_FUNCTION_ARGUMENT_39=Invalid input to ST_LineString: consecutive duplicate points at index 2
+INVALID_FUNCTION_ARGUMENT_40=Invalid input to ST_LineString: geometry is not a point: LINE_STRING at index 2
+INVALID_FUNCTION_ARGUMENT_41=Invalid input to ST_LineString: null at index 1
+INVALID_FUNCTION_ARGUMENT_42=Invalid input to ST_LineString: null at index 2
+INVALID_FUNCTION_ARGUMENT_43=Invalid input to ST_LineString: empty point at index 1
+INVALID_FUNCTION_ARGUMENT_44=Invalid input to ST_LineString: empty point at index 2
+INVALID_FUNCTION_ARGUMENT_45=Invalid input to ST_MultiPoint: %s
+INVALID_FUNCTION_ARGUMENT_46=Invalid WKT: Expected EMPTY or ( but found '0' (line 1)
+INVALID_FUNCTION_ARGUMENT_47=Invalid WKT: Invalid number of points in LineString (found 1 - must be 0 or >= 2)
+INVALID_FUNCTION_ARGUMENT_48=Invalid geometry: corrupted geometry
+INVALID_FUNCTION_ARGUMENT_49=No rows supplied to spatial partition.
+INVALID_FUNCTION_ARGUMENT_50=second argument of max_n/min_n must be positive
+INVALID_FUNCTION_ARGUMENT_51=second argument of max_n/min_n must be less than or equal to %s; found %s
+INVALID_FUNCTION_ARGUMENT_52=Percentile must be between 0 and 1
+INVALID_FUNCTION_ARGUMENT_53=Percentile accuracy must be strictly between 0 and 1
+INVALID_FUNCTION_ARGUMENT_54=percentile weight must be > 0
+INVALID_FUNCTION_ARGUMENT_55=Percentile cannot be null
+INVALID_FUNCTION_ARGUMENT_56=numeric_histogram bucket count must be greater than one
+INVALID_FUNCTION_ARGUMENT_57=Entropy count argument must be non-negative
+INVALID_FUNCTION_ARGUMENT_58=Max standard error must be in [%s, %s]: %s
+INVALID_FUNCTION_ARGUMENT_59=cannot add a double to a q-digest
+INVALID_FUNCTION_ARGUMENT_60=cannot add a long to a t-digest
+INVALID_FUNCTION_ARGUMENT_61=Unsupported number of arguments: %s
+INVALID_FUNCTION_ARGUMENT_62=%s must be a statistical digest
+INVALID_FUNCTION_ARGUMENT_63=Unsupported type %s supplied
+INVALID_FUNCTION_ARGUMENT_64=Weight must be > 0, was %s
+INVALID_FUNCTION_ARGUMENT_65=Compression factor must be positive, was %s,
+INVALID_FUNCTION_ARGUMENT_66=approx_most_frequent bucket count must be greater than one, input bucket count: %s
+INVALID_FUNCTION_ARGUMENT_67=In differential_entropy UDF, invalid method: %s
+INVALID_FUNCTION_ARGUMENT_68=In differential_entropy, strategy class is not compatible with entropy method: %s %s
+INVALID_FUNCTION_ARGUMENT_69=In differential_entropy, unknown entropy method: %s
+INVALID_FUNCTION_ARGUMENT_70=In differential_entropy UDF, bucket count must be non-negative: %s
+INVALID_FUNCTION_ARGUMENT_71=In differential_entropy UDF, min must be larger than max: min=%s, max=%s
+INVALID_FUNCTION_ARGUMENT_72=In differential_entropy UDF, weight must be non-negative: %s
+INVALID_FUNCTION_ARGUMENT_73=In differential_entropy UDF, inconsistent bucket count: prev=%s, current=%s
+INVALID_FUNCTION_ARGUMENT_74=In differential_entropy UDF, inconsistent min: prev=%s, current=%s
+INVALID_FUNCTION_ARGUMENT_75=In differential_entropy UDF, inconsistent max: prev=%s, current=%s
+INVALID_FUNCTION_ARGUMENT_76=In differential_entropy UDF, sample must be at least min: sample=%s, min=%s
+INVALID_FUNCTION_ARGUMENT_77=In differential_entropy UDF, sample must be at most max: sample=%s, max=%s
+INVALID_FUNCTION_ARGUMENT_78=In differential_entropy UDF, max samples must be positive: %s
+INVALID_FUNCTION_ARGUMENT_79=In differential_entropy UDF, max samples  must be capped: max_samples=%s, cap=%s
+INVALID_FUNCTION_ARGUMENT_80=In differential_entropy UDF, weight must be 1.0: %s
+INVALID_FUNCTION_ARGUMENT_81=In differential_entropy UDF, inconsistent maxSamples: %s, %s
+INVALID_FUNCTION_ARGUMENT_82=In differential_entropy UDF, max samples must be positive: %s
+INVALID_FUNCTION_ARGUMENT_83=In differential_entropy UDF, max samples  must be capped: max_samples=%s, cap=%s
+INVALID_FUNCTION_ARGUMENT_84=In differential_entropy UDF, weight must be non-negative: %s
+INVALID_FUNCTION_ARGUMENT_85=In differential_entropy UDF, inconsistent maxSamples: %s, %s
+INVALID_FUNCTION_ARGUMENT_86=third argument of max_by/min_by must be a positive integer
+INVALID_FUNCTION_ARGUMENT_87=third argument of max_by/min_by must be less than or equal to %s; found %s
+INVALID_FUNCTION_ARGUMENT_88=Invalid argument to %s(): NaN
+INVALID_FUNCTION_ARGUMENT_89=combination size must not be negative: %s
+INVALID_FUNCTION_ARGUMENT_90=combination size must not exceed %s: %s
+INVALID_FUNCTION_ARGUMENT_91=combinations exceed max size
+INVALID_FUNCTION_ARGUMENT_92=Number of combinations too large for array of size %s and combination length %s
+INVALID_FUNCTION_ARGUMENT_93=There must be two or more arguments to %s
+INVALID_FUNCTION_ARGUMENT_94=SQL array indices start at 1
+INVALID_FUNCTION_ARGUMENT_95=FIND_FIRST finds NULL as match, which is not supported.
+INVALID_FUNCTION_ARGUMENT_96=SQL array indices start at 1
+INVALID_FUNCTION_ARGUMENT_97=Input type %s not supported
+INVALID_FUNCTION_ARGUMENT_98=N must be positive
+INVALID_FUNCTION_ARGUMENT_99=array_normalize only supports non-negative p: %s
+INVALID_FUNCTION_ARGUMENT_100=0 is an invalid instance position for array_position.
+INVALID_FUNCTION_ARGUMENT_101=array_position cannot take a 0-valued instance argument.
+INVALID_FUNCTION_ARGUMENT_102=length must be greater than or equal to 0
+INVALID_FUNCTION_ARGUMENT_103=Lambda comparator violates the comparator contract
+INVALID_FUNCTION_ARGUMENT_104=Lambda comparator must return either -1, 0, or 1
+INVALID_FUNCTION_ARGUMENT_105=Array contains elements not supported for comparison
+INVALID_FUNCTION_ARGUMENT_106=SQL array indices start at 1
+INVALID_FUNCTION_ARGUMENT_107=Array subscript is negative
+INVALID_FUNCTION_ARGUMENT_108=Array subscript out of bounds
+INVALID_FUNCTION_ARGUMENT_109=size must not be negative: %s
+INVALID_FUNCTION_ARGUMENT_110=size must not exceed array cardinality %s: %s
+INVALID_FUNCTION_ARGUMENT_111=Bits specified in bit_count must be between 2 and 64, got %d
+INVALID_FUNCTION_ARGUMENT_112=Number must be representable with the bits specified. %d can not be represented with %d bits
+INVALID_FUNCTION_ARGUMENT_113=Bits specified must be between 2 and 64, got %d
+INVALID_FUNCTION_ARGUMENT_114=Specified shift must be positive
+INVALID_FUNCTION_ARGUMENT_115=Bits specified in must be between 2 and 64, got %d
+INVALID_FUNCTION_ARGUMENT_116=Invalid color: '%s'
+INVALID_FUNCTION_ARGUMENT_117=red must be between 0 and 255
+INVALID_FUNCTION_ARGUMENT_118=green must be between 0 and 255
+INVALID_FUNCTION_ARGUMENT_119=blue must be between 0 and 255
+INVALID_FUNCTION_ARGUMENT_120=lowColor not a valid RGB color
+INVALID_FUNCTION_ARGUMENT_121=highColor not a valid RGB color
+INVALID_FUNCTION_ARGUMENT_122=color is not a valid rgb value
+INVALID_FUNCTION_ARGUMENT_123=There must be two or more concatenation arguments
+INVALID_FUNCTION_ARGUMENT_124=Concatenated string is too large
+INVALID_FUNCTION_ARGUMENT_125=Invalid data size: '%s'
+INVALID_FUNCTION_ARGUMENT_126=Invalid time zone offset interval: interval contains seconds
+INVALID_FUNCTION_ARGUMENT_127='%s' is not a valid DATE field
+INVALID_FUNCTION_ARGUMENT_128='%s' is not a valid Time field
+INVALID_FUNCTION_ARGUMENT_129='%s' is not a valid Timestamp field
+INVALID_FUNCTION_ARGUMENT_130=format_datetime for TIMESTAMP type, cannot use 'Z' nor 'z' in format, as this type does not contain TZ information
+INVALID_FUNCTION_ARGUMENT_131=%%%s not supported in date format string
+INVALID_FUNCTION_ARGUMENT_132=IPv4 subnet size must be in range [0, 32]
+INVALID_FUNCTION_ARGUMENT_133=IPv6 subnet size must be in range [0, 128]
+INVALID_FUNCTION_ARGUMENT_134=Invalid IP address binary: %s
+INVALID_FUNCTION_ARGUMENT_135=Illegal replacement sequence: %s
+INVALID_FUNCTION_ARGUMENT_136=Illegal replacement sequence: unknown group { %s }
+INVALID_FUNCTION_ARGUMENT_137=Illegal replacement sequence: unknown group
+INVALID_FUNCTION_ARGUMENT_138=Group cannot be negative
+INVALID_FUNCTION_ARGUMENT_139=Pattern has %d groups. Cannot access group %d
+INVALID_FUNCTION_ARGUMENT_140=Index out of bounds
+INVALID_FUNCTION_ARGUMENT_141=Invalid JSON value: %s
+INVALID_FUNCTION_ARGUMENT_142=Cannot convert '%s' to JSON
+INVALID_FUNCTION_ARGUMENT_143=Invalid JSON path: '%s'
+INVALID_FUNCTION_ARGUMENT_144=There must be two or more concatenation arguments to %s
+INVALID_FUNCTION_ARGUMENT_145=Key and value arrays must be the same length
+INVALID_FUNCTION_ARGUMENT_146=map key cannot be null
+INVALID_FUNCTION_ARGUMENT_147=map key cannot be indeterminate: %s
+INVALID_FUNCTION_ARGUMENT_148=map entry cannot be null
+INVALID_FUNCTION_ARGUMENT_149=map key cannot be null
+INVALID_FUNCTION_ARGUMENT_150=Duplicate keys (%s) are not allowed
+INVALID_FUNCTION_ARGUMENT_151=Key not present in map: %s
+INVALID_FUNCTION_ARGUMENT_152=Key not present in map
+INVALID_FUNCTION_ARGUMENT_153=map key cannot be null
+INVALID_FUNCTION_ARGUMENT_154=Duplicate keys (%s) are not allowed
+INVALID_FUNCTION_ARGUMENT_155=successProbability must be in the interval [0, 1]
+INVALID_FUNCTION_ARGUMENT_156=numberOfTrials must be greater than 0
+INVALID_FUNCTION_ARGUMENT_157=p must be in the interval [0, 1]
+INVALID_FUNCTION_ARGUMENT_158=successProbability must be in the interval [0, 1]
+INVALID_FUNCTION_ARGUMENT_159=numberOfTrials must be greater than 0
+INVALID_FUNCTION_ARGUMENT_160=bound must be positive
+INVALID_FUNCTION_ARGUMENT_161=upper bound must be greater than lower bound
+INVALID_FUNCTION_ARGUMENT_162=p must be 0 > p > 1
+INVALID_FUNCTION_ARGUMENT_163=sd must be > 0
+INVALID_FUNCTION_ARGUMENT_164=standardDeviation must be > 0
+INVALID_FUNCTION_ARGUMENT_165=p must be in the interval [0, 1]
+INVALID_FUNCTION_ARGUMENT_166=a must be > 0
+INVALID_FUNCTION_ARGUMENT_167=b must be > 0
+INVALID_FUNCTION_ARGUMENT_168=value must be in the interval [0, 1]
+INVALID_FUNCTION_ARGUMENT_169=scale must be greater than 0
+INVALID_FUNCTION_ARGUMENT_170=df must be greater than 0
+INVALID_FUNCTION_ARGUMENT_171=value must non-negative
+INVALID_FUNCTION_ARGUMENT_172=numerator df must be greater than 0
+INVALID_FUNCTION_ARGUMENT_173=denominator df must be greater than 0
+INVALID_FUNCTION_ARGUMENT_174=shape must be greater than 0
+INVALID_FUNCTION_ARGUMENT_175=value must be greater than, or equal to, 0
+INVALID_FUNCTION_ARGUMENT_176=lambda must be greater than 0
+INVALID_FUNCTION_ARGUMENT_177=value must be a non-negative integer
+INVALID_FUNCTION_ARGUMENT_178=a must be greater than 0
+INVALID_FUNCTION_ARGUMENT_179=b must be greater than 0
+INVALID_FUNCTION_ARGUMENT_180=Not a valid base-%d number: %s
+INVALID_FUNCTION_ARGUMENT_181=Radix must be between %d and %d
+INVALID_FUNCTION_ARGUMENT_182=bucketCount must be greater than 0
+INVALID_FUNCTION_ARGUMENT_183=operand must not be NaN
+INVALID_FUNCTION_ARGUMENT_184=first bound must be finite
+INVALID_FUNCTION_ARGUMENT_185=second bound must be finite
+INVALID_FUNCTION_ARGUMENT_186=bounds cannot equal each other
+INVALID_FUNCTION_ARGUMENT_187=Bins cannot be an empty array
+INVALID_FUNCTION_ARGUMENT_188=Bin values are not sorted in ascending order
+INVALID_FUNCTION_ARGUMENT_189=Bin value must be finite, got
+INVALID_FUNCTION_ARGUMENT_190=map entry cannot be null
+INVALID_FUNCTION_ARGUMENT_191=map key cannot be null
+INVALID_FUNCTION_ARGUMENT_192=Quantile should be within bounds [0, 1], was: %d
+INVALID_FUNCTION_ARGUMENT_193=Scale factor should be positive.
+INVALID_FUNCTION_ARGUMENT_194=Percentile accuracy must be exclusively between 0 and 1, was %s
+INVALID_FUNCTION_ARGUMENT_195=Percentile weight must be > 0, was %s
+INVALID_FUNCTION_ARGUMENT_196=expect null values
+INVALID_FUNCTION_ARGUMENT_197=count argument of repeat function must be less than or equal to 10000
+INVALID_FUNCTION_ARGUMENT_198=count argument of repeat function must be greater than or equal to 0
+INVALID_FUNCTION_ARGUMENT_199=result of repeat function must not take more than 1000000 bytes
+INVALID_FUNCTION_ARGUMENT_200=the size of fromType and toType must match
+INVALID_FUNCTION_ARGUMENT_201=sequence step must be a day interval if start and end values are dates
+INVALID_FUNCTION_ARGUMENT_202=step must not be zero
+INVALID_FUNCTION_ARGUMENT_203=sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start
+INVALID_FUNCTION_ARGUMENT_204=result of sequence function must not have more than 10000 entries
+INVALID_FUNCTION_ARGUMENT_205=entryDelimiter is empty
+INVALID_FUNCTION_ARGUMENT_206=keyValueDelimiter is empty
+INVALID_FUNCTION_ARGUMENT_207=entryDelimiter and keyValueDelimiter must not be the same
+INVALID_FUNCTION_ARGUMENT_208=Key-value delimiter must appear exactly once in each entry. Bad input: %s
+INVALID_FUNCTION_ARGUMENT_209=Duplicate keys (%s) are not allowed. Specifying a lambda to resolve conflicts can avoid this error
+INVALID_FUNCTION_ARGUMENT_210=Not a valid Unicode code point: %d
+INVALID_FUNCTION_ARGUMENT_211=Input string must be a single character string
+INVALID_FUNCTION_ARGUMENT_212=inputs to \replace\" function are too large: when \"search\" parameter is empty, length of \"string\" times length of \"replace\" must not exceed "
+INVALID_FUNCTION_ARGUMENT_213='instance' must be a positive number.
+INVALID_FUNCTION_ARGUMENT_214=Limit must be positive
+INVALID_FUNCTION_ARGUMENT_215=Limit is too large
+INVALID_FUNCTION_ARGUMENT_216=Index must be greater than zero
+INVALID_FUNCTION_ARGUMENT_217=Invalid UTF-8 encoding
+INVALID_FUNCTION_ARGUMENT_218=Invalid UTF-8 encoding in characters: %s
+INVALID_FUNCTION_ARGUMENT_219=Padding string must not be empty
+INVALID_FUNCTION_ARGUMENT_220=The combined inputs for Levenshtein distance are too large
+INVALID_FUNCTION_ARGUMENT_221=The input strings to hamming_distance function must have the same length
+INVALID_FUNCTION_ARGUMENT_222=Normalization form must be one of [NFD, NFC, NFKD, NFKC]
+INVALID_FUNCTION_ARGUMENT_223=Replacement character string must empty or a single character
+INVALID_FUNCTION_ARGUMENT_224=Invalid replacement character
+INVALID_FUNCTION_ARGUMENT_225=Scale factor should be positive.
+INVALID_FUNCTION_ARGUMENT_226=Lower quantile bound should be in [0,1].
+INVALID_FUNCTION_ARGUMENT_227=Upper quantile bound should be in [0,1].
+INVALID_FUNCTION_ARGUMENT_228=combination size must not be negative: -1
+INVALID_FUNCTION_ARGUMENT_229=combination size must not exceed 5: 10
+INVALID_FUNCTION_ARGUMENT_230=combinations exceed max size
+INVALID_FUNCTION_ARGUMENT_231=array_normalize only supports non-negative p:.*
+INVALID_FUNCTION_ARGUMENT_232=Invalid data size: ''
+INVALID_FUNCTION_ARGUMENT_233=Invalid data size: '0'
+INVALID_FUNCTION_ARGUMENT_234=Invalid data size: '10KB'
+INVALID_FUNCTION_ARGUMENT_235=Invalid data size: 'KB'
+INVALID_FUNCTION_ARGUMENT_236=Invalid data size: '-1B'
+INVALID_FUNCTION_ARGUMENT_237=Invalid data size: '12345K'
+INVALID_FUNCTION_ARGUMENT_238=Invalid data size: 'A12345B'
+INVALID_FUNCTION_ARGUMENT_239=Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')
+INVALID_FUNCTION_ARGUMENT_240=Invalid offset minutes 3600
+INVALID_FUNCTION_ARGUMENT_241=Invalid JSON value:
+INVALID_FUNCTION_ARGUMENT_242=Invalid JSON value: [1
+INVALID_FUNCTION_ARGUMENT_243=Invalid JSON value: 1 trailing
+INVALID_FUNCTION_ARGUMENT_244=Invalid JSON value: [1, 2] trailing
+INVALID_FUNCTION_ARGUMENT_245=Lambda comparator must return either -1, 0, or 1
+INVALID_FUNCTION_ARGUMENT_246=invalid input length %d
+INVALID_FUNCTION_ARGUMENT_247=expected 8-byte input, but got instead: %d
+INVALID_FUNCTION_ARGUMENT_248=expected 4-byte input, but got instead: %d
+INVALID_FUNCTION_ARGUMENT_249=Input floating-point value must be exactly 4 bytes long
+INVALID_FUNCTION_ARGUMENT_250=Input floating-point value must be exactly 8 bytes long
+INVALID_FUNCTION_ARGUMENT_251=invalid hex character: %s
+INVALID_FUNCTION_ARGUMENT_252=Target length must be in the range [0..%d]
+INVALID_FUNCTION_ARGUMENT_253=Padding bytes must not be empty
+INVALID_FUNCTION_ARGUMENT_254=number of successes must not be negative
+INVALID_FUNCTION_ARGUMENT_255=number of trials must be positive
+INVALID_FUNCTION_ARGUMENT_256=number of successes must not be larger than number of trials
+INVALID_FUNCTION_ARGUMENT_257=z-score must not be negative
+INVALID_FUNCTION_ARGUMENT_258=Unknown stemmer language: %s
+INVALID_FUNCTION_ARGUMENT_259=Lambda comparator must return either -1, 0, or 1
+INVALID_FUNCTION_ARGUMENT_260=Offset must be at least 0
+INVALID_FUNCTION_ARGUMENT_261=Buckets must be greater than 0
+INVALID_FUNCTION_ARGUMENT_262=Cannot unnest type: %s
+INVALID_FUNCTION_ARGUMENT_263=ROW index out of bounds: %d
+INVALID_FUNCTION_ARGUMENT_264=Cannot add hour, minutes or seconds to a date
+INVALID_FUNCTION_ARGUMENT_265=Cannot subtract hour, minutes or seconds from a date
+INVALID_FUNCTION_ARGUMENT_266=Escape string must be a single character
+INVALID_FUNCTION_ARGUMENT_267=Escape character must be followed by '%%', '_' or the escape character itself
+INVALID_FUNCTION_ARGUMENT_268=No value '%d' in enum type %s
+INVALID_FUNCTION_ARGUMENT_269=Illegal replacement sequence: %s
+INVALID_FUNCTION_ARGUMENT_270=Group cannot be negative
+INVALID_FUNCTION_ARGUMENT_271=Pattern has %d groups. Cannot access group %d
+INVALID_FUNCTION_ARGUMENT_272=Lambda comparator must return either -1, 0, or 1
+INVALID_FUNCTION_ARGUMENT_273=Array contains elements not supported for comparison
+INVALID_FUNCTION_ARGUMENT_274=sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start
+INVALID_FUNCTION_ARGUMENT_275=result of sequence function must not have more than 10000 entries
+INVALID_FUNCTION_ARGUMENT_276=sequence step must be a day interval if start and end values are dates
+INVALID_FUNCTION_ARGUMENT_277=No value '%s' in enum type %s
+INVALID_FUNCTION_ARGUMENT_278=Unsupported type: %s
+INVALID_FUNCTION_ARGUMENT_279=Unknown parameter %s
+INVALID_FUNCTION_ARGUMENT_280=Primary read preference can not specify tag sets
+INVALID_FUNCTION_ARGUMENT_281=Invalid WKB
+INVALID_FUNCTION_ARGUMENT_282=Percentile must be between 0 and 1
+INVALID_FUNCTION_ARGUMENT_283=Cannot convert '%s' to JSON
+INVALID_FUNCTION_ARGUMENT_284=count must be greater than or equal to zero
+
+DIVISION_BY_ZERO_1=/ by zero
+DIVISION_BY_ZERO_2=Division by zero
+
+INVALID_CAST_ARGUMENT_1=Cannot cast value to IPADDRESS: %s
+INVALID_CAST_ARGUMENT_2=Invalid bigint tile encoding: %s
+INVALID_CAST_ARGUMENT_3=Invalid JSON string for KDB tree
+INVALID_CAST_ARGUMENT_4=Cannot cast %s to JSON
+INVALID_CAST_ARGUMENT_5=Cannot cast input json to VARCHAR
+INVALID_CAST_ARGUMENT_6=Cannot cast '%s' to %s
+INVALID_CAST_ARGUMENT_7=Cannot cast input json to BIGINT
+INVALID_CAST_ARGUMENT_8=Cannot cast input json to INTEGER
+INVALID_CAST_ARGUMENT_9=Cannot cast input json to SMALLINT
+INVALID_CAST_ARGUMENT_10=Cannot cast input json to TINYINT
+INVALID_CAST_ARGUMENT_11=Cannot cast input json to DOUBLE
+INVALID_CAST_ARGUMENT_12=Cannot cast input json to REAL
+INVALID_CAST_ARGUMENT_13=Cannot cast input json to BOOLEAN
+INVALID_CAST_ARGUMENT_14=Cannot cast JSON to %s
+INVALID_CAST_ARGUMENT_15=Cannot cast to %s. %s%n%s
+INVALID_CAST_ARGUMENT_16=Cannot cast to %s.%n%s
+INVALID_CAST_ARGUMENT_17=map key is null
+INVALID_CAST_ARGUMENT_18=Value 12300000000 cannot be represented as varchar(3)
+INVALID_CAST_ARGUMENT_19=Value -12300000000 cannot be represented as varchar(3)
+INVALID_CAST_ARGUMENT_20=Value %s cannot be represented as varchar(%s)
+INVALID_CAST_ARGUMENT_21=Value cannot be cast to date: %s
+INVALID_CAST_ARGUMENT_22=Cannot cast '%s' to BIGINT
+INVALID_CAST_ARGUMENT_23=Cannot cast BIGINT '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_24=Cannot cast '%s' to INTEGER
+INVALID_CAST_ARGUMENT_25=Cannot cast INTEGER '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_26=Cannot cast '%s' to SMALLINT
+INVALID_CAST_ARGUMENT_27=Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_28=Cannot cast '%s' to TINYINT
+INVALID_CAST_ARGUMENT_29=Cannot cast TINYINT '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_30=Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_31=Cannot cast REAL '%s' to DECIMAL(%s, %s)
+INVALID_CAST_ARGUMENT_32=Cannot cast VARCHAR '%s' to DECIMAL(%s, %s). Value is not a number.
+INVALID_CAST_ARGUMENT_33=Cannot cast VARCHAR '%s' to DECIMAL(%s, %s). Value too large.
+INVALID_CAST_ARGUMENT_34=Cannot cast '%f' to %s
+INVALID_CAST_ARGUMENT_35=Cannot cast input json to DECIMAL(%s,%s)
+INVALID_CAST_ARGUMENT_36=Cannot cast '%s' to DECIMAL(%s,%s)
+INVALID_CAST_ARGUMENT_37=Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)
+INVALID_CAST_ARGUMENT_38=Cannot cast %s to %s
+INVALID_CAST_ARGUMENT_39=Unable to cast %s to bigint
+INVALID_CAST_ARGUMENT_40=No value '%s' in enum '%s'
+INVALID_CAST_ARGUMENT_41=No value '%d' in enum '%s'
+INVALID_CAST_ARGUMENT_42=Cannot cast value to IPPREFIX: %s
+INVALID_CAST_ARGUMENT_43=Invalid IP address binary length: %d
+INVALID_CAST_ARGUMENT_44=Invalid IP address binary: %s
+INVALID_CAST_ARGUMENT_45=Value cannot be cast to time: %s
+INVALID_CAST_ARGUMENT_46=Value cannot be cast to timestamp: %s
+INVALID_CAST_ARGUMENT_47=Value cannot be cast to timestamp with time zone: %s
+INVALID_CAST_ARGUMENT_48=Invalid UUID string length: %d
+INVALID_CAST_ARGUMENT_49=Cannot cast value to UUID: %s
+INVALID_CAST_ARGUMENT_50=Invalid UUID binary length: %d
+INVALID_CAST_ARGUMENT_51=Cannot cast '%s' to BOOLEAN
+INVALID_CAST_ARGUMENT_52=Cannot cast '%s' to DOUBLE
+INVALID_CAST_ARGUMENT_53=Cannot cast '%s' to REAL
+INVALID_CAST_ARGUMENT_54=Cannot cast '%s' to BIGINT
+INVALID_CAST_ARGUMENT_55=Cannot cast '%s' to INT
+INVALID_CAST_ARGUMENT_56=Cannot cast '%s' to SMALLINT
+INVALID_CAST_ARGUMENT_57=Cannot cast '%s' to TINYINT
+INVALID_CAST_ARGUMENT_58=Cannot cast input json to DECIMAL(%s,%s)
+
+OPERATOR_NOT_FOUND_1=operatorType is null
+
+INVALID_VIEW_1=View already exists as data table
+INVALID_VIEW_2=Invalid materialized view JSON
+INVALID_VIEW_3=Invalid view JSON: %s
+
+ALREADY_EXISTS_1=View already exists
+ALREADY_EXISTS_2=Schema [%s] already exists
+ALREADY_EXISTS_3=Type %s already exists
+ALREADY_EXISTS_4=Function already exists: %s
+ALREADY_EXISTS_5=.*Function already exists: unittest\\.memory\\.power_tower\\(double\\)
+ALREADY_EXISTS_6=Partition already exists
+ALREADY_EXISTS_7=Role name cannot be one of the reserved roles: %s
+ALREADY_EXISTS_8=Role already exists: '%s'
+ALREADY_EXISTS_9=Partition already exists for table '%s.%s': %s
+ALREADY_EXISTS_10=Column already exists: %s
+ALREADY_EXISTS_11=One or more partitions already exist for table '%s.%s'
+ALREADY_EXISTS_12=Session function %s has already been defined
+ALREADY_EXISTS_13=Materialized view already exists
+ALREADY_EXISTS_14=Table already exists
+ALREADY_EXISTS_15=View already exists: %s
+ALREADY_EXISTS_16=Schema [%s] already exists
+ALREADY_EXISTS_17=Table [%s] already exists
+ALREADY_EXISTS_18=View [%s] already exists
+ALREADY_EXISTS_19=Table already exists: %s
+ALREADY_EXISTS_20=View already exists: %s
+ALREADY_EXISTS_21=Table [default.test1] already exists
+ALREADY_EXISTS_22=Table [default.test2] already exists
+
+NOT_SUPPORTED_1=Accumulo does not support renaming tables to different namespaces (schemas)
+NOT_SUPPORTED_2=Unable to rollback insert for table %s.%s. Some rows may have been written. Please run your insert again.
+NOT_SUPPORTED_3=No indexed columns in table metadata. Refusing to index a table with no indexed columns
+NOT_SUPPORTED_4=Unsupported type %s
+NOT_SUPPORTED_5=Unsupported PrestoType %s
+NOT_SUPPORTED_6=No lexicoder for type %s
+NOT_SUPPORTED_7=arrays are not (yet?) supported for StringRowSerializer
+NOT_SUPPORTED_8=maps are not (yet?) supported for StringRowSerializer
+NOT_SUPPORTED_9=StringLexicoder does not support encoding type %s, object class is %s
+NOT_SUPPORTED_10=StringLexicoder does not support decoding type
+NOT_SUPPORTED_11=EXPLAIN ANALYZE does not support statement type: %s
+NOT_SUPPORTED_12=Multiple tables matched: %s
+NOT_SUPPORTED_13=Unsupported column type: %s
+NOT_SUPPORTED_14=Views are not enabled. You can enable views by setting 'bigquery.views-enabled' to true. Notice additional cost may occur.
+NOT_SUPPORTED_15=Table type '%s' of table '%s.%s' is not supported
+NOT_SUPPORTED_16=Black hole connector does not supported distributed reads
+NOT_SUPPORTED_17=Dropping materialized views not yet supported
+NOT_SUPPORTED_18=Renaming tables not yet supported for Cassandra
+NOT_SUPPORTED_19=Inserting into materialized views not yet supported
+NOT_SUPPORTED_20=Unsupported clustering key type: %s
+NOT_SUPPORTED_21=More than one keyspace has been found for the case insensitive schema name: %s -> (%s, %s)
+NOT_SUPPORTED_22=More than one table has been found for the case insensitive table name: %s -> (%s)
+NOT_SUPPORTED_23=More than one column has been found for the case insensitive column name: %s -> (%s, %s)
+NOT_SUPPORTED_24=Cassandra versions prior to 2.1.5 are not supported
+NOT_SUPPORTED_25=Cannot create managed Delta table
+NOT_SUPPORTED_26=Invalid Delta table name: %s, Expected table name form 'tableName[@v<snapshotId>][@t<snapshotAsOfTimestamp>]'. The table can have either a particular snapshot identifier or a timestamp of the snapshot. If timestamp is given the latest snapshot of the table that was generated at or before the given timestamp is read
+NOT_SUPPORTED_27=Invalid Delta table name: %s, given snapshot timestamp (%s) format is not valid.  Expected timestamp format 'YYYY-MM-DD HH:mm:ss'
+NOT_SUPPORTED_28=Invalid Delta table name:   , Table suffix contains both snapshot id and timestamp of snapshot to read. Only one of them is supported.
+NOT_SUPPORTED_29=Unsupported representation for field '%s' of type TIMESTAMP: %s [%s]
+NOT_SUPPORTED_30=Alter Function is not supported in JsonFileBasedFunctionNamespaceManager
+NOT_SUPPORTED_31=Drop Function is not supported in JsonFileBasedFunctionNamespaceManager
+NOT_SUPPORTED_32=Alter Function is not supported in InMemoryFunctionNamespaceManager
+NOT_SUPPORTED_33=Drop Function is not supported in InMemoryFunctionNamespaceManager
+NOT_SUPPORTED_34=Unsupported coercion from %s to %s
+NOT_SUPPORTED_35=Could not create Coercer from varchar to %s
+NOT_SUPPORTED_36=Materialized view %s must have at least one column directly defined by a base table column.
+NOT_SUPPORTED_37=Unpartitioned materialized view is not supported.
+NOT_SUPPORTED_38=Materialized view %s must have at least one partition column that exists in %s as well
+NOT_SUPPORTED_39=Outer join conditions in Materialized view %s must have at least one common partition equality constraint
+NOT_SUPPORTED_40=Unsupported Hive type %s found in partition keys of table %s.%s
+NOT_SUPPORTED_41=Unexpected table present in Hive metastore: %s
+NOT_SUPPORTED_42=Bucketing/Partitioning columns not supported when Avro schema url is set
+NOT_SUPPORTED_43=Cannot create non-managed Hive table
+NOT_SUPPORTED_44=Column %s has a non-varchar map key, which is not supported by Avro
+NOT_SUPPORTED_45=Column %s is tinyint, which is not supported by Avro. Use integer instead.
+NOT_SUPPORTED_46=Column %s is smallint, which is not supported by Avro. Use integer instead.
+NOT_SUPPORTED_47=ALTER TABLE not supported when Avro schema url is set
+NOT_SUPPORTED_48=Creating non-managed Hive tables is disabled
+NOT_SUPPORTED_49=Writes to non-managed Hive tables is disabled
+NOT_SUPPORTED_50=CREATE TABLE AS not supported when Avro schema url is set
+NOT_SUPPORTED_51=Inserting into Hive table %s with column type %s not supported
+NOT_SUPPORTED_52=overwriting existing partition in transactional tables does not support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode
+NOT_SUPPORTED_53=Using dummy because column %s uses unsupported Hive type %s
+NOT_SUPPORTED_54=This connector only supports delete where one or more partitions are deleted entirely
+NOT_SUPPORTED_55=Writing to bucketed sorted Hive tables is disabled
+NOT_SUPPORTED_56=Only DWRF file format supports encryption at this time
+NOT_SUPPORTED_57=Hive CSV storage format only supports VARCHAR (unbounded). Unsupported columns:
+NOT_SUPPORTED_58=Unsupported column type %s for prefilled column: %s
+NOT_SUPPORTED_59=Unsupported type [%s] for partition: %s
+NOT_SUPPORTED_60=Unsupported Hive type %s found in partition keys of table %s.%s
+NOT_SUPPORTED_61=unsupported hidden column: %s
+NOT_SUPPORTED_62=Unsupported column type %s for partition column: %s
+NOT_SUPPORTED_63=Cannot write to non-managed Hive table
+NOT_SUPPORTED_64=Inserting into bucketed tables with skew is not supported. %s
+NOT_SUPPORTED_65=Unsupported Hive type %s found in partition keys of table %s.%s
+NOT_SUPPORTED_66=Bucketed table in SymlinkTextInputFormat is not yet supported
+NOT_SUPPORTED_67=Presto cannot read bucketed partition in an input format with UseFileSplitsFromInputFormat annotation:
+NOT_SUPPORTED_68=The bucket filter cannot be satisfied. There are restrictions on the bucket filter when all the following is true: +\
+  1. a table has a different buckets count as at least one of its partitions that is read in this query; +\
+  2. the table has a different but compatible bucket number with another table in the query; +\
+  3. some buckets of the table is filtered out from the query, most likely using a filter on \"$bucket\". (table name: %s, table bucket count: %d,  partition bucket count: %d, effective reading bucket count: %d)
+NOT_SUPPORTED_69=Anonymous row type is not supported in Hive. Please give each field a name: row(integer,varbinary)
+NOT_SUPPORTED_70=schema evolution is not supported for PageFile format
+NOT_SUPPORTED_71=Parquet reader does not support filter pushdown yet
+NOT_SUPPORTED_72=Compression extension not supported for S3 Select: %s
+NOT_SUPPORTED_73=Unsupported Hive type: %s
+NOT_SUPPORTED_74=Unsupported Hive type: %s. Supported VARCHAR types: VARCHAR(<=%d), VARCHAR.
+NOT_SUPPORTED_75=Unsupported Hive type: %s. Supported CHAR types: CHAR(<=%d).
+NOT_SUPPORTED_76=Anonymous row type is not supported in Hive. Please give each field a name: %s
+NOT_SUPPORTED_77=No default Hive type provided for unsupported Hive type: %s
+NOT_SUPPORTED_78=Cannot drop partition columns
+NOT_SUPPORTED_79=Cannot drop the only non-partition column in a table
+NOT_SUPPORTED_80=Unsupported partition key type: %s
+NOT_SUPPORTED_81=Cannot delete from non-managed Hive table
+NOT_SUPPORTED_82=dropping a partition added in the same transaction is not supported: %s %s %s
+NOT_SUPPORTED_83=Can not insert into a table with a partition that has been modified in the same transaction when Presto is configured to skip temporary directories.
+NOT_SUPPORTED_84=Unsupported combination of operations in a single transaction
+NOT_SUPPORTED_85=Cannot make schema changes to a table/view with modified partitions in the same transaction
+NOT_SUPPORTED_86=Table type not supported: %s
+NOT_SUPPORTED_87=Rename not supported for Iceberg tables
+NOT_SUPPORTED_88=Renaming partition columns is not supported
+NOT_SUPPORTED_89=Partitions can not be added to %s
+NOT_SUPPORTED_90=Glue metastore column level statistics are disabled
+NOT_SUPPORTED_91=Table rename is not yet supported by Glue service
+NOT_SUPPORTED_92=Renaming partition columns is not supported
+NOT_SUPPORTED_93=createRole is not supported by Glue
+NOT_SUPPORTED_94=dropRole is not supported by Glue
+NOT_SUPPORTED_95=grantRoles is not supported by Glue
+NOT_SUPPORTED_96=revokeRoles is not supported by Glue
+NOT_SUPPORTED_97=grantTablePrivileges is not supported by Glue
+NOT_SUPPORTED_98=revokeTablePrivileges is not supported by Glue
+NOT_SUPPORTED_99=listTablePrivileges is not supported by Glue
+NOT_SUPPORTED_100=setPartitionLeases is not supported by Glue
+NOT_SUPPORTED_101=Hive metastore does not support renaming schemas
+NOT_SUPPORTED_102=Renaming partition columns is not supported
+NOT_SUPPORTED_103=Granting %s WITH GRANT OPTION is not supported while %s possesses %s
+NOT_SUPPORTED_104=Partition key type %s not supported
+NOT_SUPPORTED_105=Invalid partition type %s
+NOT_SUPPORTED_106=Could not create page source for table type
+NOT_SUPPORTED_107=Snapshot ID not supported for history table: %s
+NOT_SUPPORTED_108=Snapshot ID not supported for snapshots table: %s
+NOT_SUPPORTED_109=This connector only supports delete where one or more partitions are deleted entirely
+NOT_SUPPORTED_110=File format not supported for Iceberg: %s
+NOT_SUPPORTED_111=Database %s location is not set
+NOT_SUPPORTED_112=Table %s contains Iceberg path override properties and cannot be dropped from Presto
+NOT_SUPPORTED_113=Unsupported Presto Iceberg catalog type %s
+NOT_SUPPORTED_114=Iceberg %s catalog does not support rename namespace
+NOT_SUPPORTED_115=File format not supported for Iceberg: %s
+NOT_SUPPORTED_116=Iceberg catalog of type %s does not support namespace operations
+NOT_SUPPORTED_117=Invalid Iceberg table name: %s
+NOT_SUPPORTED_118=Invalid Iceberg table name (unknown type '%s'): %s
+NOT_SUPPORTED_119=Invalid Iceberg table name (cannot specify two @ versions): %s
+NOT_SUPPORTED_120=Invalid Iceberg table name (cannot use @ version with table type '%s'): %s
+NOT_SUPPORTED_121=Table %s specifies %s as a location provider. Writing to Iceberg tables with custom location provider is not supported.
+NOT_SUPPORTED_122=Type not supported for Iceberg: %s
+NOT_SUPPORTED_123=Row type field does not have a name: %s
+NOT_SUPPORTED_124=Unsupported Iceberg type: %s
+NOT_SUPPORTED_125=Target query is not running: %s
+NOT_SUPPORTED_126=Unsupported statement type: %s
+NOT_SUPPORTED_127=Procedures cannot be called within a transaction (use autocommit mode)
+NOT_SUPPORTED_128=Invoking a dynamically registered function in SQL function body is not supported
+NOT_SUPPORTED_129=CASCADE is not yet supported for DROP SCHEMA
+NOT_SUPPORTED_130=Invalid statement type for prepared statement:
+NOT_SUPPORTED_131=statement is too large (stack overflow during analysis)
+NOT_SUPPORTED_132=Nested transactions not supported
+NOT_SUPPORTED_133=Invalid statement type for prepared statement: EXECUTE
+NOT_SUPPORTED_134=Connector returned multiple layouts for table %s
+NOT_SUPPORTED_135=Table has no columns: %s
+NOT_SUPPORTED_136=State type not enabled for %s: %s
+NOT_SUPPORTED_137=Cannot operate on a t-digest with real numbers
+NOT_SUPPORTED_138=Cannot operate on a t-digest with longs
+NOT_SUPPORTED_139=Too many arguments for function call %s()
+NOT_SUPPORTED_140=Too many arguments for array constructor
+NOT_SUPPORTED_141=contains does not support arrays with elements that are null or contain null
+NOT_SUPPORTED_142=array_position does not support arrays with elements that are null or contain null
+NOT_SUPPORTED_143=array_remove does not support arrays with elements that are null or contain null
+NOT_SUPPORTED_144=Too many arguments for string concatenation
+NOT_SUPPORTED_145=%s is not supported in your OS
+NOT_SUPPORTED_146=ROW comparison not supported for fields with null elements
+NOT_SUPPORTED_147=map key cannot be null or contain nulls
+NOT_SUPPORTED_148=Unsupported explain plan type %s for JSON format
+NOT_SUPPORTED_149=Too many arguments for lambda expression
+NOT_SUPPORTED_150=Too many arguments for vararg function
+NOT_SUPPORTED_151=The \partitioning_provider_catalog\" session property must be set to enable the exchanges materialization. The catalog must support providing a custom partitioning and storing temporary tables.
+NOT_SUPPORTED_152=Temporary table cannot be created in catalog "%s": %s
+NOT_SUPPORTED_153=not yet implemented: %s
+NOT_SUPPORTED_154=Dynamic filtering cannot be used with grouped execution
+NOT_SUPPORTED_155=CREATE TABLE IF NOT EXISTS is not supported in this context %s
+NOT_SUPPORTED_156=Unsupported statement type %s
+NOT_SUPPORTED_157=INSERT must write all distribution columns: %s
+NOT_SUPPORTED_158=Table-wide statistic type not supported: %s
+NOT_SUPPORTED_159=Offset support is not enabled
+NOT_SUPPORTED_160=Catalog "%s" cannot be used as a partitioning provider: %s
+NOT_SUPPORTED_161=Unsupported data type in EXPLAIN (TYPE IO): %s
+NOT_SUPPORTED_162=External function in join filter is not supported: %s
+NOT_SUPPORTED_163=Rename column not supported in catalog: '%s'
+NOT_SUPPORTED_164=Table rename across schemas is not supported in Oracle
+NOT_SUPPORTED_165=type FIXED_LEN_BYTE_ARRAY supported as DECIMAL; got %s
+NOT_SUPPORTED_166=Unsupported parquet type: %s
+NOT_SUPPORTED_167=Parquet timestamp must be 12 bytes, actual %d
+NOT_SUPPORTED_168=Parquet timestamp must be 12 bytes, actual 8
+NOT_SUPPORTED_169=Unsupported primitive type: %s
+NOT_SUPPORTED_170=Unsupported type for Parquet writer: %s
+NOT_SUPPORTED_171=This scheduler does not support setting weights
+NOT_SUPPORTED_172=Unsupported router scheduler type %s
+NOT_SUPPORTED_173=delete queries are not supported by presto on spark
+NOT_SUPPORTED_174=catalog does not support page sink commit: %s
+NOT_SUPPORTED_175=Automatic writers scaling is not supported by Presto on Spark
+NOT_SUPPORTED_176=Order sensitive exchange is not supported by Presto on Spark. fragmentId: %s, sourceFragmentIds: %s
+NOT_SUPPORTED_177=This connector does not support analyze
+NOT_SUPPORTED_178=This connector does not support creating schemas
+NOT_SUPPORTED_179=This connector does not support dropping schemas
+NOT_SUPPORTED_180=This connector does not support renaming schemas
+NOT_SUPPORTED_181=This connector does not support creating tables
+NOT_SUPPORTED_182=This connector does not support creating temporary tables
+NOT_SUPPORTED_183=This connector does not support dropping tables
+NOT_SUPPORTED_184=This connector does not support truncating tables
+NOT_SUPPORTED_185=This connector does not support renaming tables
+NOT_SUPPORTED_186=This connector does not support adding columns
+NOT_SUPPORTED_187=This connector does not support renaming columns
+NOT_SUPPORTED_188=This connector does not support dropping columns
+NOT_SUPPORTED_189=Tables with multiple layouts can not be written
+NOT_SUPPORTED_190=This connector does not support creating tables with data
+NOT_SUPPORTED_191=This connector does not support inserts
+NOT_SUPPORTED_192=This connector does not support updates or deletes
+NOT_SUPPORTED_193=This connector does not support deletes
+NOT_SUPPORTED_194=This connector does not support creating views
+NOT_SUPPORTED_195=This connector does not support dropping views
+NOT_SUPPORTED_196=This connector does not support creating materialized views
+NOT_SUPPORTED_197=This connector does not support dropping materialized views
+NOT_SUPPORTED_198=This connector does not support getting materialized views status
+NOT_SUPPORTED_199=This connector does not support refresh materialized views
+NOT_SUPPORTED_200=This connector does not support deletes
+NOT_SUPPORTED_201=This connector does not support create role
+NOT_SUPPORTED_202=This connector does not support drop role
+NOT_SUPPORTED_203=This connector does not support roles
+NOT_SUPPORTED_204=This connector does not support grants
+NOT_SUPPORTED_205=This connector does not support revokes
+NOT_SUPPORTED_206=This connector does not support page sink commit
+NOT_SUPPORTED_207=This connector does not support metadata update requests
+NOT_SUPPORTED_208=This connector does not support metadata update cleanup
+NOT_SUPPORTED_209=ORDER BY LIMIT > %s is not supported
+NOT_SUPPORTED_210=Unsupported column type %s
+
+INVALID_SESSION_PROPERTY_1=%s must be > 0 and <= 1.0: %s
+INVALID_SESSION_PROPERTY_2=%s must be greater than 0: %s
+INVALID_SESSION_PROPERTY_3=%s must not be negative: %s
+INVALID_SESSION_PROPERTY_4=%s must be between 0.0 and 100.0 inclusive: %s
+INVALID_SESSION_PROPERTY_5=Unknown session property: %s.%s
+INVALID_SESSION_PROPERTY_6=%s must be greater than or equal to 2: %s
+INVALID_SESSION_PROPERTY_7=%s cannot be set to true; no spill paths configured
+INVALID_SESSION_PROPERTY_8=%s cannot be disabled with session property when it was enabled with configuration
+INVALID_SESSION_PROPERTY_9=%s must be a power of 2: %s
+INVALID_SESSION_PROPERTY_10=%s must be non-null
+INVALID_SESSION_PROPERTY_11=%s must be equal or greater than %s
+INVALID_SESSION_PROPERTY_12=%s must be within the range of 0 and 1.0: %s
+INVALID_SESSION_PROPERTY_13=Unable to set session property '%s' to '%s': %s
+INVALID_SESSION_PROPERTY_14=Unknown connector %s
+INVALID_SESSION_PROPERTY_15=Unknown session property %s
+INVALID_SESSION_PROPERTY_16=Property %s is type %s, but requested type was %s
+INVALID_SESSION_PROPERTY_17=%s is invalid: %s
+INVALID_SESSION_PROPERTY_18=Session property value must not be null
+INVALID_SESSION_PROPERTY_19=Session property can not be null
+INVALID_SESSION_PROPERTY_20=Session property type %s is not supported
+INVALID_SESSION_PROPERTY_21=Session property map key type %s is not supported
+
+INVALID_WINDOW_FRAME_1=Window frame %s offset must not be null
+INVALID_WINDOW_FRAME_2=Window frame %s offset must not be negative
+
+CONSTRAINT_VIOLATION_1=NULL value not allowed for NOT NULL column: %s
+
+TRANSACTION_CONFLICT_1=Table already exists with a different schema: '%s'
+TRANSACTION_CONFLICT_2=Dropping and then recreating the same table in a transaction is not supported
+TRANSACTION_CONFLICT_3=Table %s.%s was dropped by another transaction
+TRANSACTION_CONFLICT_4=Another transaction created partition %s in table %s.%s
+TRANSACTION_CONFLICT_5=Operation on the same partition with different user in the same transaction is not supported
+TRANSACTION_CONFLICT_6=The partition that this transaction modified was deleted in another transaction. %s %s
+
+INVALID_TABLE_PROPERTY_1=Key/value types of a MAP column must be plain types
+INVALID_TABLE_PROPERTY_2=Duplicate column names are not supported
+INVALID_TABLE_PROPERTY_3=Duplicate column family/qualifier pair detected in column mapping, check the value of %s
+INVALID_TABLE_PROPERTY_4=Column family/qualifier mapping of %s:%s is reserved
+INVALID_TABLE_PROPERTY_5=Column generation for external tables is not supported, must specify %s
+INVALID_TABLE_PROPERTY_6=Row ID column cannot be in a locality group
+INVALID_TABLE_PROPERTY_7=Unknown Presto column defined for locality group %s
+INVALID_TABLE_PROPERTY_8=Locality groups string is malformed. See documentation for proper format.
+INVALID_TABLE_PROPERTY_9=Distribute columns not defined on table: %s
+INVALID_TABLE_PROPERTY_10=%s property is negative
+INVALID_TABLE_PROPERTY_11=All properties [%s, %s, %s] must be set if any are set
+INVALID_TABLE_PROPERTY_12=The property of %s is required for table engine %s
+INVALID_TABLE_PROPERTY_13=Bucketing columns %s not present in schema
+INVALID_TABLE_PROPERTY_14=Cannot specify %s table property for storage format: %s
+INVALID_TABLE_PROPERTY_15=Cannot locate Avro schema file: %s
+INVALID_TABLE_PROPERTY_16=Avro schema file is not a valid file system URI: %s
+INVALID_TABLE_PROPERTY_17=Cannot open Avro schema file: %s
+INVALID_TABLE_PROPERTY_18=External location must be a directory
+INVALID_TABLE_PROPERTY_19=External location is not a valid file system URI: %s
+INVALID_TABLE_PROPERTY_20=For encrypted tables, partition format (%s) should match table format (%s). Using the session property %s or appropriately setting %s can help with ensuring this
+INVALID_TABLE_PROPERTY_21=Specifying external location for materialized view is not supported.
+INVALID_TABLE_PROPERTY_22=Bucketing columns %s not present in schema
+INVALID_TABLE_PROPERTY_23=Sorting columns %s not present in schema
+INVALID_TABLE_PROPERTY_24=Partition columns %s not present in schema
+INVALID_TABLE_PROPERTY_25=Table contains only partition columns
+INVALID_TABLE_PROPERTY_26=Only one of %s or %s should be specified
+INVALID_TABLE_PROPERTY_27=Partition column (%s) cannot be used as an encryption column
+INVALID_TABLE_PROPERTY_28=In %s unable to find column %s
+INVALID_TABLE_PROPERTY_29=The same column/subfield cannot have 2 encryption keys
+INVALID_TABLE_PROPERTY_30=In %s subfields declared in %s, but %s has type %s
+INVALID_TABLE_PROPERTY_31=For (%s) found a keyReference at a higher level field (%s)
+INVALID_TABLE_PROPERTY_32=%s needs to be provided for DWRF encrypted tables
+INVALID_TABLE_PROPERTY_33=%s may be specified only when %s is specified
+INVALID_TABLE_PROPERTY_34=%s must be greater than zero
+INVALID_TABLE_PROPERTY_35=%s should be no more than 1000000
+INVALID_TABLE_PROPERTY_36=%s and %s must be specified together
+INVALID_TABLE_PROPERTY_37=%s must be a single character string, but was: '%s'
+INVALID_TABLE_PROPERTY_38=%s must not be specified when %s is specified
+INVALID_TABLE_PROPERTY_39=Encrypted columns property cannot have null value
+INVALID_TABLE_PROPERTY_40=Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: %s
+INVALID_TABLE_PROPERTY_41=Column %s has been assigned 2 key references (%s and %s). Only 1 is allowed
+INVALID_TABLE_PROPERTY_42=Failed to convert object of type %s to expression: %s
+
+NUMERIC_VALUE_OUT_OF_RANGE_1=Value out of range: '%s' ('%sB')
+NUMERIC_VALUE_OUT_OF_RANGE_2=Value -128 is out of range for abs(tinyint)
+NUMERIC_VALUE_OUT_OF_RANGE_3=Value -32768 is out of range for abs(smallint)
+NUMERIC_VALUE_OUT_OF_RANGE_4=Value -2147483648 is out of range for abs(integer)
+NUMERIC_VALUE_OUT_OF_RANGE_5=Value -9223372036854775808 is out of range for abs(bigint)
+NUMERIC_VALUE_OUT_OF_RANGE_6=Bucket for value %s is out of range
+NUMERIC_VALUE_OUT_OF_RANGE_7=decimal overflow: %s
+NUMERIC_VALUE_OUT_OF_RANGE_8=Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')
+NUMERIC_VALUE_OUT_OF_RANGE_9=bigint addition overflow: %s + %s
+NUMERIC_VALUE_OUT_OF_RANGE_10=bigint subtraction overflow: %s - %s
+NUMERIC_VALUE_OUT_OF_RANGE_11=bigint multiplication overflow: %s * %s
+NUMERIC_VALUE_OUT_OF_RANGE_12=bigint division overflow: %s / %s
+NUMERIC_VALUE_OUT_OF_RANGE_13=bigint negation overflow: %s
+NUMERIC_VALUE_OUT_OF_RANGE_14=Out of range for integer: %s
+NUMERIC_VALUE_OUT_OF_RANGE_15=Out of range for smallint: %s
+NUMERIC_VALUE_OUT_OF_RANGE_16=Out of range for tinyint: %s
+NUMERIC_VALUE_OUT_OF_RANGE_17=Decimal overflow
+NUMERIC_VALUE_OUT_OF_RANGE_18=integer addition overflow: %s + %s
+NUMERIC_VALUE_OUT_OF_RANGE_19=integer subtraction overflow: %s - %s
+NUMERIC_VALUE_OUT_OF_RANGE_20=integer multiplication overflow: %s * %s
+NUMERIC_VALUE_OUT_OF_RANGE_21=integer negation overflow: %s
+NUMERIC_VALUE_OUT_OF_RANGE_22=smallint addition overflow: %s + %s
+NUMERIC_VALUE_OUT_OF_RANGE_23=smallint subtraction overflow: %s - %s
+NUMERIC_VALUE_OUT_OF_RANGE_24=smallint multiplication overflow: %s * %s
+NUMERIC_VALUE_OUT_OF_RANGE_25=smallint negation overflow: %s
+NUMERIC_VALUE_OUT_OF_RANGE_26=tinyint addition overflow: %s + %s"
+NUMERIC_VALUE_OUT_OF_RANGE_27=tinyint subtraction overflow: %s - %s
+NUMERIC_VALUE_OUT_OF_RANGE_28=tinyint multiplication overflow: %s * %s
+NUMERIC_VALUE_OUT_OF_RANGE_29=tinyint negation overflow: %s
+
+UNKNOWN_TRANSACTION_1=Unknown transaction ID: %s. Possibly expired? Commands ignored until end of transaction block
+
+NOT_IN_TRANSACTION_1=No transaction in progress
+
+TRANSACTION_ALREADY_ABORTED_1=Current transaction is aborted, commands ignored until end of transaction block
+TRANSACTION_ALREADY_ABORTED_2=Current transaction has already been aborted
+
+READ_ONLY_VIOLATION_1=Cannot execute write in a read-only transaction
+
+MULTI_CATALOG_WRITE_CONFLICT_1=Multi-catalog writes not supported in a single transaction. Attempt write to catalog %s, but already wrote to catalog %s
+
+AUTOCOMMIT_WRITE_CONFLICT_1=Catalog %s only supports writes using autocommit
+
+UNSUPPORTED_ISOLATION_LEVEL_1=Connector supported isolation level %s does not meet requested isolation level %s
+
+INCOMPATIBLE_CLIENT_1=Client does not support transactions
+
+SUBQUERY_MULTIPLE_ROWS_1=Scalar sub-query has returned multiple rows
+
+PROCEDURE_NOT_FOUND_1=Procedure not registered: %s
+
+INVALID_PROCEDURE_ARGUMENT_1=input partition column names does not match actual partition column names
+INVALID_PROCEDURE_ARGUMENT_2=Table is not partitioned: %s
+INVALID_PROCEDURE_ARGUMENT_3=Invalid partition metadata sync mode: %s
+INVALID_PROCEDURE_ARGUMENT_4=Procedure argument cannot be null: %s
+INVALID_PROCEDURE_ARGUMENT_5=test exception from procedure
+
+QUERY_REJECTED_1=Table %s has no range partition
+QUERY_REJECTED_2=Query did not match any selection rule
+
+AMBIGUOUS_FUNCTION_CALL_1=Function '%s' has multiple signatures: %s. Please specify parameter types.
+AMBIGUOUS_FUNCTION_CALL_2=Ambiguous function call (%s) for %s
+
+INVALID_SCHEMA_PROPERTY_1=Invalid location URI: %s
+
+SCHEMA_NOT_EMPTY_1=Schema not empty: %s
+
+QUERY_TEXT_TOO_LARGE_1=Query text length (%s) exceeds the maximum length (%s)
+
+UNSUPPORTED_SUBQUERY_1=Given correlated subquery is not supported
+
+EXCEEDED_FUNCTION_MEMORY_LIMIT_1=The input to %s is too large. More than %s of memory is needed to hold the intermediate hash set.%n
+
+ADMINISTRATIVELY_KILLED_1=Query killed. %s No message provided. Message: %s
+
+QUERY_HAS_TOO_MANY_STAGES_1=Query killed because the cluster is overloaded with too many tasks (%s) and this query was running with the highest number of tasks (%s). %s Otherwise, please try again later.
+QUERY_HAS_TOO_MANY_STAGES_2=Number of stages in the query (%s) exceeds the allowed maximum (%s).
+
+INVALID_SPATIAL_PARTITIONING_1=Table not found: %s
+INVALID_SPATIAL_PARTITIONING_2=Invalid name: %s
+INVALID_SPATIAL_PARTITIONING_3=Expected exception message '%s' to match '%s' for query: %s
+
+INVALID_ANALYZE_PROPERTY_1=Invalid null value in analyze partitions property
+INVALID_ANALYZE_PROPERTY_2=Only partitioned table can be analyzed with a partition list
+
+WARNING_AS_ERROR_1=Warning handling level set to AS_ERROR. Warnings: %n %s
+
+INVALID_ARGUMENTS_1=Elasticsearch query for '%s' is not base32-encoded correctly
+INVALID_ARGUMENTS_2=Elasticsearch query for '%s' is not valid JSON
+INVALID_ARGUMENTS_3=Type ConnectorCommitHandle is expected
+INVALID_ARGUMENTS_4=Type %s does not allow ordering
+
+EXCEEDED_PLAN_NODE_LIMIT_1=Number of leaf nodes in logical plan exceeds threshold %s set in max_leaf_nodes_in_plan
+
+GENERIC_INTERNAL_ERROR_1=cannot create cache directory %s
+GENERIC_INTERNAL_ERROR_2=Failed to load Delta table: %s
+GENERIC_INTERNAL_ERROR_3=Invalid InetAddress length: %s
+GENERIC_INTERNAL_ERROR_4=Error getting UserDefinedType: %s
+GENERIC_INTERNAL_ERROR_5=Error getting ScalarFunctionImplementation for handle: unittest\\.memory\\.power_tower\\(double\\):123
+GENERIC_INTERNAL_ERROR_6=Neither of encryptColumn or encryptTable present. We should never hit this
+GENERIC_INTERNAL_ERROR_7=Cannot have both table and column level settings. Given: %s
+GENERIC_INTERNAL_ERROR_8=RecordCursor was interrupted
+GENERIC_INTERNAL_ERROR_9=columnEncryptionInformation cannot be empty
+GENERIC_INTERNAL_ERROR_10=Layout does not contain partitions
+GENERIC_INTERNAL_ERROR_11=SchedulingPolicy is bucketed, but BucketHandle is not present
+GENERIC_INTERNAL_ERROR_12=readBucketCount (%s) is greater than the tableBucketCount (%s) which generally points to an issue in plan generation
+GENERIC_INTERNAL_ERROR_13=Expected %s partitions but found %s
+GENERIC_INTERNAL_ERROR_14=Partition not loaded: %s
+GENERIC_INTERNAL_ERROR_15=Failed to find compressionCodec for inputFormat: %s
+GENERIC_INTERNAL_ERROR_16=cannot create caching file system
+GENERIC_INTERNAL_ERROR_17=%s compression is not supported for %s
+GENERIC_INTERNAL_ERROR_18=Unenforced filter found %s but not handled
+GENERIC_INTERNAL_ERROR_19=Cannot provide null column name for encryption columns
+GENERIC_INTERNAL_ERROR_20=Expected row value field count does not match type field count
+GENERIC_INTERNAL_ERROR_21=Invalid partition type %s
+GENERIC_INTERNAL_ERROR_22=Unknown ColumnType: %s
+GENERIC_INTERNAL_ERROR_23=Leader election in progress for Kafka topic '%s' partition %s
+GENERIC_INTERNAL_ERROR_24=Could not parse the Avro schema at: %s
+GENERIC_INTERNAL_ERROR_25=Unknown compression algorithm %s for column %s
+GENERIC_INTERNAL_ERROR_26=Unknown encoding %s for column %s
+GENERIC_INTERNAL_ERROR_27=Distribution for dynamic system table must be %s
+GENERIC_INTERNAL_ERROR_28=Duplicate column name: %s
+GENERIC_INTERNAL_ERROR_29=Column does not exist: %s.%s
+GENERIC_INTERNAL_ERROR_30=Query failed for an unknown reason
+GENERIC_INTERNAL_ERROR_31=Invalid TableElement: %s
+GENERIC_INTERNAL_ERROR_32=Query %s already registered
+GENERIC_INTERNAL_ERROR_33=A task failed for an unknown reason
+GENERIC_INTERNAL_ERROR_34=A task is in the ABORTED state but stage is %s
+GENERIC_INTERNAL_ERROR_35=Query stage was aborted
+GENERIC_INTERNAL_ERROR_36=Scheduling is complete, but stage execution %s is in state %s
+GENERIC_INTERNAL_ERROR_37=Driver was interrupted
+GENERIC_INTERNAL_ERROR_38=unsupported task result client scheme %s
+GENERIC_INTERNAL_ERROR_39=cannot create cache directory %s
+GENERIC_INTERNAL_ERROR_40=Operator %s has non-zero system memory (%d bytes) after destroy()
+GENERIC_INTERNAL_ERROR_41=Operator %s has non-zero user memory (%d bytes) after destroy()
+GENERIC_INTERNAL_ERROR_42=Operator %s has non-zero revocable memory (%d bytes) after destroy()
+GENERIC_INTERNAL_ERROR_43=Exception while running the listener
+GENERIC_INTERNAL_ERROR_44=Spill failed
+GENERIC_INTERNAL_ERROR_45=Unspill failed
+GENERIC_INTERNAL_ERROR_46=Error loading index for join
+GENERIC_INTERNAL_ERROR_47=Error casting array element to VARCHAR
+GENERIC_INTERNAL_ERROR_48=Invalid color index: %s
+GENERIC_INTERNAL_ERROR_49=Unable to find error for code: %s
+GENERIC_INTERNAL_ERROR_50=Invalid InetAddress length: %d
+GENERIC_INTERNAL_ERROR_51=internal error, should not be suppressed by $internal$try
+GENERIC_INTERNAL_ERROR_52=Failed query %s has no error code
+GENERIC_INTERNAL_ERROR_53=Request failed with null response
+GENERIC_INTERNAL_ERROR_54=Request failed with HTTP status %s
+GENERIC_INTERNAL_ERROR_55=Encrypted data size is too small: %s. It must be at least the size of the initialization vector: %s.
+GENERIC_INTERNAL_ERROR_56=Cannot decrypt previously encrypted data: %s
+GENERIC_INTERNAL_ERROR_57=Failed to encrypt data: %s
+GENERIC_INTERNAL_ERROR_58=Spill cipher already destroyed
+GENERIC_INTERNAL_ERROR_59=Failed to initialize spill cipher for encryption: %s
+GENERIC_INTERNAL_ERROR_60=Failed to initialize spill cipher for decryption: %s
+GENERIC_INTERNAL_ERROR_61=Failed to create spill cipher: %s
+GENERIC_INTERNAL_ERROR_62=Failed to generate new secret key: %s
+GENERIC_INTERNAL_ERROR_63=Failed to create spill sink
+GENERIC_INTERNAL_ERROR_64=Failed to commit spill file
+GENERIC_INTERNAL_ERROR_65=Failed to read spilled pages
+GENERIC_INTERNAL_ERROR_66=Failed to close spiller
+GENERIC_INTERNAL_ERROR_67=Failed to spill pages
+GENERIC_INTERNAL_ERROR_68=Formatted query does not parse: %s
+GENERIC_INTERNAL_ERROR_69=Query does not round-trip: %s
+GENERIC_INTERNAL_ERROR_70=Cannot assign canonical plan id to Canonical join node: %s
+GENERIC_INTERNAL_ERROR_71=Cannot assign canonical plan id to Canonical table scan node: %s
+GENERIC_INTERNAL_ERROR_72=Unknown plan phase %s
+GENERIC_INTERNAL_ERROR_73=Mixing spherical and euclidean geometric types
+GENERIC_INTERNAL_ERROR_74=Unexpected call replaceChildren for %s
+GENERIC_INTERNAL_ERROR_75=Cannot assign canonical plan id for: %s
+GENERIC_INTERNAL_ERROR_76=Cannot assign canonical plan id to Group Reference node: %s
+GENERIC_INTERNAL_ERROR_77=Unexpected plan node between partial and final aggregation
+GENERIC_INTERNAL_ERROR_78=CodePoints type cannot be serialized
+GENERIC_INTERNAL_ERROR_79=Invalid InetAddress length: %s
+GENERIC_INTERNAL_ERROR_80=RegExp type cannot be serialized
+GENERIC_INTERNAL_ERROR_81=JsonPath type cannot be serialized
+GENERIC_INTERNAL_ERROR_82=LikePattern type cannot be serialized
+GENERIC_INTERNAL_ERROR_83=Expected row value field count does not match type field count
+GENERIC_INTERNAL_ERROR_84=Unhandled type for %s : %s
+GENERIC_INTERNAL_ERROR_85=Unhandled type for Slice: %s
+GENERIC_INTERNAL_ERROR_86=Unhandled type for Block: %s
+GENERIC_INTERNAL_ERROR_87=Expected to find the pinot table handle for the scan node
+GENERIC_INTERNAL_ERROR_88=Map must never contain null keys
+GENERIC_INTERNAL_ERROR_89=No avro record found
+GENERIC_INTERNAL_ERROR_90=Unexpected extra record found
+GENERIC_INTERNAL_ERROR_91=Decoding Avro record failed.
+GENERIC_INTERNAL_ERROR_92=unsupported hash algorithm
+GENERIC_INTERNAL_ERROR_93=trying to start an already started TaskResultFetcher
+GENERIC_INTERNAL_ERROR_94=Request failed with HTTP status %s
+GENERIC_INTERNAL_ERROR_95=Native task failed for an unknown reason
+GENERIC_INTERNAL_ERROR_96=Code is not sequential: %s
+GENERIC_INTERNAL_ERROR_97=ConnectorMetadata getCommonPartitioningHandle() is implemented without getAlternativeLayout()
+GENERIC_INTERNAL_ERROR_98=ConnectorMetadata getTableHandleForStatisticsCollection() is implemented without getStatisticsCollectionMetadata()
+GENERIC_INTERNAL_ERROR_99=ConnectorMetadata getStatisticsCollectionMetadata() is implemented without beginStatisticsCollection()
+GENERIC_INTERNAL_ERROR_100=ConnectorMetadata beginStatisticsCollection() is implemented without finishStatisticsCollection()
+GENERIC_INTERNAL_ERROR_101=ConnectorMetadata beginCreateTable() is implemented without finishCreateTable()
+GENERIC_INTERNAL_ERROR_102=ConnectorMetadata beginInsert() is implemented without finishInsert()
+GENERIC_INTERNAL_ERROR_103=ConnectorMetadata finishRefreshMaterializedView() is not implemented
+GENERIC_INTERNAL_ERROR_104=Expect exactly 1 child PlanNode
+GENERIC_INTERNAL_ERROR_105=mock exception
+
+TOO_MANY_REQUESTS_FAILED_1=Too many requests failed
+TOO_MANY_REQUESTS_FAILED_2=%s (%s %s - %s failures, failure duration %s, total failed request time %s)
+TOO_MANY_REQUESTS_FAILED_3=fake exception 1
+
+PAGE_TOO_LARGE_1=Remote page is too large
+
+NO_NODES_AVAILABLE_1=sortedCandidates is null or empty for ModularHashingNodeProvider
+NO_NODES_AVAILABLE_2=No nodes available to run query
+NO_NODES_AVAILABLE_3=No worker nodes available
+NO_NODES_AVAILABLE_4=No worker nodes available
+
+REMOTE_TASK_ERROR_1=Remote Task Error
+
+COMPILER_ERROR_1=Lambda function interface is required to be annotated with FunctionalInterface
+COMPILER_ERROR_2=Expect to have exactly 1 method with name 'apply' in interface %s
+COMPILER_ERROR_3=Compiler failed
+
+REMOTE_TASK_MISMATCH_1=%s (%s)
+
+SERVER_SHUTTING_DOWN_1=Server is shutting down
+SERVER_SHUTTING_DOWN_2=Server is shutting down. Query
+SERVER_SHUTTING_DOWN_3=Server is shutting down. Query %s has been cancelled
+SERVER_SHUTTING_DOWN_4=Server is shutting down. Task %s has been canceled
+
+FUNCTION_IMPLEMENTATION_MISSING_1=%s not found
+FUNCTION_IMPLEMENTATION_MISSING_2=Unsupported type parameters (%s) for %s
+FUNCTION_IMPLEMENTATION_MISSING_3=Unsupported array element type for array_normalize function: %s
+FUNCTION_IMPLEMENTATION_MISSING_4=Unsupported array element type for array_normalize function: integer
+FUNCTION_IMPLEMENTATION_MISSING_5=Unsupported type parameters.*
+
+SERVER_STARTING_UP_1=Presto server is still initializing
+
+FUNCTION_IMPLEMENTATION_ERROR_1=Scan for default tablet returned more than one entry
+FUNCTION_IMPLEMENTATION_ERROR_2=loadAll called with a non-homogeneous collection of cache keys
+FUNCTION_IMPLEMENTATION_ERROR_3=Should have received only one entry when scanning for number of rows in metrics table
+FUNCTION_IMPLEMENTATION_ERROR_4=Row ID ordinal not found
+FUNCTION_IMPLEMENTATION_ERROR_5=Object is not a Block, but %s
+FUNCTION_IMPLEMENTATION_ERROR_6=Object is not a Long, but %s
+FUNCTION_IMPLEMENTATION_ERROR_7=Object is not a Long or Integer, but %s
+FUNCTION_IMPLEMENTATION_ERROR_8=Object is not a Boolean, but %s
+FUNCTION_IMPLEMENTATION_ERROR_9=Object is not a Calendar, Date, or Long, but %s
+FUNCTION_IMPLEMENTATION_ERROR_10=Object is not a Double, but %s
+FUNCTION_IMPLEMENTATION_ERROR_11=Object is not a Float, but %s
+FUNCTION_IMPLEMENTATION_ERROR_12=Object is not a Short, but %s
+FUNCTION_IMPLEMENTATION_ERROR_13=Object is not a Long or Time, but %s
+FUNCTION_IMPLEMENTATION_ERROR_14=Object is not a Long or Timestamp, but %s
+FUNCTION_IMPLEMENTATION_ERROR_15=Object is not a Byte, but %s
+FUNCTION_IMPLEMENTATION_ERROR_16=Object is not a Slice byte[], but %s
+FUNCTION_IMPLEMENTATION_ERROR_17=Object is not a Slice or String, but %s
+FUNCTION_IMPLEMENTATION_ERROR_18=Unexpected group enum type %s
+FUNCTION_IMPLEMENTATION_ERROR_19=expected group enum type %s
+FUNCTION_IMPLEMENTATION_ERROR_20=Function-defining method [%s] is missing @SqlType
+FUNCTION_IMPLEMENTATION_ERROR_21=Function-defining method [%s] must return MethodHandle
+FUNCTION_IMPLEMENTATION_ERROR_22=Codegen scalar function %s must have parameter [%s] of type Type
+FUNCTION_IMPLEMENTATION_ERROR_23=Block and Position format is not supported for codegen function %s
+FUNCTION_IMPLEMENTATION_ERROR_24=Null flag format is not supported for codegen function %s
+FUNCTION_IMPLEMENTATION_ERROR_25=Only unary and binary functions are supported in codegen function %s
+FUNCTION_IMPLEMENTATION_ERROR_26=Method %s does not return valid MethodHandle
+FUNCTION_IMPLEMENTATION_ERROR_27=All parameters of a constructor in a function definition class must be Dependencies. Signature: %s
+FUNCTION_IMPLEMENTATION_ERROR_28=Method [%s] has more than 1 SqlFunctionProperties in the parameter list
+FUNCTION_IMPLEMENTATION_ERROR_29=Method [%s] has parameters annotated with Dependency annotations that appears after other parameters
+FUNCTION_IMPLEMENTATION_ERROR_30=argument %s is marked as lambda but the function interface class is not annotated: %s
+FUNCTION_IMPLEMENTATION_ERROR_31=Method [%s] has parameter with primitive type %s annotated with @SqlNullable
+FUNCTION_IMPLEMENTATION_ERROR_32=A parameter with USE_NULL_FLAG or RETURN_NULL_ON_NULL convention must not use wrapper type. Found in method [%s]
+FUNCTION_IMPLEMENTATION_ERROR_33=@SqlType can only contain an explicitly specified nativeContainerType when using @BlockPosition
+FUNCTION_IMPLEMENTATION_ERROR_34=Parametric class [%s] does not have any annotated methods
+FUNCTION_IMPLEMENTATION_ERROR_35=Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator
+FUNCTION_IMPLEMENTATION_ERROR_36=Function-defining method [%s] cannot have @SqlInvokedScalarFunction
+FUNCTION_IMPLEMENTATION_ERROR_37=Function-defining method [%s] is missing @SqlType
+FUNCTION_IMPLEMENTATION_ERROR_38=Function-defining method [%s] is missing @SqlInvokedScalarFunction or @SqlType
+FUNCTION_IMPLEMENTATION_ERROR_39=Function-defining method [%s] is annotated with both @SqlParameter and @SqlParameters
+FUNCTION_IMPLEMENTATION_ERROR_40=Failed to get function body for method [%s]
+FUNCTION_IMPLEMENTATION_ERROR_41=Function-defining method [%s] must return String
+
+INVALID_PROCEDURE_DEFINITION_1=Unknown procedure argument type: %s
+
+AMBIGUOUS_FUNCTION_IMPLEMENTATION_1=Ambiguous implementation for %s with bindings %s
+
+ABANDONED_TASK_1=something went wrong
+ABANDONED_TASK_2=Task %s has not been accessed since %s: currentTime %s
+
+OPTIMIZER_TIMEOUT_1=The optimizer exhausted the time limit of %d ms
+
+OUT_OF_SPILL_SPACE_1=No spill paths configured
+OUT_OF_SPILL_SPACE_2=No free space available for spill
+OUT_OF_SPILL_SPACE_3=Cannot determine free space for spill
+
+CONFIGURATION_INVALID_1=Invalid duration value '%s' for property '%s' in '%s'
+CONFIGURATION_INVALID_2=Error in password file line %s: %s
+CONFIGURATION_INVALID_3=No root groups are configured
+CONFIGURATION_INVALID_4=No selectors are configured
+CONFIGURATION_INVALID_5=Failed to load router config
+
+CONFIGURATION_UNAVAILABLE_1=Failed to read password file: %s
+
+INVALID_RESOURCE_GROUP_1=Cannot add queries to %s. It is not a leaf group.
+
+GENERIC_RECOVERY_ERROR_1=Encountered error when trying to recover task %s
+
+INDEX_LOADER_TIMEOUT_1=Exceeded the time limit of %s loading indexes for index join
+
+EXCEEDED_TASK_UPDATE_SIZE_LIMIT_1=TaskUpdate size of %d Bytes has exceeded the limit of %d Bytes
+
+NODE_SELECTION_NOT_SUPPORTED_1=Unsupported node selection strategy %s
+NODE_SELECTION_NOT_SUPPORTED_2=Unsupported node selection strategy for TTL scheduling: %s
+
+SPOOLING_STORAGE_ERROR_1=Failed to read file from TempStorage
+
+SERIALIZED_PAGE_CHECKSUM_ERROR_1=Received corrupted serialized page from host %s
+
+RETRY_QUERY_NOT_FOUND_1=failed to find the query to retry with ID %s
+
+DISTRIBUTED_TRACING_ERROR_1=Duplicated block inserted: %s
+DISTRIBUTED_TRACING_ERROR_2=Adding point to non-existing block: %s
+DISTRIBUTED_TRACING_ERROR_3=Trying to end a non-existing block: %s
+DISTRIBUTED_TRACING_ERROR_4=SAMPLE_BASED Tracing Mode is currently not supported.
+
+GENERIC_SPILL_FAILURE_1=Spilling failed: %s"
+GENERIC_SPILL_FAILURE_2=Failed to create spill file: %s
+GENERIC_SPILL_FAILURE_3=Failed to spill pages: %s
+GENERIC_SPILL_FAILURE_4=Failed to read spilled pages: %s
+GENERIC_SPILL_FAILURE_5=Failed to close spiller: %s
+GENERIC_SPILL_FAILURE_6=Failed to spill pages
+GENERIC_SPILL_FAILURE_7=Failed to read spilled pages
+GENERIC_SPILL_FAILURE_8=Failed to delete spill file
+
+INVALID_PLAN_ERROR_1=When grouped execution can not be enabled, merge join plan is not valid. %s is currently set to %s; left node grouped execution capable is %s and  right node grouped execution capable is %s.
+
+INVALID_RETRY_EXECUTION_STRATEGY_1=Retry execution strategy not supported: %s
+
+PLAN_SERIALIZATION_ERROR_1=Cannot serialize plan to JSON
+
+QUERY_PLANNING_TIMEOUT_1=The query optimizer exceeded the timeout of %s.
+QUERY_PLANNING_TIMEOUT_2=The query planner exceeded the timeout of %s.
+
+UNSUPPORTED_ANALYZER_TYPE_1=Unsupported analyzer type: %s
+
+UPDATE_EVENT_LISTENER_FAILURE_1=Failed to write query stats for query to MySQL.
+
+INVALID_ROW_FILTER_1=Row filter for '%s' is recursive
+INVALID_ROW_FILTER_2=Invalid row filter for '%s': %s
+INVALID_ROW_FILTER_3=Column mask for '%s.%s' is recursive
+INVALID_ROW_FILTER_4=Invalid column mask for '%s.%s': %s
+
+DATATYPE_MISMATCH_1=Expected row filter for '%s' to be of type BOOLEAN, but was %s
+DATATYPE_MISMATCH_2=Expected column mask for '%s.%s' to be of type %s, but was %s
+
+GENERIC_INSUFFICIENT_RESOURCES_1=Insufficient active worker nodes. Waited %s for at least %s workers, but only %s workers are active
+GENERIC_INSUFFICIENT_RESOURCES_2=Insufficient active coordinator nodes. Waited %s for at least %s coordinators, but only %s coordinators are active
+GENERIC_INSUFFICIENT_RESOURCES_3=Size of hash table cannot exceed 1 billion entries
+GENERIC_INSUFFICIENT_RESOURCES_4=Size of hash table cannot exceed %d entries ( %d)
+
+EXCEEDED_GLOBAL_MEMORY_LIMIT_1=Query exceeded distributed user memory limit of %s
+EXCEEDED_GLOBAL_MEMORY_LIMIT_2=Query exceeded distributed total memory limit of %s defined at the %s
+EXCEEDED_GLOBAL_MEMORY_LIMIT_3=Control query uses more memory than the test cluster memory limit
+EXCEEDED_GLOBAL_MEMORY_LIMIT_4=warning message
+
+QUERY_QUEUE_FULL_1=Too many queued queries for "%s"
+
+EXCEEDED_TIME_LIMIT_1=Query exceeded the maximum execution time limit of %s defined at the %s level
+EXCEEDED_TIME_LIMIT_2=Query exceeded maximum time limit of %s
+EXCEEDED_TIME_LIMIT_3=Query exceeded the maximum execution time limit of 1.00ms
+EXCEEDED_TIME_LIMIT_4=Time limit exceeded when running control checksum query
+EXCEEDED_TIME_LIMIT_5=Time limit exceeded on test cluster
+
+CLUSTER_OUT_OF_MEMORY_1=The cluster is out of memory and %s=true, so this query was killed. It was using %s of memory
+CLUSTER_OUT_OF_MEMORY_2=Query killed because the cluster is out of memory. Please try again in a few minutes.
+
+EXCEEDED_CPU_LIMIT_1=Exceeded CPU limit of %s defined at the %s level
+
+EXCEEDED_LOCAL_MEMORY_LIMIT_1=Query exceeded per-node user memory limit of %s [%s]
+EXCEEDED_LOCAL_MEMORY_LIMIT_2=Query exceeded per-node total memory limit of %s [%s]
+
+ADMINISTRATIVELY_PREEMPTED_1=Query preempted. %s No message provided. Message: %s
+
+EXCEEDED_SCAN_RAW_BYTES_READ_LIMIT_1=Query has exceeded Scan Raw Bytes Read Limit of %s
+
+EXCEEDED_OUTPUT_SIZE_LIMIT_1=Query has exceeded output size Limit of %s
+
+EXCEEDED_REVOCABLE_MEMORY_LIMIT_1=Query exceeded per-node revocable memory limit of %s [%s]
+
+EXCEEDED_OUTPUT_POSITIONS_LIMIT_1=Query has exceeded output rows Limit of %d
+
+NATIVE_EXECUTION_BINARY_NOT_EXIST_1=File does not exist %s
+
+NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR_1=Cannot start native process: %s
+NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR_2=Cannot start %s
+
+UNEXPECTED_ACCUMULO_ERROR_1=Failed to get splits from Accumulo
+UNEXPECTED_ACCUMULO_ERROR_2=Failed to get connector to Accumulo
+UNEXPECTED_ACCUMULO_ERROR_3=Failed to check for existence or create Accumulo namespace
+UNEXPECTED_ACCUMULO_ERROR_4=Failed to create Accumulo table
+UNEXPECTED_ACCUMULO_ERROR_5=Failed to set locality groups
+UNEXPECTED_ACCUMULO_ERROR_6=Failed to set iterator on table
+UNEXPECTED_ACCUMULO_ERROR_7=Failed to delete Accumulo table
+UNEXPECTED_ACCUMULO_ERROR_8=Failed to rename table
+UNEXPECTED_ACCUMULO_ERROR_9=Exception when getting cardinality
+UNEXPECTED_ACCUMULO_ERROR_10=Index mutation rejected by server
+UNEXPECTED_ACCUMULO_ERROR_11=Index mutation was rejected by server on flush
+UNEXPECTED_ACCUMULO_ERROR_12=Mutation was rejected by server on close
+UNEXPECTED_ACCUMULO_ERROR_13=Exception when getting index ranges
+UNEXPECTED_ACCUMULO_ERROR_14=Accumulo error when creating BatchWriter and/or Indexer
+UNEXPECTED_ACCUMULO_ERROR_15=Mutation rejected by server
+UNEXPECTED_ACCUMULO_ERROR_16=Mutation rejected by server on flush
+UNEXPECTED_ACCUMULO_ERROR_17=Failed to create batch scanner for table %s
+
+ZOOKEEPER_ERROR_1=ZK error checking metadata root
+ZOOKEEPER_ERROR_2=ZK error checking/creating default schema
+ZOOKEEPER_ERROR_3=Error fetching schemas
+ZOOKEEPER_ERROR_4=Error checking if schema exists
+ZOOKEEPER_ERROR_5=Error fetching table
+ZOOKEEPER_ERROR_6=Error fetching view
+ZOOKEEPER_ERROR_7=ZK error when checking if table already exists
+ZOOKEEPER_ERROR_8=Error creating table znode in ZooKeeper
+ZOOKEEPER_ERROR_9=ZK error when deleting table metadata
+ZOOKEEPER_ERROR_10=ZK error when checking if view already exists
+ZOOKEEPER_ERROR_11=Error creating view znode in ZooKeeper
+ZOOKEEPER_ERROR_12=ZK error when deleting view metadata
+ZOOKEEPER_ERROR_13=Error checking if path %s is an AccumuloTable object
+ZOOKEEPER_ERROR_14=Error checking if path is an AccumuloView object
+
+IO_ERROR_1=Caught IO error from serializer on read
+
+ACCUMULO_TABLE_DNE_1=Table %s does not exist
+ACCUMULO_TABLE_DNE_2=Failed to set locality groups, table does not exist
+ACCUMULO_TABLE_DNE_3=Failed to set iterator, table does not exist
+ACCUMULO_TABLE_DNE_4=Failed to delete Accumulo table, does not exist
+ACCUMULO_TABLE_DNE_5=Failed to rename table, old table does not exist
+ACCUMULO_TABLE_DNE_6=Accumulo table does not exist
+ACCUMULO_TABLE_DNE_7=Accumulo error when creating BatchWriter and/or Indexer, table does not exist
+
+ACCUMULO_TABLE_EXISTS_1=Cannot create internal table when an Accumulo table already exists
+ACCUMULO_TABLE_EXISTS_2=Internal table is indexed, but the index table and/or index metrics table(s) already exist
+ACCUMULO_TABLE_EXISTS_3=Table %s already exists
+ACCUMULO_TABLE_EXISTS_4=Accumulo table already exists
+ACCUMULO_TABLE_EXISTS_5=Failed to rename table, new table already exists
+
+MINI_ACCUMULO_1=Failed to shut down MAC instance
+MINI_ACCUMULO_2=Failed to clean up MAC directory
+
+ATOP_CANNOT_START_PROCESS_ERROR_1=Cannot start %s
+
+ATOP_READ_TIMEOUT_1=Timeout reading from atop process
+
+BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED_1=Error creating destination table
+
+BIGQUERY_FAILED_TO_EXECUTE_QUERY_1=Failed to compute empty projection
+
+BIGQUERY_QUERY_FAILED_UNKNOWN_1=Failed to run the query [%s]
+
+BIGQUERY_UNSUPPORTED_TYPE_FOR_SLICE_1=Unhandled type for Slice: %s
+
+BIGQUERY_UNSUPPORTED_COLUMN_TYPE_1=Unhandled type for %s: %s
+BIGQUERY_UNSUPPORTED_COLUMN_TYPE_2=Not support type conversion for BigQuery data type: %s
+
+BIGQUERY_UNSUPPORTED_TYPE_FOR_BLOCK_1=Unhandled type for Block: %s
+
+BIGQUERY_UNSUPPORTED_TYPE_FOR_LONG_1=Unhandled type for %s: %s
+
+BIGQUERY_UNSUPPORTED_TYPE_FOR_VARBINARY_1=Unhandled type for VarBinaryType: %s
+
+BIGQUERY_TABLE_DISAPPEAR_DURING_LIST_1=Table disappeared during listing operation
+
+BIGQUERY_ERROR_END_OF_AVRO_BUFFER_1=Error determining the end of Avro buffer
+
+BIGQUERY_ERROR_READING_NEXT_AVRO_RECORD_1=Error reading next Avro Record
+
+CASSANDRA_METADATA_ERROR_1=The cluster metadata is not available. Please make sure that the Cassandra cluster is up and running, and that the contact points are specified correctly.
+
+CASSANDRA_VERSION_ERROR_1=The cluster version is not available. Please make sure that the Cassandra cluster is up and running, and that the contact points are specified correctly.
+
+JDBC_ERROR_1=Query: %s
+JDBC_ERROR_2=Failed to find remote table name: %s
+JDBC_ERROR_3=Failed to find remote schema name: %s
+JDBC_ERROR_4=Type name is missing: %s
+
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_1=%s is not supported in ClickHouse filter
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_2=Unknown logical binary: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_3=Between operator not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_4=NOT operator is supported only on top of IN operator. Received: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_5=Non implicit casts not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_6=This type of CAST operator not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_7=Arithmetic expressions are not supported in ClickHouse filter: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_8=Function %s not supported in ClickHouse filter
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_9=ClickHouse does not support struct dereference: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_10=ClickHouse does not support lambda: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_11=ClickHouse does not support special form: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_12=Unsupported function in ClickHouse aggregation: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_13=Input reference not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_14=Special form not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_15=Call not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_16=Constant not supported: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_17=Unsupported aggregation node %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_18=Null constant expression: %s with value of type: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_19=Cannot handle the constant expression: %s with value of type: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_20=Unsupported pushdown for ClickHouse connector with plan node of type %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_21=Unsupported pushdown for ClickHouse connector. Expect variable reference, but get: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_22=Unsupported pushdown for clickhouse connector. Unknown aggregation expression: %s
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_23=Unsupported pushdown for ClickHouse connector. Aggregation function: %s not supported
+CLICKHOUSE_PUSHDOWN_UNSUPPORTED_EXPRESSION_24=ClickHouse does not support filter on top of AggregationNode.
+
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_1=Expected to find a clickhouse table scan node id
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_2=Expected to find a clickhouse table scan node
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_3=Expected to find a clickhouse table handle
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_4=Invalid limit: %d
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_5=Could not pushdown multiple aggregates in the presence of group by and limit
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_6=Empty ClickHouse query
+CLICKHOUSE_QUERY_GENERATOR_FAILURE_7=Table name missing in ClickHouse query
+
+DECODER_CONVERSION_NOT_SUPPORTED_1=conversion to boolean not supported
+DECODER_CONVERSION_NOT_SUPPORTED_2=conversion to long not supported
+DECODER_CONVERSION_NOT_SUPPORTED_3=conversion to double not supported
+DECODER_CONVERSION_NOT_SUPPORTED_4=conversion to Slice not supported
+DECODER_CONVERSION_NOT_SUPPORTED_5=conversion to Block not supported
+DECODER_CONVERSION_NOT_SUPPORTED_6=cannot decode object of '%s' as '%s' for column '%s'
+DECODER_CONVERSION_NOT_SUPPORTED_7=could not parse value '%s' as '%s' for column '%s'
+DECODER_CONVERSION_NOT_SUPPORTED_8=could not parse non-value node as '%s' for column '%s'
+DECODER_CONVERSION_NOT_SUPPORTED_9=start offset %s for column '%s' must be less that or equal to value length %s
+DECODER_CONVERSION_NOT_SUPPORTED_10=end offset %s for column '%s' must be less that or equal to value length %s
+DECODER_CONVERSION_NOT_SUPPORTED_11=conversion '%s' to boolean not supported
+DECODER_CONVERSION_NOT_SUPPORTED_12=conversion '%s' to long not supported
+DECODER_CONVERSION_NOT_SUPPORTED_13=conversion '%s' to double not supported
+
+DELTA_UNSUPPORTED_COLUMN_TYPE_1=Unsupported data type '%s' for partition column %s
+DELTA_UNSUPPORTED_COLUMN_TYPE_2=Column '%s' in Delta table %s contains unsupported data type: %s
+
+DELTA_UNSUPPORTED_DATA_FORMAT_1=Delta table %s has unsupported data format: %s. Currently only Parquet data format is supported
+
+DELTA_PARQUET_SCHEMA_MISMATCH_1=The column %s of table %s is declared as type %s, but the Parquet file (%s) declares the column as type %s
+
+DELTA_CANNOT_OPEN_SPLIT_1=Error opening Hive split %s (offset=%s, length=%s): %s
+
+DELTA_MISSING_DATA_1=Error opening Hive split %s (offset=%s, length=%s): %s
+
+DELTA_INVALID_PARTITION_VALUE_1=Can not parse partition value '%s' of type '%s' for partition column '%s' in file '%s'
+DELTA_INVALID_PARTITION_VALUE_2=Can not parse partition value '%s' of type '%s' for partition column '%s'
+DELTA_INVALID_PARTITION_VALUE_3=Can not parse partition value .* of type .* for partition column 'p1'
+
+DRUID_METADATA_ERROR_1=Malformed segment loadSpecification: %s
+DRUID_METADATA_ERROR_2=Unsupported segment filesystem: %s
+
+DRUID_DEEP_STORAGE_ERROR_1=Failed to create page source on %s
+DRUID_DEEP_STORAGE_ERROR_2=Ingestion failed on %s
+DRUID_DEEP_STORAGE_ERROR_3=Error reading from %s at position %s
+
+DRUID_SEGMENT_LOAD_ERROR_1=failed to load druid segment
+DRUID_SEGMENT_LOAD_ERROR_2=Internal file %s does not exist
+DRUID_SEGMENT_LOAD_ERROR_3=Malformed metadata file: first line should be version,maxChunkSize,numChunks, got null.
+DRUID_SEGMENT_LOAD_ERROR_4=Malformed metadata file: unknown version[%s], v1 is all I know.
+DRUID_SEGMENT_LOAD_ERROR_5=Malformed metadata file: wrong number of splits[%d] in line[%s]
+DRUID_SEGMENT_LOAD_ERROR_6=Zip does not contain file: %s
+DRUID_SEGMENT_LOAD_ERROR_7=Malformed zip file: %s
+DRUID_SEGMENT_LOAD_ERROR_8=Zip file '%s' is malformed. It does not contain an end of central directory record.
+DRUID_SEGMENT_LOAD_ERROR_9=Malformed Central Directory File Header; does not start with %08x
+DRUID_SEGMENT_LOAD_ERROR_10=Malformed End of Central Directory Record; does not start with %08x
+DRUID_SEGMENT_LOAD_ERROR_11=File comment too long. Is %d; max %d.
+DRUID_SEGMENT_LOAD_ERROR_12=The file '%s' is not a correctly formatted zip file: Expected a File Header at offset %d, but not present.
+
+DRUID_UNSUPPORTED_TYPE_ERROR_1=Unsupported type: %s
+
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_1=Unsupported operator: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_2=Unsupported time function: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_3=Unsupported interval unit: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_4=Unsupported binary expression: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_5=Unsupported arithmetic expression: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_6=Unsupported function: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_7=Expected string literal but found: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_8=Could not dig function out of expression: %s, inside of: %s to pushdown for Druid connector.
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_9=%s is not supported in Druid filter
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_10=Unknown logical binary: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_11=Between operator not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_12=NOT operator is supported only on top of IN operator. Received: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_13=Non implicit casts not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_14=This type of CAST operator not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_15=Arithmetic expressions are not supported in Druid filter: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_16=Function %s not supported in Druid filter
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_17=Druid does not support struct dereference: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_18=Druid does not support lambda: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_19=Druid does not support special form: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_20=Unsupported function in Druid aggregation: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_21=Input reference not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_22=Special form not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_23=Call not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_24=Constant not supported: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_25=Unsupported aggregation node %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_26=Unsupported aggregation node with mask %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_27=Null constant expression: %s with value of type: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_28=Cannot handle the constant expression: %s with value of type: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_29=Unsupported pushdown for Druid connector with plan node of type %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_30=Unsupported pushdown for Druid connector. Expect variable reference, but get: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_31=Unsupported pushdown for Druid connector. Unknown aggregation expression: %s
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_32=Unsupported pushdown for Druid connector. Aggregation function: %s not supported
+DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION_33=Druid does not support filter on top of AggregationNode.
+
+DRUID_QUERY_GENERATOR_FAILURE_1=Expected to find a druid table scan node id
+DRUID_QUERY_GENERATOR_FAILURE_2=Expected to find a druid table scan node
+DRUID_QUERY_GENERATOR_FAILURE_3=Expected to find a druid table handle
+DRUID_QUERY_GENERATOR_FAILURE_4=Invalid limit: %d
+DRUID_QUERY_GENERATOR_FAILURE_5=Could not pushdown multiple aggregates in the presence of group by and limit
+DRUID_QUERY_GENERATOR_FAILURE_6=Empty Druid query
+DRUID_QUERY_GENERATOR_FAILURE_7=Table name missing in Druid query
+
+DRUID_BROKER_RESULT_ERROR_1=Parse druid client response error
+DRUID_BROKER_RESULT_ERROR_2=Request to worker failed
+DRUID_BROKER_RESULT_ERROR_3=Response received was not of type %s
+DRUID_BROKER_RESULT_ERROR_4=Unable to read response from worker
+
+DRUID_AMBIGUOUS_OBJECT_NAME_1=Found ambiguous names in Druid when looking up '%s':
+
+ELASTICSEARCH_TYPE_MISMATCH_1=Expected list of elements for field '%s' of type ARRAY: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_2=Expected a numeric value for field %s of type BIGINT: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_3=Expected a boolean value for field %s of type BOOLEAN: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_4=Expected a numeric value for field %s of type DOUBLE: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_5=Expected a numeric value for field '%s' of type INTEGER: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_6=Expected a string value for field '%s' of type IP: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_7=Expected a numeric value for field %s of type REAL: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_8=Expected object for field '%s' of type ROW: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_9=Expected a numeric value for field '%s' of type SMALLINT: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_10=Value out of range for field '%s' of type SMALLINT: %s
+ELASTICSEARCH_TYPE_MISMATCH_11=Expected single value for column '%s', found: %s
+ELASTICSEARCH_TYPE_MISMATCH_12=Value out of range for field '%s' of type TINYINT: %s
+ELASTICSEARCH_TYPE_MISMATCH_13=Expected a numeric value for field '%s' of type TINYINT: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_14=Expected a string value for field '%s' of type VARBINARY: %s [%s]
+ELASTICSEARCH_TYPE_MISMATCH_15=Expected a string or numeric value for field '%s' of type VARCHAR: %s [%s]
+
+HIVE_METASTORE_ERROR_1=currentStatistics is null
+HIVE_METASTORE_ERROR_2=Database can not be created with a location set
+HIVE_METASTORE_ERROR_3=Database %s is not empty
+HIVE_METASTORE_ERROR_4=Could not rename database metadata directory
+HIVE_METASTORE_ERROR_5=Table directory must be %s
+HIVE_METASTORE_ERROR_6=External table location does not exist
+HIVE_METASTORE_ERROR_7=External table location can not be inside the system metadata directory
+HIVE_METASTORE_ERROR_8=Could not validate external location
+HIVE_METASTORE_ERROR_9=Only views can be updated with replaceTable
+HIVE_METASTORE_ERROR_10=Replacement table must have same name
+HIVE_METASTORE_ERROR_11=Could not rename table directory
+HIVE_METASTORE_ERROR_12=Partition already exists
+HIVE_METASTORE_ERROR_13=Could not write partition schema
+HIVE_METASTORE_ERROR_14=Partition directory must be %s
+HIVE_METASTORE_ERROR_15=External partition location does not exist
+HIVE_METASTORE_ERROR_16=External partition location can not be inside the system metadata directory
+HIVE_METASTORE_ERROR_17=Could not validate external partition location
+HIVE_METASTORE_ERROR_18=Error listing partition directories
+HIVE_METASTORE_ERROR_19=Could not create permissions directory
+HIVE_METASTORE_ERROR_20=Could not delete table permissions
+HIVE_METASTORE_ERROR_21=Could not delete metadata directory
+HIVE_METASTORE_ERROR_22=Could not read %s
+HIVE_METASTORE_ERROR_23=%s file already exists
+HIVE_METASTORE_ERROR_24=Could not write %s
+HIVE_METASTORE_ERROR_25=Could not delete %s schema
+HIVE_METASTORE_ERROR_26=Failed to fetch partitions from Glue Data Catalog
+HIVE_METASTORE_ERROR_27=%s: %s
+HIVE_METASTORE_ERROR_28=Metastore returned multiple partitions for name: %s
+HIVE_METASTORE_ERROR_29=Hive metastore only added %s of %s partitions
+HIVE_METASTORE_ERROR_30=Failed to create schema due to incorrect bucket details or storage path. Check the details and retry.
+
+HIVE_CURSOR_ERROR_1=Failed to read ORC file: %s
+HIVE_CURSOR_ERROR_2=Failed to read RC file: %s
+
+HIVE_TABLE_OFFLINE_1=tableName is null
+
+HIVE_CANNOT_OPEN_SPLIT_1=Error opening Hive split %s (offset=%s, length=%s) using %s: %s
+HIVE_CANNOT_OPEN_SPLIT_2=The file used to create the table is not in ORC format. Specify the correct file format or use an ORC file.
+HIVE_CANNOT_OPEN_SPLIT_3=Error opening Hive split %s (offset=%s, length=%s): %s
+
+HIVE_FILE_NOT_FOUND_1=Partition location does not exist: %s
+
+HIVE_UNKNOWN_ERROR_1=Partition %s does not have a value for partition column %s
+HIVE_UNKNOWN_ERROR_2=%s is not supported
+
+HIVE_BAD_DATA_1=Line too long in text file: %s
+HIVE_BAD_DATA_2=Error parsing symlinks from: %s
+HIVE_BAD_DATA_3=ORC file is empty: %s
+HIVE_BAD_DATA_4=Malformed PageFile format, incorrect footer length.
+HIVE_BAD_DATA_5=%s is invalid compression method in the footer of %s
+HIVE_BAD_DATA_6=Malformed PageFile format, incorrect stripe count.
+HIVE_BAD_DATA_7=Corrupted RC file: %s
+HIVE_BAD_DATA_8=RCFile is empty: %s
+
+HIVE_PARTITION_SCHEMA_MISMATCH_1=Hive table (%s) is bucketed but partition (%s) is not bucketed
+HIVE_PARTITION_SCHEMA_MISMATCH_2=Hive table (%s) bucketing (columns=%s, buckets=%s) is not compatible with partition (%s) bucketing (columns=%s, buckets=%s)
+HIVE_PARTITION_SCHEMA_MISMATCH_3=There is a mismatch between the table and partition schemas. The types are incompatible and cannot be coerced. The column '%s' in table '%s' is declared as type '%s', but partition '%s' declared column '%s' as type '%s'.
+HIVE_PARTITION_SCHEMA_MISMATCH_4=There is a mismatch between the table and partition schemas.  The column '%s' in table '%s.%s' is declared as type '%s', but partition '%s' declared column '%s' as type '%s'.
+HIVE_PARTITION_SCHEMA_MISMATCH_5=You are trying to write into an existing partition in a table. The table schema has changed since the creation of the partition. Inserting rows into such partition is not supported. The column '%s' in table '%s' is declared as type '%s', but partition '%s' declared column '%s' as type '%s'.
+HIVE_PARTITION_SCHEMA_MISMATCH_6=The column %s of table %s is declared as type %s, but the Parquet file (%s) declares the column as type %s
+
+HIVE_INVALID_PARTITION_VALUE_1=partition key value cannot be null for field: %s
+HIVE_INVALID_PARTITION_VALUE_2=Invalid partition value '%s' for BOOLEAN partition key: %s
+HIVE_INVALID_PARTITION_VALUE_3=Invalid partition value '%s' for BIGINT partition key: %s
+HIVE_INVALID_PARTITION_VALUE_4=Invalid partition value '%s' for INTEGER partition key: %s
+HIVE_INVALID_PARTITION_VALUE_5=Invalid partition value '%s' for SMALLINT partition key: %s
+HIVE_INVALID_PARTITION_VALUE_6=Invalid partition value '%s' for TINYINT partition key: %s
+HIVE_INVALID_PARTITION_VALUE_7=Invalid partition value '%s' for FLOAT partition key: %s
+HIVE_INVALID_PARTITION_VALUE_8=Invalid partition value '%s' for DOUBLE partition key: %s
+HIVE_INVALID_PARTITION_VALUE_9=Invalid partition value '%s' for DATE partition key: %s
+HIVE_INVALID_PARTITION_VALUE_10=Invalid partition value '%s' for TIMESTAMP partition key: %s
+HIVE_INVALID_PARTITION_VALUE_11=Invalid partition value '%s' for %s partition key: %s
+HIVE_INVALID_PARTITION_VALUE_12=partition key value cannot be null for field: %s
+HIVE_INVALID_PARTITION_VALUE_13=Hive partition keys can only contain printable ASCII characters (0x20 - 0x7E). Invalid value: %s
+
+HIVE_TIMEZONE_MISMATCH_1=To write Hive data, your JVM timezone must match the Hive storage timezone. Add -Duser.timezone=%s to your JVM arguments.
+
+HIVE_INVALID_METADATA_1=Table '%s.%s' is bucketed on non-existent column '%s'
+HIVE_INVALID_METADATA_2=Expected %d partition key values, but got %d
+HIVE_INVALID_METADATA_3=bucketed table %s should not specify preferred_ordering_columns
+HIVE_INVALID_METADATA_4=Only single character can be set for property: %s
+HIVE_INVALID_METADATA_5=Different values for '%s' set in serde properties and table properties: '%s' and '%s'
+HIVE_INVALID_METADATA_6=Hive metadata for table %s is invalid: Table descriptor contains duplicate columns
+HIVE_INVALID_METADATA_7=Table '%s' or partition '%s' has null columns
+HIVE_INVALID_METADATA_8=Table or partition is missing Hive input format property: %s
+HIVE_INVALID_METADATA_9=Table or partition is missing Hive deserializer property: %s
+HIVE_INVALID_METADATA_10=Invalid value for %s property: %s
+HIVE_INVALID_METADATA_11=Table %s.%s was dropped during insert
+HIVE_INVALID_METADATA_12=Sorting column '%s' does not exist in table '%s.%s'
+HIVE_INVALID_METADATA_13=Partition '%s' in table '%s.%s' has mismatched metadata for column names and types
+HIVE_INVALID_METADATA_14=Table '%s' is flattened, but flat map writer is not enabled for this session.
+HIVE_INVALID_METADATA_15=Expected %s partition key values, but got %s
+HIVE_INVALID_METADATA_16=Table/partition metadata has 'numBuckets' set, but 'bucketCols' is not set: %s
+HIVE_INVALID_METADATA_17=Invalid Hive struct type: %s
+HIVE_INVALID_METADATA_18=Table/partition metadata has invalid sorting order: %s
+HIVE_INVALID_METADATA_19=SerDe is not present in StorageFormat
+HIVE_INVALID_METADATA_20=Invalid column statistics data: %s
+HIVE_INVALID_METADATA_21=Invalid column statistics type: %s
+HIVE_INVALID_METADATA_22=Table is missing storage descriptor
+HIVE_INVALID_METADATA_23=Table does not contain a storage descriptor: %s
+HIVE_INVALID_METADATA_24=Table storage descriptor is missing SerDe info
+HIVE_INVALID_METADATA_25=Partition does not contain a storage descriptor: %s
+HIVE_INVALID_METADATA_26=Invalid column statistics data: %s
+HIVE_INVALID_METADATA_27=Table storage descriptor is missing SerDe info
+
+HIVE_INVALID_VIEW_DATA_1=View data missing prefix: %s
+HIVE_INVALID_VIEW_DATA_2=View data missing suffix: %s
+
+HIVE_DATABASE_LOCATION_ERROR_1=Database '%s' location is not set
+HIVE_DATABASE_LOCATION_ERROR_2=Database '%s' location does not exist: %s
+HIVE_DATABASE_LOCATION_ERROR_3=Database '%s' location is not a directory: %s
+
+HIVE_PATH_ALREADY_EXISTS_1=Unable to rename from %s to %s: target directory already exists
+HIVE_PATH_ALREADY_EXISTS_2=Unable to create directory %s: target directory already exists
+HIVE_PATH_ALREADY_EXISTS_3=Target directory for table '%s.%s' already exists: %s
+HIVE_PATH_ALREADY_EXISTS_4=Target directory for new partition '%s' of table '%s.%s' already exists: %s
+
+HIVE_FILESYSTEM_ERROR_1=Failed getting FileSystem: %s
+HIVE_FILESYSTEM_ERROR_2=Failed to delete partition %s files during overwrite
+HIVE_FILESYSTEM_ERROR_3=Error renaming file. fromPath: %s toPath: %s
+HIVE_FILESYSTEM_ERROR_4=Failed checking path: %s
+HIVE_FILESYSTEM_ERROR_5=Error reading from %s at position %s
+HIVE_FILESYSTEM_ERROR_6=Failed to list directory: %s. %s
+HIVE_FILESYSTEM_ERROR_7=Error getting file system. Path: %s
+HIVE_FILESYSTEM_ERROR_8=Failed to create directory: %s
+HIVE_FILESYSTEM_ERROR_9=Failed to set permission on directory: %s
+HIVE_FILESYSTEM_ERROR_10=Error deleting from unpartitioned table %s. These items can not be deleted: %s
+HIVE_FILESYSTEM_ERROR_11=Failed to rename %s to %s: rename returned false
+HIVE_FILESYSTEM_ERROR_12=Failed to rename %s to %s
+
+HIVE_SERDE_NOT_FOUND_1=deserializer does not exist: %s
+HIVE_SERDE_NOT_FOUND_2=Serializer does not exist: %s
+
+HIVE_UNSUPPORTED_FORMAT_1=Not a Hive table '%s'
+HIVE_UNSUPPORTED_FORMAT_2=Output format %s with SerDe %s is not supported
+HIVE_UNSUPPORTED_FORMAT_3=Unable to create input format %s
+HIVE_UNSUPPORTED_FORMAT_4=Failed to load compression codec: %s
+HIVE_UNSUPPORTED_FORMAT_5=Attempted to build SQL for unknown S3SelectDataType
+HIVE_UNSUPPORTED_FORMAT_6=Unknown %s compression type %s
+HIVE_UNSUPPORTED_FORMAT_7=Split converter %s failed to create FileSplit.
+HIVE_UNSUPPORTED_FORMAT_8=InputFormat is not present in StorageFormat
+HIVE_UNSUPPORTED_FORMAT_9=OutputFormat is not present in StorageFormat
+HIVE_UNSUPPORTED_FORMAT_10=Table StorageDescriptor is null for table %s.%s (%s)
+
+HIVE_PARTITION_READ_ONLY_1=Cannot insert into an existing partition of Hive table: %s
+HIVE_PARTITION_READ_ONLY_2=partition is null
+HIVE_PARTITION_READ_ONLY_3=Cannot insert into bucketed unpartitioned Hive table
+HIVE_PARTITION_READ_ONLY_4=Unpartitioned Hive tables are immutable
+HIVE_PARTITION_READ_ONLY_5=Cannot insert into existing partition of bucketed Hive table: %s
+HIVE_PARTITION_READ_ONLY_6=Cannot insert into an existing partition of Hive table: %s
+
+HIVE_TOO_MANY_OPEN_PARTITIONS_1=Exceeded limit of %s open writers for partitions/buckets
+
+HIVE_CONCURRENT_MODIFICATION_DETECTED_1=Table format changed during insert
+HIVE_CONCURRENT_MODIFICATION_DETECTED_2=Partition format changed during insert
+HIVE_CONCURRENT_MODIFICATION_DETECTED_3=Partition %s was added or modified during INSERT
+
+HIVE_COLUMN_ORDER_MISMATCH_1=Partition keys must be the last columns in the table and in the same order as the table properties: %s
+
+HIVE_FILE_MISSING_COLUMN_NAMES_1=ORC file does not contain column names in the footer: %s
+
+HIVE_WRITER_OPEN_ERROR_1=Error creating %s file. %s
+HIVE_WRITER_OPEN_ERROR_2=Error creating RCFile file
+HIVE_WRITER_OPEN_ERROR_3=Error creating pagefile
+HIVE_WRITER_OPEN_ERROR_4=Error creating empty pagefile
+HIVE_WRITER_OPEN_ERROR_5=Error creating Parquet file
+
+HIVE_WRITER_CLOSE_ERROR_1=Error rolling back write to Hive
+HIVE_WRITER_CLOSE_ERROR_2=Error write zero-row file to Hive
+HIVE_WRITER_CLOSE_ERROR_3=Error committing write to Hive. %s
+HIVE_WRITER_CLOSE_ERROR_4=Error committing write to Hive
+HIVE_WRITER_CLOSE_ERROR_5=Error committing writing parquet to Hive
+HIVE_WRITER_CLOSE_ERROR_6=Error rolling back write parquet to Hive
+
+HIVE_WRITER_DATA_ERROR_1=Failed to write temporary file: %s
+HIVE_WRITER_DATA_ERROR_2=Failed to read temporary data
+
+HIVE_INVALID_BUCKET_FILES_1=A row that is supposed to be in bucket %s is encountered. Only rows in bucket %s (modulo %s) are expected
+HIVE_INVALID_BUCKET_FILES_2=Hive table '%s' is corrupt. Found sub-directory in bucket directory for partition: %s
+HIVE_INVALID_BUCKET_FILES_3=invalid hive bucket file name: %s
+HIVE_INVALID_BUCKET_FILES_4=Hive table '%s' is corrupt. File '%s' does not match the standard naming pattern, and the number of files in the directory (%s) does not match the declared bucket count (%s) for partition: %s
+
+HIVE_EXCEEDED_PARTITION_LIMIT_1=Query over table '%s' can potentially read more than %s partitions
+
+HIVE_PARTITION_DROPPED_DURING_QUERY_1=Partition no longer exists: %s
+HIVE_PARTITION_DROPPED_DURING_QUERY_2=Statistics result does not contain entry for partition: %s
+
+HIVE_TABLE_READ_ONLY_1=tableName is null
+
+HIVE_PARTITION_NOT_READABLE_1=partition is null
+
+HIVE_TABLE_DROPPED_DURING_QUERY_1=The metastore delete operation failed: %s
+
+HIVE_CORRUPTED_COLUMN_STATISTICS_1=Corrupted partition statistics (Table: %s Partition: [%s] Column: %s): %s
+HIVE_CORRUPTED_COLUMN_STATISTICS_2=Corrupted partition statistics (Table: %s Partition: [%s]): %s
+HIVE_CORRUPTED_COLUMN_STATISTICS_3=Corrupted statistics found when altering partition. Table: %s.%s. Partition: %s
+
+HIVE_EXCEEDED_SPLIT_BUFFERING_LIMIT_1=Split buffering for %s.%s exceeded memory limit (%s). %s splits are buffered.
+
+HIVE_UNKNOWN_COLUMN_STATISTIC_TYPE_1=Unknown column statistics type: %s
+
+HIVE_TABLE_BUCKETING_IS_IGNORED_1=Table bucketing is ignored. The virtual "$bucket" column cannot be referenced.
+
+HIVE_TRANSACTION_NOT_FOUND_1=Transaction not found: %s
+
+HIVE_INVALID_ENCRYPTION_METADATA_1=no column found for encryption field %s
+HIVE_INVALID_ENCRYPTION_METADATA_2=subfield not found
+HIVE_INVALID_ENCRYPTION_METADATA_3=Both %s and %s need to be set for DWRF encryption
+HIVE_INVALID_ENCRYPTION_METADATA_4=Unknown encryptionMetadata type: %s
+HIVE_INVALID_ENCRYPTION_METADATA_5=Exactly one of table or column settings can be present. Both are present
+HIVE_INVALID_ENCRYPTION_METADATA_6=Exactly one of table or column settings can be present. None are present
+
+HIVE_UNSUPPORTED_ENCRYPTION_OPERATION_1=Creating an encrypted table without partitions is not supported. Use CREATE TABLE AS SELECT to create an encrypted table without partitions
+HIVE_UNSUPPORTED_ENCRYPTION_OPERATION_2=Inserting into an existing table with encryption enabled is not supported yet
+HIVE_UNSUPPORTED_ENCRYPTION_OPERATION_3=Inserting into an existing partition with encryption enabled is not supported yet
+
+MALFORMED_HIVE_FILE_STATISTICS_1=Invalid position: %d specified for FileStatistics page
+MALFORMED_HIVE_FILE_STATISTICS_2=During manifest creation for partition= %s, filename count= %s is not equal to filesizes count= %s
+MALFORMED_HIVE_FILE_STATISTICS_3=Failed de-compressing the file names in manifest
+MALFORMED_HIVE_FILE_STATISTICS_4=Failed compressing the file sizes for manifest
+MALFORMED_HIVE_FILE_STATISTICS_5=Failed de-compressing the file sizes in manifest
+MALFORMED_HIVE_FILE_STATISTICS_6=Filename = %s not stored in manifest. Partition = %s, TableName = %s
+MALFORMED_HIVE_FILE_STATISTICS_7=FilesizeFromManifest = %s is not equal to FilesizeFromStorage = %s. File = %s, Partition = %s, TableName = %s
+MALFORMED_HIVE_FILE_STATISTICS_8=Number of files in Manifest = %s is not equal to Number of files in storage = %s. Partition = %s, TableName = %s
+
+HIVE_INVALID_FILE_NAMES_1=Hive table '%s' is corrupt. Some of the filenames in the partition: %s are not integers
+
+HIVE_FUNCTION_UNSUPPORTED_HIVE_TYPE_1=Unsupported Hive type %s
+
+HIVE_FUNCTION_UNSUPPORTED_PRESTO_TYPE_1=Unsupported Presto type %s"
+
+HIVE_FUNCTION_UNSUPPORTED_FUNCTION_TYPE_1=Unsupported function type %s / %s
+
+HUDI_UNKNOWN_TABLE_TYPE_1=Unknown table type %s
+
+HUDI_INVALID_METADATA_1=Table %s.%s expected but not found
+HUDI_INVALID_METADATA_2=Partition %s expected but not found
+
+HUDI_INVALID_PARTITION_VALUE_1=Invalid partition value '%s' for %s partition key: %s
+
+HUDI_FILESYSTEM_ERROR_1=Could not open file system for %s
+
+HUDI_CANNOT_OPEN_SPLIT_1=Split without base file is invalid
+HUDI_CANNOT_OPEN_SPLIT_2=Error opening Hudi split %s (offset=%s, length=%s): %s
+HUDI_CANNOT_OPEN_SPLIT_3=Error opening Hive split %s using %s: %s
+HUDI_CANNOT_OPEN_SPLIT_4=Unable to create input format %s
+
+HUDI_CANNOT_GENERATE_SPLIT_1=Error generating Hudi split
+
+ICEBERG_UNKNOWN_TABLE_TYPE_1=Not an Iceberg table: %s
+
+ICEBERG_INVALID_METADATA_1=Table is missing [%s] property: %s
+ICEBERG_INVALID_METADATA_2=Snapshot ID [%s] does not exist for table: %s
+
+ICEBERG_TOO_MANY_OPEN_PARTITIONS_1=Exceeded limit of %s open writers for partitions
+
+ICEBERG_INVALID_PARTITION_VALUE_1=Invalid partition value '%s' for %s partition key: %s
+
+ICEBERG_BAD_DATA_1=Error opening Iceberg split %s (offset=%s, length=%s): %s
+
+ICEBERG_MISSING_DATA_1=Error opening Iceberg split %s (offset=%s, length=%s): %s
+
+ICEBERG_CANNOT_OPEN_SPLIT_1=Error opening Iceberg split %s (offset=%s, length=%s): %s
+
+ICEBERG_WRITER_OPEN_ERROR_1=Error creating Parquet file
+ICEBERG_WRITER_OPEN_ERROR_2=Error creating ORC file
+
+ICEBERG_FILESYSTEM_ERROR_1=Failed to delete file: %s
+ICEBERG_FILESYSTEM_ERROR_2=Failed to create input file: %s
+ICEBERG_FILESYSTEM_ERROR_3=Failed to create output file: %s
+
+ICEBERG_INVALID_SNAPSHOT_ID_1=Invalid snapshot [%s] for table: %s
+
+JDBC_ERROR_5=Failed to find remote schema name: %s
+JDBC_ERROR_6=Failed to find remote table name: %s
+JDBC_ERROR_7=Conversion to json failed for %s
+
+KAFKA_SPLIT_ERROR_1=Cannot read data from topic '%s', partition '%s', startOffset %s, endOffset %s, leader %s
+KAFKA_SPLIT_ERROR_2=Cannot list splits for table '%s' reading topic '%s'
+
+KAFKA_CONSUMER_ERROR_1=Failed to find offset by timestamp: %d for partition %d
+
+KAFKA_SCHEMA_ERROR_1=Unable to read data schema at '%s'
+
+KAFKA_PRODUCER_ERROR_1=%d producer record('s) failed to send
+
+NOT_PERMITTED_1=Schema is required to list tables
+NOT_PERMITTED_2=User '%s' is not permitted to perform '%s' on schema '%s'
+
+LARK_API_ERROR_1=Illegal response data of sheet %s @ %s
+LARK_API_ERROR_2=Bad response: [%d] %s
+
+SCHEMA_TOKEN_NOT_PROVIDED_1=Schema token is required but not provided
+
+SCHEMA_ALREADY_EXISTS_1=Schema '%s' already exists or created by others
+
+SCHEMA_NOT_EXISTS_1=Schema %s not exists or not visible
+SCHEMA_NOT_EXISTS_2=Schema '%s' does not exist
+
+SCHEMA_NOT_READABLE_1=Spreadsheet %s not readable
+
+SHEET_NAME_AMBIGUOUS_1=Ambiguous name %s in spreadsheet %s: matched sheets: %s
+
+SHEET_INVALID_HEADER_1=Duplicated name %s in Column#%s and Column#%s
+
+SHEET_BAD_DATA_1=Sheet %s.%s is empty
+
+LOCAL_FILE_NO_FILES_1=No matching files found in directory: %s
+
+LOCAL_FILE_FILESYSTEM_ERROR_1=Error listing files in directory: %s
+
+LOCAL_FILE_READ_ERROR_1=Error reading file: %s
+
+MISSING_DATA_1=Failed to find table on a worker.
+MISSING_DATA_2=Expected to find [%s] rows on a worker, but found [%s].
+
+MEMORY_LIMIT_EXCEEDED_1=Memory limit [%d] for memory connector exceeded
+
+OPEN_TELEMETRY_CONTEXT_PROPAGATOR_ERROR_1=Only b3 single header context propagation mode is currently supported.
+
+PARQUET_UNSUPPORTED_COLUMN_TYPE_1=Column: %s, Encoding: %s
+
+PARQUET_UNSUPPORTED_ENCODING_1=Column: %s, Encoding: %s
+PARQUET_UNSUPPORTED_ENCODING_2=Dictionary encoding is not supported: %s
+
+PARQUET_IO_READ_ERROR_1=Error reading Parquet column %s
+PARQUET_IO_READ_ERROR_2=Error reading parquet page %s in column %s
+
+PARQUET_INCORRECT_DECODING_1=Wrong count: ex=%d, act=%d, col=%s, file=%s
+PARQUET_INCORRECT_DECODING_2=Wrong value: pos=%d, ex=%s, act=%s, col=%s-%s, file=%s
+PARQUET_INCORRECT_DECODING_3=Wrong RL count: ex=%s, act=%s, col=%s-%s, file=%s
+PARQUET_INCORRECT_DECODING_4=Wrong RL value: pos=%d, ex=%s, act=%s, col=%s-%s, file=%s
+PARQUET_INCORRECT_DECODING_5=Wrong DL count: ex=%s, act=%s, col=%s-%s, file=%s
+
+PINOT_UNSUPPORTED_COLUMN_TYPE_1=type '%s' not supported
+PINOT_UNSUPPORTED_COLUMN_TYPE_2=Not support type conversion for pinot data type: %s
+PINOT_UNSUPPORTED_COLUMN_TYPE_3=Failed to write column %s. pinotColumnType %s, javaType %s
+PINOT_UNSUPPORTED_COLUMN_TYPE_4=Failed to write column %s. pinotColumnType %s, prestoType %s
+
+PINOT_QUERY_GENERATOR_FAILURE_1=Limit %d not supported: Limit is not being pushed down
+PINOT_QUERY_GENERATOR_FAILURE_2=Table name not encountered yet
+PINOT_QUERY_GENERATOR_FAILURE_3=Broker non aggregate queries have to have a limit
+
+PINOT_INSUFFICIENT_SERVER_RESPONSE_1=Only %s out of %s servers responded for query %s
+
+PINOT_EXCEPTION_1=Query %s encountered exception %s
+PINOT_EXCEPTION_2=Encountered %d pinot exceptions for split %s: %s
+PINOT_EXCEPTION_3=Expected pinot to contain %d columns but got %d: %s
+
+PINOT_HTTP_ERROR_1=Unexpected response status: %d for request %s to url %s, with headers %s, full response %s
+
+PINOT_UNEXPECTED_RESPONSE_1=Expected row of %d columns
+PINOT_UNEXPECTED_RESPONSE_2=Couldn't parse response
+PINOT_UNEXPECTED_RESPONSE_3=Expected data schema in the response
+PINOT_UNEXPECTED_RESPONSE_4=ColumnDataTypes and results expected for %s, expected %d columnDataTypes but got %d
+PINOT_UNEXPECTED_RESPONSE_5=ColumnNames and results expected for %s, expected %d columnNames but got %d
+PINOT_UNEXPECTED_RESPONSE_6=Empty routingTableEntries for %s. RoutingTable: %s
+PINOT_UNEXPECTED_RESPONSE_7=Encountered Pinot exceptions, unknown response type - %s
+
+PINOT_UNSUPPORTED_EXPRESSION_1=Unsupported aggregation node %s
+PINOT_UNSUPPORTED_EXPRESSION_2=Unsupported aggregation node with mask %s
+PINOT_UNSUPPORTED_EXPRESSION_3=Null constant expression %s with value of type %s
+PINOT_UNSUPPORTED_EXPRESSION_4=Cannot handle the constant expression %s with value of type %s
+PINOT_UNSUPPORTED_EXPRESSION_5=Expected to find realtime and offline pinot query in %s
+PINOT_UNSUPPORTED_EXPRESSION_6=Unsupported function in pinot aggregation: %s
+PINOT_UNSUPPORTED_EXPRESSION_7=Comparison operator not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_8=not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_9=interval unit in date_trunc is not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_10=interval in date_trunc is not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_11=function %s not supported yet
+PINOT_UNSUPPORTED_EXPRESSION_12=Expected string literal but found %s
+PINOT_UNSUPPORTED_EXPRESSION_13=Could not dig function out of expression: %s, inside of %s
+PINOT_UNSUPPORTED_EXPRESSION_14=%s' is not supported in filter
+PINOT_UNSUPPORTED_EXPRESSION_15=Unknown logical binary: '%s'
+PINOT_UNSUPPORTED_EXPRESSION_16=Unable to parse timestamp string: '%s'
+PINOT_UNSUPPORTED_EXPRESSION_17=Unable to parse date string: '%s'
+PINOT_UNSUPPORTED_EXPRESSION_18=Contains operator not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_19=Contains operator can not push down non-literal value: %s
+PINOT_UNSUPPORTED_EXPRESSION_20=Between operator not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_21=NOT operator is supported only on top of IN and IS_NULL operator. Received: %s
+PINOT_UNSUPPORTED_EXPRESSION_22=Cast date value expression is not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_23=Non implicit casts not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_24=This type of CAST operator not supported. Received: %s
+PINOT_UNSUPPORTED_EXPRESSION_25=Coalesce operator not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_26=Coalesce operator can not push down non-table column: %s
+PINOT_UNSUPPORTED_EXPRESSION_27=Coalesce operator does not support: %s
+PINOT_UNSUPPORTED_EXPRESSION_28=function %s not supported in filter yet
+PINOT_UNSUPPORTED_EXPRESSION_29=Arithmetic expressions are not supported in filter: %s
+PINOT_UNSUPPORTED_EXPRESSION_30=Non implicit Date/Timestamp Literal is not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_31=The Date/Timestamp Literal is not supported. Received: %s
+PINOT_UNSUPPORTED_EXPRESSION_32=Pinot does not support struct dereferencing %s
+PINOT_UNSUPPORTED_EXPRESSION_33=Pinot does not support lambda %s
+PINOT_UNSUPPORTED_EXPRESSION_34=Pinot does not support the special form %s
+PINOT_UNSUPPORTED_EXPRESSION_35=Unexpected special form: %s
+PINOT_UNSUPPORTED_EXPRESSION_36=Unsupported binary expression %s
+PINOT_UNSUPPORTED_EXPRESSION_37=Don't know how to interpret %s as an arithmetic expression
+PINOT_UNSUPPORTED_EXPRESSION_38=Pinot does not support struct dereferencing: %s
+PINOT_UNSUPPORTED_EXPRESSION_39=Special form not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_40=Pinot does not support the special form %s
+PINOT_UNSUPPORTED_EXPRESSION_41=Call not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_42=Constant not supported: %s
+PINOT_UNSUPPORTED_EXPRESSION_43=Don't know how to handle plan node of type %s
+PINOT_UNSUPPORTED_EXPRESSION_44=Expected a variable reference but got %s
+PINOT_UNSUPPORTED_EXPRESSION_45=aggregation function '%s' not supported yet
+PINOT_UNSUPPORTED_EXPRESSION_46=Cannot handle approx_percentile function %s
+PINOT_UNSUPPORTED_EXPRESSION_47=Cannot handle approx_percentile percentage argument be a non literal %s
+PINOT_UNSUPPORTED_EXPRESSION_48=Expected the fraction to be a constant or a variable %s
+PINOT_UNSUPPORTED_EXPRESSION_49=Cannot handle approx_percentile parsed as %d from input %s (function %s)
+PINOT_UNSUPPORTED_EXPRESSION_50=Cannot handle approx_distinct function %s
+PINOT_UNSUPPORTED_EXPRESSION_51=Cannot handle approx_distinct standard error argument be a non literal %s
+PINOT_UNSUPPORTED_EXPRESSION_52=Expected the standard error to be a constant or a variable %s
+PINOT_UNSUPPORTED_EXPRESSION_53=Cannot handle approx_distinct parsed as %f from input %s (function %s)
+PINOT_UNSUPPORTED_EXPRESSION_54=Cannot handle approx_distinct parsing to numerical value from input %s (function %s)
+PINOT_UNSUPPORTED_EXPRESSION_55=Cannot handle approx_distinct, the log2m generated from error is %d from input %s (function %s)
+PINOT_UNSUPPORTED_EXPRESSION_56=unknown aggregation expression: %s
+PINOT_UNSUPPORTED_EXPRESSION_57=TopN query is not allowed to push down. Please refer to config: 'pinot.pushdown-topn-broker-queries'
+PINOT_UNSUPPORTED_EXPRESSION_58=Expected Pinot column handle %s to occur only once, but we have: %s
+
+PINOT_UNABLE_TO_FIND_BROKER_1=Cannot parse %s in the broker instance
+PINOT_UNABLE_TO_FIND_BROKER_2=No valid brokers found for %s
+PINOT_UNABLE_TO_FIND_BROKER_3=Error when getting brokers for table %s
+
+PINOT_DECODE_ERROR_1=Cannot decode double value from pinot %s
+
+PINOT_INVALID_SQL_GENERATED_1=Expected column handle %s to be present in the handles %s corresponding to the segment Pinot SQL
+
+PINOT_INVALID_CONFIGURATION_1=No pinot controllers specified
+
+PINOT_DATA_FETCH_EXCEPTION_1=Encountered %d pinot exceptions for split %s: %s
+PINOT_DATA_FETCH_EXCEPTION_2=Encountered Pinot exceptions when fetching data table from Split: < %s >
+
+PINOT_REQUEST_GENERATOR_FAILURE_1=Unable to Jsonify request: %s
+
+PINOT_UNABLE_TO_FIND_INSTANCE_1=Error when fetching instance configs for %s
+PINOT_UNABLE_TO_FIND_INSTANCE_2=Error when getting instance config for %s
+
+PINOT_INVALID_SEGMENT_QUERY_GENERATED_1=Expected the segment split to contain the pinot query
+PINOT_INVALID_SEGMENT_QUERY_GENERATED_2=Expected the segment split to contain the grpc host
+PINOT_INVALID_SEGMENT_QUERY_GENERATED_3=Expected the segment split to contain the grpc port
+PINOT_INVALID_SEGMENT_QUERY_GENERATED_4=Expected the grpc port > 0 always
+PINOT_INVALID_SEGMENT_QUERY_GENERATED_5=Query and segmentsToQuery must be set
+
+PINOT_UNAUTHENTICATED_EXCEPTION_1=Query authentication failed.
+
+PINOT_UNCLASSIFIED_ERROR_1=Cannot fetch from cache %s
+PINOT_UNCLASSIFIED_ERROR_2=Unable to find the presto table %s in %s
+PINOT_UNCLASSIFIED_ERROR_3=Expected to find a pinot table handle
+
+PROMETHEUS_UNKNOWN_ERROR_1=Error reading metrics
+PROMETHEUS_UNKNOWN_ERROR_2=Bad response %s %s
+PROMETHEUS_UNKNOWN_ERROR_3=Failed to read bearer token file: %s
+PROMETHEUS_UNKNOWN_ERROR_4=split URI invalid: %s
+PROMETHEUS_UNKNOWN_ERROR_5=unable to deserialize timestamp: %s
+
+PROMETHEUS_TABLES_METRICS_RETRIEVE_ERROR_1=Prometheus did no return metrics list (table names): %s
+
+PROMETHEUS_PARSE_ERROR_1=Unable to parse Prometheus response: %s %s %s
+
+PROMETHEUS_OUTPUT_ERROR_1=Unable to handle Prometheus result: %s
+
+SHEETS_UNKNOWN_TABLE_ERROR_1=Sheet expression not found for table %s
+SHEETS_UNKNOWN_TABLE_ERROR_2=Failed reading data from sheet: %s
+SHEETS_UNKNOWN_TABLE_ERROR_3=Metadata not found for table %s
+
+SHEETS_TABLE_LOAD_ERROR_1=Error loading data for table: %s
+
+UNSUPPORTED_STORAGE_TYPE_1=Configured TempStorage does not support remote access required for distributing broadcast tables.
+
+STORAGE_ERROR_1=Unable to delete broadcast spill file
+STORAGE_ERROR_2=Disk page checksum does not match. Data seems to be corrupted on disk for file %s
+STORAGE_ERROR_3=Unable to read data from disk:
+
+MALFORMED_QUERY_FILE_1=sql file size %s is different from expected sqlFileSizeInBytes %s
+MALFORMED_QUERY_FILE_2=actual hash code %s is different from expected sqlFileHexHash %s
+
+THRIFT_SERVICE_CONNECTION_ERROR_1=Error communicating with remote Thrift server
+
+THRIFT_SERVICE_INVALID_RESPONSE_1=Requested and actual table names are different
+
+THRIFT_SERVICE_GENERIC_REMOTE_ERROR_1=Exception raised by remote Thrift server: %s

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PrestoException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PrestoException.java
@@ -19,10 +19,17 @@ public class PrestoException
         extends RuntimeException
 {
     private final ErrorCode errorCode;
+    private final ErrorCodeSupplier errorCodeSupplier;
+    private final String errorKey;
+    private final Object[] args;
 
     public PrestoException(ErrorCodeSupplier errorCode, String message)
     {
         this(errorCode, message, null);
+    }
+    public PrestoException(String errorKey, ErrorCodeSupplier errorCodeSupplier, Object...args)
+    {
+        this(errorKey, errorCodeSupplier, null, args);
     }
 
     public PrestoException(ErrorCodeSupplier errorCode, Throwable throwable)
@@ -34,11 +41,38 @@ public class PrestoException
     {
         super(message, cause);
         this.errorCode = errorCodeSupplier.toErrorCode();
+        this.errorCodeSupplier = errorCodeSupplier;
+        this.errorKey = null;
+        this.args = null;
+    }
+
+    public PrestoException(String errorKey, ErrorCodeSupplier errorCodeSupplier, Throwable cause, Object...args)
+    {
+        super(cause);
+        this.errorCodeSupplier = errorCodeSupplier;
+        this.errorKey = errorKey;
+        this.errorCode = errorCodeSupplier.toErrorCode();
+        this.args = args;
     }
 
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    public ErrorCodeSupplier getErrorCodeSupplier()
+    {
+        return errorCodeSupplier;
+    }
+
+    public String getErrorKey()
+    {
+        return errorKey;
+    }
+
+    public Object[] getArgs()
+    {
+        return args;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/error/ErrorRetriever.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/error/ErrorRetriever.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.error;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import static java.util.Objects.requireNonNull;
+
+public class ErrorRetriever
+{
+    private static boolean isErrorI18nEnabled;
+    private static List<Locale> availableBundles = Collections.emptyList();
+
+    private ErrorRetriever() {}
+
+    public static void preloadErrorBundles(boolean isErrorI18nEnabled)
+    {
+        ErrorRetriever.isErrorI18nEnabled = isErrorI18nEnabled;
+        ResourceBundle.getBundle("Messages");
+        if (isErrorI18nEnabled) {
+            // If internationalization is enabled, load the locale specific error bundles
+            // already available.
+            availableBundles.forEach(locale -> ResourceBundle.getBundle("Messages", locale));
+        }
+    }
+
+    public static String getErrorMessage(String errorKey, Locale locale)
+    {
+        if (isErrorI18nEnabled) {
+            requireNonNull(locale, "locale cannot be null");
+        }
+        else {
+            locale = Locale.US;
+        }
+
+        // ResourceBundle.getBundle returns cached instances of the bundle
+        ResourceBundle selectedBundle = ResourceBundle.getBundle("Messages", locale);
+        return selectedBundle.getString(errorKey);
+    }
+}


### PR DESCRIPTION
This commit udates instances of PrestoException in presto-delta module to use error messages from resource bundles instead of hardcoding in code. This would help in collecting all error messages in a single location and also help in internationalization of error messages based on client's locale.

## Description
<!---Describe your changes in detail-->
Save the error messages used in creating PrestoException instances in a resource bundle. For now there is only one default essages.properties file, but can be updated in future to support multiple languages. Use the property key from messages.properties when creating new instances of PrestoException. Intercept exception at failure handles where we also have access to client session. In the failure handlers convert the PrestoException to a localised form of PrestoException by using the appropriate property value from Messages resource bundle based on the client's locale.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
This is a PR to partly address https://github.com/prestodb/presto/issues/21199. This PR is still work in progress and I'm looking forward to feedback on the approach I followed to resolve this issue.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add Presto changes to support internationalisation of error messages. 
* This can be enabled by setting ``error.i18n.enabled`` configuration property to true.


```



