### PR TITLE
Fix logging of plan optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -608,7 +608,7 @@ public class LegacySqlQueryScheduler
         PlanFragment fragment = subPlan.getFragment();
         PlanNode newRoot = fragment.getRoot();
         for (PlanOptimizer optimizer : runtimePlanOptimizers) {
-            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector).getPlanNode();
         }
         if (newRoot != fragment.getRoot()) {
             StatsAndCosts estimatedStatsAndCosts = fragment.getStatsAndCosts();

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -496,7 +496,7 @@ public class SqlQueryScheduler
         PlanFragment fragment = subPlan.getFragment();
         PlanNode newRoot = fragment.getRoot();
         for (PlanOptimizer optimizer : runtimePlanOptimizers) {
-            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector).getPlanNode();
         }
         if (newRoot != fragment.getRoot()) {
             StatsAndCosts estimatedStatsAndCosts = fragment.getStatsAndCosts();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -164,10 +164,11 @@ public class AddExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager).accept(plan, PreferredProperties.any());
-        return result.getNode();
+        boolean optimizerTriggered = PlanNodeSearcher.searchFrom(result.getNode()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isRemote()).findFirst().isPresent();
+        return PlanOptimizerResult.optimizerResult(result.getNode(), optimizerTriggered);
     }
 
     private class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -118,10 +118,11 @@ public class AddLocalExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         PlanWithProperties result = new Rewriter(variableAllocator, idAllocator, session).accept(plan, any());
-        return result.getNode();
+        boolean optimizerTriggered = PlanNodeSearcher.searchFrom(result.getNode()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isLocal()).findFirst().isPresent();
+        return PlanOptimizerResult.optimizerResult(result.getNode(), optimizerTriggered);
     }
 
     private class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -79,7 +79,7 @@ public class ApplyConnectorOptimization
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -89,7 +89,7 @@ public class ApplyConnectorOptimization
 
         Map<ConnectorId, Set<ConnectorPlanOptimizer>> connectorOptimizers = connectorOptimizersSupplier.get();
         if (connectorOptimizers.isEmpty()) {
-            return plan;
+            return PlanOptimizerResult.optimizerResult(plan, false);
         }
 
         // retrieve all the connectors
@@ -173,7 +173,7 @@ public class ApplyConnectorOptimization
             }
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, true);
     }
 
     private static void getAllConnectorIds(PlanNode node, ImmutableSet.Builder<ConnectorId> builder)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -36,7 +36,7 @@ public class CheckSubqueryNodesAreRewritten
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         searchFrom(plan).where(ApplyNode.class::isInstance)
                 .findFirst()
@@ -52,7 +52,7 @@ public class CheckSubqueryNodesAreRewritten
                     error(lateralJoinNode.getCorrelation(), lateralJoinNode.getOriginSubqueryError());
                 });
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private void error(List<VariableReferenceExpression> correlation, String originSubqueryError)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -113,7 +113,7 @@ public class HashGenerationOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -122,9 +122,9 @@ public class HashGenerationOptimizer
         requireNonNull(idAllocator, "idAllocator is null");
         if (isEnabled(session)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, functionAndTypeManager).accept(plan, new HashComputationSet());
-            return result.getNode();
+            return PlanOptimizerResult.optimizerResult(result.getNode(), true);
         }
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -112,7 +112,7 @@ public class ImplementIntersectAndExceptAsUnion
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -120,7 +120,9 @@ public class ImplementIntersectAndExceptAsUnion
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator), plan);
+        Rewriter rewriter = new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
 
     private static class Rewriter
@@ -132,6 +134,7 @@ public class ImplementIntersectAndExceptAsUnion
         private final StandardFunctionResolution functionResolution;
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
+        private boolean planChanged;
 
         private Rewriter(Session session, FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)
         {
@@ -164,6 +167,7 @@ public class ImplementIntersectAndExceptAsUnion
             AggregationNode aggregation = computeCounts(union, node.getOutputVariables(), markers, aggregationOutputs);
             FilterNode filterNode = addFilterForIntersect(aggregation);
 
+            planChanged = true;
             return project(filterNode, outputs);
         }
 
@@ -189,6 +193,7 @@ public class ImplementIntersectAndExceptAsUnion
             AggregationNode aggregation = computeCounts(union, node.getOutputVariables(), markers, aggregationOutputs);
             FilterNode filterNode = addFilterForExcept(aggregation, aggregationOutputs.get(0), aggregationOutputs.subList(1, aggregationOutputs.size()));
 
+            planChanged = true;
             return project(filterNode, outputs);
         }
 
@@ -297,6 +302,11 @@ public class ImplementIntersectAndExceptAsUnion
                     idAllocator.getNextId(),
                     node,
                     identityAssignments(columns));
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -77,14 +77,17 @@ public class IndexJoinOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, metadata, session), plan, null);
+        Rewriter rewriter = new Rewriter(idAllocator, metadata, session);
+
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
 
     private static class Rewriter
@@ -93,12 +96,18 @@ public class IndexJoinOptimizer
         private final PlanNodeIdAllocator idAllocator;
         private final Metadata metadata;
         private final Session session;
+        private boolean planChanged;
 
         private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.session = requireNonNull(session, "session is null");
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -158,6 +167,7 @@ public class IndexJoinOptimizer
                                         identityAssignments(node.getOutputVariables()));
                             }
 
+                            planChanged = true;
                             return indexJoinNode;
                         }
                         break;
@@ -165,6 +175,7 @@ public class IndexJoinOptimizer
                     case LEFT:
                         // We cannot use indices for outer joins until index join supports in-line filtering
                         if (!node.getFilter().isPresent() && rightIndexCandidate.isPresent()) {
+                            planChanged = true;
                             return createIndexJoinWithExpectedOutputs(node.getOutputVariables(), IndexJoinNode.Type.SOURCE_OUTER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinVariables, rightJoinVariables), idAllocator);
                         }
                         break;
@@ -172,6 +183,7 @@ public class IndexJoinOptimizer
                     case RIGHT:
                         // We cannot use indices for outer joins until index join supports in-line filtering
                         if (!node.getFilter().isPresent() && leftIndexCandidate.isPresent()) {
+                            planChanged = true;
                             return createIndexJoinWithExpectedOutputs(node.getOutputVariables(), IndexJoinNode.Type.SOURCE_OUTER, rightRewritten, leftIndexCandidate.get(), createEquiJoinClause(rightJoinVariables, leftJoinVariables), idAllocator);
                         }
                         break;
@@ -185,6 +197,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
+                planChanged = true;
                 return new JoinNode(
                         node.getSourceLocation(),
                         node.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -88,7 +88,7 @@ public class KeyBasedSampler
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
             List<String> sampledFields = new ArrayList<>(2);
@@ -103,10 +103,10 @@ public class KeyBasedSampler
                 }
             }
 
-            return rewritten;
+            return PlanOptimizerResult.optimizerResult(rewritten, true);
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -39,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -110,13 +108,15 @@ public class MergePartialAggregationsWithFilter
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager), plan, new Context());
+            Rewriter rewriter = new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager);
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new Context());
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Context
@@ -159,6 +159,7 @@ public class MergePartialAggregationsWithFilter
         private final VariableAllocator variableAllocator;
         private final PlanNodeIdAllocator planNodeIdAllocator;
         private final FunctionAndTypeManager functionAndTypeManager;
+        private boolean planChanged;
 
         public Rewriter(Session session, VariableAllocator variableAllocator, PlanNodeIdAllocator planNodeIdAllocator, FunctionAndTypeManager functionAndTypeManager)
         {
@@ -171,6 +172,11 @@ public class MergePartialAggregationsWithFilter
         public static RowExpression ifThenElse(RowExpression... arguments)
         {
             return specialForm(SpecialFormExpression.Form.IF, arguments[1].getType(), arguments);
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -198,9 +204,11 @@ public class MergePartialAggregationsWithFilter
             if (canOptimize) {
                 checkState(node.getAggregations().values().stream().noneMatch(x -> x.getFilter().isPresent()), "All aggregation filters should already be rewritten to mask before this optimization");
                 if (node.getStep().equals(PARTIAL)) {
+                    planChanged = true;
                     return createPartialAggregationNode(node, rewrittenSource, context);
                 }
                 else if (node.getStep().equals(FINAL)) {
+                    planChanged = true;
                     return createFinalAggregationNode(node, rewrittenSource, context);
                 }
             }
@@ -237,9 +245,6 @@ public class MergePartialAggregationsWithFilter
             Set<VariableReferenceExpression> partialResultToMerge = new HashSet<>(aggregationsToMergeOutput.values());
             Map<VariableReferenceExpression, AggregationNode.Aggregation> newAggregations = node.getAggregations().entrySet().stream()
                     .filter(x -> !partialResultToMerge.contains(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            session.getOptimizerInformationCollector().addInformation(
-                    new PlanOptimizerInformation(MergePartialAggregationsWithFilter.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.of(false), Optional.empty()));
 
             return new AggregationNode(
                     node.getSourceLocation(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -104,13 +104,15 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new Optimizer(idAllocator, variableAllocator, metadata, functionResolution), plan, Optional.empty());
+            Optimizer optimizer = new Optimizer(idAllocator, variableAllocator, metadata, functionResolution);
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(optimizer, plan, Optional.empty());
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, optimizer.isPlanChanged());
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Optimizer
@@ -120,6 +122,7 @@ public class OptimizeMixedDistinctAggregations
         private final VariableAllocator variableAllocator;
         private final Metadata metadata;
         private final StandardFunctionResolution functionResolution;
+        private boolean planChanged;
 
         private Optimizer(PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Metadata metadata, StandardFunctionResolution functionResolution)
         {
@@ -127,6 +130,11 @@ public class OptimizeMixedDistinctAggregations
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -231,6 +239,8 @@ public class OptimizeMixedDistinctAggregations
                     node.getStep(),
                     Optional.empty(),
                     node.getGroupIdVariable());
+
+            planChanged = true;
 
             if (coalesceVariables.isEmpty()) {
                 return aggregationNode;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -133,13 +133,15 @@ public class PayloadJoinOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
         if (isEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator), plan, new JoinContext());
+            Rewriter rewriter = new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator);
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new JoinContext());
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
         }
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     @Override
@@ -163,6 +165,7 @@ public class PayloadJoinOptimizer
         private final FunctionAndTypeManager functionAndTypeManager;
         private final PlanNodeIdAllocator planNodeIdAllocator;
         private final VariableAllocator variableAllocator;
+        private boolean planChanged;
 
         private Rewriter(Session session, Metadata metadata, TypeProvider types, FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator variableAllocator)
         {
@@ -172,6 +175,11 @@ public class PayloadJoinOptimizer
             this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
             this.planNodeIdAllocator = requireNonNull(planNodeIdAllocator, "planNodeIdAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -246,6 +254,7 @@ public class PayloadJoinOptimizer
                 return restrictOutput(payloadJoin, planNodeIdAllocator, outputVariables);
             }
 
+            planChanged = true;
             return newJoinNode;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
@@ -22,7 +22,7 @@ import com.facebook.presto.sql.planner.TypeProvider;
 
 public interface PlanOptimizer
 {
-    PlanNode optimize(PlanNode plan,
+    PlanOptimizerResult optimize(PlanNode plan,
             Session session,
             TypeProvider types,
             VariableAllocator variableAllocator,
@@ -62,8 +62,8 @@ public interface PlanOptimizer
         boolean isApplicable = false;
         try {
             // wrap in try/catch block in case optimization throws an error
-            PlanNode newPlan = optimize(plan, session, types, variableAllocator, idAllocator, warningCollector);
-            isApplicable = !plan.equals(newPlan);
+            PlanOptimizerResult optimizerResult = optimize(plan, session, types, variableAllocator, idAllocator, warningCollector);
+            isApplicable = optimizerResult.isOptimizerTriggered();
         }
         finally {
             setEnabledForTesting(false);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizerResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizerResult.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.plan.PlanNode;
+
+import static java.util.Objects.requireNonNull;
+
+public final class PlanOptimizerResult
+{
+    private final PlanNode planNode;
+    private final boolean optimizerTriggered;
+
+    public static PlanOptimizerResult optimizerResult(PlanNode planNode, boolean optimizerTriggered)
+    {
+        return new PlanOptimizerResult(planNode, optimizerTriggered);
+    }
+    private PlanOptimizerResult(PlanNode planNode, boolean optimizerTriggered)
+    {
+        this.planNode = requireNonNull(planNode, "planNode is null");
+        this.optimizerTriggered = optimizerTriggered;
+    }
+
+    public PlanNode getPlanNode()
+    {
+        return planNode;
+    }
+
+    public boolean isOptimizerTriggered()
+    {
+        return optimizerTriggered;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -134,17 +134,16 @@ public class PredicatePushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(
-                new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, sqlParser, session),
-                plan,
-                TRUE_CONSTANT);
+        Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, sqlParser, session);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, TRUE_CONSTANT);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
 
     public static RowExpression createDynamicFilterExpression(String id, RowExpression input, FunctionAndTypeManager functionAndTypeManager)
@@ -181,6 +180,7 @@ public class PredicatePushDown
         private final LogicalRowExpressions logicalRowExpressions;
         private final FunctionAndTypeManager functionAndTypeManager;
         private final ExternalCallExpressionChecker externalCallExpressionChecker;
+        private boolean planChanged;
 
         private Rewriter(
                 VariableAllocator variableAllocator,
@@ -202,12 +202,18 @@ public class PredicatePushDown
             this.externalCallExpressionChecker = new ExternalCallExpressionChecker(functionAndTypeManager);
         }
 
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+
         @Override
         public PlanNode visitPlan(PlanNode node, RewriteContext<RowExpression> context)
         {
             PlanNode rewrittenNode = context.defaultRewrite(node, TRUE_CONSTANT);
             if (!context.get().equals(TRUE_CONSTANT)) {
                 // Drop in a FilterNode b/c we cannot push our predicate down any further
+                planChanged = true;
                 rewrittenNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode, context.get());
             }
             return rewrittenNode;
@@ -236,6 +242,7 @@ public class PredicatePushDown
             }
 
             if (modified) {
+                planChanged = true;
                 return new ExchangeNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -268,6 +275,7 @@ public class PredicatePushDown
             PlanNode rewrittenNode = context.defaultRewrite(node, logicalRowExpressions.combineConjuncts(conjuncts.get(true)));
 
             if (!conjuncts.get(false).isEmpty()) {
+                planChanged = true;
                 rewrittenNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode, logicalRowExpressions.combineConjuncts(conjuncts.get(false)));
             }
 
@@ -307,6 +315,7 @@ public class PredicatePushDown
             nonInliningConjuncts.addAll(conjuncts.get(false));
 
             if (!nonInliningConjuncts.isEmpty()) {
+                planChanged = true;
                 rewrittenNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode, logicalRowExpressions.combineConjuncts(nonInliningConjuncts));
             }
 
@@ -347,6 +356,7 @@ public class PredicatePushDown
 
             // All other conjuncts, if any, will be in the filter node.
             if (!conjuncts.get(false).isEmpty()) {
+                planChanged = true;
                 rewrittenNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode, logicalRowExpressions.combineConjuncts(conjuncts.get(false)));
             }
 
@@ -363,6 +373,7 @@ public class PredicatePushDown
             PlanNode rewrittenNode = context.defaultRewrite(node, logicalRowExpressions.combineConjuncts(conjuncts.get(true)));
 
             if (!conjuncts.get(false).isEmpty()) {
+                planChanged = true;
                 rewrittenNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode, logicalRowExpressions.combineConjuncts(conjuncts.get(false)));
             }
             return rewrittenNode;
@@ -390,6 +401,7 @@ public class PredicatePushDown
             }
 
             if (modified) {
+                planChanged = true;
                 return new UnionNode(node.getSourceLocation(), node.getId(), builder.build(), node.getOutputVariables(), node.getVariableMapping());
             }
 
@@ -402,12 +414,14 @@ public class PredicatePushDown
         {
             PlanNode rewrittenPlan = context.rewrite(node.getSource(), logicalRowExpressions.combineConjuncts(node.getPredicate(), context.get()));
             if (!(rewrittenPlan instanceof FilterNode)) {
+                planChanged = true;
                 return rewrittenPlan;
             }
 
             FilterNode rewrittenFilterNode = (FilterNode) rewrittenPlan;
             if (!areExpressionsEquivalent(rewrittenFilterNode.getPredicate(), node.getPredicate())
                     || node.getSource() != rewrittenFilterNode.getSource()) {
+                planChanged = true;
                 return rewrittenPlan;
             }
 
@@ -605,6 +619,7 @@ public class PredicatePushDown
                             .build();
                 }
 
+                planChanged = true;
                 output = new JoinNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -621,10 +636,12 @@ public class PredicatePushDown
             }
 
             if (!postJoinPredicate.equals(TRUE_CONSTANT)) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, postJoinPredicate);
             }
 
             if (!node.getOutputVariables().equals(output.getOutputVariables())) {
+                planChanged = true;
                 output = new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), output, identityAssignments(node.getOutputVariables()), LOCAL);
             }
 
@@ -869,6 +886,7 @@ public class PredicatePushDown
 
             // See if we can rewrite left join in terms of a plain inner join
             if (node.getType() == SpatialJoinNode.Type.LEFT && canConvertOuterToInner(node.getRight().getOutputVariables(), inheritedPredicate)) {
+                planChanged = true;
                 node = new SpatialJoinNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -942,6 +960,7 @@ public class PredicatePushDown
                 leftSource = new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), leftSource, leftProjections.build(), LOCAL);
                 rightSource = new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), rightSource, rightProjections.build(), LOCAL);
 
+                planChanged = true;
                 output = new SpatialJoinNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -956,6 +975,7 @@ public class PredicatePushDown
             }
 
             if (!postJoinPredicate.equals(TRUE_CONSTANT)) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, postJoinPredicate);
             }
 
@@ -1439,9 +1459,11 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource() || rewrittenFilteringSource != node.getFilteringSource()) {
+                planChanged = true;
                 output = new SemiJoinNode(node.getSourceLocation(), node.getId(), rewrittenSource, rewrittenFilteringSource, node.getSourceJoinVariable(), node.getFilteringSourceJoinVariable(), node.getSemiJoinOutput(), node.getSourceHashVariable(), node.getFilteringSourceHashVariable(), node.getDistributionType(), node.getDynamicFilters());
             }
             if (!postJoinConjuncts.isEmpty()) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, logicalRowExpressions.combineConjuncts(postJoinConjuncts));
             }
             return output;
@@ -1523,6 +1545,7 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource() || rewrittenFilteringSource != node.getFilteringSource() || !dynamicFilters.isEmpty()) {
+                planChanged = true;
                 output = new SemiJoinNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -1537,6 +1560,7 @@ public class PredicatePushDown
                         dynamicFilters);
             }
             if (!postJoinConjuncts.isEmpty()) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, logicalRowExpressions.combineConjuncts(postJoinConjuncts));
             }
             return output;
@@ -1607,6 +1631,7 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource()) {
+                planChanged = true;
                 output = new AggregationNode(
                         node.getSourceLocation(),
                         node.getId(),
@@ -1619,6 +1644,7 @@ public class PredicatePushDown
                         node.getGroupIdVariable());
             }
             if (!postAggregationConjuncts.isEmpty()) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, logicalRowExpressions.combineConjuncts(postAggregationConjuncts));
             }
             return output;
@@ -1659,9 +1685,11 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource()) {
+                planChanged = true;
                 output = new UnnestNode(node.getSourceLocation(), node.getId(), rewrittenSource, node.getReplicateVariables(), node.getUnnestVariables(), node.getOrdinalityVariable());
             }
             if (!postUnnestConjuncts.isEmpty()) {
+                planChanged = true;
                 output = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), output, logicalRowExpressions.combineConjuncts(postUnnestConjuncts));
             }
             return output;
@@ -1679,6 +1707,7 @@ public class PredicatePushDown
             RowExpression predicate = simplifyExpression(context.get());
 
             if (!TRUE_CONSTANT.equals(predicate)) {
+                planChanged = true;
                 return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, predicate);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -69,7 +69,7 @@ import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static java.lang.Boolean.TRUE;
 
 /**
- * An optimization for quicker execution of simple group by + limit queres. In SQL terms, it will be:
+ * An optimization for quicker execution of simple group by + limit queries. In SQL terms, it will be:
  *
  * Original:
  *
@@ -110,7 +110,7 @@ public class PrefilterForLimitingAggregation
     }
 
     @Override
-    public PlanNode optimize(
+    public PlanOptimizerResult optimize(
             PlanNode plan,
             Session session,
             TypeProvider types,
@@ -119,10 +119,12 @@ public class PrefilterForLimitingAggregation
             WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata, types, statsCalculator, idAllocator, variableAllocator), plan);
+            Rewriter rewriter = new Rewriter(session, metadata, types, statsCalculator, idAllocator, variableAllocator);
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan);
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Rewriter
@@ -134,6 +136,7 @@ public class PrefilterForLimitingAggregation
         private final StatsCalculator statsCalculator;
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
+        private boolean planChanged;
 
         private Rewriter(
                 Session session,
@@ -149,6 +152,11 @@ public class PrefilterForLimitingAggregation
             this.statsCalculator = statsCalculator;
             this.idAllocator = idAllocator;
             this.variableAllocator = variableAllocator;
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -179,6 +187,7 @@ public class PrefilterForLimitingAggregation
                         !isAllLowCardinalityGroupByKeys(aggregationNode, scanNode.get(), session, statsCalculator, types, limitNode.getCount())) {
                     PlanNode rewrittenAggregation = addPrefilter(aggregationNode, limitNode.getCount());
                     if (rewrittenAggregation != aggregationNode) {
+                        planChanged = true;
                         if (source == aggregationNode) {
                             return replaceChildren(limitNode, ImmutableList.of(rewrittenAggregation));
                         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -22,7 +22,6 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -42,7 +41,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -83,7 +81,7 @@ import static java.util.function.Function.identity;
  * Randomize the join key of outer joins if the join key has many NULL values so as to mitigate skew.
  * The optimization has three strategies, `DISABLED` to skip the optimization, `ALWAYS` to always enabled for all outer joins, and `KEY_FROM_OUTER_JOIN` to enable only when the
  * join key is from the outer side of a outer join which is likely to have many NULLs.
- *
+ * <p>
  * When Strategy is `KEY_FROM_OUTER_JOIN`:
  * <pre>
  * - LeftJoin
@@ -112,7 +110,7 @@ import static java.util.function.Function.identity;
  *          r.key = COALESCE(T3.k, Randomize(T3.k))
  *          - Scan T3(k)
  * </pre>
- *
+ * <p>
  * When Strategy is `ALWAYS`:
  * <pre>
  * - LeftJoin
@@ -179,14 +177,16 @@ public class RandomizeNullKeyInOuterJoin
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
             StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
-            return SimplePlanRewriter.rewriteWith(new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator, statsProvider), plan, new HashSet<>());
+            Rewriter rewriter = new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator, statsProvider);
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new HashSet<>());
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
         }
 
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Rewriter
@@ -202,6 +202,7 @@ public class RandomizeNullKeyInOuterJoin
         private final StatsProvider statsProvider;
         private final Map<String, Map<VariableReferenceExpression, VariableReferenceExpression>> keyToRandomKeyMap;
         private final RandomizeOuterJoinNullKeyStrategy strategy;
+        private boolean planChanged;
 
         private Rewriter(Session session,
                 FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator planNodeIdAllocator, VariableAllocator planVariableAllocator, StatsProvider statsProvider)
@@ -223,6 +224,11 @@ public class RandomizeNullKeyInOuterJoin
         private static boolean isPartitionedJoin(JoinNode joinNode)
         {
             return joinNode.getDistributionType().isPresent() && joinNode.getDistributionType().get() == PARTITIONED;
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -284,10 +290,7 @@ public class RandomizeNullKeyInOuterJoin
             boolean isValidEstimate = !Double.isNaN(joinEstimate.getJoinBuildKeyCount()) && !Double.isNaN(joinEstimate.getNullJoinBuildKeyCount());
             boolean enabledByCostModel = isValidEstimate && strategy.equals(COST_BASED) && joinEstimate.getNullJoinBuildKeyCount() > NULL_BUILD_KEY_COUNT_THRESHOLD
                     && joinEstimate.getNullJoinBuildKeyCount() / joinEstimate.getJoinBuildKeyCount() > getRandomizeOuterJoinNullKeyNullRatioThreshold(session);
-            String statsSource = null;
-            if (enabledByCostModel) {
-                statsSource = statsProvider.getStats(joinNode).getSourceInfo().getSourceInfoName();
-            }
+
             List<JoinNode.EquiJoinClause> candidateEquiJoinClauses = joinNode.getCriteria().stream()
                     .filter(x -> isSupportedType(x.getLeft()) && isSupportedType(x.getRight()))
                     .filter(x -> enabledByCostModel || strategy.equals(ALWAYS) || enabledForJoinKeyFromOuterJoin(context.get(), x))
@@ -358,14 +361,7 @@ public class RandomizeNullKeyInOuterJoin
             joinOutputBuilder.addAll(rightKeyRandomVariableMap.keySet());
             joinOutputBuilder.addAll(joinNode.getOutputVariables().stream().filter(x -> newRight.getOutputVariables().contains(x)).collect(toImmutableList()));
 
-            session.getOptimizerInformationCollector().addInformation(
-                    new PlanOptimizerInformation(
-                            RandomizeNullKeyInOuterJoin.class.getSimpleName(),
-                            true,
-                            Optional.empty(),
-                            Optional.empty(),
-                            Optional.of(enabledByCostModel),
-                            statsSource == null ? Optional.empty() : Optional.of(statsSource)));
+            planChanged = true;
             JoinNode newJoinNode = new JoinNode(
                     joinNode.getSourceLocation(),
                     joinNode.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
@@ -107,7 +107,7 @@ public class RewriteIfOverAggregation
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan,
+    public PlanOptimizerResult optimize(PlanNode plan,
             Session session,
             TypeProvider types,
             VariableAllocator variableAllocator,
@@ -115,10 +115,11 @@ public class RewriteIfOverAggregation
             WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(
-                    new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager)), plan, ImmutableMap.of());
+            Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager));
+            PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, ImmutableMap.of());
+            return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
         }
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     // Map<VariableReferenceExpression, RowExpression> stores the candidate IF expressions for rewrite.
@@ -128,6 +129,7 @@ public class RewriteIfOverAggregation
         private final VariableAllocator planVariableAllocator;
         private final PlanNodeIdAllocator planNodeIdAllocator;
         private final RowExpressionDeterminismEvaluator determinismEvaluator;
+        private boolean planChanged;
 
         private Rewriter(VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, RowExpressionDeterminismEvaluator determinismEvaluator)
         {
@@ -146,6 +148,11 @@ public class RewriteIfOverAggregation
         private static RowExpression inlineReferences(RowExpression expression, Assignments assignments)
         {
             return RowExpressionVariableInliner.inlineVariables(variable -> assignments.getMap().getOrDefault(variable, variable), expression);
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -223,6 +230,7 @@ public class RewriteIfOverAggregation
             newAggregations.putAll(
                     node.getAggregations().entrySet().stream().filter(x -> !candidate.containsKey(x.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
 
+            planChanged = true;
             AggregationNode aggregationNode = new AggregationNode(
                     node.getSourceLocation(),
                     node.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -16,7 +16,6 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
@@ -119,18 +118,14 @@ public class SimplifyPlanWithEmptyInput
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
             Rewriter rewriter = new Rewriter(idAllocator);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(rewriter, plan);
-            if (rewriter.isPlanChanged()) {
-                session.getOptimizerInformationCollector().addInformation(
-                        new PlanOptimizerInformation(SimplifyPlanWithEmptyInput.class.getSimpleName(), true, Optional.empty(), Optional.empty(), Optional.of(false), Optional.empty()));
-            }
-            return rewrittenNode;
+            return PlanOptimizerResult.optimizerResult(rewrittenNode, rewriter.isPlanChanged());
         }
-        return plan;
+        return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -43,7 +43,7 @@ public final class StatsRecordingPlanOptimizer
         return delegate;
     }
 
-    public final PlanNode optimize(
+    public final PlanOptimizerResult optimize(
             PlanNode plan,
             Session session,
             TypeProvider types,
@@ -51,7 +51,7 @@ public final class StatsRecordingPlanOptimizer
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector)
     {
-        PlanNode result;
+        PlanOptimizerResult result;
         long duration;
         try {
             long start = System.nanoTime();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -87,9 +87,11 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        return rewriteWith(new Rewriter(functionResolution, idAllocator, variableAllocator, logicalRowExpressions), plan, null);
+        Rewriter rewriter = new Rewriter(functionResolution, idAllocator, variableAllocator, logicalRowExpressions);
+        PlanNode rewrittenPlan = rewriteWith(rewriter, plan, null);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
 
     private static class Rewriter
@@ -99,6 +101,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final LogicalRowExpressions logicalRowExpressions;
+        private boolean planChanged;
 
         public Rewriter(StandardFunctionResolution functionResolution, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, LogicalRowExpressions logicalRowExpressions)
         {
@@ -106,6 +109,11 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
             this.logicalRowExpressions = requireNonNull(logicalRowExpressions, "logicalRowExpressions is null");
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
         }
 
         @Override
@@ -122,6 +130,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
 
             QuantifiedComparisonExpression quantifiedComparison = (QuantifiedComparisonExpression) expression;
 
+            planChanged = true;
             return rewriteQuantifiedApplyNode(node, quantifiedComparison, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -118,7 +118,7 @@ public class UnaliasSymbolReferences
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -126,7 +126,8 @@ public class UnaliasSymbolReferences
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(types, functionAndTypeManager, warningCollector), plan);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(new Rewriter(types, functionAndTypeManager, warningCollector), plan);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, !rewrittenPlan.equals(plan));
     }
 
     private static class Rewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -76,7 +76,7 @@ public class WindowFilterPushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -84,7 +84,9 @@ public class WindowFilterPushDown
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, metadata, domainTranslator, logicalRowExpressions, session), plan, null);
+        Rewriter rewriter = new Rewriter(idAllocator, metadata, domainTranslator, logicalRowExpressions, session);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
 
     private static class Rewriter
@@ -95,6 +97,7 @@ public class WindowFilterPushDown
         private final RowExpressionDomainTranslator domainTranslator;
         private final LogicalRowExpressions logicalRowExpressions;
         private final Session session;
+        private boolean planChanged;
 
         private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, RowExpressionDomainTranslator domainTranslator, LogicalRowExpressions logicalRowExpressions, Session session)
         {
@@ -105,6 +108,11 @@ public class WindowFilterPushDown
             this.session = requireNonNull(session, "session is null");
         }
 
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+
         @Override
         public PlanNode visitWindow(WindowNode node, RewriteContext<Void> context)
         {
@@ -112,6 +120,7 @@ public class WindowFilterPushDown
             PlanNode rewrittenSource = context.rewrite(node.getSource());
 
             if (canReplaceWithRowNumber(node, metadata.getFunctionAndTypeManager())) {
+                planChanged = true;
                 return new RowNumberNode(
                         rewrittenSource.getSourceLocation(),
                         idAllocator.getNextId(),
@@ -140,6 +149,7 @@ public class WindowFilterPushDown
                 if (rowNumberNode.getPartitionBy().isEmpty()) {
                     return rowNumberNode;
                 }
+                planChanged = true;
                 source = rowNumberNode;
             }
             else if (source instanceof WindowNode && canOptimizeWindowFunction((WindowNode) source, metadata.getFunctionAndTypeManager()) && isOptimizeTopNRowNumber(session)) {
@@ -150,6 +160,7 @@ public class WindowFilterPushDown
                 if (windowNode.getPartitionBy().isEmpty()) {
                     return topNRowNumberNode;
                 }
+                planChanged = true;
                 source = topNRowNumberNode;
             }
             return replaceChildren(node, ImmutableList.of(source));
@@ -168,6 +179,7 @@ public class WindowFilterPushDown
 
                 if (upperBound.isPresent()) {
                     source = mergeLimit(((RowNumberNode) source), upperBound.getAsInt());
+                    planChanged = true;
                     return rewriteFilterSource(node, source, rowNumberVariable, upperBound.getAsInt());
                 }
             }
@@ -178,6 +190,7 @@ public class WindowFilterPushDown
 
                 if (upperBound.isPresent()) {
                     source = convertToTopNRowNumber(windowNode, upperBound.getAsInt());
+                    planChanged = true;
                     return rewriteFilterSource(node, source, rowNumberVariable, upperBound.getAsInt());
                 }
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -135,7 +135,7 @@ public class OptimizerAssert
 
     private Plan applyRules()
     {
-        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(), idAllocator, WarningCollector.NOOP);
+        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(), idAllocator, WarningCollector.NOOP).getPlanNode();
 
         if (!ImmutableSet.copyOf(plan.getOutputVariables()).equals(ImmutableSet.copyOf(actual.getOutputVariables()))) {
             fail(String.format(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
@@ -285,7 +285,7 @@ public class TestConnectorOptimization
     private static PlanNode optimize(PlanNode plan, Map<ConnectorId, Set<ConnectorPlanOptimizer>> optimizers)
     {
         ApplyConnectorOptimization optimizer = new ApplyConnectorOptimization(() -> optimizers);
-        return optimizer.optimize(plan, TEST_SESSION, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP);
+        return optimizer.optimize(plan, TEST_SESSION, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
     }
 
     private static ConnectorPlanOptimizer filterPushdown()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -245,7 +245,7 @@ public class TestRemoveUnsupportedDynamicFilters
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP);
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
             new DynamicFiltersChecker().validate(rewrittenPlan, session, metadata, new SqlParser(), TypeProvider.empty(), WarningCollector.NOOP);
             return rewrittenPlan;
         });

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -330,7 +330,7 @@ public class PrestoSparkAdaptiveQueryExecution
             // Re-optimize plan.
             PlanNode optimizedPlan = planAndFragments.getRemainingPlan().get();
             for (PlanOptimizer optimizer : adaptivePlanOptimizers) {
-                optimizedPlan = optimizer.optimize(optimizedPlan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+                optimizedPlan = optimizer.optimize(optimizedPlan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector).getPlanNode();
             }
 
             if (!optimizedPlan.equals(planAndFragments.getRemainingPlan().get())) {


### PR DESCRIPTION
## Description
Change the result type of PlanOptimizer, so that it not only returns the new plan node, but also returns whether the optimizer is triggered or not.

## Motivation and Context
Currently, the logging of PlanOptimizer is to compare the old and new plan root with the equal operator. However, this leads to false positives, where any non meaningful changes (for example reorder of outputs etc) will show as optimizer triggered. It also relies on proper equal() override for all data structures in query plans.

In this PR, I change the PlanOptimizer to explicitly return whether an optimizer is triggered or not. I've implemented them for all existing plan optimizers.

## Impact
Fix logging of optimizers, and eliminate false positives.

## Test Plan
Existing unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix logging of optimizer triggering, eliminating false positives where optimizer is logged as triggered but actually not. The PlanOptimizer now return both result plan and whether the plan changed or not.
```

