### PR TITLE
Fix OptimizedPartitionedOutputOperator memory usage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -377,6 +377,9 @@ public abstract class AbstractBlockEncodingBuffer
             bufferAllocator.returnArray(nullsBuffer);
             nullsBuffer = null;
         }
+
+        // Recycle the decodedBlock. It will be set by setupDecodedBlocksAndPositions in the next call.
+        decodedBlock = null;
     }
 
     protected void serializeNullsTo(SliceOutput output)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -222,6 +222,8 @@ public class MapBlockEncodingBuffer
             bufferAllocator.returnArray(offsets);
             offsets = null;
         }
+
+        columnarMap = null;
     }
 
     @Override


### PR DESCRIPTION
## Description

decodedBlock are kept in each of the partition buffers. We should let them go when we don't need them anymore.

In some rare cases of wide columns, some buffer overheads are higher than expected, and can lead to query using too much memory.

```
== NO RELEASE NOTE ==
```

