### PR TITLE
Correct Lead/Lag + Null Offset behavior in the doc

### DIFF
--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -190,16 +190,18 @@ null for all rows, the ``default_value`` is returned, or if it is not specified,
 
 .. function:: lead(x[, offset [, default_value]]) -> [same as input]
 
-    Returns the value at ``offset`` rows after the current row in the window.
+    Returns the value at ``offset`` rows after the current row in the window partition.
     Offsets start at ``0``, which is the current row. The
     offset can be any scalar expression. The default ``offset`` is ``1``. If the
-    offset is null or larger than the window, the ``default_value`` is returned,
-    or if it is not specified ``null`` is returned.
+    offset is null, null is returned. If the offset refers to a row that is not
+    within the partition, the ``default_value`` is returned, or if it is not specified
+    ``null`` is returned.
 
 .. function:: lag(x[, offset [, default_value]]) -> [same as input]
 
-    Returns the value at ``offset`` rows before the current row in the window
+    Returns the value at ``offset`` rows before the current row in the window partition.
     Offsets start at ``0``, which is the current row. The
     offset can be any scalar expression. The default ``offset`` is ``1``. If the
-    offset is null or larger than the window, the ``default_value`` is returned,
-    or if it is not specified ``null`` is returned.
+    offset is null, null is returned. If the offset refers to a row that is not
+    within the partition, the ``default_value`` is returned, or if it is not specified
+    ``null`` is returned.

--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -193,7 +193,7 @@ null for all rows, the ``default_value`` is returned, or if it is not specified,
     Returns the value at ``offset`` rows after the current row in the window partition.
     Offsets start at ``0``, which is the current row. The
     offset can be any scalar expression. The default ``offset`` is ``1``. If the
-    offset is null, null is returned. If the offset refers to a row that is not
+    offset is ``null``, ``null`` is returned. If the offset refers to a row that is not
     within the partition, the ``default_value`` is returned, or if it is not specified
     ``null`` is returned.
 
@@ -202,6 +202,6 @@ null for all rows, the ``default_value`` is returned, or if it is not specified,
     Returns the value at ``offset`` rows before the current row in the window partition.
     Offsets start at ``0``, which is the current row. The
     offset can be any scalar expression. The default ``offset`` is ``1``. If the
-    offset is null, null is returned. If the offset refers to a row that is not
+    offset is ``null``, ``null`` is returned. If the offset refers to a row that is not
     within the partition, the ``default_value`` is returned, or if it is not specified
     ``null`` is returned.


### PR DESCRIPTION
## Description

Describe Lead/Lag + Null Offset behavior more clearly: when the offset is null, return null(not default value).
Fixes #20835

## Motivation and Context
N/A

## Impact
N/A

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

