### PR TITLE
[native pos] Rely on Spark to decide if stage writes to a shuffle

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1240,6 +1240,30 @@ public abstract class AbstractTestNativeGeneralQueries
         }
     }
 
+    @Test
+    public void testUnionAllInsert()
+    {
+        String tableName = generateRandomTableName();
+        try {
+            String union = "SELECT orderkey * 2 orderkey " +
+                    "FROM ( " +
+                    "  SELECT orderkey " +
+                    "  FROM orders " +
+                    "  UNION ALL " +
+                    "  SELECT orderkey " +
+                    "  FROM orders " +
+                    ") " +
+                    "UNION ALL " +
+                    "SELECT orderkey " +
+                    "FROM orders";
+            getQueryRunner().execute(format("CREATE TABLE %s AS %s", tableName, union));
+            assertQuery(format("SELECT * FROM %s", tableName), union);
+        }
+        finally {
+            dropTableIfExists(tableName);
+        }
+    }
+
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkNativeExecutionShuffleManager.StageAndMapId;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionModule;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spi.security.PrincipalType;
@@ -170,10 +171,10 @@ public class PrestoSparkNativeQueryRunnerUtils
         assertNotNull(SparkEnv.get());
         assertTrue(SparkEnv.get().shuffleManager() instanceof PrestoSparkNativeExecutionShuffleManager);
         PrestoSparkNativeExecutionShuffleManager shuffleManager = (PrestoSparkNativeExecutionShuffleManager) SparkEnv.get().shuffleManager();
-        Set<Integer> partitions = shuffleManager.getAllPartitions();
+        Set<StageAndMapId> partitions = shuffleManager.getAllPartitions();
 
-        for (Integer partition : partitions) {
-            Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(partition);
+        for (StageAndMapId partition : partitions) {
+            Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(partition.getStageId(), partition.getMapId());
             assertTrue(shuffleHandle.isPresent());
             assertTrue(shuffleHandle.get() instanceof BypassMergeSortShuffleHandle);
         }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeAggregations.java
@@ -32,11 +32,4 @@ public class TestPrestoSparkNativeAggregations
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
@@ -32,11 +32,4 @@ public class TestPrestoSparkNativeArrayFunctionQueries
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeBitwiseFunctionQueries.java
@@ -32,11 +32,4 @@ public class TestPrestoSparkNativeBitwiseFunctionQueries
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -34,13 +34,6 @@ public class TestPrestoSparkNativeGeneralQueries
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
 
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
-
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeJoinQueries.java
@@ -34,13 +34,6 @@ public class TestPrestoSparkNativeJoinQueries
     }
 
     @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
-
-    @Override
     public Object[][] joinTypeProviderImpl()
     {
         return new Object[][] {{partitionedJoin()}};

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -76,13 +76,6 @@ public class TestPrestoSparkNativeSimpleQueries
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
 
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
-
     @Test
     public void testMapOnlyQueries()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -35,13 +35,6 @@ public class TestPrestoSparkNativeTpchConnectorQueries
     }
 
     @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
-
-    @Override
     public void testMissingTpchConnector()
     {
         super.testMissingTpchConnector(".*Catalog tpch does not exist*");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -34,13 +34,6 @@ public class TestPrestoSparkNativeTpchQueries
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
 
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
-
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     // Following tests require broadcast join
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeWindowQueries.java
@@ -32,11 +32,4 @@ public class TestPrestoSparkNativeWindowQueries
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    @Override
-    protected void assertQuery(String sql)
-    {
-        super.assertQuery(sql);
-        PrestoSparkNativeQueryRunnerUtils.assertShuffleMetadata();
-    }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -59,7 +59,6 @@ import com.facebook.presto.spark.util.PrestoSparkUtils;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.page.SerializedPage;
-import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.security.TokenAuthenticator;
@@ -287,11 +286,8 @@ public class PrestoSparkNativeTaskExecutorFactory
 
         boolean isFixedBroadcastDistribution = fragment.getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION);
         // 2.b Populate Shuffle Write info
-        Optional<PrestoSparkShuffleWriteInfo> shuffleWriteInfo = nativeInputs.getShuffleWriteDescriptor().isPresent()
-                && !findTableWriteNode(fragment.getRoot()).isPresent()
-                && !(fragment.getRoot() instanceof OutputNode)
-                && !isFixedBroadcastDistribution ?
-                Optional.of(shuffleInfoTranslator.createShuffleWriteInfo(session, nativeInputs.getShuffleWriteDescriptor().get())) : Optional.empty();
+        Optional<PrestoSparkShuffleWriteInfo> shuffleWriteInfo = nativeInputs.getShuffleWriteDescriptor()
+                .map(descriptor -> shuffleInfoTranslator.createShuffleWriteInfo(session, descriptor));
         Optional<String> serializedShuffleWriteInfo = shuffleWriteInfo.map(shuffleInfoTranslator::createSerializedWriteInfo);
 
         // 2.c populate broadcast path

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNativeTaskRdd.java
@@ -105,7 +105,7 @@ public class PrestoSparkNativeTaskRdd<T extends PrestoSparkTaskOutput>
         return getTaskProcessor().process(
                 taskSourceIterator,
                 getShuffleReadDescriptors(partitions),
-                getShuffleWriteDescriptor(split));
+                getShuffleWriteDescriptor(context.stageId(), split));
     }
 
     private PrestoSparkNativeTaskRdd(
@@ -158,14 +158,14 @@ public class PrestoSparkNativeTaskRdd<T extends PrestoSparkTaskOutput>
         return shuffleReadDescriptors.build();
     }
 
-    private Optional<PrestoSparkShuffleWriteDescriptor> getShuffleWriteDescriptor(Partition split)
+    private Optional<PrestoSparkShuffleWriteDescriptor> getShuffleWriteDescriptor(int stageId, Partition split)
     {
         // Get shuffle information from Spark shuffle manager for shuffle write
         checkState(
                 SparkEnv.get().shuffleManager() instanceof PrestoSparkNativeExecutionShuffleManager,
                 "Native execution requires to use PrestoSparkNativeExecutionShuffleManager. But got: %s", SparkEnv.get().shuffleManager().getClass().getName());
         PrestoSparkNativeExecutionShuffleManager shuffleManager = (PrestoSparkNativeExecutionShuffleManager) SparkEnv.get().shuffleManager();
-        Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(split.index());
+        Optional<ShuffleHandle> shuffleHandle = shuffleManager.getShuffleHandle(stageId, split.index());
 
         return shuffleHandle.map(handle -> new PrestoSparkShuffleWriteDescriptor(handle, shuffleManager.getNumOfPartitions(handle.shuffleId())));
     }


### PR DESCRIPTION
## Description

Only register shuffle handles for shuffle stages by including stage id into shuffle handle key

## Motivation and Context

Remove extra conditions that may not always be accurate. 

For example a table writer stage is not always guaranteed to be consumed by a stage running on coordinator, hence may require to write into shuffle.

The extra conditions were necessary as sometimes the `nativeInputs.getShuffleWriteDescriptor()` is available for non shuffle stages due to a problem in PrestoSparkNativeExecutionShuffleManager:

1. `ShuffleManager#getWriter` is correctly called by the Spark engine only for shuffle output stages
2. `partitionIdToShuffleHandle` uses mapId as a key
3. `PrestoSparkNativeExecutionShuffleManager#getShuffleHandle` is called for a different stage (non shuffle stage), but since the key only contains "mapId" the method may return a handle even for a stage consumed by the driver.

The idea is to extend the key to also include the stage id to resolve this issue. Once `nativeInputs.getShuffleWriteDescriptor()` correctly returns `Optional#empty()` for non shuffle stages the extra checks in PrestoSparkNativeTaskExecutorFactory can be removed.

## Impact

Shuffle is always accurately enabled for shuffle stages

## Test Plan

Existing integration tests + additional test to cover corner case when extra conditions result into an incorrect decision

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

