### PR TITLE
[native] Add google::InstallFailureSignalHandler()

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -24,6 +24,7 @@ DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
 
+  google::InstallFailureSignalHandler();
   PRESTO_STARTUP_LOG(INFO) << "Entering main()";
   facebook::presto::PrestoServer presto(FLAGS_etc_dir);
   presto.run();


### PR DESCRIPTION
## Description
Prestissimo workers crash without any backtraces on receiving signals such as SIGSEGV.
Adding a signal handler will help dump information to debug these signals. 

```
== NO RELEASE NOTE ==
```

