### PR TITLE
Publish query plan while a query is in running state

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -65,6 +65,7 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.units.Duration;
 import org.apache.spark.MapOutputStatistics;
@@ -91,6 +92,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.execution.QueryState.PLANNING;
+import static com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.createQueryInfo;
+import static com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.createStageInfo;
 import static com.facebook.presto.spark.execution.RuntimeStatistics.createRuntimeStats;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
 import static com.facebook.presto.sql.planner.PlanFragmenterUtils.isCoordinatorOnlyDistribution;
@@ -247,6 +251,17 @@ public class PrestoSparkAdaptiveQueryExecution
         log.info("Using AdaptiveQueryExecutor");
         log.info(format("Logical plan : %s",
                 textLogicalPlan(this.planAndMore.getPlan().getRoot(), this.planAndMore.getPlan().getTypes(), this.planAndMore.getPlan().getStatsAndCosts(), metadata.getFunctionAndTypeManager(), session, 0)));
+        queryMonitor.queryUpdatedEvent(
+                createQueryInfo(
+                        session,
+                        query,
+                        PLANNING,
+                        Optional.of(planAndMore),
+                        sparkQueueName,
+                        Optional.empty(),
+                        queryStateTimer,
+                        Optional.of(createStageInfo(session.getQueryId(), planFragmenter.fragmentQueryPlan(session, planAndMore.getPlan(), warningCollector), ImmutableList.of())),
+                        warningCollector));
 
         IterativePlanFragmenter.PlanAndFragments planAndFragments = iterativePlanFragmenter.createReadySubPlans(this.planAndMore.getPlan().getRoot());
 


### PR DESCRIPTION
## Description
Fixes a bug where query plan is not visible on presto query tool when a query is running with AQE enabled.

## Motivation and Context
This fixes a bug where AdaptiveQueryExecution doesn't publish query event before completion of query. This is deviation from queries running with AQE disabled where one can see query plan while query is running. This is required to keep the behavior consistent between aqe & non-aqe execution and ease debugging.

## Test Plan
Ran verifier with sampled queries from production and validated on presto query tool.

```
== NO RELEASE NOTE ==
```

