### PR TITLE
Add histograms for optimizer cost calculation

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.JoinDistributionType;
@@ -37,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZER_USE_HISTOGRAMS;
 import static com.facebook.presto.spi.plan.JoinDistributionType.REPLICATED;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED;
@@ -76,9 +78,40 @@ public abstract class AbstractCostBasedPlanTest
         assertEquals(generateQueryPlan(read(queryResourcePath)), read(getQueryPlanResourcePath(queryResourcePath)));
     }
 
+    @Test(dataProvider = "getQueriesDataProvider")
+    public void histogramsPlansMatch(String queryResourcePath)
+    {
+        String sql = read(queryResourcePath);
+        Session histogramSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "true")
+                .build();
+        Session noHistogramSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "false")
+                .build();
+        String regularPlan = generateQueryPlan(sql, noHistogramSession);
+        String histogramPlan = generateQueryPlan(sql, histogramSession);
+        if (!regularPlan.equals(histogramPlan)) {
+            assertEquals(histogramPlan, read(getHistogramPlanResourcePath(getQueryPlanResourcePath(queryResourcePath))));
+        }
+    }
+
     private String getQueryPlanResourcePath(String queryResourcePath)
     {
         return queryResourcePath.replaceAll("\\.sql$", ".plan.txt");
+    }
+
+    private String getHistogramPlanResourcePath(String regularPlanResourcePath)
+    {
+        Path root = Paths.get(regularPlanResourcePath);
+        return root.getParent().resolve("histogram/" + root.getFileName()).toString();
+    }
+
+    private Path getResourceWritePath(String queryResourcePath)
+    {
+        return Paths.get(
+                getSourcePath().toString(),
+                "src/test/resources",
+                getQueryPlanResourcePath(queryResourcePath));
     }
 
     public void generate()
@@ -90,12 +123,24 @@ public abstract class AbstractCostBasedPlanTest
                     .parallel()
                     .forEach(queryResourcePath -> {
                         try {
-                            Path queryPlanWritePath = Paths.get(
-                                    getSourcePath().toString(),
-                                    "src/test/resources",
-                                    getQueryPlanResourcePath(queryResourcePath));
+                            Path queryPlanWritePath = getResourceWritePath(queryResourcePath);
                             createParentDirs(queryPlanWritePath.toFile());
-                            write(generateQueryPlan(read(queryResourcePath)).getBytes(UTF_8), queryPlanWritePath.toFile());
+                            Session histogramSession = Session.builder(getQueryRunner().getDefaultSession())
+                                    .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "true")
+                                    .build();
+                            Session noHistogramSession = Session.builder(getQueryRunner().getDefaultSession())
+                                    .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "false")
+                                    .build();
+                            String sql = read(queryResourcePath);
+                            String regularPlan = generateQueryPlan(sql, noHistogramSession);
+                            String histogramPlan = generateQueryPlan(sql, histogramSession);
+                            write(regularPlan.getBytes(UTF_8), queryPlanWritePath.toFile());
+                            // write out the histogram plan if it differs
+                            if (!regularPlan.equals(histogramPlan)) {
+                                Path histogramPlanWritePath = getResourceWritePath(getHistogramPlanResourcePath(queryResourcePath));
+                                createParentDirs(histogramPlanWritePath.toFile());
+                                write(histogramPlan.getBytes(UTF_8), histogramPlanWritePath.toFile());
+                            }
                             System.out.println("Generated expected plan for query: " + queryResourcePath);
                         }
                         catch (IOException e) {
@@ -120,10 +165,15 @@ public abstract class AbstractCostBasedPlanTest
 
     private String generateQueryPlan(String query)
     {
+        return generateQueryPlan(query, getQueryRunner().getDefaultSession());
+    }
+
+    private String generateQueryPlan(String query, Session session)
+    {
         String sql = query.replaceAll("\\s+;\\s+$", "")
                 .replace("${database}.${schema}.", "")
                 .replace("\"${database}\".\"${schema}\".\"${prefix}", "\"");
-        Plan plan = plan(sql, OPTIMIZED_AND_VALIDATED, false);
+        Plan plan = plan(session, sql, OPTIMIZED_AND_VALIDATED, false);
 
         JoinOrderPrinter joinOrderPrinter = new JoinOrderPrinter();
         plan.getRoot().accept(joinOrderPrinter, 0);

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/histogram/q85.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/histogram/q85.plan.txt
@@ -1,0 +1,38 @@
+local exchange (GATHER, SINGLE, [])
+    remote exchange (GATHER, SINGLE, [])
+        final aggregation over (r_reason_desc)
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPARTITION, HASH, [r_reason_desc])
+                    partial aggregation over (r_reason_desc)
+                        join (INNER, REPLICATED):
+                            join (INNER, REPLICATED):
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [cd_demo_sk, cd_education_status, cd_marital_status])
+                                        scan customer_demographics
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [cd_education_status_3, cd_marital_status_2, wr_refunded_cdemo_sk])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [wr_refunded_addr_sk])
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
+                                                            join (INNER, REPLICATED):
+                                                                scan web_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
+                                                                join (INNER, REPLICATED):
+                                                                    scan web_returns
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan customer_demographics
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                        scan customer_address
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan web_page
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    scan reason

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4435,39 +4435,39 @@ public class TestHiveIntegrationSmokeTest
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null), " +
-                        "('c_array', 176.0E0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('c_array', 176.0E0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null), " +
-                        "('c_array', 96.0E0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('c_array', 96.0E0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)");
 
         // non existing partition
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 0E0, 0E0, null, null, null), " +
-                        "('c_bigint', null, 0E0, 0E0, null, null, null), " +
-                        "('c_double', null, 0E0, 0E0, null, null, null), " +
-                        "('c_timestamp', null, 0E0, 0E0, null, null, null), " +
-                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "('c_varbinary', null, 0E0, 0E0, null, null, null), " +
-                        "('c_array', null, 0E0, 0E0, null, null, null), " +
-                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "(null, null, null, null, 0E0, null, null)");
+                        "('c_boolean', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_bigint', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_double', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_timestamp', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varbinary', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_array', null, 0E0, 0E0, null, null, null, null), " +
+                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "(null, null, null, null, 0E0, null, null, null)");
 
         assertUpdate(format("DROP TABLE %s", tableName));
     }
@@ -4508,39 +4508,39 @@ public class TestHiveIntegrationSmokeTest
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null), " +
-                        "('c_array', 176.0E0, null, 0.5E0, null, null, null), " +
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('c_array', 176.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null), " +
-                        "('c_array', 96.0E0, null, 0.5E0, null, null, null), " +
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 8.0E0, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varbinary', 8.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('c_array', 96.0E0, null, 0.5E0, null, null, null, null), " +
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)");
 
         // non existing partition
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 0E0, 0E0, null, null, null), " +
-                        "('c_bigint', null, 0E0, 0E0, null, null, null), " +
-                        "('c_double', null, 0E0, 0E0, null, null, null), " +
-                        "('c_timestamp', null, 0E0, 0E0, null, null, null), " +
-                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "('c_varbinary', null, 0E0, 0E0, null, null, null), " +
-                        "('c_array', null, 0E0, 0E0, null, null, null), " +
-                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "(null, null, null, null, 0E0, null, null)");
+                        "('c_boolean', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_bigint', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_double', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_timestamp', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varbinary', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_array', null, 0E0, 0E0, null, null, null, null), " +
+                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "(null, null, null, null, 0E0, null, null, null)");
 
         assertUpdate(format("DROP TABLE %s", tableName));
     }
@@ -4614,109 +4614,109 @@ public class TestHiveIntegrationSmokeTest
         // No column stats before running analyze
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null), " +
-                        "('p_bigint', null, 2.0, 0.25, null, '7', '8'), " +
-                        "(null, null, null, null, 16.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null, null), " +
+                        "('p_bigint', null, 2.0, 0.25, null, '7', '8', null), " +
+                        "(null, null, null, null, 16.0, null, null, null)");
 
         // No column stats after running an empty analyze
         assertUpdate(format("ANALYZE %s WITH (partitions = ARRAY[])", tableName), 0);
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null), " +
-                        "('p_bigint', null, 2.0, 0.25, null, '7', '8'), " +
-                        "(null, null, null, null, 16.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null, null), " +
+                        "('p_bigint', null, 2.0, 0.25, null, '7', '8', null), " +
+                        "(null, null, null, null, 16.0, null, null, null)");
 
         // Run analyze on 3 partitions including a null partition and a duplicate partition
         assertUpdate(format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['p1', '7'], ARRAY['p2', '7'], ARRAY['p2', '7'], ARRAY[NULL, NULL]])", tableName), 12);
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1' AND p_bigint = 7)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.5, null, null, null), " +
-                        "('c_bigint', null, 2.0, 0.5, null, '0', '1'), " +
-                        "('c_double', null, 2.0, 0.5, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
-                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
-                        "('c_varbinary', 4.0, null, 0.5, null, null, null), " +
-                        "('c_array', 176.0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '0', '1', null), " +
+                        "('c_double', null, 2.0, 0.5, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varbinary', 4.0, null, 0.5, null, null, null, null), " +
+                        "('c_array', 176.0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2' AND p_bigint = 7)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.5, null, null, null), " +
-                        "('c_bigint', null, 2.0, 0.5, null, '1', '2'), " +
-                        "('c_double', null, 2.0, 0.5, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
-                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
-                        "('c_varbinary', 4.0, null, 0.5, null, null, null), " +
-                        "('c_array', 96.0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '1', '2', null), " +
+                        "('c_double', null, 2.0, 0.5, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varbinary', 4.0, null, 0.5, null, null, null, null), " +
+                        "('c_array', 96.0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar IS NULL AND p_bigint IS NULL)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 1.0, 0.0, null, null, null), " +
-                        "('c_bigint', null, 4.0, 0.0, null, '4', '7'), " +
-                        "('c_double', null, 4.0, 0.0, null, '4.7', '7.7'), " +
-                        "('c_timestamp', null, 4.0, 0.0, null, null, null), " +
-                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null), " +
-                        "('c_varbinary', 8.0, null, 0.0, null, null, null), " +
-                        "('c_array', 192.0, null, 0.0, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 1.0, null, null, null), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 1.0, 0.0, null, null, null, null), " +
+                        "('c_bigint', null, 4.0, 0.0, null, '4', '7', null), " +
+                        "('c_double', null, 4.0, 0.0, null, '4.7', '7.7', null), " +
+                        "('c_timestamp', null, 4.0, 0.0, null, null, null, null), " +
+                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null, null), " +
+                        "('c_varbinary', 8.0, null, 0.0, null, null, null, null), " +
+                        "('c_array', 192.0, null, 0.0, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 1.0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
 
         // Partition [p3, 8], [e1, 9], [e2, 9] have no column stats
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3' AND p_bigint = 8)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '8', '8'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '8', '8', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e1' AND p_bigint = 9)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "(null, null, null, null, 0.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e2' AND p_bigint = 9)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "(null, null, null, null, 0.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null, null)");
 
         // Run analyze on the whole table
         assertUpdate("ANALYZE " + tableName, 16);
@@ -4724,76 +4724,76 @@ public class TestHiveIntegrationSmokeTest
         // All partitions except empty partitions have column stats
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1' AND p_bigint = 7)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.5, null, null, null), " +
-                        "('c_bigint', null, 2.0, 0.5, null, '0', '1'), " +
-                        "('c_double', null, 2.0, 0.5, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
-                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
-                        "('c_varbinary', 4.0, null, 0.5, null, null, null), " +
-                        "('c_array', 176.0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '0', '1', null), " +
+                        "('c_double', null, 2.0, 0.5, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varbinary', 4.0, null, 0.5, null, null, null, null), " +
+                        "('c_array', 176.0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2' AND p_bigint = 7)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.5, null, null, null), " +
-                        "('c_bigint', null, 2.0, 0.5, null, '1', '2'), " +
-                        "('c_double', null, 2.0, 0.5, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
-                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
-                        "('c_varbinary', 4.0, null, 0.5, null, null, null), " +
-                        "('c_array', 96.0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '1', '2', null), " +
+                        "('c_double', null, 2.0, 0.5, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varbinary', 4.0, null, 0.5, null, null, null, null), " +
+                        "('c_array', 96.0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar IS NULL AND p_bigint IS NULL)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 1.0, 0.0, null, null, null), " +
-                        "('c_bigint', null, 4.0, 0.0, null, '4', '7'), " +
-                        "('c_double', null, 4.0, 0.0, null, '4.7', '7.7'), " +
-                        "('c_timestamp', null, 4.0, 0.0, null, null, null), " +
-                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null), " +
-                        "('c_varbinary', 8.0, null, 0.0, null, null, null), " +
-                        "('c_array', 192.0, null, 0.0, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 1.0, null, null, null), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 1.0, 0.0, null, null, null, null), " +
+                        "('c_bigint', null, 4.0, 0.0, null, '4', '7', null), " +
+                        "('c_double', null, 4.0, 0.0, null, '4.7', '7.7', null), " +
+                        "('c_timestamp', null, 4.0, 0.0, null, null, null, null), " +
+                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null, null), " +
+                        "('c_varbinary', 8.0, null, 0.0, null, null, null, null), " +
+                        "('c_array', 192.0, null, 0.0, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 1.0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3' AND p_bigint = 8)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.5, null, null, null), " +
-                        "('c_bigint', null, 2.0, 0.5, null, '2', '3'), " +
-                        "('c_double', null, 2.0, 0.5, null, '3.4', '4.4'), " +
-                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
-                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
-                        "('c_varbinary', 4.0, null, 0.5, null, null, null), " +
-                        "('c_array', 96.0, null, 0.5, null, null, null), " +
-                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 1.0, 0.0, null, '8', '8'), " +
-                        "(null, null, null, null, 4.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '2', '3', null), " +
+                        "('c_double', null, 2.0, 0.5, null, '3.4', '4.4', null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null, null), " +
+                        "('c_varbinary', 4.0, null, 0.5, null, null, null, null), " +
+                        "('c_array', 96.0, null, 0.5, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '8', '8', null), " +
+                        "(null, null, null, null, 4.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e1' AND p_bigint = 9)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 0.0, 0.0, null, null, null), " +
-                        "('c_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "('c_double', null, 0.0, 0.0, null, null, null), " +
-                        "('c_timestamp', null, 0.0, 0.0, null, null, null), " +
-                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('c_varbinary', 0.0, null, 0.0, null, null, null), " +
-                        "('c_array', 0.0, null, 0.0, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "(null, null, null, null, 0.0, null, null)");
+                        "('c_boolean', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_double', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_timestamp', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('c_varbinary', 0.0, null, 0.0, null, null, null, null), " +
+                        "('c_array', 0.0, null, 0.0, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null, null)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e2' AND p_bigint = 9)", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 0.0, 0.0, null, null, null), " +
-                        "('c_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "('c_double', null, 0.0, 0.0, null, null, null), " +
-                        "('c_timestamp', null, 0.0, 0.0, null, null, null), " +
-                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('c_varbinary', 0.0, null, 0.0, null, null, null), " +
-                        "('c_array', 0.0, null, 0.0, null, null, null), " +
-                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
-                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
-                        "(null, null, null, null, 0.0, null, null)");
+                        "('c_boolean', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_double', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_timestamp', null, 0.0, 0.0, null, null, null, null), " +
+                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('c_varbinary', 0.0, null, 0.0, null, null, null, null), " +
+                        "('c_array', 0.0, null, 0.0, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null, null)");
 
         // Drop the partitioned test table
         assertUpdate(format("DROP TABLE %s", tableName));
@@ -4808,32 +4808,32 @@ public class TestHiveIntegrationSmokeTest
         // No column stats before running analyze
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, null, null, null, null, null), " +
-                        "('c_bigint', null, null, null, null, null, null), " +
-                        "('c_double', null, null, null, null, null, null), " +
-                        "('c_timestamp', null, null, null, null, null, null), " +
-                        "('c_varchar', null, null, null, null, null, null), " +
-                        "('c_varbinary', null, null, null, null, null, null), " +
-                        "('c_array', null, null, null, null, null, null), " +
-                        "('p_varchar', null, null, null, null, null, null), " +
-                        "('p_bigint', null, null, null, null, null, null), " +
-                        "(null, null, null, null, 16.0, null, null)");
+                        "('c_boolean', null, null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null, null), " +
+                        "('c_array', null, null, null, null, null, null, null), " +
+                        "('p_varchar', null, null, null, null, null, null, null), " +
+                        "('p_bigint', null, null, null, null, null, null, null), " +
+                        "(null, null, null, null, 16.0, null, null, null)");
 
         // Run analyze on the whole table
         assertUpdate("ANALYZE " + tableName, 16);
 
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
-                        "('c_boolean', null, 2.0, 0.375, null, null, null), " +
-                        "('c_bigint', null, 8.0, 0.375, null, '0', '7'), " +
-                        "('c_double', null, 10.0, 0.375, null, '1.2', '7.7'), " +
-                        "('c_timestamp', null, 10.0, 0.375, null, null, null), " +
-                        "('c_varchar', 40.0, 10.0, 0.375, null, null, null), " +
-                        "('c_varbinary', 20.0, null, 0.375, null, null, null), " +
-                        "('c_array', 560.0, null, 0.375, null, null, null), " +
-                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null), " +
-                        "('p_bigint', null, 2.0, 0.25, null, '7', '8'), " +
-                        "(null, null, null, null, 16.0, null, null)");
+                        "('c_boolean', null, 2.0, 0.375, null, null, null, null), " +
+                        "('c_bigint', null, 8.0, 0.375, null, '0', '7', null), " +
+                        "('c_double', null, 10.0, 0.375, null, '1.2', '7.7', null), " +
+                        "('c_timestamp', null, 10.0, 0.375, null, null, null, null), " +
+                        "('c_varchar', 40.0, 10.0, 0.375, null, null, null, null), " +
+                        "('c_varbinary', 20.0, null, 0.375, null, null, null, null), " +
+                        "('c_array', 560.0, null, 0.375, null, null, null, null), " +
+                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null, null), " +
+                        "('p_bigint', null, 2.0, 0.25, null, '7', '8', null), " +
+                        "(null, null, null, null, 16.0, null, null, null)");
 
         // Drop the unpartitioned test table
         assertUpdate(format("DROP TABLE %s", tableName));
@@ -4918,11 +4918,11 @@ public class TestHiveIntegrationSmokeTest
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar_1 = '2' AND p_varchar_2 = '2')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_bigint_1', null, 1.0E0, 0.0E0, null, '1', '1'), " +
-                        "('c_bigint_2', null, 1.0E0, 0.0E0, null, '1', '1'), " +
-                        "('p_varchar_1', 1.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "('p_varchar_2', 1.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 1.0E0, null, null)");
+                        "('c_bigint_1', null, 1.0E0, 0.0E0, null, '1', '1', null), " +
+                        "('c_bigint_2', null, 1.0E0, 0.0E0, null, '1', '1', null), " +
+                        "('p_varchar_1', 1.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "('p_varchar_2', 1.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 1.0E0, null, null, null)");
 
         assertUpdate(format("" +
                 "INSERT INTO %s (c_bigint_1, c_bigint_2, p_varchar_1, p_varchar_2) " +
@@ -4932,11 +4932,11 @@ public class TestHiveIntegrationSmokeTest
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar_1 = 'O' AND p_varchar_2 = 'O')", tableName),
                 "SELECT * FROM VALUES " +
-                        "('c_bigint_1', null, 1.0E0, 0.0E0, null, '15008', '15008'), " +
-                        "('c_bigint_2', null, 1.0E0, 0.0E0, null, '15008', '15008'), " +
-                        "('p_varchar_1', 1.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "('p_varchar_2', 1.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 1.0E0, null, null)");
+                        "('c_bigint_1', null, 1.0E0, 0.0E0, null, '15008', '15008', null), " +
+                        "('c_bigint_2', null, 1.0E0, 0.0E0, null, '15008', '15008', null), " +
+                        "('p_varchar_1', 1.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "('p_varchar_2', 1.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 1.0E0, null, null, null)");
 
         assertUpdate(format("DROP TABLE %s", tableName));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
@@ -73,22 +73,22 @@ public class TestParquetDistributedQueries
             // Since no stats were collected during write, all column stats will be null
             assertQuery("SHOW STATS FOR test_quick_stats",
                     "SELECT * FROM (VALUES " +
-                            "   ('orderkey', null, null, null, null, null, null), " +
-                            "   ('linenumber', null, null, null, null, null, null), " +
-                            "   ('shipdate', null, null, null, null, null, null), " +
-                            "   ('arr', null, null, null, null, null, null), " +
-                            "   ('rrow', null, null, null, null, null, null), " +
-                            "   (null, null, null, null, 60175.0, null, null))");
+                            "   ('orderkey', null, null, null, null, null, null, null), " +
+                            "   ('linenumber', null, null, null, null, null, null, null), " +
+                            "   ('shipdate', null, null, null, null, null, null, null), " +
+                            "   ('arr', null, null, null, null, null, null, null), " +
+                            "   ('rrow', null, null, null, null, null, null, null), " +
+                            "   (null, null, null, null, 60175.0, null, null, null))");
 
             // With quick stats enabled, we should get nulls_fraction, low_value and high_value for the non-nested columns
             assertQuery(session, "SHOW STATS FOR test_quick_stats",
                     "SELECT * FROM (VALUES " +
-                            "   ('orderkey', null, null, 0.0, null, '1', '60000'), " +
-                            "   ('linenumber', null, null, 0.0, null, '1', '7'), " +
-                            "   ('shipdate', null, null, 0.0, null, '1992-01-04', '1998-11-29'), " +
-                            "   ('arr', null, null, null, null, null, null), " +
-                            "   ('rrow', null, null, null, null, null, null), " +
-                            "   (null, null, null, null, 60175.0, null, null))");
+                            "   ('orderkey', null, null, 0.0, null, '1', '60000', null), " +
+                            "   ('linenumber', null, null, 0.0, null, '1', '7', null), " +
+                            "   ('shipdate', null, null, 0.0, null, '1992-01-04', '1998-11-29', null), " +
+                            "   ('arr', null, null, null, null, null, null, null), " +
+                            "   ('rrow', null, null, null, null, null, null, null), " +
+                            "   (null, null, null, null, 60175.0, null, null, null))");
         }
         finally {
             getQueryRunner().execute("DROP TABLE test_quick_stats");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestShowStats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestShowStats.java
@@ -44,97 +44,97 @@ public class TestShowStats
     {
         assertQuery("SHOW STATS FOR nation_partitioned",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24), " +
-                        "   ('name', 177.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 25.0, null, null))");
+                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24, null), " +
+                        "   ('name', 177.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 25.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24), " +
-                        "   ('name', 177.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 25.0, null, null))");
+                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24, null), " +
+                        "   ('name', 177.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 25.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT regionkey, name FROM nation_partitioned)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4), " +
-                        "   ('name', 177.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 25.0, null, null))");
+                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4, null), " +
+                        "   ('name', 177.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 25.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey IS NOT NULL)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24), " +
-                        "   ('name', 177.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 25.0, null, null))");
+                        "   ('regionkey', null, 5.0, 0.0, null, 0, 4, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 0, 24, null), " +
+                        "   ('name', 177.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 1857.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 25.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey IS NULL)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 0.0, 0.0, null, null, null), " +
-                        "   ('nationkey', null, 0.0, 0.0, null, null, null), " +
-                        "   ('name', 0.0, 0.0, 0.0, null, null, null), " +
-                        "   ('comment', 0.0, 0.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 0.0, null, null))");
+                        "   ('regionkey', null, 0.0, 0.0, null, null, null, null), " +
+                        "   ('nationkey', null, 0.0, 0.0, null, null, null, null), " +
+                        "   ('name', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 0.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey = 1)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 1.0, 0.0, null, 1, 1), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24), " +
-                        "   ('name', 38.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 500.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 5.0, null, null))");
+                        "   ('regionkey', null, 1.0, 0.0, null, 1, 1, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24, null), " +
+                        "   ('name', 38.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 500.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 5.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey IN (1, 3))",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 2.0, 0.0, null, 1, 3), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24), " +
-                        "   ('name', 78.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 847.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 10.0, null, null))");
+                        "   ('regionkey', null, 2.0, 0.0, null, 1, 3, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24, null), " +
+                        "   ('name', 78.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 847.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 10.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey BETWEEN 1 AND 1 + 2)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 3.0, 0.0, null, 1, 3), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24), " +
-                        "   ('name', 109.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 1199.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 15.0, null, null))");
+                        "   ('regionkey', null, 3.0, 0.0, null, 1, 3, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24, null), " +
+                        "   ('name', 109.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 1199.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 15.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey > 3)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 1.0, 0.0, null, 4, 4), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 4, 20), " +
-                        "   ('name', 31.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 348.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 5.0, null, null))");
+                        "   ('regionkey', null, 1.0, 0.0, null, 4, 4, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 4, 20, null), " +
+                        "   ('name', 31.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 348.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 5.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey < 1)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 1.0, 0.0, null, 0, 0), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 0, 16), " +
-                        "   ('name', 37.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 310.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 5.0, null, null))");
+                        "   ('regionkey', null, 1.0, 0.0, null, 0, 0, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 0, 16, null), " +
+                        "   ('name', 37.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 310.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 5.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey > 0 and regionkey < 4)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 3.0, 0.0, null, 1, 3), " +
-                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24), " +
-                        "   ('name', 109.0, 5.0, 0.0, null, null, null), " +
-                        "   ('comment', 1199.0, 5.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 15.0, null, null))");
+                        "   ('regionkey', null, 3.0, 0.0, null, 1, 3, null), " +
+                        "   ('nationkey', null, 5.0, 0.0, null, 1, 24, null), " +
+                        "   ('name', 109.0, 5.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 1199.0, 5.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 15.0, null, null, null))");
 
         assertQuery("SHOW STATS FOR (SELECT * FROM nation_partitioned WHERE regionkey > 10 or regionkey < 0)",
                 "SELECT * FROM (VALUES " +
-                        "   ('regionkey', null, 0.0, 0.0, null, null, null), " +
-                        "   ('nationkey', null, 0.0, 0.0, null, null, null), " +
-                        "   ('name', 0.0, 0.0, 0.0, null, null, null), " +
-                        "   ('comment', 0.0, 0.0, 0.0, null, null, null), " +
-                        "   (null, null, null, null, 0.0, null, null))");
+                        "   ('regionkey', null, 0.0, 0.0, null, null, null, null), " +
+                        "   ('nationkey', null, 0.0, 0.0, null, null, null, null), " +
+                        "   ('name', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "   ('comment', 0.0, 0.0, 0.0, null, null, null, null), " +
+                        "   (null, null, null, null, 0.0, null, null, null))");
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -995,21 +995,21 @@ public class IcebergDistributedSmokeTestBase
 
         assertQuery(session, "SHOW STATS FOR " + tableName,
                 "VALUES " +
-                        "  ('col', null, null, null, NULL, NULL, NULL), " +
-                        "  (NULL, NULL, NULL, NULL, 0e0, NULL, NULL)");
+                        "  ('col', null, null, null, NULL, NULL, NULL, NULL), " +
+                        "  (NULL, NULL, NULL, NULL, 0e0, NULL, NULL, NULL)");
 
         assertUpdate("INSERT INTO " + tableName + " VALUES -10", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES 100", 1);
 
         assertQuery(session, "SHOW STATS FOR " + tableName,
                 "VALUES " +
-                        "  ('col', NULL, NULL, 0.0, NULL, '-10.0', '100.0'), " +
-                        "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL)");
+                        "  ('col', NULL, NULL, 0.0, NULL, '-10.0', '100.0', NULL), " +
+                        "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL, NULL)");
         assertUpdate("INSERT INTO " + tableName + " VALUES 200", 1);
         assertQuery(session, "SHOW STATS FOR " + tableName,
                 "VALUES " +
-                        "  ('col', NULL, NULL, 0.0, NULL, '-10.0', '200.0'), " +
-                        "  (NULL, NULL, NULL, NULL, 3e0, NULL, NULL)");
+                        "  ('col', NULL, NULL, 0.0, NULL, '-10.0', '200.0', NULL), " +
+                        "  (NULL, NULL, NULL, NULL, 3e0, NULL, NULL, NULL)");
 
         dropTable(session, tableName);
     }
@@ -1157,16 +1157,16 @@ public class IcebergDistributedSmokeTestBase
 
         assertQuery(session, "SHOW STATS FOR " + tableName,
                 "VALUES " +
-                        "  ('col', null, null, null, NULL, NULL, NULL), " +
-                        "  (NULL, NULL, NULL, NULL, 0e0, NULL, NULL)");
+                        "  ('col', null, null, null, NULL, NULL, NULL, NULL), " +
+                        "  (NULL, NULL, NULL, NULL, 0e0, NULL, NULL, NULL)");
 
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES TIMESTAMP '2021-01-02 09:04:05.321'", 1);
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES TIMESTAMP '2022-12-22 10:07:08.456'", 1);
 
         assertQuery(session, "SHOW STATS FOR " + tableName,
                 "VALUES " +
-                        "  ('col', NULL, NULL, 0.0, NULL, '2021-01-02 09:04:05.321', '2022-12-22 10:07:08.456'), " +
-                        "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL)");
+                        "  ('col', NULL, NULL, 0.0, NULL, '2021-01-02 09:04:05.321', '2022-12-22 10:07:08.456', NULL), " +
+                        "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL, NULL)");
         dropTable(session, tableName);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -344,6 +344,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
     public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug_validate_output_from_operators";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
+    public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1897,7 +1898,7 @@ public final class SystemSessionProperties
                         GENERATE_DOMAIN_FILTERS,
                         "Infer predicates from column domains during predicate pushdown",
                         featuresConfig.getGenerateDomainFilters(),
-                                false),
+                        false),
                 booleanProperty(
                         REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION,
                         "Rewrite left join with is null check to semi join",
@@ -1914,7 +1915,11 @@ public final class SystemSessionProperties
                         featuresConfig.getDefaultViewSecurityMode(),
                         false,
                         value -> CreateView.Security.valueOf(((String) value).toUpperCase()),
-                        CreateView.Security::name));
+                        CreateView.Security::name),
+                booleanProperty(OPTIMIZER_USE_HISTOGRAMS,
+                        "whether or not to use histograms in the CBO",
+                        featuresConfig.isUseHistograms(),
+                        false));
     }
 
     public static boolean isSpoolingOutputBufferEnabled(Session session)
@@ -3190,5 +3195,10 @@ public final class SystemSessionProperties
     public static CreateView.Security getDefaultViewSecurityMode(Session session)
     {
         return session.getSystemProperty(DEFAULT_VIEW_SECURITY_MODE, CreateView.Security.class);
+    }
+
+    public static boolean shouldOptimizerUseHistograms(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZER_USE_HISTOGRAMS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/DisjointRangeDomainHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/DisjointRangeDomainHistogram.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.cost.HistogramCalculator.calculateFilterFactor;
+import static com.facebook.presto.util.MoreMath.max;
+import static com.facebook.presto.util.MoreMath.min;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isFinite;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class represents a set of disjoint ranges that span an input domain.
+ * Each range is used to represent filters over the domain of an original
+ * "source" histogram.
+ * <br>
+ * For example, assume a source histogram represents a uniform distribution
+ * over the range [0, 100]. Next, assume a query with multiple filters such as
+ * <code>x < 10 OR x > 75</code>. This translates to two disjoint ranges over
+ * the histogram of [0, 10) and (75, 100], representing roughly 35% of the
+ * values in the original dataset. Using the example above, a cumulative
+ * probability for value 5 represents 5% of the original dataset, but 20% (1/5)
+ * of the range of constrained dataset. Similarly, all values in [10, 75] should
+ * compute their cumulative probability as 40% (2/5).
+ * <br>
+ * The goal of this class is to implement the {@link ConnectorHistogram} API
+ * given a source histogram whose domain has been constrained by a set of filter
+ * ranges.
+ * <br>
+ * This class is intended to be immutable. Changing the set of ranges should
+ * result in a new copy being created.
+ */
+public class DisjointRangeDomainHistogram
+        implements ConnectorHistogram
+{
+    private final ConnectorHistogram source;
+    // use RangeSet as the internal representation of the ranges, but the constructor arguments
+    // use StatisticRange to support serialization and deserialization.
+    private final RangeSet<Double> rangeSet;
+    private final Range<Double> sourceSpan;
+
+    @JsonCreator
+    public DisjointRangeDomainHistogram(@JsonProperty("source") ConnectorHistogram source, @JsonProperty("ranges") Collection<StatisticRange> ranges)
+    {
+        this(source, ranges.stream().map(StatisticRange::toRange).collect(Collectors.toSet()));
+    }
+
+    public DisjointRangeDomainHistogram(ConnectorHistogram source, Iterable<Range<Double>> ranges)
+    {
+        this.source = requireNonNull(source, "source is null");
+        this.sourceSpan = getSourceSpan(source);
+        this.rangeSet = TreeRangeSet.create(ranges).subRangeSet(sourceSpan);
+    }
+
+    private static Range<Double> getSourceSpan(ConnectorHistogram source)
+    {
+        return Range.closed(
+                source.inverseCumulativeProbability(0.0).orElse(() -> NEGATIVE_INFINITY),
+                source.inverseCumulativeProbability(1.0).orElse(() -> POSITIVE_INFINITY));
+    }
+
+    @JsonProperty
+    public ConnectorHistogram getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public Set<StatisticRange> getRanges()
+    {
+        return rangeSet.asRanges().stream().map(StatisticRange::fromRange).collect(Collectors.toSet());
+    }
+
+    public DisjointRangeDomainHistogram(ConnectorHistogram source)
+    {
+        this(source, ImmutableSet.<Range<Double>>of());
+    }
+
+    @Override
+    public Estimate cumulativeProbability(double value, boolean inclusive)
+    {
+        // 1. compute the total probability for every existing range on the source
+        // 2. find the range, r, where `value` falls
+        // 3. compute the cumulative probability across all ranges that intersect [min, value]
+        // 4. divide the result from (3) by the result from (1) to get the true cumulative
+        //    probability of the disjoint domains over the original histogram
+        if (Double.isNaN(value)) {
+            return Estimate.unknown();
+        }
+        Optional<Range<Double>> optionalSpan = getSpan();
+        if (!optionalSpan.isPresent()) {
+            return Estimate.of(0.0);
+        }
+        Range<Double> span = optionalSpan.get();
+        if (value <= span.lowerEndpoint()) {
+            return Estimate.of(0.0);
+        }
+        Range<Double> input = Range.range(span.lowerEndpoint(), span.lowerBoundType(), value, inclusive ? BoundType.CLOSED : BoundType.OPEN);
+        Estimate fullSetOverlap = calculateRangeSetOverlap(rangeSet);
+        RangeSet<Double> spanned = rangeSet.subRangeSet(input);
+        Estimate spannedOverlap = calculateRangeSetOverlap(spanned);
+
+        return spannedOverlap.flatMap(spannedProbability ->
+                fullSetOverlap.map(fullSetProbability -> {
+                    if (fullSetProbability == 0.0) {
+                        return 0.0;
+                    }
+                    return min(spannedProbability / fullSetProbability, 1.0);
+                }));
+    }
+
+    private Estimate calculateRangeSetOverlap(RangeSet<Double> ranges)
+    {
+        // we require knowing bounds on all ranges
+        double cumulativeTotal = 0.0;
+        for (Range<Double> range : ranges.asRanges()) {
+            Estimate rangeProbability = getRangeProbability(range);
+            if (rangeProbability.isUnknown()) {
+                return Estimate.unknown();
+            }
+            cumulativeTotal += rangeProbability.getValue();
+        }
+        return Estimate.of(cumulativeTotal);
+    }
+
+    /**
+     * Calculates the percent of the source distribution that {@code range}
+     * spans.
+     *
+     * @param range the range over the source domain
+     * @return estimate of the total probability the range covers in the source
+     */
+    private Estimate getRangeProbability(Range<Double> range)
+    {
+        return calculateFilterFactor(StatisticRange.fromRange(range), source, Estimate.unknown(), false);
+    }
+
+    @Override
+    public Estimate inverseCumulativeProbability(double percentile)
+    {
+        checkArgument(percentile >= 0.0 && percentile <= 1.0, "percentile must fall in [0.0, 1.0]");
+        // 1. compute the probability for each range on the source in order until reaching a range
+        // where the cumulative total exceeds the percentile argument (totalCumulative)
+        // 2. compute the source probability of the left endpoint of the given range (percentileLow)
+        // 3. compute the "true" source percentile:
+        //    rangedPercentile = percentile - percentileLow
+        //
+        // percentileLow + (rangedPercentile * rangePercentileLength)
+        Optional<Range<Double>> optionalSpan = getSpan();
+        if (!optionalSpan.isPresent()) {
+            return Estimate.unknown();
+        }
+        Range<Double> span = optionalSpan.get();
+        if (percentile == 0.0 && isFinite(span.lowerEndpoint())) {
+            return source.inverseCumulativeProbability(0.0).map(sourceMin -> max(span.lowerEndpoint(), sourceMin));
+        }
+
+        if (percentile == 1.0 && isFinite(span.upperEndpoint())) {
+            return source.inverseCumulativeProbability(1.0).map(sourceMax -> min(span.upperEndpoint(), sourceMax));
+        }
+
+        Estimate totalCumulativeEstimate = calculateRangeSetOverlap(rangeSet);
+        if (totalCumulativeEstimate.isUnknown()) {
+            return Estimate.unknown();
+        }
+        double totalCumulativeProbabilitySourceDomain = totalCumulativeEstimate.getValue();
+        if (totalCumulativeProbabilitySourceDomain == 0.0) {
+            // calculations will fail with NaN
+            return Estimate.unknown();
+        }
+        double cumulativeProbabilityNewDomain = 0.0;
+        double lastRangeEstimateSourceDomain = 0.0;
+        Range<Double> currentRange = null;
+        // find the range where the percentile falls
+        for (Range<Double> range : rangeSet.asRanges()) {
+            Estimate rangeEstimate = getRangeProbability(range);
+            if (rangeEstimate.isUnknown()) {
+                return Estimate.unknown();
+            }
+            currentRange = range;
+            lastRangeEstimateSourceDomain = rangeEstimate.getValue();
+            cumulativeProbabilityNewDomain += lastRangeEstimateSourceDomain / totalCumulativeProbabilitySourceDomain;
+            if (cumulativeProbabilityNewDomain >= percentile) {
+                break;
+            }
+        }
+        if (currentRange == null) {
+            // no ranges to iterate over. Did a constraint cut the entire domain of values?
+            return Estimate.unknown();
+        }
+        Estimate rangeLeftSourceEstimate = source.cumulativeProbability(currentRange.lowerEndpoint(), currentRange.lowerBoundType() == BoundType.OPEN);
+        if (rangeLeftSourceEstimate.isUnknown()) {
+            return Estimate.unknown();
+        }
+        double rangeLeftSource = rangeLeftSourceEstimate.getValue();
+        double lastRangeProportionalProbability = lastRangeEstimateSourceDomain / totalCumulativeProbabilitySourceDomain;
+        double percentileLeftFromNewDomain = percentile - cumulativeProbabilityNewDomain + lastRangeProportionalProbability;
+        double percentilePoint = lastRangeEstimateSourceDomain * percentileLeftFromNewDomain / lastRangeProportionalProbability;
+        double finalPercentile = rangeLeftSource + percentilePoint;
+
+        return source.inverseCumulativeProbability(min(max(finalPercentile, 0.0), 1.0));
+    }
+
+    /**
+     * Adds a new domain (logical disjunction) to the existing set.
+     *
+     * @param other the new range to add to the set.
+     * @return a new {@link DisjointRangeDomainHistogram}
+     */
+    public DisjointRangeDomainHistogram addDisjunction(StatisticRange other)
+    {
+        Set<Range<Double>> ranges = new HashSet<>(rangeSet.asRanges());
+        ranges.add(other.toRange());
+        return new DisjointRangeDomainHistogram(source, ranges);
+    }
+
+    /**
+     * Adds a constraint (logical conjunction). This will constrain all ranges
+     * in the set to ones that are contained by the argument range.
+     *
+     * @param other the range that should enclose the set.
+     * @return a new {@link DisjointRangeDomainHistogram} where
+     */
+    public DisjointRangeDomainHistogram addConjunction(StatisticRange other)
+    {
+        return new DisjointRangeDomainHistogram(source, rangeSet.subRangeSet(other.toRange()).asRanges());
+    }
+
+    /**
+     * Adds a new range to the available ranges that this histogram computes over
+     * <br>
+     * e.g. if the source histogram represents values [0, 100], and an existing
+     * range in the set constrains it to [0, 25], and this method is called with
+     * a range of [50, 75], then it will attempt to push [50, 75] down onto the
+     * existing histogram to expand the set of intervals that are used to
+     * computed probabilities to [[0, 25], [50, 75]].
+     * <br>
+     * This method should be called for cases where we want to calculate plan
+     * statistics for queries that have multiple filters combined with OR.
+     *
+     * @param histogram the source histogram to add the range conjunction
+     * @param range the range representing the conjunction to add
+     * @return a new histogram with the conjunction applied.
+     */
+    public static ConnectorHistogram addDisjunction(ConnectorHistogram histogram, StatisticRange range)
+    {
+        if (histogram instanceof DisjointRangeDomainHistogram) {
+            return ((DisjointRangeDomainHistogram) histogram).addDisjunction(range);
+        }
+
+        return new DisjointRangeDomainHistogram(histogram, ImmutableSet.of(range.toRange()));
+    }
+
+    /**
+     * Similar to {@link #addDisjunction(ConnectorHistogram, StatisticRange)} this method constrains
+     * the entire domain such that <em>all ranges</em> in the set intersect with the given range
+     * argument to this method.
+     * <br>
+     * This should be used when an AND clause is present in the query and all tuples MUST satisfy
+     * the condition.
+     *
+     * @param histogram the source histogram
+     * @param range the range of values that the entire histogram's domain must fall within
+     * @return a histogram with the new range constraint
+     */
+    public static ConnectorHistogram addConjunction(ConnectorHistogram histogram, StatisticRange range)
+    {
+        if (histogram instanceof DisjointRangeDomainHistogram) {
+            return ((DisjointRangeDomainHistogram) histogram).addConjunction(range);
+        }
+
+        return new DisjointRangeDomainHistogram(histogram, ImmutableSet.of(range.toRange()));
+    }
+
+    /**
+     * @return the span if it exists, empty otherwise
+     */
+    private Optional<Range<Double>> getSpan()
+    {
+        try {
+            return Optional.of(rangeSet.span());
+        }
+        catch (NoSuchElementException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("source", this.source)
+                .add("sourceSpan", this.sourceSpan)
+                .add("rangeSet", this.rangeSet)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof DisjointRangeDomainHistogram)) {
+            return false;
+        }
+        DisjointRangeDomainHistogram other = (DisjointRangeDomainHistogram) o;
+        return Objects.equals(source, other.source) &&
+                Objects.equals(sourceSpan, other.sourceSpan) &&
+                Objects.equals(rangeSet, other.rangeSet);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(source, sourceSpan, rangeSet);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistogramCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistogramCalculator.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.google.common.math.DoubleMath;
+
+import java.util.Optional;
+
+import static java.lang.Double.isFinite;
+import static java.lang.Double.isNaN;
+import static java.lang.Math.min;
+
+public class HistogramCalculator
+{
+    private HistogramCalculator()
+    {}
+
+    /**
+     * Calculates the "filter factor" corresponding to the overlap between the statistic range
+     * and the histogram distribution.
+     * <br>
+     * The filter factor is a fractional value in [0.0, 1.0] that represents the proportion of
+     * tuples in the source column that would be included in the result of a filter where the valid
+     * values in the filter are represented by the {@code range} parameter of this function.
+     *
+     * @param range the intersecting range with the histogram
+     * @param histogram the source histogram
+     * @param totalDistinctValues the total number of distinct values in the domain of the histogram
+     * @param useHeuristics whether to return heuristic values based on constants and/or distinct
+     * value counts. If false, {@link Estimate#unknown()} will be returned in any case a
+     * heuristic would have been used
+     * @return an estimate, x, where 0.0 <= x <= 1.0.
+     */
+    public static Estimate calculateFilterFactor(StatisticRange range, ConnectorHistogram histogram, Estimate totalDistinctValues, boolean useHeuristics)
+    {
+        boolean openHigh = range.getOpenHigh();
+        boolean openLow = range.getOpenLow();
+        Estimate min = histogram.inverseCumulativeProbability(0.0);
+        Estimate max = histogram.inverseCumulativeProbability(1.0);
+
+        // range is either above or below histogram
+        if ((!max.isUnknown() && max.getValue() < range.getLow())
+                || (!min.isUnknown() && min.getValue() > range.getHigh())) {
+            return Estimate.of(0.0);
+        }
+
+        // one of the max/min bounds can't be determined
+        if ((max.isUnknown() && !min.isUnknown()) || (!max.isUnknown() && min.isUnknown())) {
+            // when the range length is 0, the filter factor should be 1/distinct value count
+            if (!useHeuristics) {
+                return Estimate.unknown();
+            }
+
+            if (range.length() == 0.0) {
+                return totalDistinctValues.map(distinct -> 1.0 / distinct);
+            }
+
+            if (isFinite(range.length())) {
+                return Estimate.of(StatisticRange.INFINITE_TO_FINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR);
+            }
+            return Estimate.of(StatisticRange.INFINITE_TO_INFINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR);
+        }
+
+        // we know the bounds are both known, so calculate the percentile for each bound
+        // The inclusivity arguments can be derived from the open-ness of the interval we're
+        // calculating the filter factor for
+        // e.g. given a variable with values in [0, 10] to calculate the filter of
+        // [1, 9) (openness: false, true) we need the percentile from
+        // [0.0 to 1.0) (openness: false, true) and from [0.0, 9.0) (openness: false, true)
+        // thus for the "lowPercentile" calculation we should pass "false" to be non-inclusive
+        // (same as openness) however, on the high-end we want the inclusivity to be the opposite
+        // of the openness since if it's open, we _don't_ want to include the bound.
+        Estimate lowPercentile = histogram.cumulativeProbability(range.getLow(), openLow);
+        Estimate highPercentile = histogram.cumulativeProbability(range.getHigh(), !openHigh);
+
+        // both bounds are probably infinity, use the infinite-infinite heuristic
+        if (lowPercentile.isUnknown() || highPercentile.isUnknown()) {
+            if (!useHeuristics) {
+                return Estimate.unknown();
+            }
+            // in the case the histogram has no values
+            if (totalDistinctValues.equals(Estimate.zero()) || range.getDistinctValuesCount() == 0.0) {
+                return Estimate.of(0.0);
+            }
+
+            // in the case only one is unknown
+            if (((lowPercentile.isUnknown() && !highPercentile.isUnknown()) ||
+                    (!lowPercentile.isUnknown() && highPercentile.isUnknown())) &&
+                    isFinite(range.length())) {
+                return useHeuristics ? Estimate.of(StatisticRange.INFINITE_TO_FINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR) : Estimate.unknown();
+            }
+
+            if (range.length() == 0.0) {
+                return totalDistinctValues.map(distinct -> 1.0 / distinct);
+            }
+
+            if (!isNaN(range.getDistinctValuesCount())) {
+                return totalDistinctValues.map(distinct -> min(1.0, range.getDistinctValuesCount() / distinct));
+            }
+
+            return Estimate.of(StatisticRange.INFINITE_TO_INFINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR);
+        }
+
+        // in the case the range is a single value, this can occur if the input
+        // filter range is a single value (low == high) OR in the case that the
+        // bounds of the filter or this histogram are infinite.
+        // in the case of infinite bounds, we should return an estimate that
+        // correlates to the overlapping distinct values.
+        if (lowPercentile.equals(highPercentile)) {
+            if (!useHeuristics) {
+                return Estimate.zero();
+            }
+            // If one of the bounds is unknown, but both percentiles are equal,
+            // it's likely that a heuristic value was returned
+            if (max.isUnknown() || min.isUnknown()) {
+                return totalDistinctValues.flatMap(distinct -> lowPercentile.map(lowPercent -> distinct * lowPercent));
+            }
+
+            return totalDistinctValues.map(distinct -> 1.0 / distinct);
+        }
+
+        // in the case that we return the entire range, the returned factor percent should be
+        // proportional to the number of distinct values in the range
+        if (lowPercentile.equals(Estimate.zero()) && highPercentile.equals(Estimate.of(1.0)) && min.isUnknown() && max.isUnknown()) {
+            if (!useHeuristics) {
+                return Estimate.unknown();
+            }
+
+            if (totalDistinctValues.equals(Estimate.zero())) {
+                return Estimate.of(1.0);
+            }
+            return totalDistinctValues.flatMap(totalDistinct -> {
+                if (DoubleMath.fuzzyEquals(totalDistinct, 0.0, 1E-6)) {
+                    return Estimate.unknown();
+                }
+                return Estimate.of(min(1.0, range.getDistinctValuesCount() / totalDistinct));
+            })
+            // in the case totalDistinct is NaN or 0
+            .or(() -> Estimate.of(StatisticRange.INFINITE_TO_INFINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR));
+        }
+
+        return Optional.of(lowPercentile)
+                .filter(lowPercent -> !lowPercent.isUnknown())
+                .map(Estimate::getValue)
+                .map(lowPercent -> Optional.of(highPercentile)
+                        .filter(highPercent -> !highPercent.isUnknown())
+                        .map(Estimate::getValue)
+                        .map(highPercent -> highPercent - lowPercent)
+                        .map(Estimate::of)
+                        .orElseGet(() -> Estimate.of(1.0)))
+                .orElse(highPercentile);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Queue;
 
 import static com.facebook.presto.SystemSessionProperties.getDefaultJoinSelectivityCoefficient;
+import static com.facebook.presto.cost.DisjointRangeDomainHistogram.addConjunction;
 import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEFFICIENT;
 import static com.facebook.presto.cost.VariableStatsEstimate.buildFrom;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
@@ -246,12 +247,14 @@ public class JoinStatsRule
                 .setNullsFraction(0)
                 .setStatisticsRange(intersect)
                 .setDistinctValuesCount(retainedNdv)
+                .setHistogram(addConjunction(leftStats.getHistogram(), intersect))
                 .build();
 
         VariableStatsEstimate newRightStats = buildFrom(rightStats)
                 .setNullsFraction(0)
                 .setStatisticsRange(intersect)
                 .setDistinctValuesCount(retainedNdv)
+                .setHistogram(addConjunction(rightStats.getHistogram(), intersect))
                 .build();
 
         PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(stats)

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
@@ -90,6 +90,7 @@ final class StatsUtil
             result.setLowValue(range.getMin());
             result.setHighValue(range.getMax());
         });
+        columnStatistics.getHistogram().ifPresent(result::setHistogram);
         return result.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/UniformDistributionHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/UniformDistributionHistogram.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static java.lang.Double.isInfinite;
+import static java.lang.Double.isNaN;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.util.Objects.hash;
+
+/**
+ * This {@link ConnectorHistogram} implementation returns values assuming a
+ * uniform distribution between a given high and low value.
+ * <br>
+ * In the case that statistics don't exist for a particular table, the Presto
+ * optimizer will fall back on this uniform distribution assumption.
+ */
+public class UniformDistributionHistogram
+        implements ConnectorHistogram
+{
+    private final double lowValue;
+    private final double highValue;
+
+    @JsonCreator
+    public UniformDistributionHistogram(
+            @JsonProperty("lowValue") double lowValue,
+            @JsonProperty("highValue") double highValue)
+    {
+        verify(isNaN(lowValue) || isNaN(highValue) || (lowValue <= highValue), "lowValue must be <= highValue");
+        this.lowValue = lowValue;
+        this.highValue = highValue;
+    }
+
+    @JsonProperty
+    public double getLowValue()
+    {
+        return lowValue;
+    }
+
+    @JsonProperty
+    public double getHighValue()
+    {
+        return highValue;
+    }
+
+    @Override
+    public Estimate cumulativeProbability(double value, boolean inclusive)
+    {
+        if (isNaN(lowValue) ||
+                isNaN(highValue) ||
+                isNaN(value)) {
+            return Estimate.unknown();
+        }
+
+        if (value >= highValue) {
+            return Estimate.of(1.0);
+        }
+
+        if (value <= lowValue) {
+            return Estimate.of(0.0);
+        }
+
+        if (isInfinite(lowValue) || isInfinite(highValue)) {
+            return Estimate.unknown();
+        }
+
+        return Estimate.of(min(1.0, max(0.0, ((value - lowValue) / (highValue - lowValue)))));
+    }
+
+    @Override
+    public Estimate inverseCumulativeProbability(double percentile)
+    {
+        checkArgument(percentile >= 0.0 && percentile <= 1.0, "percentile must be in [0.0, 1.0]: " + percentile);
+        if (isNaN(lowValue) ||
+                isNaN(highValue)) {
+            return Estimate.unknown();
+        }
+
+        if (percentile == 0.0 && !isInfinite(lowValue)) {
+            return Estimate.of(lowValue);
+        }
+
+        if (percentile == 1.0 && !isInfinite(highValue)) {
+            return Estimate.of(highValue);
+        }
+
+        if (isInfinite(lowValue) || isInfinite(highValue)) {
+            return Estimate.unknown();
+        }
+
+        return Estimate.of(lowValue + (percentile * (highValue - lowValue)));
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("lowValue", lowValue)
+                .add("highValue", highValue)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UniformDistributionHistogram)) {
+            return false;
+        }
+
+        UniformDistributionHistogram other = (UniformDistributionHistogram) o;
+        return equalsOrBothNaN(lowValue, other.lowValue) &&
+                equalsOrBothNaN(highValue, other.highValue);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(lowValue, highValue);
+    }
+
+    private static boolean equalsOrBothNaN(Double first, Double second)
+    {
+        return first.equals(second) || (Double.isNaN(first) && Double.isNaN(second));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/VariableStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/VariableStatsEstimate.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.cost;
 
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -27,6 +29,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class VariableStatsEstimate
 {
@@ -39,6 +42,7 @@ public class VariableStatsEstimate
     private final double nullsFraction;
     private final double averageRowSize;
     private final double distinctValuesCount;
+    private final ConnectorHistogram histogram;
 
     public static VariableStatsEstimate unknown()
     {
@@ -56,7 +60,8 @@ public class VariableStatsEstimate
             @JsonProperty("highValue") double highValue,
             @JsonProperty("nullsFraction") double nullsFraction,
             @JsonProperty("averageRowSize") double averageRowSize,
-            @JsonProperty("distinctValuesCount") double distinctValuesCount)
+            @JsonProperty("distinctValuesCount") double distinctValuesCount,
+            @JsonProperty("histogram") ConnectorHistogram histogram)
     {
         checkArgument(
                 lowValue <= highValue || (isNaN(lowValue) && isNaN(highValue)),
@@ -79,6 +84,16 @@ public class VariableStatsEstimate
         checkArgument(distinctValuesCount >= 0 || isNaN(distinctValuesCount), "Distinct values count should be non-negative, got: %s", distinctValuesCount);
         // TODO normalize distinctValuesCount for an empty range (or validate it is already normalized)
         this.distinctValuesCount = distinctValuesCount;
+        this.histogram = requireNonNull(histogram, "histogram is null");
+    }
+
+    public VariableStatsEstimate(double lowValue,
+            double highValue,
+            double nullsFraction,
+            double averageRowSize,
+            double distinctValuesCount)
+    {
+        this(lowValue, highValue, nullsFraction, averageRowSize, distinctValuesCount, new UniformDistributionHistogram(lowValue, highValue));
     }
 
     @JsonProperty
@@ -97,6 +112,12 @@ public class VariableStatsEstimate
     public double getNullsFraction()
     {
         return nullsFraction;
+    }
+
+    @JsonProperty
+    public ConnectorHistogram getHistogram()
+    {
+        return histogram;
     }
 
     public StatisticRange statisticRange()
@@ -153,6 +174,8 @@ public class VariableStatsEstimate
             return false;
         }
         VariableStatsEstimate that = (VariableStatsEstimate) o;
+        // histograms are explicitly left out because equals calculations would
+        // be expensive.
         return Double.compare(nullsFraction, that.nullsFraction) == 0 &&
                 Double.compare(averageRowSize, that.averageRowSize) == 0 &&
                 Double.compare(distinctValuesCount, that.distinctValuesCount) == 0 &&
@@ -174,6 +197,7 @@ public class VariableStatsEstimate
                 .add("nulls", nullsFraction)
                 .add("ndv", distinctValuesCount)
                 .add("rowSize", averageRowSize)
+                .add("histogram", histogram)
                 .toString();
     }
 
@@ -189,7 +213,8 @@ public class VariableStatsEstimate
                 .setHighValue(other.getHighValue())
                 .setNullsFraction(other.getNullsFraction())
                 .setAverageRowSize(other.getAverageRowSize())
-                .setDistinctValuesCount(other.getDistinctValuesCount());
+                .setDistinctValuesCount(other.getDistinctValuesCount())
+                .setHistogram(other.getHistogram());
     }
 
     public static final class Builder
@@ -199,6 +224,7 @@ public class VariableStatsEstimate
         private double nullsFraction = NaN;
         private double averageRowSize = NaN;
         private double distinctValuesCount = NaN;
+        private Optional<ConnectorHistogram> histogram = Optional.empty();
 
         public Builder setStatisticsRange(StatisticRange range)
         {
@@ -237,9 +263,16 @@ public class VariableStatsEstimate
             return this;
         }
 
+        public Builder setHistogram(ConnectorHistogram histogram)
+        {
+            this.histogram = Optional.of(histogram);
+            return this;
+        }
+
         public VariableStatsEstimate build()
         {
-            return new VariableStatsEstimate(lowValue, highValue, nullsFraction, averageRowSize, distinctValuesCount);
+            return new VariableStatsEstimate(lowValue, highValue, nullsFraction, averageRowSize, distinctValuesCount,
+                    histogram.orElseGet(() -> new UniformDistributionHistogram(lowValue, highValue)));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -306,6 +306,7 @@ public class FeaturesConfig
     private boolean limitNumberOfGroupsForKHyperLogLogAggregations = true;
     private boolean generateDomainFilters;
     private CreateView.Security defaultViewSecurityMode = DEFINER;
+    private boolean useHistograms;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3071,6 +3072,19 @@ public class FeaturesConfig
     public FeaturesConfig setDefaultViewSecurityMode(CreateView.Security securityMode)
     {
         this.defaultViewSecurityMode = securityMode;
+        return this;
+    }
+
+    public boolean isUseHistograms()
+    {
+        return useHistograms;
+    }
+
+    @Config("optimizer.use-histograms")
+    @ConfigDescription("Use histogram statistics in cost-based calculations in the optimizer")
+    public FeaturesConfig setUseHistograms(boolean useHistograms)
+    {
+        this.useHistograms = useHistograms;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -71,6 +71,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -258,6 +259,7 @@ public class ShowStatsRewrite
                     .add("row_count")
                     .add("low_value")
                     .add("high_value")
+                    .add("histogram")
                     .build();
         }
 
@@ -303,6 +305,7 @@ public class ShowStatsRewrite
             rowValues.add(NULL_DOUBLE);
             rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMin)));
             rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMax)));
+            rowValues.add(columnStatistics.getHistogram().map(Objects::toString).<Expression>map(StringLiteral::new).orElse(NULL_VARCHAR));
             return new Row(rowValues.build());
         }
 
@@ -316,6 +319,7 @@ public class ShowStatsRewrite
             rowValues.add(NULL_DOUBLE);
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
+            rowValues.add(NULL_VARCHAR);
             return new Row(rowValues.build());
         }
 
@@ -327,6 +331,7 @@ public class ShowStatsRewrite
             rowValues.add(NULL_DOUBLE);
             rowValues.add(NULL_DOUBLE);
             rowValues.add(createEstimateRepresentation(tableStatistics.getRowCount()));
+            rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
             return new Row(rowValues.build());

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZER_USE_HISTOGRAMS;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
@@ -51,7 +52,8 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
-public class TestComparisonStatsCalculator
+@Test
+public abstract class AbstractTestComparisonStatsCalculator
 {
     private FilterStatsCalculator filterStatsCalculator;
     private Session session;
@@ -68,11 +70,17 @@ public class TestComparisonStatsCalculator
     private VariableStatsEstimate emptyRangeStats;
     private VariableStatsEstimate varcharStats;
 
+    public AbstractTestComparisonStatsCalculator(boolean withHistograms)
+    {
+        session = testSessionBuilder()
+                .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, Boolean.toString(withHistograms))
+                .build();
+    }
+
     @BeforeClass
     public void setUp()
             throws Exception
     {
-        session = testSessionBuilder().build();
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
         filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZER_USE_HISTOGRAMS;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -36,7 +37,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
-public class TestFilterStatsCalculator
+public abstract class AbstractTestFilterStatsCalculator
 {
     private static final VarcharType MEDIUM_VARCHAR_TYPE = VarcharType.createVarcharType(100);
 
@@ -53,6 +54,13 @@ public class TestFilterStatsCalculator
     private TypeProvider standardTypes;
     private Session session;
     private TestingRowExpressionTranslator translator;
+
+    public AbstractTestFilterStatsCalculator(boolean withHistograms)
+    {
+        session = testSessionBuilder()
+                .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, Boolean.toString(withHistograms))
+                .build();
+    }
 
     @BeforeClass
     public void setUp()
@@ -137,7 +145,6 @@ public class TestFilterStatsCalculator
                 .add(new VariableReferenceExpression(Optional.empty(), "mediumVarchar", MEDIUM_VARCHAR_TYPE))
                 .build());
 
-        session = testSessionBuilder().build();
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
         statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
         translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
@@ -377,6 +384,33 @@ public class TestFilterStatsCalculator
     }
 
     @Test
+    public void testBetweenOperatorFilterLeftOpen()
+    {
+        // Left side open, cut on open side
+        assertExpression("leftOpen BETWEEN DOUBLE '-10' AND 10e0")
+                .outputRowsCount(180.0)
+                .variableStats(new VariableReferenceExpression(Optional.empty(), "leftOpen", DOUBLE), variableStats ->
+                        variableStats.distinctValuesCount(10.0)
+                                .lowValue(-10.0)
+                                .highValue(10.0)
+                                .nullsFraction(0.0));
+    }
+
+    @Test
+    public void testBetweenOperatorFilterRightOpen()
+    {
+        // Left side open, cut on open side
+        // Right side open, cut on open side
+        assertExpression("rightOpen BETWEEN DOUBLE '-10' AND 10e0")
+                .outputRowsCount(180.0)
+                .variableStats(new VariableReferenceExpression(Optional.empty(), "rightOpen", DOUBLE), variableStats ->
+                        variableStats.distinctValuesCount(10.0)
+                                .lowValue(-10.0)
+                                .highValue(10.0)
+                                .nullsFraction(0.0));
+    }
+
+    @Test
     public void testBetweenOperatorFilter()
     {
         // Only right side cut
@@ -420,24 +454,6 @@ public class TestFilterStatsCalculator
                         variableStats.distinctValuesCount(6.25)
                                 .lowValue(2.72)
                                 .highValue(3.14)
-                                .nullsFraction(0.0));
-
-        // Left side open, cut on open side
-        assertExpression("leftOpen BETWEEN DOUBLE '-10' AND 10e0")
-                .outputRowsCount(180.0)
-                .variableStats(new VariableReferenceExpression(Optional.empty(), "leftOpen", DOUBLE), variableStats ->
-                        variableStats.distinctValuesCount(10.0)
-                                .lowValue(-10.0)
-                                .highValue(10.0)
-                                .nullsFraction(0.0));
-
-        // Right side open, cut on open side
-        assertExpression("rightOpen BETWEEN DOUBLE '-10' AND 10e0")
-                .outputRowsCount(180.0)
-                .variableStats(new VariableReferenceExpression(Optional.empty(), "rightOpen", DOUBLE), variableStats ->
-                        variableStats.distinctValuesCount(10.0)
-                                .lowValue(-10.0)
-                                .highValue(10.0)
                                 .nullsFraction(0.0));
 
         // Filter all
@@ -588,7 +604,7 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.0));
     }
 
-    private PlanNodeStatsAssertion assertExpression(String expression)
+    protected PlanNodeStatsAssertion assertExpression(String expression)
     {
         return assertExpression(expression(expression));
     }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculatorHistograms.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculatorHistograms.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+public class TestComparisonStatsCalculatorHistograms
+        extends AbstractTestComparisonStatsCalculator
+{
+    public TestComparisonStatsCalculatorHistograms()
+    {
+        super(true);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculatorNoHistograms.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculatorNoHistograms.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+public class TestComparisonStatsCalculatorNoHistograms
+        extends AbstractTestComparisonStatsCalculator
+{
+    public TestComparisonStatsCalculatorNoHistograms()
+    {
+        super(false);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -98,20 +98,20 @@ public class TestConnectorFilterStatsCalculatorService
         TableStatistics filteredToZeroStatistics = TableStatistics.builder()
                 .setRowCount(Estimate.zero())
                 .setTotalSize(Estimate.zero())
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.of(1.0), Estimate.zero(), Estimate.zero(), Optional.empty()))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.of(1.0), Estimate.zero(), Estimate.zero(), Optional.empty(), Optional.empty()))
                 .build();
         assertPredicate("false", originalTableStatistics, filteredToZeroStatistics);
 
         TableStatistics filteredStatistics = TableStatistics.builder()
                 .setRowCount(Estimate.of(37.5))
                 .setTotalSize(Estimate.of(300))
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0))))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty()))
                 .build();
         assertPredicate("x < 0", originalTableStatistics, filteredStatistics);
 
         TableStatistics filteredStatisticsWithoutTotalSize = TableStatistics.builder()
                 .setRowCount(Estimate.of(37.5))
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0))))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty()))
                 .build();
         assertPredicate("x < 0", originalTableStatisticsWithoutTotalSize, filteredStatisticsWithoutTotalSize);
     }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestDisjointRangeDomainHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestDisjointRangeDomainHistogram.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.distribution.RealDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDisjointRangeDomainHistogram
+        extends TestHistogram
+{
+    /**
+     * A uniform base with 2 ranges that are fully within the range of the uniform histogram.
+     */
+    @Test
+    public void testBasicDisjointRanges()
+    {
+        ConnectorHistogram source = new UniformDistributionHistogram(0, 100);
+        ConnectorHistogram constrained = DisjointRangeDomainHistogram
+                .addDisjunction(source, StatisticRange.fromRange(Range.open(0d, 25d)));
+        constrained = DisjointRangeDomainHistogram
+                .addDisjunction(constrained, StatisticRange.fromRange(Range.open(75d, 100d)));
+        assertEquals(constrained.inverseCumulativeProbability(0.75).getValue(), 87.5);
+        assertEquals(constrained.inverseCumulativeProbability(0.0).getValue(), 0.0);
+        assertEquals(constrained.inverseCumulativeProbability(1.0).getValue(), 100);
+        assertEquals(constrained.inverseCumulativeProbability(0.5).getValue(), 25);
+    }
+
+    /**
+     * A uniform base with a range that (1) doesn't have any overlap with the base distribution (2)
+     * has partial overlap (both ends of the base) and (3) complete overlap.
+     */
+    @Test
+    public void testSingleDisjointRange()
+    {
+        ConnectorHistogram source = new UniformDistributionHistogram(0, 10);
+
+        // no overlap, left bound
+        ConnectorHistogram constrained = DisjointRangeDomainHistogram
+                .addDisjunction(source, StatisticRange.fromRange(Range.open(-10d, -5d)));
+        for (int i = -11; i < 12; i++) {
+            assertEquals(constrained.cumulativeProbability(i, true).getValue(), 0.0, 1E-8);
+            assertEquals(constrained.cumulativeProbability(i, false).getValue(), 0.0, 1E-8);
+        }
+        assertEquals(constrained.inverseCumulativeProbability(0.0), Estimate.unknown());
+        assertEquals(constrained.inverseCumulativeProbability(1.0), Estimate.unknown());
+
+        // partial overlap left bound
+        constrained = new DisjointRangeDomainHistogram(source, ImmutableSet.of(Range.open(-2d, 2d)));
+        assertEquals(constrained.cumulativeProbability(-3, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(-1, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(0, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1, false).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1.5, false).getValue(), 0.75, 1E-8);
+        assertEquals(constrained.cumulativeProbability(2, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(4, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.0).getValue(), 0d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.5).getValue(), 1d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.75).getValue(), 1.5d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(1.0).getValue(), 2d, 1E-8);
+
+        //full overlap
+        constrained = new DisjointRangeDomainHistogram(source, ImmutableSet.of(Range.open(3d, 4d)));
+        assertEquals(constrained.cumulativeProbability(-3, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(0, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(3, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(3.5, false).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(4, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(4.5, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.0).getValue(), 3d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.5).getValue(), 3.5d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.75).getValue(), 3.75d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(1.0).getValue(), 4d, 1E-8);
+
+        //right side overlap
+        constrained = new DisjointRangeDomainHistogram(source, ImmutableSet.of(Range.open(8d, 12d)));
+        assertEquals(constrained.cumulativeProbability(-3, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(0, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(5, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(8, false).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(9, false).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(9.5, false).getValue(), 0.75, 1E-8);
+        assertEquals(constrained.cumulativeProbability(10, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(11, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(12, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(13, false).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.0).getValue(), 8d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.5).getValue(), 9d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.75).getValue(), 9.5d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(1.0).getValue(), 10d, 1E-8);
+
+        // no overlap, right bound
+        constrained = DisjointRangeDomainHistogram
+                .addDisjunction(source, StatisticRange.fromRange(Range.open(15d, 20d)));
+        for (int i = 15; i < 20; i++) {
+            assertEquals(constrained.cumulativeProbability(i, true).getValue(), 0.0, 1E-8);
+            assertEquals(constrained.cumulativeProbability(i, false).getValue(), 0.0, 1E-8);
+        }
+        assertEquals(constrained.inverseCumulativeProbability(0.0), Estimate.unknown());
+        assertEquals(constrained.inverseCumulativeProbability(1.0), Estimate.unknown());
+    }
+
+    /**
+     * Tests that calculations across N > 1 disjunctions applied to the source histogram are
+     * calculated properly.
+     */
+    @Test
+    public void testMultipleDisjunction()
+    {
+        StandardNormalHistogram source = new StandardNormalHistogram();
+        RealDistribution dist = source.getDistribution();
+        ConnectorHistogram constrained = disjunction(source, Range.closed(-2d, -1d));
+        constrained = disjunction(constrained, Range.closed(1d, 2d));
+        double rangeLeftProb = dist.cumulativeProbability(-1) - dist.cumulativeProbability(-2);
+        double rangeRightProb = dist.cumulativeProbability(2) - dist.cumulativeProbability(1);
+        double sumRangeProb = rangeLeftProb + rangeRightProb;
+        assertEquals(constrained.cumulativeProbability(-2, true).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(-1.5, true).getValue(), (dist.cumulativeProbability(-1.5d) - dist.cumulativeProbability(-2)) / sumRangeProb, 1E-8);
+        assertEquals(constrained.cumulativeProbability(-1, true).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1, true).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1.5, true).getValue(), (rangeLeftProb / sumRangeProb) + ((dist.cumulativeProbability(1.5) - dist.cumulativeProbability(1.0)) / sumRangeProb));
+        assertEquals(constrained.cumulativeProbability(2, true).getValue(), 1.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(3, true).getValue(), 1.0, 1E-8);
+    }
+
+    /**
+     * Ensures assumptions made in tests for uniform distributions apply correctly for
+     * a non-uniform distribution.
+     */
+    @Test
+    public void testNormalDistribution()
+    {
+        // standard normal
+        StandardNormalHistogram source = new StandardNormalHistogram();
+        RealDistribution dist = source.getDistribution();
+        ConnectorHistogram constrained = new DisjointRangeDomainHistogram(source, ImmutableSet.of(Range.open(-1d, 1d)));
+        assertEquals(constrained.cumulativeProbability(-1.0, true).getValue(), 0.0, 1E-8);
+        assertEquals(constrained.cumulativeProbability(0.0, true).getValue(), 0.5, 1E-8);
+        assertEquals(constrained.cumulativeProbability(1.0, true).getValue(), 1.0, 1E-8);
+        double probability = (dist.cumulativeProbability(-0.5) - dist.cumulativeProbability(-1.0)) / (dist.cumulativeProbability(1.0) - dist.cumulativeProbability(-1));
+        assertEquals(constrained.cumulativeProbability(-0.5, true).getValue(), probability, 1E-8);
+        assertEquals(constrained.cumulativeProbability(0.5, true).getValue(), probability + (1.0 - (2 * probability)), 1E-8);
+
+        assertEquals(constrained.inverseCumulativeProbability(0.0).getValue(), -1.0d, 1E-8);
+        probability = dist.inverseCumulativeProbability(dist.cumulativeProbability(-1) + 0.25 * (dist.cumulativeProbability(1) - dist.cumulativeProbability(-1)));
+        assertEquals(constrained.inverseCumulativeProbability(0.25).getValue(), -0.44177054668d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.5).getValue(), 0.0d, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(0.75).getValue(), -1 * probability, 1E-8);
+        assertEquals(constrained.inverseCumulativeProbability(1.0).getValue(), 1.0d, 1E-8);
+    }
+
+    /**
+     * Ensures disjunctions of ranges works properly
+     */
+    @Test
+    public void testAddDisjunction()
+    {
+        ConnectorHistogram source = new UniformDistributionHistogram(0, 100);
+        DisjointRangeDomainHistogram constrained = disjunction(source, Range.open(-1d, 2d));
+        assertEquals(constrained.getRanges().size(), 1);
+        assertEquals(ranges(constrained).get(0), Range.closedOpen(0d, 2d));
+        constrained = disjunction(constrained, Range.open(1d, 10d));
+        assertEquals(ranges(constrained).size(), 1);
+        assertEquals(ranges(constrained).get(0), Range.closedOpen(0d, 10d));
+        constrained = disjunction(constrained, Range.closedOpen(50d, 100d));
+        assertEquals(ranges(constrained).size(), 2);
+        assertEquals(ranges(constrained).get(0), Range.closedOpen(0d, 10d));
+        assertEquals(ranges(constrained).get(1), Range.closedOpen(50d, 100d));
+    }
+
+    /**
+     * Ensures conjunctions of ranges works properly
+     */
+    @Test
+    public void testAddConjunction()
+    {
+        ConnectorHistogram source = new UniformDistributionHistogram(0, 100);
+        DisjointRangeDomainHistogram constrained = disjunction(source, Range.open(10d, 90d));
+        assertEquals(constrained.getRanges().size(), 1);
+        assertEquals(ranges(constrained).get(0), Range.open(10d, 90d));
+        constrained = conjunction(constrained, Range.atMost(50d));
+        assertEquals(ranges(constrained).size(), 1);
+        assertEquals(ranges(constrained).get(0), Range.openClosed(10d, 50d));
+        constrained = conjunction(constrained, Range.atLeast(25d));
+        assertEquals(ranges(constrained).size(), 1);
+        assertEquals(ranges(constrained).get(0), Range.closed(25d, 50d));
+    }
+
+    private static DisjointRangeDomainHistogram disjunction(ConnectorHistogram source, Range<Double> range)
+    {
+        return (DisjointRangeDomainHistogram) DisjointRangeDomainHistogram.addDisjunction(source, StatisticRange.fromRange(range));
+    }
+
+    private static DisjointRangeDomainHistogram conjunction(ConnectorHistogram source, Range<Double> range)
+    {
+        return (DisjointRangeDomainHistogram) DisjointRangeDomainHistogram.addConjunction(source, StatisticRange.fromRange(range));
+    }
+
+    private static List<Range<Double>> ranges(DisjointRangeDomainHistogram hist)
+    {
+        return hist.getRanges().stream().map(StatisticRange::toRange).collect(Collectors.toList());
+    }
+
+    private static class StandardNormalHistogram
+            implements ConnectorHistogram
+    {
+        private final NormalDistribution distribution = new NormalDistribution();
+
+        public NormalDistribution getDistribution()
+        {
+            return distribution;
+        }
+
+        @Override
+        public Estimate cumulativeProbability(double value, boolean inclusive)
+        {
+            return Estimate.of(distribution.cumulativeProbability(value));
+        }
+
+        @Override
+        public Estimate inverseCumulativeProbability(double percentile)
+        {
+            // assume lower/upper limit is 10, in order to not throw
+            // exception, even though technically the bounds are technically
+            // INF
+            if (percentile <= 0.0) {
+                return Estimate.of(-10);
+            }
+            if (percentile >= 1.0) {
+                return Estimate.of(10);
+            }
+            return Estimate.of(distribution.inverseCumulativeProbability(percentile));
+        }
+    }
+
+    @Override
+    ConnectorHistogram createHistogram()
+    {
+        RealDistribution distribution = getDistribution();
+        return new DisjointRangeDomainHistogram(
+                new UniformDistributionHistogram(
+                        distribution.getSupportLowerBound(), distribution.getSupportUpperBound()))
+                .addDisjunction(new StatisticRange(0.0, 100.0, 0.0));
+    }
+
+    @Override
+    double getDistinctValues()
+    {
+        return 100;
+    }
+
+    @Override
+    RealDistribution getDistribution()
+    {
+        return new UniformRealDistribution(0.0, 100.0);
+    }
+
+    /**
+     * Support depends on the underlying distribution.
+     */
+    @Override
+    public void testInclusiveExclusive()
+    {
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorHistograms.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorHistograms.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+
+public class TestFilterStatsCalculatorHistograms
+        extends AbstractTestFilterStatsCalculator
+{
+    public TestFilterStatsCalculatorHistograms()
+    {
+        super(true);
+    }
+
+    /**
+     * We override this test because the original logic utilizes heuristics in cases where stats
+     * don't exist and infinite bound exists. We choose to use slightly different heuristics
+     * for these cases when histograms are enabled.
+     * <br>
+     * See {@link StatisticRange#overlapPercentWith(StatisticRange)}
+     */
+    @Test
+    public void testBetweenOperatorFilterLeftOpen()
+    {
+        assertExpression("leftOpen BETWEEN DOUBLE '-10' AND 10e0")
+                .outputRowsCount(56.25)
+                .variableStats(new VariableReferenceExpression(Optional.empty(), "leftOpen", DOUBLE), variableStats ->
+                        variableStats.distinctValuesCount(10.0)
+                                .lowValue(-10.0)
+                                .highValue(10.0)
+                                .nullsFraction(0.0));
+    }
+
+    /**
+     * We override this test because the original logic utilizes heuristics in cases where stats
+     * don't exist and infinite bound exists. We choose to use slightly different heuristics
+     * for these cases when histograms are enabled.
+     * <br>
+     * See {@link StatisticRange#overlapPercentWith(StatisticRange)}
+     */
+    @Test
+    public void testBetweenOperatorFilterRightOpen()
+    {
+        // Left side open, cut on open side
+        // Right side open, cut on open side
+        assertExpression("rightOpen BETWEEN DOUBLE '-10' AND 10e0")
+                .outputRowsCount(56.25)
+                .variableStats(new VariableReferenceExpression(Optional.empty(), "rightOpen", DOUBLE), variableStats ->
+                        variableStats.distinctValuesCount(10.0)
+                                .lowValue(-10.0)
+                                .highValue(10.0)
+                                .nullsFraction(0.0));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorNoHistograms.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorNoHistograms.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+public class TestFilterStatsCalculatorNoHistograms
+        extends AbstractTestFilterStatsCalculator
+{
+    public TestFilterStatsCalculatorNoHistograms()
+    {
+        super(false);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistogram.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import org.apache.commons.math3.distribution.RealDistribution;
+import org.testng.annotations.Test;
+
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public abstract class TestHistogram
+{
+    abstract ConnectorHistogram createHistogram();
+
+    abstract RealDistribution getDistribution();
+
+    abstract double getDistinctValues();
+
+    @Test
+    public void testInverseCumulativeProbability()
+    {
+        ConnectorHistogram hist = createHistogram();
+        RealDistribution dist = getDistribution();
+        assertThrows(IllegalArgumentException.class, () -> hist.inverseCumulativeProbability(Double.NaN));
+        assertThrows(IllegalArgumentException.class, () -> hist.inverseCumulativeProbability(-1.0));
+        assertThrows(IllegalArgumentException.class, () -> hist.inverseCumulativeProbability(2.0));
+        assertEquals(hist.inverseCumulativeProbability(0.0).getValue(), dist.getSupportLowerBound(), .001);
+        assertEquals(hist.inverseCumulativeProbability(0.25).getValue(), dist.inverseCumulativeProbability(0.25), .001);
+        assertEquals(hist.inverseCumulativeProbability(0.5).getValue(), dist.getNumericalMean(), .001);
+        assertEquals(hist.inverseCumulativeProbability(1.0).getValue(), dist.getSupportUpperBound(), .001);
+    }
+
+    @Test
+    public void testCumulativeProbability()
+    {
+        ConnectorHistogram hist = createHistogram();
+        RealDistribution dist = getDistribution();
+
+        assertTrue(hist.cumulativeProbability(Double.NaN, true).isUnknown());
+        assertEquals(hist.cumulativeProbability(NEGATIVE_INFINITY, true).getValue(), 0.0, .001);
+        assertEquals(hist.cumulativeProbability(NEGATIVE_INFINITY, false).getValue(), 0.0, .001);
+        assertEquals(hist.cumulativeProbability(POSITIVE_INFINITY, true).getValue(), 1.0, .001);
+        assertEquals(hist.cumulativeProbability(POSITIVE_INFINITY, false).getValue(), 1.0, .001);
+
+        assertEquals(hist.cumulativeProbability(dist.getSupportLowerBound() - 1, true).getValue(), 0.0, .001);
+        assertEquals(hist.cumulativeProbability(dist.getSupportLowerBound(), true).getValue(), 0.0, .001);
+        assertEquals(hist.cumulativeProbability(dist.getSupportUpperBound() + 1, true).getValue(), 1.0, .001);
+        assertEquals(hist.cumulativeProbability(dist.getSupportUpperBound(), true).getValue(), 1.0, .001);
+        assertEquals(hist.cumulativeProbability(dist.getNumericalMean(), true).getValue(), 0.5, .001);
+        for (int i = 0; i < 10; i++) {
+            assertEquals(hist.cumulativeProbability(dist.inverseCumulativeProbability(0.1 * i), true).getValue(), dist.cumulativeProbability(dist.inverseCumulativeProbability(0.1 * i)), .001);
+        }
+    }
+
+    @Test
+    public void testInclusiveExclusive()
+    {
+        double ndvs = getDistinctValues();
+        ConnectorHistogram hist = createHistogram();
+        // test maximums
+        assertEquals(hist.cumulativeProbability(hist.inverseCumulativeProbability(1.0).getValue(), false).getValue(), 1.0 - (1.0 / ndvs), .0001);
+        assertEquals(hist.cumulativeProbability(hist.inverseCumulativeProbability(1.0).getValue(), true).getValue(), 1.0, .0001);
+
+        // test minimums
+        assertEquals(hist.cumulativeProbability(hist.inverseCumulativeProbability(0.0).getValue(), false).getValue(), 0.0, .0001);
+        assertEquals(hist.cumulativeProbability(hist.inverseCumulativeProbability(0.0).getValue(), true).getValue(), 0.0, .0001);
+
+        // test non-max/min
+        double midPercent = hist.inverseCumulativeProbability(0.5).getValue();
+        assertEquals(hist.cumulativeProbability(midPercent, true).getValue() - hist.cumulativeProbability(midPercent, false).getValue(), 1.0 / ndvs, .0001);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistogramCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistogramCalculator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.cost.HistogramCalculator.calculateFilterFactor;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.testng.Assert.assertEquals;
+
+public class TestHistogramCalculator
+{
+    @Test
+    public void testCalculateFilterFactor()
+    {
+        StatisticRange zeroToTen = range(0, 10, 10);
+        StatisticRange empty = StatisticRange.empty();
+
+        // Equal ranges
+        assertFilterFactor(Estimate.of(1.0), zeroToTen, uniformHist(0, 10), 5);
+        assertFilterFactor(Estimate.of(1.0), zeroToTen, uniformHist(0, 10), 20);
+
+        // Some overlap
+        assertFilterFactor(Estimate.of(0.5), range(5, 3000, 5), uniformHist(zeroToTen), zeroToTen.getDistinctValuesCount());
+
+        // Single value overlap
+        assertFilterFactor(Estimate.of(1.0 / zeroToTen.getDistinctValuesCount()), range(3, 3, 1), uniformHist(zeroToTen), zeroToTen.getDistinctValuesCount());
+        assertFilterFactor(Estimate.of(1.0 / zeroToTen.getDistinctValuesCount()), range(10, 100, 357), uniformHist(zeroToTen), zeroToTen.getDistinctValuesCount());
+
+        // No overlap
+        assertFilterFactor(Estimate.zero(), range(20, 30, 10), uniformHist(zeroToTen), zeroToTen.getDistinctValuesCount());
+
+        // Empty ranges
+        assertFilterFactor(Estimate.zero(), zeroToTen, uniformHist(empty), empty.getDistinctValuesCount());
+        assertFilterFactor(Estimate.zero(), empty, uniformHist(zeroToTen), zeroToTen.getDistinctValuesCount());
+
+        // no test for (empty, empty) since any return value is correct
+        assertFilterFactor(Estimate.zero(), unboundedRange(10), uniformHist(empty), empty.getDistinctValuesCount());
+        assertFilterFactor(Estimate.zero(), empty, uniformHist(unboundedRange(10)), 10);
+
+        // Unbounded (infinite), NDV-based
+        assertFilterFactor(Estimate.of(0.5), unboundedRange(10), uniformHist(unboundedRange(20)), 20);
+        assertFilterFactor(Estimate.of(1.0), unboundedRange(20), uniformHist(unboundedRange(10)), 10);
+
+        // NEW TESTS (TPC-H Q2)
+        // unbounded ranges
+        assertFilterFactor(Estimate.of(.5), unboundedRange(0.5), uniformHist(unboundedRange(NaN)), NaN);
+        // unbounded ranges with limited distinct values
+        assertFilterFactor(Estimate.of(0.2), unboundedRange(1.0),
+                domainConstrained(unboundedRange(5.0), uniformHist(unboundedRange(7.0))), 5.0);
+    }
+
+    private static StatisticRange range(double low, double high, double distinctValues)
+    {
+        return new StatisticRange(low, high, distinctValues);
+    }
+
+    private static StatisticRange unboundedRange(double distinctValues)
+    {
+        return new StatisticRange(NEGATIVE_INFINITY, POSITIVE_INFINITY, distinctValues);
+    }
+
+    private static void assertFilterFactor(Estimate expected, StatisticRange range, ConnectorHistogram histogram, double totalDistinctValues)
+    {
+        assertEquals(
+                calculateFilterFactor(range, histogram, Estimate.estimateFromDouble(totalDistinctValues), true),
+                expected);
+    }
+
+    private static ConnectorHistogram uniformHist(StatisticRange range)
+    {
+        return uniformHist(range.getLow(), range.getHigh());
+    }
+
+    private static ConnectorHistogram uniformHist(double low, double high)
+    {
+        return new UniformDistributionHistogram(low, high);
+    }
+
+    private static ConnectorHistogram domainConstrained(StatisticRange range, ConnectorHistogram source)
+    {
+        return DisjointRangeDomainHistogram.addDisjunction(source, range);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestStatisticRange.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestStatisticRange.java
@@ -20,6 +20,8 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestStatisticRange
 {
@@ -104,9 +106,64 @@ public class TestStatisticRange
         assertEquals(range(0, 3, 3).addAndCollapseDistinctValues(range(2, 6, 4)), range(0, 6, 6));
     }
 
+    @Test
+    public void testIntersectOpenness()
+    {
+        StatisticRange first = range(0, true, 10, true, 10);
+        StatisticRange second = range(0, true, 5, true, 5);
+        StatisticRange intersect = first.intersect(second);
+        assertTrue(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+        intersect = second.intersect(first);
+        assertTrue(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+
+        // second range bounds only on high
+        second = range(-1, true, 5, false, 5);
+        intersect = first.intersect(second);
+        assertTrue(intersect.getOpenLow());
+        assertFalse(intersect.getOpenHigh());
+        intersect = second.intersect(first);
+        assertTrue(intersect.getOpenLow());
+        assertFalse(intersect.getOpenHigh());
+
+        // second range bounds on low and high
+        second = range(1, false, 5, false, 5);
+        intersect = first.intersect(second);
+        assertFalse(intersect.getOpenLow());
+        assertFalse(intersect.getOpenHigh());
+        intersect = second.intersect(first);
+        assertFalse(intersect.getOpenLow());
+        assertFalse(intersect.getOpenHigh());
+
+        // second range bounds only on low
+        second = range(1, false, 5, true, 5);
+        intersect = first.intersect(second);
+        assertFalse(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+        intersect = second.intersect(first);
+        assertFalse(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+
+        // same bounds but one is open and one is closed
+        first = range(0, false, 5, false, 5);
+        second = range(0, true, 5, true, 5);
+        intersect = first.intersect(second);
+        assertTrue(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+        intersect = second.intersect(first);
+        assertTrue(intersect.getOpenLow());
+        assertTrue(intersect.getOpenHigh());
+    }
+
     private static StatisticRange range(double low, double high, double distinctValues)
     {
         return new StatisticRange(low, high, distinctValues);
+    }
+
+    private static StatisticRange range(double low, boolean openLow, double high, boolean openHigh, double distinctValues)
+    {
+        return new StatisticRange(low, openLow, high, openHigh, distinctValues);
     }
 
     private static StatisticRange unboundedRange(double distinctValues)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestUniformHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestUniformHistogram.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.ConnectorHistogram;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.google.common.base.VerifyException;
+import org.apache.commons.math3.distribution.RealDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
+import org.testng.annotations.Test;
+
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestUniformHistogram
+        extends TestHistogram
+{
+    ConnectorHistogram createHistogram()
+    {
+        return new UniformDistributionHistogram(0, 1);
+    }
+
+    RealDistribution getDistribution()
+    {
+        return new UniformRealDistribution();
+    }
+
+    @Override
+    double getDistinctValues()
+    {
+        return 100;
+    }
+
+    @Test
+    public void testInvalidConstruction()
+    {
+        assertThrows(VerifyException.class, () -> new UniformDistributionHistogram(2.0, 1.0));
+    }
+
+    @Test
+    public void testNanRangeValues()
+    {
+        ConnectorHistogram hist = new UniformDistributionHistogram(Double.NaN, 2);
+        assertTrue(hist.inverseCumulativeProbability(0.5).isUnknown());
+
+        hist = new UniformDistributionHistogram(1.0, Double.NaN);
+        assertTrue(hist.inverseCumulativeProbability(0.5).isUnknown());
+
+        hist = new UniformDistributionHistogram(1.0, 2.0);
+        assertEquals(hist.inverseCumulativeProbability(0.5).getValue(), 1.5);
+    }
+
+    @Test
+    public void testInfiniteRangeValues()
+    {
+        // test low value as infinite
+        ConnectorHistogram hist = new UniformDistributionHistogram(Double.NEGATIVE_INFINITY, 2);
+
+        assertTrue(hist.inverseCumulativeProbability(0.5).isUnknown());
+        assertEquals(hist.inverseCumulativeProbability(0.0), Estimate.unknown());
+        assertEquals(hist.inverseCumulativeProbability(1.0).getValue(), 2.0);
+
+        assertEquals(hist.cumulativeProbability(0.0, true), Estimate.unknown());
+        assertEquals(hist.cumulativeProbability(1.0, true), Estimate.unknown());
+        assertEquals(hist.cumulativeProbability(2.0, true).getValue(), 1.0);
+        assertEquals(hist.cumulativeProbability(2.5, true).getValue(), 1.0);
+
+        // test high value as infinite
+        hist = new UniformDistributionHistogram(1.0, POSITIVE_INFINITY);
+
+        assertTrue(hist.inverseCumulativeProbability(0.5).isUnknown());
+        assertEquals(hist.inverseCumulativeProbability(0.0).getValue(), 1.0);
+        assertEquals(hist.inverseCumulativeProbability(1.0), Estimate.unknown());
+
+        assertEquals(hist.cumulativeProbability(0.0, true).getValue(), 0.0);
+        assertEquals(hist.cumulativeProbability(1.0, true).getValue(), 0.0);
+        assertEquals(hist.cumulativeProbability(1.5, true), Estimate.unknown());
+    }
+
+    @Test
+    public void testSingleValueRange()
+    {
+        UniformDistributionHistogram hist = new UniformDistributionHistogram(1.0, 1.0);
+
+        assertEquals(hist.inverseCumulativeProbability(0.0).getValue(), 1.0);
+        assertEquals(hist.inverseCumulativeProbability(1.0).getValue(), 1.0);
+        assertEquals(hist.inverseCumulativeProbability(0.5).getValue(), 1.0);
+
+        assertEquals(hist.cumulativeProbability(0.0, true).getValue(), 0.0);
+        assertEquals(hist.cumulativeProbability(0.5, true).getValue(), 0.0);
+        assertEquals(hist.cumulativeProbability(1.0, true).getValue(), 1.0);
+        assertEquals(hist.cumulativeProbability(1.5, true).getValue(), 1.0);
+    }
+
+    /**
+     * {@link UniformDistributionHistogram} does not support the inclusive/exclusive arguments
+     */
+    @Override
+    public void testInclusiveExclusive()
+    {
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctionUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctionUtils.java
@@ -46,21 +46,36 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b_1<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +
@@ -118,21 +133,36 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "           \"highValue\" : \"NaN\",\n" +
                     "           \"nullsFraction\" : 1.0,\n" +
                     "           \"averageRowSize\" : 0.0,\n" +
-                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "           \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "         },\n" +
                     "         \"a_0<integer>\" : {\n" +
                     "           \"lowValue\" : \"NaN\",\n" +
                     "           \"highValue\" : \"NaN\",\n" +
                     "           \"nullsFraction\" : 1.0,\n" +
                     "           \"averageRowSize\" : 0.0,\n" +
-                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "           \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "         },\n" +
                     "         \"b_1<integer>\" : {\n" +
                     "           \"lowValue\" : \"NaN\",\n" +
                     "           \"highValue\" : \"NaN\",\n" +
                     "           \"nullsFraction\" : 1.0,\n" +
                     "           \"averageRowSize\" : 0.0,\n" +
-                    "           \"distinctValuesCount\" : 0.0\n" +
+                    "           \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "         }\n" +
                     "       },\n" +
                     "       \"joinNodeStatsEstimate\" : {\n" +
@@ -161,21 +191,36 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b_1<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +
@@ -212,14 +257,24 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +
@@ -245,21 +300,36 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"a<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +
@@ -296,14 +366,24 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b_1<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +
@@ -329,21 +409,36 @@ public class TestJsonPrestoQueryPlanFunctionUtils
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"a_0<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       },\n" +
                     "       \"b_1<integer>\" : {\n" +
                     "         \"lowValue\" : \"NaN\",\n" +
                     "         \"highValue\" : \"NaN\",\n" +
                     "         \"nullsFraction\" : 1.0,\n" +
                     "         \"averageRowSize\" : 0.0,\n" +
-                    "         \"distinctValuesCount\" : 0.0\n" +
+                    "         \"distinctValuesCount\" : 0.0,\n" +
+                    "         \"histogram\" : {\n" +
+                    "           \"@class\" : \"com.facebook.presto.cost.UniformDistributionHistogram\",\n" +
+                    "           \"lowValue\" : \"NaN\",\n" +
+                    "           \"highValue\" : \"NaN\"\n" +
+                    "         }\n" +
                     "       }\n" +
                     "     },\n" +
                     "     \"joinNodeStatsEstimate\" : {\n" +

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -268,7 +268,8 @@ public class TestFeaturesConfig
                 .setRewriteExpressionWithConstantVariable(true)
                 .setDefaultWriterReplicationCoefficient(3.0)
                 .setDefaultViewSecurityMode(DEFINER)
-                .setCteHeuristicReplicationThreshold(4));
+                .setCteHeuristicReplicationThreshold(4)
+                .setUseHistograms(false));
     }
 
     @Test
@@ -481,6 +482,7 @@ public class TestFeaturesConfig
                 .put("optimizer.default-writer-replication-coefficient", "5.0")
                 .put("default-view-security-mode", INVOKER.name())
                 .put("cte-heuristic-replication-threshold", "2")
+                .put("optimizer.use-histograms", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -690,7 +692,8 @@ public class TestFeaturesConfig
                 .setRewriteExpressionWithConstantVariable(false)
                 .setDefaultWriterReplicationCoefficient(5.0)
                 .setDefaultViewSecurityMode(INVOKER)
-                .setCteHeuristicReplicationThreshold(2);
+                .setCteHeuristicReplicationThreshold(2)
+                .setUseHistograms(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -281,8 +281,13 @@ public class BasePlanTest
 
     protected Plan plan(String sql, Optimizer.PlanStage stage, boolean forceSingleNode)
     {
+        return plan(queryRunner.getDefaultSession(), sql, stage, forceSingleNode);
+    }
+
+    protected Plan plan(Session session, String sql, Optimizer.PlanStage stage, boolean forceSingleNode)
+    {
         try {
-            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage, forceSingleNode, WarningCollector.NOOP));
+            return queryRunner.inTransaction(session, transactionSession -> queryRunner.createPlan(transactionSession, sql, stage, forceSingleNode, WarningCollector.NOOP));
         }
         catch (RuntimeException e) {
             throw new AssertionError("Planning failed for SQL: " + sql, e);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -258,10 +258,10 @@ public abstract class AbstractTestNativeGeneralQueries
         // column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
         assertQuery("SHOW STATS FOR region",
                 "SELECT * FROM (VALUES" +
-                        "('regionkey', NULL, 5.0, 0.0, NULL, '0', '4')," +
-                        "('name', 54.0, 5.0, 0.0, NULL, NULL, NULL)," +
-                        "('comment', 350.0, 5.0, 0.0, NULL, NULL, NULL)," +
-                        "(NULL, NULL, NULL, NULL, 5.0, NULL, NULL))");
+                        "('regionkey', NULL, 5.0, 0.0, NULL, '0', '4', NULL)," +
+                        "('name', 54.0, 5.0, 0.0, NULL, NULL, NULL, NULL)," +
+                        "('comment', 350.0, 5.0, 0.0, NULL, NULL, NULL, NULL)," +
+                        "(NULL, NULL, NULL, NULL, 5.0, NULL, NULL, NULL))");
 
         // Create a partitioned table and run analyze on it.
         String tmpTableName = generateRandomTableName();
@@ -275,17 +275,17 @@ public abstract class AbstractTestNativeGeneralQueries
             assertUpdate(String.format("ANALYZE %s", tmpTableName), 25);
             assertQuery(String.format("SHOW STATS for %s", tmpTableName),
                     "SELECT * FROM (VALUES" +
-                            "('name', 277.0, 1.0, 0.0, NULL, NULL, NULL)," +
-                            "('regionkey', NULL, 5.0, 0.0, NULL, '0', '4')," +
-                            "('nationkey', NULL, 25.0, 0.0, NULL, '0', '24')," +
-                            "(NULL, NULL, NULL, NULL, 25.0, NULL, NULL))");
+                            "('name', 277.0, 1.0, 0.0, NULL, NULL, NULL, NULL)," +
+                            "('regionkey', NULL, 5.0, 0.0, NULL, '0', '4', NULL)," +
+                            "('nationkey', NULL, 25.0, 0.0, NULL, '0', '24', NULL)," +
+                            "(NULL, NULL, NULL, NULL, 25.0, NULL, NULL, NULL))");
             assertUpdate(String.format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['0','0'],ARRAY['4', '11']])", tmpTableName), 2);
             assertQuery(String.format("SHOW STATS for (SELECT * FROM %s where regionkey=4 and nationkey=11)", tmpTableName),
                     "SELECT * FROM (VALUES" +
-                            "('name', 8.0, 1.0, 0.0, NULL, NULL, NULL)," +
-                            "('regionkey', NULL, 1.0, 0.0, NULL, '4', '4')," +
-                            "('nationkey', NULL, 1.0, 0.0, NULL, '11', '11')," +
-                            "(NULL, NULL, NULL, NULL, 1.0, NULL, NULL))");
+                            "('name', 8.0, 1.0, 0.0, NULL, NULL, NULL, NULL)," +
+                            "('regionkey', NULL, 1.0, 0.0, NULL, '4', '4', NULL)," +
+                            "('nationkey', NULL, 1.0, 0.0, NULL, '11', '11', NULL)," +
+                            "(NULL, NULL, NULL, NULL, 1.0, NULL, NULL, NULL))");
         }
         finally {
             dropTableIfExists(tmpTableName);
@@ -305,9 +305,9 @@ public abstract class AbstractTestNativeGeneralQueries
             assertUpdate(String.format("ANALYZE %s", tmpTableName), 7);
             assertQuery(String.format("SHOW STATS for %s", tmpTableName),
                     "SELECT * FROM (VALUES" +
-                            "('c0', NULL,4.0 , 0.2857142857142857, NULL, '-542392.89', '1000000.12')," +
-                            "('c1', NULL,4.0 , 0.2857142857142857, NULL,  '-6.72398239210929E12', '2.823982323232357E13')," +
-                            "(NULL, NULL, NULL, NULL, 7.0, NULL, NULL))");
+                            "('c0', NULL,4.0 , 0.2857142857142857, NULL, '-542392.89', '1000000.12', NULL)," +
+                            "('c1', NULL,4.0 , 0.2857142857142857, NULL,  '-6.72398239210929E12', '2.823982323232357E13', NULL)," +
+                            "(NULL, NULL, NULL, NULL, 7.0, NULL, NULL, NULL))");
         }
         finally {
             dropTableIfExists(tmpTableName);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestWriter.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestWriter.java
@@ -279,36 +279,36 @@ public abstract class AbstractTestWriter
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null), " + // 8.0
-                        "('c_array', 184.0E0, null, 0.5, null, null, null), " + // 176
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null, null), " + // 8.0
+                        "('c_array', 184.0E0, null, 0.5, null, null, null, null), " + // 176
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, h_varchar)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null), " + // 8
-                        "('c_array', 104.0E0, null, 0.5, null, null, null), " + // 96
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null, null), " + // 8
+                        "('c_array', 104.0E0, null, 0.5, null, null, null, null), " + // 96
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, h_varchar)");
 
         // non existing partition
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 0E0, 0E0, null, null, null), " +
-                        "('c_bigint', null, 0E0, 0E0, null, null, null), " +
-                        "('c_double', null, 0E0, 0E0, null, null, null), " +
-                        "('c_timestamp', null, 0E0, 0E0, null, null, null), " +
-                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "('c_array', null, 0E0, 0E0, null, null, null), " +
-                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "(null, null, null, null, 0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_bigint', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_double', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_timestamp', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "('c_array', null, 0E0, 0E0, null, null, null, null), " +
+                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "(null, null, null, null, 0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, h_varchar)");
 
         dropTableIfExists(tmpTableName);
     }
@@ -349,36 +349,36 @@ public abstract class AbstractTestWriter
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null), " + // 8
-                        "('c_array', 184.0E0, null, 0.5E0, null, null, null), " + // 176
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null, null), " + // 8
+                        "('c_array', 184.0E0, null, 0.5E0, null, null, null, null), " + // 176
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, p_varchar)");
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
-                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
-                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null), " +
-                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null), " + // 8
-                        "('c_array', 104.0E0, null, 0.5, null, null, null), " + // 96
-                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null), " +
-                        "(null, null, null, null, 4.0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2', null), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3', null), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, null, null, null), " +
+                        "('c_varchar', 16.0E0, 2.0E0, 0.5E0, null, null, null, null), " + // 8
+                        "('c_array', 104.0E0, null, 0.5, null, null, null, null), " + // 96
+                        "('p_varchar', 8.0E0, 1.0E0, 0.0E0, null, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, p_varchar)");
 
         // non existing partition
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3')", tmpTableName),
                 "SELECT * FROM (VALUES " +
-                        "('c_boolean', null, 0E0, 0E0, null, null, null), " +
-                        "('c_bigint', null, 0E0, 0E0, null, null, null), " +
-                        "('c_double', null, 0E0, 0E0, null, null, null), " +
-                        "('c_timestamp', null, 0E0, 0E0, null, null, null), " +
-                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "('c_array', null, 0E0, 0E0, null, null, null), " +
-                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null), " +
-                        "(null, null, null, null, 0E0, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar)");
+                        "('c_boolean', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_bigint', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_double', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_timestamp', null, 0E0, 0E0, null, null, null, null), " +
+                        "('c_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "('c_array', null, 0E0, 0E0, null, null, null, null), " +
+                        "('p_varchar', 0E0, 0E0, 0E0, null, null, null, null), " +
+                        "(null, null, null, null, 0E0, null, null, null)) AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_array, p_varchar, p_varchar)");
 
         dropTableIfExists(tmpTableName);
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
@@ -55,19 +55,19 @@ public class TestExternalHiveTable
 
         onHive().executeQuery("ANALYZE TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey) COMPUTE STATISTICS");
         assertThat(query("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
         assertThat(query("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row(null, null, null, null, 5.0, null, null, null));
     }
 
     @Test

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -102,58 +102,58 @@ public class TestHiveTableStatistics
             .build();
 
     private static final List<Row> ALL_TYPES_TABLE_STATISTICS = ImmutableList.of(
-            row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
-            row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
-            row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
-            row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807"),
-            row("c_float", null, 2.0, 0.0, null, "123.341", "123.345"),
-            row("c_double", null, 2.0, 0.0, null, "234.561", "235.567"),
-            row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0"),
-            row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678"),
-            row("c_timestamp", null, 2.0, 0.0, null, null, null),
-            row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10"),
-            row("c_string", 22.0, 2.0, 0.0, null, null, null),
-            row("c_varchar", 20.0, 2.0, 0.0, null, null, null),
-            row("c_char", 12.0, 2.0, 0.0, null, null, null),
-            row("c_boolean", null, 2.0, 0.0, null, null, null),
-            row("c_binary", 23.0, null, 0.0, null, null, null),
-            row(null, null, null, null, 2.0, null, null));
+            row("c_tinyint", null, 2.0, 0.0, null, "121", "127", null),
+            row("c_smallint", null, 2.0, 0.0, null, "32761", "32767", null),
+            row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647", null),
+            row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807", null),
+            row("c_float", null, 2.0, 0.0, null, "123.341", "123.345", null),
+            row("c_double", null, 2.0, 0.0, null, "234.561", "235.567", null),
+            row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0", null),
+            row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678", null),
+            row("c_timestamp", null, 2.0, 0.0, null, null, null, null),
+            row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10", null),
+            row("c_string", 22.0, 2.0, 0.0, null, null, null, null),
+            row("c_varchar", 20.0, 2.0, 0.0, null, null, null, null),
+            row("c_char", 12.0, 2.0, 0.0, null, null, null, null),
+            row("c_boolean", null, 2.0, 0.0, null, null, null, null),
+            row("c_binary", 23.0, null, 0.0, null, null, null, null),
+            row(null, null, null, null, 2.0, null, null, null));
 
     private static final List<Row> ALL_TYPES_ALL_NULL_TABLE_STATISTICS = ImmutableList.of(
-            row("c_tinyint", null, 0.0, 1.0, null, null, null),
-            row("c_smallint", null, 0.0, 1.0, null, null, null),
-            row("c_int", null, 0.0, 1.0, null, null, null),
-            row("c_bigint", null, 0.0, 1.0, null, null, null),
-            row("c_float", null, 0.0, 1.0, null, null, null),
-            row("c_double", null, 0.0, 1.0, null, null, null),
-            row("c_decimal", null, 0.0, 1.0, null, null, null),
-            row("c_decimal_w_params", null, 0.0, 1.0, null, null, null),
-            row("c_timestamp", null, 0.0, 1.0, null, null, null),
-            row("c_date", null, 0.0, 1.0, null, null, null),
-            row("c_string", 0.0, 0.0, 1.0, null, null, null),
-            row("c_varchar", 0.0, 0.0, 1.0, null, null, null),
-            row("c_char", 0.0, 0.0, 1.0, null, null, null),
-            row("c_boolean", null, 0.0, 1.0, null, null, null),
-            row("c_binary", 0.0, null, 1.0, null, null, null),
-            row(null, null, null, null, 1.0, null, null));
+            row("c_tinyint", null, 0.0, 1.0, null, null, null, null),
+            row("c_smallint", null, 0.0, 1.0, null, null, null, null),
+            row("c_int", null, 0.0, 1.0, null, null, null, null),
+            row("c_bigint", null, 0.0, 1.0, null, null, null, null),
+            row("c_float", null, 0.0, 1.0, null, null, null, null),
+            row("c_double", null, 0.0, 1.0, null, null, null, null),
+            row("c_decimal", null, 0.0, 1.0, null, null, null, null),
+            row("c_decimal_w_params", null, 0.0, 1.0, null, null, null, null),
+            row("c_timestamp", null, 0.0, 1.0, null, null, null, null),
+            row("c_date", null, 0.0, 1.0, null, null, null, null),
+            row("c_string", 0.0, 0.0, 1.0, null, null, null, null),
+            row("c_varchar", 0.0, 0.0, 1.0, null, null, null, null),
+            row("c_char", 0.0, 0.0, 1.0, null, null, null, null),
+            row("c_boolean", null, 0.0, 1.0, null, null, null, null),
+            row("c_binary", 0.0, null, 1.0, null, null, null, null),
+            row(null, null, null, null, 1.0, null, null, null));
 
     private static final List<Row> ALL_TYPES_EMPTY_TABLE_STATISTICS = ImmutableList.of(
-            row("c_tinyint", null, 0.0, 0.0, null, null, null),
-            row("c_smallint", null, 0.0, 0.0, null, null, null),
-            row("c_int", null, 0.0, 0.0, null, null, null),
-            row("c_bigint", null, 0.0, 0.0, null, null, null),
-            row("c_float", null, 0.0, 0.0, null, null, null),
-            row("c_double", null, 0.0, 0.0, null, null, null),
-            row("c_decimal", null, 0.0, 0.0, null, null, null),
-            row("c_decimal_w_params", null, 0.0, 0.0, null, null, null),
-            row("c_timestamp", null, 0.0, 0.0, null, null, null),
-            row("c_date", null, 0.0, 0.0, null, null, null),
-            row("c_string", 0.0, 0.0, 0.0, null, null, null),
-            row("c_varchar", 0.0, 0.0, 0.0, null, null, null),
-            row("c_char", 0.0, 0.0, 0.0, null, null, null),
-            row("c_boolean", null, 0.0, 0.0, null, null, null),
-            row("c_binary", 0.0, null, 0.0, null, null, null),
-            row(null, null, null, null, 0.0, null, null));
+            row("c_tinyint", null, 0.0, 0.0, null, null, null, null),
+            row("c_smallint", null, 0.0, 0.0, null, null, null, null),
+            row("c_int", null, 0.0, 0.0, null, null, null, null),
+            row("c_bigint", null, 0.0, 0.0, null, null, null, null),
+            row("c_float", null, 0.0, 0.0, null, null, null, null),
+            row("c_double", null, 0.0, 0.0, null, null, null, null),
+            row("c_decimal", null, 0.0, 0.0, null, null, null, null),
+            row("c_decimal_w_params", null, 0.0, 0.0, null, null, null, null),
+            row("c_timestamp", null, 0.0, 0.0, null, null, null, null),
+            row("c_date", null, 0.0, 0.0, null, null, null, null),
+            row("c_string", 0.0, 0.0, 0.0, null, null, null, null),
+            row("c_varchar", 0.0, 0.0, 0.0, null, null, null, null),
+            row("c_char", 0.0, 0.0, 0.0, null, null, null, null),
+            row("c_boolean", null, 0.0, 0.0, null, null, null, null),
+            row("c_binary", 0.0, null, 0.0, null, null, null, null),
+            row(null, null, null, null, 0.0, null, null, null));
 
     private static final class AllTypesTable
             implements RequirementsProvider
@@ -179,33 +179,33 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_name", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_regionkey", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_comment", null, null, anyOf(null, 0.0), null, null, null),
-                row(null, null, null, null, anyOf(null, 0.0), null, null)); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
+                row("n_nationkey", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_name", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_regionkey", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_comment", null, null, anyOf(null, 0.0), null, null, null, null),
+                row(null, null, null, null, anyOf(null, 0.0), null, null, null)); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
 
         // basic analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, null, null, null, null, null),
-                row("n_name", null, null, null, null, null, null),
-                row("n_regionkey", null, null, null, null, null, null),
-                row("n_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 25.0, null, null));
+                row("n_nationkey", null, null, null, null, null, null, null),
+                row("n_name", null, null, null, null, null, null, null),
+                row("n_regionkey", null, null, null, null, null, null, null),
+                row("n_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 25.0, null, null, null));
 
         // column analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, 19.0, 0.0, null, "0", "24"),
-                row("n_name", 177.0, 24.0, 0.0, null, null, null),
-                row("n_regionkey", null, 5.0, 0.0, null, "0", "4"),
-                row("n_comment", 1857.0, 25.0, 0.0, null, null, null),
-                row(null, null, null, null, 25.0, null, null));
+                row("n_nationkey", null, 19.0, 0.0, null, "0", "24", null),
+                row("n_name", 177.0, 24.0, 0.0, null, null, null, null),
+                row("n_regionkey", null, 5.0, 0.0, null, "0", "4", null),
+                row("n_comment", 1857.0, 25.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 25.0, null, null, null));
     }
 
     @Test
@@ -221,118 +221,118 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // basic analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // basic analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         // column analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 114.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 114.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", 1497.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2", null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         // column analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 109.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 109.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", 1197.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 4.0, 0.0, null, "8", "21"),
-                row("p_name", 31.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
-                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 4.0, 0.0, null, "8", "21", null),
+                row("p_name", 31.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2", null),
+                row("p_comment", 351.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
     }
 
     @Test
@@ -348,118 +348,118 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // basic analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // basic analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         // column analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 114.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 114.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", 1497.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         // column analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 109.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 109.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", 1197.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 4.0, 0.0, null, "8", "21"),
-                row("p_name", 31.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 4.0, 0.0, null, "8", "21", null),
+                row("p_name", 31.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 351.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
     }
 
     // This covers also stats calculation for unpartitioned table
@@ -472,43 +472,43 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
-                row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
-                row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
-                row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807"),
-                row("c_float", null, 2.0, 0.0, null, "123.341", "123.345"),
-                row("c_double", null, 2.0, 0.0, null, "234.561", "235.567"),
-                row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0"),
-                row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678"),
-                row("c_timestamp", null, 2.0, 0.0, null, null, null), // timestamp is shifted by hive.time-zone on read
-                row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10"),
-                row("c_string", 22.0, 2.0, 0.0, null, null, null),
-                row("c_varchar", 20.0, 2.0, 0.0, null, null, null),
-                row("c_char", 12.0, 2.0, 0.0, null, null, null),
-                row("c_boolean", null, 2.0, 0.0, null, null, null),
-                row("c_binary", 23.0, null, 0.0, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_tinyint", null, 2.0, 0.0, null, "121", "127", null),
+                row("c_smallint", null, 2.0, 0.0, null, "32761", "32767", null),
+                row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647", null),
+                row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807", null),
+                row("c_float", null, 2.0, 0.0, null, "123.341", "123.345", null),
+                row("c_double", null, 2.0, 0.0, null, "234.561", "235.567", null),
+                row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0", null),
+                row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678", null),
+                row("c_timestamp", null, 2.0, 0.0, null, null, null, null), // timestamp is shifted by hive.time-zone on read
+                row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10", null),
+                row("c_string", 22.0, 2.0, 0.0, null, null, null, null),
+                row("c_varchar", 20.0, 2.0, 0.0, null, null, null, null),
+                row("c_char", 12.0, 2.0, 0.0, null, null, null, null),
+                row("c_boolean", null, 2.0, 0.0, null, null, null, null),
+                row("c_binary", 23.0, null, 0.0, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
     }
 
     @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -520,42 +520,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 0.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 0.0, 0.0, null, null, null),
-                row("c_smallint", null, 0.0, 0.0, null, null, null),
-                row("c_int", null, 0.0, 0.0, null, null, null),
-                row("c_bigint", null, 0.0, 0.0, null, null, null),
-                row("c_float", null, 0.0, 0.0, null, null, null),
-                row("c_double", null, 0.0, 0.0, null, null, null),
-                row("c_decimal", null, 0.0, 0.0, null, null, null),
-                row("c_decimal_w_params", null, 0.0, 0.0, null, null, null),
-                row("c_timestamp", null, 0.0, 0.0, null, null, null),
-                row("c_date", null, 0.0, 0.0, null, null, null),
-                row("c_string", 0.0, 0.0, 0.0, null, null, null),
-                row("c_varchar", 0.0, 0.0, 0.0, null, null, null),
-                row("c_char", 0.0, 0.0, 0.0, null, null, null),
-                row("c_boolean", null, 0.0, 0.0, null, null, null),
-                row("c_binary", 0.0, null, 0.0, null, null, null),
-                row(null, null, null, null, 0.0, null, null));
+                row("c_tinyint", null, 0.0, 0.0, null, null, null, null),
+                row("c_smallint", null, 0.0, 0.0, null, null, null, null),
+                row("c_int", null, 0.0, 0.0, null, null, null, null),
+                row("c_bigint", null, 0.0, 0.0, null, null, null, null),
+                row("c_float", null, 0.0, 0.0, null, null, null, null),
+                row("c_double", null, 0.0, 0.0, null, null, null, null),
+                row("c_decimal", null, 0.0, 0.0, null, null, null, null),
+                row("c_decimal_w_params", null, 0.0, 0.0, null, null, null, null),
+                row("c_timestamp", null, 0.0, 0.0, null, null, null, null),
+                row("c_date", null, 0.0, 0.0, null, null, null, null),
+                row("c_string", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_varchar", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_char", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_boolean", null, 0.0, 0.0, null, null, null, null),
+                row("c_binary", 0.0, null, 0.0, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null, null));
     }
 
     @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -568,42 +568,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 0.0, 1.0, null, null, null),
-                row("c_smallint", null, 0.0, 1.0, null, null, null),
-                row("c_int", null, 0.0, 1.0, null, null, null),
-                row("c_bigint", null, 0.0, 1.0, null, null, null),
-                row("c_float", null, 0.0, 1.0, null, null, null),
-                row("c_double", null, 0.0, 1.0, null, null, null),
-                row("c_decimal", null, 0.0, 1.0, null, null, null),
-                row("c_decimal_w_params", null, 0.0, 1.0, null, null, null),
-                row("c_timestamp", null, 0.0, 1.0, null, null, null),
-                row("c_date", null, 0.0, 1.0, null, null, null),
-                row("c_string", 0.0, 0.0, 1.0, null, null, null),
-                row("c_varchar", 0.0, 0.0, 1.0, null, null, null),
-                row("c_char", 0.0, 0.0, 1.0, null, null, null),
-                row("c_boolean", null, 0.0, 1.0, null, null, null),
-                row("c_binary", 0.0, null, 1.0, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row("c_tinyint", null, 0.0, 1.0, null, null, null, null),
+                row("c_smallint", null, 0.0, 1.0, null, null, null, null),
+                row("c_int", null, 0.0, 1.0, null, null, null, null),
+                row("c_bigint", null, 0.0, 1.0, null, null, null, null),
+                row("c_float", null, 0.0, 1.0, null, null, null, null),
+                row("c_double", null, 0.0, 1.0, null, null, null, null),
+                row("c_decimal", null, 0.0, 1.0, null, null, null, null),
+                row("c_decimal_w_params", null, 0.0, 1.0, null, null, null, null),
+                row("c_timestamp", null, 0.0, 1.0, null, null, null, null),
+                row("c_date", null, 0.0, 1.0, null, null, null, null),
+                row("c_string", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_varchar", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_char", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_boolean", null, 0.0, 1.0, null, null, null, null),
+                row("c_binary", 0.0, null, 1.0, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null, null));
     }
 
     @Test
@@ -616,22 +616,22 @@ public class TestHiveTableStatistics
         onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES ('c1', 1), ('c1', 2)");
 
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                row("c_string", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                row("c_string", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS FOR COLUMNS");
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                row("c_string", 4.0, 1.0, 0.0, null, null, null),
-                row("c_int", null, 2.0, 0.0, null, "1", "2"),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_string", 4.0, 1.0, 0.0, null, null, null, null),
+                row("c_int", null, 2.0, 0.0, null, "1", "2", null),
+                row(null, null, null, null, 2.0, null, null, null));
     }
 
     @Test
@@ -644,15 +644,15 @@ public class TestHiveTableStatistics
         onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES ('c1', 1), ('c1', 2)");
 
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                row("c_string", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
 
         assertThat(query("ANALYZE " + tableName)).containsExactly(row(2));
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                row("c_string", 4.0, 1.0, 0.0, null, null, null),
-                row("c_int", null, 2.0, 0.0, null, "1", "2"),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_string", 4.0, 1.0, 0.0, null, null, null, null),
+                row("c_int", null, 2.0, 0.0, null, "1", "2", null),
+                row(null, null, null, null, 2.0, null, null, null));
     }
 
     @Test
@@ -665,20 +665,20 @@ public class TestHiveTableStatistics
 
         // table not analyzed
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_name", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_regionkey", null, null, anyOf(null, 0.0), null, null, null),
-                row("n_comment", null, null, anyOf(null, 0.0), null, null, null),
-                row(null, null, null, null, anyOf(null, 0.0), null, null)); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
+                row("n_nationkey", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_name", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_regionkey", null, null, anyOf(null, 0.0), null, null, null, null),
+                row("n_comment", null, null, anyOf(null, 0.0), null, null, null, null),
+                row(null, null, null, null, anyOf(null, 0.0), null, null, null)); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(25));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, 25.0, 0.0, null, "0", "24"),
-                row("n_name", 177.0, 25.0, 0.0, null, null, null),
-                row("n_regionkey", null, 5.0, 0.0, null, "0", "4"),
-                row("n_comment", 1857.0, 25.0, 0.0, null, null, null),
-                row(null, null, null, null, 25.0, null, null));
+                row("n_nationkey", null, 25.0, 0.0, null, "0", "24", null),
+                row("n_name", 177.0, 25.0, 0.0, null, null, null, null),
+                row("n_regionkey", null, 5.0, 0.0, null, "0", "4", null),
+                row("n_comment", 1857.0, 25.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 25.0, null, null, null));
     }
 
     @Test
@@ -693,10 +693,10 @@ public class TestHiveTableStatistics
 
         assertThat(query("ANALYZE " + tableName)).containsExactly(row(1));
         assertThat(query(showStatsTable)).containsOnly(
-                row("c_row", null, null, null, null, null, null),
-                row("c_char", 1.0, 1.0, 0.0, null, null, null),
-                row("c_int", null, 1.0, 0.0, null, "3", "3"),
-                row(null, null, null, null, 1.0, null, null));
+                row("c_row", null, null, null, null, null, null, null),
+                row("c_char", 1.0, 1.0, 0.0, null, null, null, null),
+                row("c_int", null, 1.0, 0.0, null, "3", "3", null),
+                row(null, null, null, null, 1.0, null, null, null));
     }
 
     @Test
@@ -715,11 +715,11 @@ public class TestHiveTableStatistics
 
         assertThat(query("ANALYZE " + tableName)).containsExactly(row(3));
         assertThat(query(showStatsTable)).containsOnly(
-                row("c_row", null, null, null, null, null, null),
-                row("c_char", 3.0, 2.0, 0.0, null, null, null),
-                row("c_int", null, 1.0, 0.0, null, "3", "5"),
-                row("c_part", 3.0, 2.0, 0.0, null, null, null),
-                row(null, null, null, null, 3.0, null, null));
+                row("c_row", null, null, null, null, null, null, null),
+                row("c_char", 3.0, 2.0, 0.0, null, null, null, null),
+                row("c_int", null, 1.0, 0.0, null, "3", "5", null),
+                row("c_part", 3.0, 2.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 3.0, null, null, null));
     }
 
     @Test
@@ -735,68 +735,68 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // analyze for single partition
 
         assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['1']])")).containsExactly(row(5));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 114.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 114.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", 1497.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // analyze for all partitions
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(15));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 109.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 109.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3", null),
+                row("p_comment", 1197.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1", null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "8", "21"),
-                row("p_name", 31.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
-                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "8", "21", null),
+                row("p_name", 31.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2", null),
+                row("p_comment", 351.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
     }
 
     @Test
@@ -812,68 +812,68 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // analyze for single partition
 
         assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['AMERICA']])")).containsExactly(row(5));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 114.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 114.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", 1497.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null, null, null),
-                row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, null, null, null, null, null),
-                row("p_comment", null, null, null, null, null, null),
-                row(null, null, null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null, null),
+                row("p_regionkey", null, null, null, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null, null));
 
         // column analysis for all partitions
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(15));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 109.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
-                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 109.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 85.0, 3.0, 0.0, null, null, null, null),
+                row("p_comment", 1197.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 38.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 499.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24", null),
+                row("p_name", 38.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 35.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 499.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "8", "21"),
-                row("p_name", 31.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
-                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+                row("p_nationkey", null, 5.0, 0.0, null, "8", "21", null),
+                row("p_name", 31.0, 5.0, 0.0, null, null, null, null),
+                row("p_regionkey", 20.0, 1.0, 0.0, null, null, null, null),
+                row("p_comment", 351.0, 5.0, 0.0, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null, null));
     }
 
     // This covers also stats calculation for unpartitioned table
@@ -884,43 +884,43 @@ public class TestHiveTableStatistics
         String tableNameInDatabase = mutableTablesState().get(ALL_TYPES_TABLE_NAME).getNameInDatabase();
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 0.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null, null));
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(2));
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
-                row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
-                row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
-                row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807"),
-                row("c_float", null, 2.0, 0.0, null, "123.341", "123.345"),
-                row("c_double", null, 2.0, 0.0, null, "234.561", "235.567"),
-                row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0"),
-                row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678"),
-                row("c_timestamp", null, 2.0, 0.0, null, null, null),
-                row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10"),
-                row("c_string", 22.0, 2.0, 0.0, null, null, null),
-                row("c_varchar", 20.0, 2.0, 0.0, null, null, null),
-                row("c_char", 12.0, 2.0, 0.0, null, null, null),
-                row("c_boolean", null, 2.0, 0.0, null, null, null),
-                row("c_binary", 23.0, null, 0.0, null, null, null),
-                row(null, null, null, null, 2.0, null, null));
+                row("c_tinyint", null, 2.0, 0.0, null, "121", "127", null),
+                row("c_smallint", null, 2.0, 0.0, null, "32761", "32767", null),
+                row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647", null),
+                row("c_bigint", null, 2.0, 0.0, null, "9223372036854775807", "9223372036854775807", null),
+                row("c_float", null, 2.0, 0.0, null, "123.341", "123.345", null),
+                row("c_double", null, 2.0, 0.0, null, "234.561", "235.567", null),
+                row("c_decimal", null, 2.0, 0.0, null, "345.0", "346.0", null),
+                row("c_decimal_w_params", null, 2.0, 0.0, null, "345.671", "345.678", null),
+                row("c_timestamp", null, 2.0, 0.0, null, null, null, null),
+                row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10", null),
+                row("c_string", 22.0, 2.0, 0.0, null, null, null, null),
+                row("c_varchar", 20.0, 2.0, 0.0, null, null, null, null),
+                row("c_char", 12.0, 2.0, 0.0, null, null, null, null),
+                row("c_boolean", null, 2.0, 0.0, null, null, null, null),
+                row("c_binary", 23.0, null, 0.0, null, null, null, null),
+                row(null, null, null, null, 2.0, null, null, null));
     }
 
     @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -930,42 +930,42 @@ public class TestHiveTableStatistics
         String tableNameInDatabase = mutableTablesState().get(EMPTY_ALL_TYPES_TABLE_NAME).getNameInDatabase();
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 0.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null, null));
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(0));
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 0.0, 0.0, null, null, null),
-                row("c_smallint", null, 0.0, 0.0, null, null, null),
-                row("c_int", null, 0.0, 0.0, null, null, null),
-                row("c_bigint", null, 0.0, 0.0, null, null, null),
-                row("c_float", null, 0.0, 0.0, null, null, null),
-                row("c_double", null, 0.0, 0.0, null, null, null),
-                row("c_decimal", null, 0.0, 0.0, null, null, null),
-                row("c_decimal_w_params", null, 0.0, 0.0, null, null, null),
-                row("c_timestamp", null, 0.0, 0.0, null, null, null),
-                row("c_date", null, 0.0, 0.0, null, null, null),
-                row("c_string", 0.0, 0.0, 0.0, null, null, null),
-                row("c_varchar", 0.0, 0.0, 0.0, null, null, null),
-                row("c_char", 0.0, 0.0, 0.0, null, null, null),
-                row("c_boolean", null, 0.0, 0.0, null, null, null),
-                row("c_binary", 0.0, null, 0.0, null, null, null),
-                row(null, null, null, null, 0.0, null, null));
+                row("c_tinyint", null, 0.0, 0.0, null, null, null, null),
+                row("c_smallint", null, 0.0, 0.0, null, null, null, null),
+                row("c_int", null, 0.0, 0.0, null, null, null, null),
+                row("c_bigint", null, 0.0, 0.0, null, null, null, null),
+                row("c_float", null, 0.0, 0.0, null, null, null, null),
+                row("c_double", null, 0.0, 0.0, null, null, null, null),
+                row("c_decimal", null, 0.0, 0.0, null, null, null, null),
+                row("c_decimal_w_params", null, 0.0, 0.0, null, null, null, null),
+                row("c_timestamp", null, 0.0, 0.0, null, null, null, null),
+                row("c_date", null, 0.0, 0.0, null, null, null, null),
+                row("c_string", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_varchar", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_char", 0.0, 0.0, 0.0, null, null, null, null),
+                row("c_boolean", null, 0.0, 0.0, null, null, null, null),
+                row("c_binary", 0.0, null, 0.0, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null, null));
     }
 
     @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -978,42 +978,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("INSERT INTO TABLE " + tableNameInDatabase + " VALUES(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null, null, null),
-                row("c_smallint", null, null, null, null, null, null),
-                row("c_int", null, null, null, null, null, null),
-                row("c_bigint", null, null, null, null, null, null),
-                row("c_float", null, null, null, null, null, null),
-                row("c_double", null, null, null, null, null, null),
-                row("c_decimal", null, null, null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null, null, null),
-                row("c_timestamp", null, null, null, null, null, null),
-                row("c_date", null, null, null, null, null, null),
-                row("c_string", null, null, null, null, null, null),
-                row("c_varchar", null, null, null, null, null, null),
-                row("c_char", null, null, null, null, null, null),
-                row("c_boolean", null, null, null, null, null, null),
-                row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row("c_tinyint", null, null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null, null));
 
         assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(1));
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 0.0, 1.0, null, null, null),
-                row("c_smallint", null, 0.0, 1.0, null, null, null),
-                row("c_int", null, 0.0, 1.0, null, null, null),
-                row("c_bigint", null, 0.0, 1.0, null, null, null),
-                row("c_float", null, 0.0, 1.0, null, null, null),
-                row("c_double", null, 0.0, 1.0, null, null, null),
-                row("c_decimal", null, 0.0, 1.0, null, null, null),
-                row("c_decimal_w_params", null, 0.0, 1.0, null, null, null),
-                row("c_timestamp", null, 0.0, 1.0, null, null, null),
-                row("c_date", null, 0.0, 1.0, null, null, null),
-                row("c_string", 0.0, 0.0, 1.0, null, null, null),
-                row("c_varchar", 0.0, 0.0, 1.0, null, null, null),
-                row("c_char", 0.0, 0.0, 1.0, null, null, null),
-                row("c_boolean", null, 0.0, 1.0, null, null, null),
-                row("c_binary", 0.0, null, 1.0, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row("c_tinyint", null, 0.0, 1.0, null, null, null, null),
+                row("c_smallint", null, 0.0, 1.0, null, null, null, null),
+                row("c_int", null, 0.0, 1.0, null, null, null, null),
+                row("c_bigint", null, 0.0, 1.0, null, null, null, null),
+                row("c_float", null, 0.0, 1.0, null, null, null, null),
+                row("c_double", null, 0.0, 1.0, null, null, null, null),
+                row("c_decimal", null, 0.0, 1.0, null, null, null, null),
+                row("c_decimal_w_params", null, 0.0, 1.0, null, null, null, null),
+                row("c_timestamp", null, 0.0, 1.0, null, null, null, null),
+                row("c_date", null, 0.0, 1.0, null, null, null, null),
+                row("c_string", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_varchar", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_char", 0.0, 0.0, 1.0, null, null, null, null),
+                row("c_boolean", null, 0.0, 1.0, null, null, null, null),
+                row("c_binary", 0.0, null, 1.0, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null, null));
     }
 
     @Test
@@ -1049,22 +1049,22 @@ public class TestHiveTableStatistics
             query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
             query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
             assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
-                    row("c_tinyint", null, 2.0, 0.5, null, "121", "127"),
-                    row("c_smallint", null, 2.0, 0.5, null, "32761", "32767"),
-                    row("c_int", null, 2.0, 0.5, null, "2147483641", "2147483647"),
-                    row("c_bigint", null, 2.0, 0.5, null, "9223372036854775807", "9223372036854775807"),
-                    row("c_float", null, 2.0, 0.5, null, "123.341", "123.345"),
-                    row("c_double", null, 2.0, 0.5, null, "234.561", "235.567"),
-                    row("c_decimal", null, 2.0, 0.5, null, "345.0", "346.0"),
-                    row("c_decimal_w_params", null, 2.0, 0.5, null, "345.671", "345.678"),
-                    row("c_timestamp", null, 2.0, 0.5, null, null, null),
-                    row("c_date", null, 2.0, 0.5, null, "2015-05-09", "2015-06-10"),
-                    row("c_string", 22.0, 2.0, 0.5, null, null, null),
-                    row("c_varchar", 20.0, 2.0, 0.5, null, null, null),
-                    row("c_char", 12.0, 2.0, 0.5, null, null, null),
-                    row("c_boolean", null, 2.0, 0.5, null, null, null),
-                    row("c_binary", 23.0, null, 0.5, null, null, null),
-                    row(null, null, null, null, 4.0, null, null));
+                    row("c_tinyint", null, 2.0, 0.5, null, "121", "127", null),
+                    row("c_smallint", null, 2.0, 0.5, null, "32761", "32767", null),
+                    row("c_int", null, 2.0, 0.5, null, "2147483641", "2147483647", null),
+                    row("c_bigint", null, 2.0, 0.5, null, "9223372036854775807", "9223372036854775807", null),
+                    row("c_float", null, 2.0, 0.5, null, "123.341", "123.345", null),
+                    row("c_double", null, 2.0, 0.5, null, "234.561", "235.567", null),
+                    row("c_decimal", null, 2.0, 0.5, null, "345.0", "346.0", null),
+                    row("c_decimal_w_params", null, 2.0, 0.5, null, "345.671", "345.678", null),
+                    row("c_timestamp", null, 2.0, 0.5, null, null, null, null),
+                    row("c_date", null, 2.0, 0.5, null, "2015-05-09", "2015-06-10", null),
+                    row("c_string", 22.0, 2.0, 0.5, null, null, null, null),
+                    row("c_varchar", 20.0, 2.0, 0.5, null, null, null, null),
+                    row("c_char", 12.0, 2.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 2.0, 0.5, null, null, null, null),
+                    row("c_binary", 23.0, null, 0.5, null, null, null, null),
+                    row(null, null, null, null, 4.0, null, null, null));
 
             query(format("INSERT INTO %s VALUES( " +
                     "TINYINT '120', " +
@@ -1084,22 +1084,22 @@ public class TestHiveTableStatistics
                     "CAST('cGllcyBiaW5hcm54' as VARBINARY))", tableName));
 
             assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 2.0, 0.4, null, "120", "127"),
-                    row("c_smallint", null, 2.0, 0.4, null, "32760", "32767"),
-                    row("c_int", null, 2.0, 0.4, null, "2147483640", "2147483647"),
-                    row("c_bigint", null, 2.0, 0.4, null, "9223372036854775807", "9223372036854775807"),
-                    row("c_float", null, 2.0, 0.4, null, "123.34", "123.345"),
-                    row("c_double", null, 2.0, 0.4, null, "234.56", "235.567"),
-                    row("c_decimal", null, 2.0, 0.4, null, "343.0", "346.0"),
-                    row("c_decimal_w_params", null, 2.0, 0.4, null, "345.67", "345.678"),
-                    row("c_timestamp", null, 2.0, 0.4, null, null, null),
-                    row("c_date", null, 2.0, 0.4, null, "2015-05-08", "2015-06-10"),
-                    row("c_string", 32.0, 2.0, 0.4, null, null, null),
-                    row("c_varchar", 29.0, 2.0, 0.4, null, null, null),
-                    row("c_char", 17.0, 2.0, 0.4, null, null, null),
-                    row("c_boolean", null, 2.0, 0.4, null, null, null),
-                    row("c_binary", 39.0, null, 0.4, null, null, null),
-                    row(null, null, null, null, 5.0, null, null)));
+                    row("c_tinyint", null, 2.0, 0.4, null, "120", "127", null),
+                    row("c_smallint", null, 2.0, 0.4, null, "32760", "32767", null),
+                    row("c_int", null, 2.0, 0.4, null, "2147483640", "2147483647", null),
+                    row("c_bigint", null, 2.0, 0.4, null, "9223372036854775807", "9223372036854775807", null),
+                    row("c_float", null, 2.0, 0.4, null, "123.34", "123.345", null),
+                    row("c_double", null, 2.0, 0.4, null, "234.56", "235.567", null),
+                    row("c_decimal", null, 2.0, 0.4, null, "343.0", "346.0", null),
+                    row("c_decimal_w_params", null, 2.0, 0.4, null, "345.67", "345.678", null),
+                    row("c_timestamp", null, 2.0, 0.4, null, null, null, null),
+                    row("c_date", null, 2.0, 0.4, null, "2015-05-08", "2015-06-10", null),
+                    row("c_string", 32.0, 2.0, 0.4, null, null, null, null),
+                    row("c_varchar", 29.0, 2.0, 0.4, null, null, null, null),
+                    row("c_char", 17.0, 2.0, 0.4, null, null, null, null),
+                    row("c_boolean", null, 2.0, 0.4, null, null, null, null),
+                    row("c_binary", 39.0, null, 0.4, null, null, null, null),
+                    row(null, null, null, null, 5.0, null, null, null)));
         }
         finally {
             query(format("DROP TABLE IF EXISTS %s", tableName));
@@ -1160,44 +1160,44 @@ public class TestHiveTableStatistics
                     ") AS t (c_tinyint, c_smallint, c_int, c_bigint, c_float, c_double, c_decimal, c_decimal_w_params, c_timestamp, c_date, c_string, c_varchar, c_char, c_boolean, c_binary, p_bigint, p_varchar)", tableName));
 
             assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName))).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
-                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
-                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
-                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807"),
-                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34"),
-                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "343.0", "343.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67", "345.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08"),
-                    row("c_string", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 9.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 1.0, 0.5, null, null, null),
-                    row("c_binary", 9.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
-                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 2.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760", null),
+                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807", null),
+                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "343.0", "343.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67", "345.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08", null),
+                    row("c_string", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 9.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null, null),
+                    row("c_binary", 9.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1", null),
+                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 2.0, null, null, null)));
 
             assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName))).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
-                    row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
-                    row("c_int", null, 1.0, 0.5, null, "444", "444"),
-                    row("c_bigint", null, 1.0, 0.5, null, "555", "555"),
-                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34"),
-                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "888.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "999.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09"),
-                    row("c_string", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 9.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 1.0, 0.5, null, null, null),
-                    row("c_binary", 9.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
-                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 2.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "333", null),
+                    row("c_int", null, 1.0, 0.5, null, "444", "444", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "555", null),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "888.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "999.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09", null),
+                    row("c_string", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 9.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null, null),
+                    row("c_binary", 9.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2", null),
+                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 2.0, null, null, null)));
         }
         finally {
             query(format("DROP TABLE IF EXISTS %s", tableName));
@@ -1246,90 +1246,90 @@ public class TestHiveTableStatistics
             String showStatsPartitionTwo = format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName);
 
             assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
-                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
-                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
-                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807"),
-                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34"),
-                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "343.0", "343.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67", "345.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08"),
-                    row("c_string", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 9.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 1.0, 0.5, null, null, null),
-                    row("c_binary", 9.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
-                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 2.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760", null),
+                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807", null),
+                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "343.0", "343.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67", "345.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08", null),
+                    row("c_string", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 9.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null, null),
+                    row("c_binary", 9.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1", null),
+                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 2.0, null, null, null)));
 
             assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
-                    row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
-                    row("c_int", null, 1.0, 0.5, null, "444", "444"),
-                    row("c_bigint", null, 1.0, 0.5, null, "555", "555"),
-                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34"),
-                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "888.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "999.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09"),
-                    row("c_string", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 9.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 1.0, 0.5, null, null, null),
-                    row("c_binary", 9.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
-                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 2.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "333", null),
+                    row("c_int", null, 1.0, 0.5, null, "444", "444", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "555", null),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "888.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "999.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09", null),
+                    row("c_string", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 10.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 9.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null, null),
+                    row("c_binary", 9.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2", null),
+                    row("p_varchar", 20.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 2.0, null, null, null)));
 
             query(format("INSERT INTO %s VALUES( TINYINT '119', SMALLINT '32759', INTEGER '2147483639', BIGINT '9223372036854775799', REAL '122.340', DOUBLE '233.560', CAST(342.0 AS DECIMAL(10, 0)), CAST(344.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:29', DATE '2015-05-07', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), true, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')", tableName));
             query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
 
             assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "119", "120"),
-                    row("c_smallint", null, 1.0, 0.5, null, "32759", "32760"),
-                    row("c_int", null, 1.0, 0.5, null, "2147483639", "2147483640"),
-                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807"),
-                    row("c_float", null, 1.0, 0.5, null, "122.34", "123.34"),
-                    row("c_double", null, 1.0, 0.5, null, "233.56", "234.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "342.0", "343.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "344.67", "345.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-07", "2015-05-08"),
-                    row("c_string", 20.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 20.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 18.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 2.0, 0.5, null, null, null),
-                    row("c_binary", 18.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
-                    row("p_varchar", 40.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 4.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "119", "120", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "32759", "32760", null),
+                    row("c_int", null, 1.0, 0.5, null, "2147483639", "2147483640", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775807", "9223372036854775807", null),
+                    row("c_float", null, 1.0, 0.5, null, "122.34", "123.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "233.56", "234.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "342.0", "343.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "344.67", "345.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-07", "2015-05-08", null),
+                    row("c_string", 20.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 20.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 18.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 2.0, 0.5, null, null, null, null),
+                    row("c_binary", 18.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1", null),
+                    row("p_varchar", 40.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 4.0, null, null, null)));
 
             query(format("INSERT INTO %s VALUES( TINYINT '100', SMALLINT '334', INTEGER '445', BIGINT '556', REAL '667.340', DOUBLE '778.560', CAST(889.0 AS DECIMAL(10, 0)), CAST(1000.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:31', DATE '2015-05-10', CAST('p2 varchar' AS VARCHAR), CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')", tableName));
             query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
 
             assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
-                    row("c_tinyint", null, 1.0, 0.5, null, "99", "100"),
-                    row("c_smallint", null, 1.0, 0.5, null, "333", "334"),
-                    row("c_int", null, 1.0, 0.5, null, "444", "445"),
-                    row("c_bigint", null, 1.0, 0.5, null, "555", "556"),
-                    row("c_float", null, 1.0, 0.5, null, "666.34", "667.34"),
-                    row("c_double", null, 1.0, 0.5, null, "777.56", "778.56"),
-                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "889.0"),
-                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "1000.67"),
-                    row("c_timestamp", null, 1.0, 0.5, null, null, null),
-                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-10"),
-                    row("c_string", 20.0, 1.0, 0.5, null, null, null),
-                    row("c_varchar", 20.0, 1.0, 0.5, null, null, null),
-                    row("c_char", 18.0, 1.0, 0.5, null, null, null),
-                    row("c_boolean", null, 1.0, 0.5, null, null, null),
-                    row("c_binary", 18.0, null, 0.5, null, null, null),
-                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
-                    row("p_varchar", 40.0, 1.0, 0.0, null, null, null),
-                    row(null, null, null, null, 4.0, null, null)));
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "100", null),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "334", null),
+                    row("c_int", null, 1.0, 0.5, null, "444", "445", null),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "556", null),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "667.34", null),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "778.56", null),
+                    row("c_decimal", null, 1.0, 0.5, null, "888.0", "889.0", null),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67", "1000.67", null),
+                    row("c_timestamp", null, 1.0, 0.5, null, null, null, null),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-10", null),
+                    row("c_string", 20.0, 1.0, 0.5, null, null, null, null),
+                    row("c_varchar", 20.0, 1.0, 0.5, null, null, null, null),
+                    row("c_char", 18.0, 1.0, 0.5, null, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null, null),
+                    row("c_binary", 18.0, null, 0.5, null, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2", null),
+                    row("p_varchar", 40.0, 1.0, 0.0, null, null, null, null),
+                    row(null, null, null, null, 4.0, null, null, null)));
         }
         finally {
             query(format("DROP TABLE IF EXISTS %s", tableName));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
@@ -21,7 +21,8 @@ public enum ColumnStatisticType
     NUMBER_OF_DISTINCT_VALUES("approx_distinct"),
     NUMBER_OF_NON_NULL_VALUES("count"),
     NUMBER_OF_TRUE_VALUES("count_if"),
-    TOTAL_SIZE_IN_BYTES("sum_data_size_for_stats");
+    TOTAL_SIZE_IN_BYTES("sum_data_size_for_stats"),
+    HISTOGRAM("tdigest_agg");
     private final String functionName;
 
     ColumnStatisticType(String functionName)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ConnectorHistogram.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ConnectorHistogram.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * This interface contains functions which the Presto optimizer can use to
+ * answer questions about a particular column's data distribution. These
+ * functions will be used to return answers to the query optimizer to build
+ * more realistic cost models for joins and filter predicates.
+ * <br>
+ * Currently, this interface supports representing histograms of columns whose
+ * domains map to real values.
+ * <br>
+ * Null values should not be represented in underlying histogram implementation.
+ * When calculating filter statistics using the {@link ColumnStatisticType#NUMBER_OF_NON_NULL_VALUES}
+ * are used to account for nulls in cost-based calculations.
+ *
+ * @see ColumnStatisticType#NUMBER_OF_NON_NULL_VALUES
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, property = "@class")
+public interface ConnectorHistogram
+{
+    /**
+     * Calculates an estimate for the percentile at which a particular value
+     * falls in a distribution.
+     * <br>
+     * Put another way, this function returns the value of F(x) where F(x)
+     * represents the CDF of this particular distribution. Traditionally, the
+     * true CDF of a random variable X is represented by F(x) = P(x <= X). This
+     * function signature allows for a slight modification by using the
+     * {@code inclusive} parameter to return the value for F(x) = P(x < X)
+     * should the underlying implementation support it.
+     *
+     * @param value the value to calculate percentile
+     * @param inclusive whether this calculation should be inclusive or exclusive of the value (<= or <)
+     * @return an {@link Estimate} of the percentile
+     */
+    Estimate cumulativeProbability(double value, boolean inclusive);
+
+    /**
+     * Calculates the value which occurs at a particular percentile in the given
+     * distribution.
+     * <br>
+     * Put another way, calculates the inverse CDF. Given F(x) is the CDF of
+     * a particular distribution, this function computes F^(-1)(x).
+     *
+     * @param percentile the percentile. Must be in the range [0.0, 1.0]
+     * @return the value in the distribution corresponding to the percentile
+     */
+    Estimate inverseCumulativeProbability(double percentile);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.lang.Double.NaN;
 import static java.lang.Double.isInfinite;
@@ -84,6 +86,75 @@ public final class Estimate
     public double getValue()
     {
         return value;
+    }
+
+    /**
+     * If the estimate is not an unknown value, maps the current estimate using
+     * the given function.
+     *
+     * @param mapper mapping function
+     * @return a new estimate with the mapped value
+     */
+    public Estimate map(Function<Double, Double> mapper)
+    {
+        if (!isUnknown()) {
+            return Estimate.of(mapper.apply(value));
+        }
+        return this;
+    }
+
+    /**
+     * If the estimate is not unknown, maps the existing value where the mapping
+     * function should return a new estimate.
+     *
+     * @param mapper the mapping function
+     * @return a new estimate with the mapped value
+     */
+    public Estimate flatMap(Function<Double, Estimate> mapper)
+    {
+        if (!isUnknown()) {
+            return mapper.apply(value);
+        }
+        return this;
+    }
+
+    /**
+     * If the estimate is unknown, run another function to generate an estimate
+     *
+     * @param supplier function to supply a new estimate
+     * @return a new estimate
+     */
+    public Estimate or(Supplier<Estimate> supplier)
+    {
+        if (isUnknown()) {
+            return supplier.get();
+        }
+        return this;
+    }
+
+    /**
+     * If the estimate is unknown, run another function to generate an estimate
+     *
+     * @param supplier function to supply a new estimate
+     * @return a new estimate
+     */
+    public double orElse(Supplier<Double> supplier)
+    {
+        if (isUnknown()) {
+            return supplier.get();
+        }
+        return this.getValue();
+    }
+
+    public boolean fuzzyEquals(Estimate other, double tolerance)
+    {
+        if (equals(other)) {
+            return true;
+        }
+        if (isUnknown() || other.isUnknown()) {
+            return false;
+        }
+        return Math.copySign(value - other.value, 1.0) <= tolerance;
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -88,12 +88,12 @@ public class TestLocalQueries
         MaterializedResult result = computeActual("SHOW STATS FOR nation");
 
         MaterializedResult expectedStatistics =
-                resultBuilder(getSession(), VARCHAR, DOUBLE, DOUBLE, DOUBLE, DOUBLE, VARCHAR, VARCHAR)
-                        .row("nationkey", null, 25.0, 0.0, null, "0", "24")
-                        .row("name", 177.0, 25.0, 0.0, null, null, null)
-                        .row("regionkey", null, 5.0, 0.0, null, "0", "4")
-                        .row("comment", 1857.0, 25.0, 0.0, null, null, null)
-                        .row(null, null, null, null, 25.0, null, null)
+                resultBuilder(getSession(), VARCHAR, DOUBLE, DOUBLE, DOUBLE, DOUBLE, VARCHAR, VARCHAR, VARCHAR)
+                        .row("nationkey", null, 25.0, 0.0, null, "0", "24", null)
+                        .row("name", 177.0, 25.0, 0.0, null, null, null, null)
+                        .row("regionkey", null, 5.0, 0.0, null, "0", "4", null)
+                        .row("comment", 1857.0, 25.0, 0.0, null, null, null, null)
+                        .row(null, null, null, null, 25.0, null, null, null)
                         .build();
 
         assertEquals(result, expectedStatistics);


### PR DESCRIPTION
## Description

Closes #22042 

This commits provides two critical changes:

1. Adds a new enum value to ColumnStatisticType: Histogram.
2. Utilizes the new histograms in optimizer's cost calculations

## Histogram SPI Additions

With this change, a new column statistic type for histograms is introduced. In addition, a new SPI class `ConnectorHistogram` is also introduced. This interface is designed to be able to be implemented by either the connectors or in the main presto codebase. This should allow connectors to return histogram statistics in any format regardless of the source as long as they implement the interface.

The API is straightforward and includes 2 methods.

- cumulativeProbability(double value, boolean inclusive): -> CDF function
- inverseCumulativeProbability(double probability) -> inverse CDF function

A simple reference implementation is provided inside of
UniformDistributionHistogram. This implementation results in the same logic and same plans as the previous cost-based calculations. When the optimizer uses it, the calculations end up with the same number as prior to this PR, but now just utilizing the histogram API.

Additionally, to propagate statistics further up into a plan, another implementation of histograms is provided inside of DomainConstrainedHistogram. This class is used to bound a source histogram with a given domain as additional filters may be applied further up in the plan.

### Cost Calculations

Previously all cost calculations were performed inside of the ComparisonStatsCalculator using logic from the StatisticRange class to calculate the filter factors of overlapping and intersecting ranges. Instead, this change introduces cost calculation using the new histogram model and API. The core of the filter proportion calculation logic exists in the new HistogramCalculator utility class.

If the underlying Histogram implementation is swapped from the UniformDistributionHistogram, then the stats calculator will calculate the costs using the histogram information correctly.

If for some reason the new logic breaks existing plans for queries outside of the TPC-H/TPC-DS tests we have in the codebase, a new session flag `optimizer.use-histograms` is provided in order to fall back on the old logic.

### Testing

I verified through additional unit tests and the existing testing infrastructure that the implementation here results in the same cost and filter proportion calculations as the previous logic.

I also did a few small runs with TPC-DS SF1 on a real cluster with and without the cost calculations to verify there were no serious regressions

## Motivation and Context

By using histograms for cost calculations, we can get much more accurate predictions on how predicates will
affect the output of a node, potentially resulting in more cost-efficient plans.

## Impact

1. A new value in the `ColumnStatisticType` enum: `HISTOGRAM`
2. A new SPI interface to be implemented by connectors or inside `presto-main`: `ConnectorHistogram`

## Test Plan

1. Use existing test coverage to ensure no regressions
2. Extensive unit testing for corner cases without statistics (a majority of cases) to ensure no regressions

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add histogram column statistic to Presto for the optimizer. Connectors can now implement support for them.
```


