### PR TITLE
[native] Offload application work from io thread pool to cpu thread pool

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -31,6 +31,13 @@ static std::shared_ptr<folly::CPUThreadPoolExecutor>& executor() {
   return executor;
 }
 
+std::shared_ptr<folly::CPUThreadPoolExecutor>& httpProcessingExecutor() {
+  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
+      SystemConfig::instance()->numQueryThreads(),
+      std::make_shared<folly::NamedThreadFactory>("HttpProcessing"));
+  return executor;
+}
+
 std::shared_ptr<folly::IOThreadPoolExecutor> spillExecutor() {
   const int32_t numSpillThreads = SystemConfig::instance()->numSpillThreads();
   if (numSpillThreads <= 0) {
@@ -44,6 +51,10 @@ std::shared_ptr<folly::IOThreadPoolExecutor> spillExecutor() {
 
 folly::CPUThreadPoolExecutor* driverCPUExecutor() {
   return executor().get();
+}
+
+folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr() {
+  return httpProcessingExecutor().get();
 }
 
 folly::IOThreadPoolExecutor* spillExecutorPtr() {

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -25,6 +25,7 @@
 namespace facebook::presto {
 
 folly::CPUThreadPoolExecutor* driverCPUExecutor();
+folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr();
 folly::IOThreadPoolExecutor* spillExecutorPtr();
 
 class QueryContextCache {

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -179,6 +179,7 @@ class TaskManager {
   std::shared_ptr<velox::exec::OutputBufferManager> bufferManager_;
   folly::Synchronized<TaskMap> taskMap_;
   QueryContextManager queryContextManager_;
+  folly::Executor* httpProcessingExecutor_{httpProcessingExecutorPtr()};
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -139,14 +139,27 @@ proxygen::RequestHandler* TaskResource::abortResults(
       [this, taskId, destination](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
-          proxygen::ResponseHandler* downstream) {
-        try {
-          taskManager_.abortResults(taskId, destination);
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
-        http::sendOkResponse(downstream);
+          proxygen::ResponseHandler* downstream,
+          std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this, taskId, destination, handlerState]() {
+              taskManager_.abortResults(taskId, destination);
+              return true;
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenValue([downstream, handlerState](auto&& /* unused */) {
+              if (!handlerState->requestExpired()) {
+                http::sendOkResponse(downstream);
+              }
+            })
+            .thenError(
+                folly::tag_t<std::exception>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                });
       });
 }
 
@@ -161,17 +174,32 @@ proxygen::RequestHandler* TaskResource::acknowledgeResults(
       [this, taskId, bufferId, token](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
-          proxygen::ResponseHandler* downstream) {
-        try {
-          taskManager_.acknowledgeResults(taskId, bufferId, token);
-        } catch (const velox::VeloxException& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
-        http::sendOkResponse(downstream);
+          proxygen::ResponseHandler* downstream,
+          std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this, taskId, bufferId, token]() {
+              taskManager_.acknowledgeResults(taskId, bufferId, token);
+              return true;
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenValue([downstream, handlerState](auto&& /* unused */) {
+              if (!handlerState->requestExpired()) {
+                http::sendOkResponse(downstream);
+              }
+            })
+            .thenError(
+                folly::tag_t<velox::VeloxException>{},
+                [downstream](auto&& e) {
+                  http::sendErrorResponse(downstream, e.what());
+                })
+            .thenError(
+                folly::tag_t<std::exception>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                });
       });
 }
 
@@ -183,45 +211,61 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
         const std::string& updateJson,
         long startProcessCpuTime)>& createOrUpdateFunc) {
   protocol::TaskId taskId = pathMatch[1];
-
-  const auto startProcessCpuTime = PrestoTask::getProcessCpuTime();
-
   return new http::CallbackRequestHandler(
-      [this, taskId, createOrUpdateFunc, startProcessCpuTime](
+      [this, taskId, createOrUpdateFunc](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& body,
-          proxygen::ResponseHandler* downstream) {
-        // TODO Avoid copy
-        std::ostringstream oss;
-        for (auto& buf : body) {
-          oss << std::string((const char*)buf->data(), buf->length());
-        }
-        std::string updateJson = oss.str();
+          proxygen::ResponseHandler* downstream,
+          std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this, &body, taskId, createOrUpdateFunc]() {
+              const auto startProcessCpuTime = PrestoTask::getProcessCpuTime();
 
-        std::unique_ptr<protocol::TaskInfo> taskInfo;
-        try {
-          taskInfo =
-              createOrUpdateFunc(taskId, updateJson, startProcessCpuTime);
-        } catch (const velox::VeloxException& e) {
-          // Creating an empty task, putting errors inside so that next status
-          // fetch from coordinator will catch the error and well categorize it.
-          try {
-            taskInfo = taskManager_.createOrUpdateErrorTask(
-                taskId, std::current_exception(), startProcessCpuTime);
-          } catch (const velox::VeloxUserError& e) {
-            http::sendErrorResponse(downstream, e.what());
-            return;
-          } catch (const std::exception& e) {
-            http::sendErrorResponse(downstream, e.what());
-            return;
-          }
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
+              // TODO Avoid copy
+              std::ostringstream oss;
+              for (auto& buf : body) {
+                oss << std::string((const char*)buf->data(), buf->length());
+              }
+              std::string updateJson = oss.str();
 
-        json taskInfoJson = *taskInfo;
-        http::sendOkResponse(downstream, taskInfoJson);
+              std::unique_ptr<protocol::TaskInfo> taskInfo;
+              try {
+                taskInfo =
+                    createOrUpdateFunc(taskId, updateJson, startProcessCpuTime);
+              } catch (const velox::VeloxException& e) {
+                // Creating an empty task, putting errors inside so that next
+                // status fetch from coordinator will catch the error and well
+                // categorize it.
+                try {
+                  taskInfo = taskManager_.createOrUpdateErrorTask(
+                      taskId, std::current_exception(), startProcessCpuTime);
+                } catch (const velox::VeloxUserError& e) {
+                  throw;
+                }
+              }
+              return json(*taskInfo);
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenValue([downstream, handlerState](auto&& taskInfoJson) {
+              if (!handlerState->requestExpired()) {
+                http::sendOkResponse(downstream, taskInfoJson);
+              }
+            })
+            .thenError(
+                folly::tag_t<velox::VeloxException>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                })
+            .thenError(
+                folly::tag_t<std::exception>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                });
       });
 }
 
@@ -324,25 +368,38 @@ proxygen::RequestHandler* TaskResource::deleteTask(
       [this, taskId, abort](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
-          proxygen::ResponseHandler* downstream) {
-        std::unique_ptr<protocol::TaskInfo> taskInfo;
-        try {
-          taskInfo = taskManager_.deleteTask(taskId, abort);
-        } catch (const velox::VeloxException& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
-
-        if (!taskInfo) {
-          sendTaskNotFound(downstream, taskId);
-          return;
-        }
-
-        json taskInfoJson = *taskInfo;
-        http::sendOkResponse(downstream, taskInfoJson);
+          proxygen::ResponseHandler* downstream,
+          std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this, taskId, abort, downstream]() {
+              std::unique_ptr<protocol::TaskInfo> taskInfo;
+              taskInfo = taskManager_.deleteTask(taskId, abort);
+              return std::move(taskInfo);
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenValue([taskId, downstream, handlerState](auto&& taskInfo) {
+              if (!handlerState->requestExpired()) {
+                if (taskInfo == nullptr) {
+                  sendTaskNotFound(downstream, taskId);
+                }
+                http::sendOkResponse(downstream, json(*taskInfo));
+              }
+            })
+            .thenError(
+                folly::tag_t<velox::VeloxException>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                })
+            .thenError(
+                folly::tag_t<std::exception>{},
+                [downstream, handlerState](auto&& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                });
       });
 }
 
@@ -360,56 +417,71 @@ proxygen::RequestHandler* TaskResource::getResults(
           : protocol::PRESTO_MAX_SIZE_DEFAULT);
   auto maxWait = getMaxWait(message).value_or(
       protocol::Duration(protocol::PRESTO_MAX_WAIT_DEFAULT));
-
   return new http::CallbackRequestHandler(
       [this, taskId, bufferId, token, maxSize, maxWait](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
-        taskManager_
-            .getResults(taskId, bufferId, token, maxSize, maxWait, handlerState)
-            .via(folly::EventBaseManager::get()->getEventBase())
-            .thenValue([downstream, taskId, handlerState](
-                           std::unique_ptr<Result> result) {
-              if (handlerState->requestExpired()) {
-                return;
-              }
-              auto status = result->data && result->data->length() == 0
-                  ? http::kHttpNoContent
-                  : http::kHttpOk;
-              proxygen::ResponseBuilder(downstream)
-                  .status(status, "")
-                  .header(
-                      proxygen::HTTP_HEADER_CONTENT_TYPE,
-                      protocol::PRESTO_PAGES_MIME_TYPE)
-                  .header(protocol::PRESTO_TASK_INSTANCE_ID_HEADER, taskId)
-                  .header(
-                      protocol::PRESTO_PAGE_TOKEN_HEADER,
-                      std::to_string(result->sequence))
-                  .header(
-                      protocol::PRESTO_PAGE_NEXT_TOKEN_HEADER,
-                      std::to_string(result->nextSequence))
-                  .header(
-                      protocol::PRESTO_BUFFER_COMPLETE_HEADER,
-                      result->complete ? "true" : "false")
-                  .body(std::move(result->data))
-                  .sendWithEOM();
-            })
-            .thenError(
-                folly::tag_t<velox::VeloxException>{},
-                [downstream, handlerState](const velox::VeloxException& e) {
-                  if (!handlerState->requestExpired()) {
-                    http::sendErrorResponse(downstream, e.what());
-                  }
-                })
-            .thenError(
-                folly::tag_t<std::exception>{},
-                [downstream, handlerState](const std::exception& e) {
-                  if (!handlerState->requestExpired()) {
-                    http::sendErrorResponse(downstream, e.what());
-                  }
-                });
+        auto evb = folly::EventBaseManager::get()->getEventBase();
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this,
+             evb,
+             taskId,
+             bufferId,
+             token,
+             maxSize,
+             maxWait,
+             downstream,
+             handlerState]() {
+              taskManager_
+                  .getResults(
+                      taskId, bufferId, token, maxSize, maxWait, handlerState)
+                  .via(evb)
+                  .thenValue([downstream, taskId, handlerState](
+                                 std::unique_ptr<Result> result) {
+                    if (handlerState->requestExpired()) {
+                      return;
+                    }
+                    auto status = result->data && result->data->length() == 0
+                        ? http::kHttpNoContent
+                        : http::kHttpOk;
+                    proxygen::ResponseBuilder(downstream)
+                        .status(status, "")
+                        .header(
+                            proxygen::HTTP_HEADER_CONTENT_TYPE,
+                            protocol::PRESTO_PAGES_MIME_TYPE)
+                        .header(
+                            protocol::PRESTO_TASK_INSTANCE_ID_HEADER, taskId)
+                        .header(
+                            protocol::PRESTO_PAGE_TOKEN_HEADER,
+                            std::to_string(result->sequence))
+                        .header(
+                            protocol::PRESTO_PAGE_NEXT_TOKEN_HEADER,
+                            std::to_string(result->nextSequence))
+                        .header(
+                            protocol::PRESTO_BUFFER_COMPLETE_HEADER,
+                            result->complete ? "true" : "false")
+                        .body(std::move(result->data))
+                        .sendWithEOM();
+                  })
+                  .thenError(
+                      folly::tag_t<velox::VeloxException>{},
+                      [downstream,
+                       handlerState](const velox::VeloxException& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      })
+                  .thenError(
+                      folly::tag_t<std::exception>{},
+                      [downstream, handlerState](const std::exception& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      });
+            });
       });
 }
 
@@ -431,41 +503,55 @@ proxygen::RequestHandler* TaskResource::getTaskStatus(
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
-        try {
-          taskManager_
-              .getTaskStatus(taskId, currentState, maxWait, handlerState)
-              .via(folly::EventBaseManager::get()->getEventBase())
-              .thenValue([useThrift, downstream, taskId, handlerState](
-                             std::unique_ptr<protocol::TaskStatus> taskStatus) {
-                if (!handlerState->requestExpired()) {
-                  if (useThrift) {
-                    thrift::TaskStatus thriftTaskStatus;
-                    toThrift(*taskStatus, thriftTaskStatus);
-                    http::sendOkThriftResponse(
-                        downstream, thriftWrite(thriftTaskStatus));
-                  } else {
-                    json taskStatusJson = *taskStatus;
-                    http::sendOkResponse(downstream, taskStatusJson);
-                  }
-                }
-              })
-              .thenError(
-                  folly::tag_t<velox::VeloxException>{},
-                  [downstream, handlerState](const velox::VeloxException& e) {
-                    if (!handlerState->requestExpired()) {
-                      http::sendErrorResponse(downstream, e.what());
-                    }
-                  })
-              .thenError(
-                  folly::tag_t<std::exception>{},
-                  [downstream, handlerState](const std::exception& e) {
-                    if (!handlerState->requestExpired()) {
-                      http::sendErrorResponse(downstream, e.what());
-                    }
-                  });
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-        }
+        auto evb = folly::EventBaseManager::get()->getEventBase();
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this,
+             evb,
+             useThrift,
+             taskId,
+             currentState,
+             maxWait,
+             handlerState,
+             downstream]() {
+              taskManager_
+                  .getTaskStatus(taskId, currentState, maxWait, handlerState)
+                  .via(evb)
+                  .thenValue(
+                      [useThrift, downstream, taskId, handlerState](
+                          std::unique_ptr<protocol::TaskStatus> taskStatus) {
+                        if (!handlerState->requestExpired()) {
+                          if (useThrift) {
+                            thrift::TaskStatus thriftTaskStatus;
+                            toThrift(*taskStatus, thriftTaskStatus);
+                            http::sendOkThriftResponse(
+                                downstream, thriftWrite(thriftTaskStatus));
+                          } else {
+                            json taskStatusJson = *taskStatus;
+                            http::sendOkResponse(downstream, taskStatusJson);
+                          }
+                        }
+                      })
+                  .thenError(
+                      folly::tag_t<velox::VeloxException>{},
+                      [downstream,
+                       handlerState](const velox::VeloxException& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      })
+                  .thenError(
+                      folly::tag_t<std::exception>{},
+                      [downstream, handlerState](const std::exception& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      });
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenError(folly::tag_t<std::exception>{}, [downstream](auto&& e) {
+              http::sendErrorResponse(downstream, e.what());
+            });
       });
 }
 
@@ -483,36 +569,46 @@ proxygen::RequestHandler* TaskResource::getTaskInfo(
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
-        try {
-          taskManager_
-              .getTaskInfo(
-                  taskId, summarize, currentState, maxWait, handlerState)
-              .via(folly::EventBaseManager::get()->getEventBase())
-              .thenValue([downstream, taskId, handlerState](
-                             std::unique_ptr<protocol::TaskInfo> taskInfo) {
-                if (!handlerState->requestExpired()) {
-                  json taskInfoJson = *taskInfo;
-                  http::sendOkResponse(downstream, taskInfoJson);
-                }
-              })
-              .thenError(
-                  folly::tag_t<velox::VeloxException>{},
-                  [downstream, handlerState](const velox::VeloxException& e) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this,
+             evb = folly::EventBaseManager::get()->getEventBase(),
+             taskId,
+             currentState,
+             maxWait,
+             summarize,
+             handlerState,
+             downstream]() {
+              taskManager_
+                  .getTaskInfo(
+                      taskId, summarize, currentState, maxWait, handlerState)
+                  .via(evb)
+                  .thenValue([downstream, taskId, handlerState](
+                                 std::unique_ptr<protocol::TaskInfo> taskInfo) {
                     if (!handlerState->requestExpired()) {
-                      http::sendErrorResponse(downstream, e.what());
+                      json taskInfoJson = *taskInfo;
+                      http::sendOkResponse(downstream, taskInfoJson);
                     }
                   })
-              .thenError(
-                  folly::tag_t<std::exception>{},
-                  [downstream, handlerState](const std::exception& e) {
-                    if (!handlerState->requestExpired()) {
-                      http::sendErrorResponse(downstream, e.what());
-                    }
-                  });
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
+                  .thenError(
+                      folly::tag_t<velox::VeloxException>{},
+                      [downstream,
+                       handlerState](const velox::VeloxException& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      })
+                  .thenError(
+                      folly::tag_t<std::exception>{},
+                      [downstream, handlerState](const std::exception& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      });
+            })
+            .thenError(folly::tag_t<std::exception>{}, [downstream](auto&& e) {
+              http::sendErrorResponse(downstream, e.what());
+            });
       });
 }
 
@@ -526,17 +622,33 @@ proxygen::RequestHandler* TaskResource::removeRemoteSource(
       [this, taskId, remoteId](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
-          proxygen::ResponseHandler* downstream) {
-        try {
-          taskManager_.removeRemoteSource(taskId, remoteId);
-        } catch (const velox::VeloxException& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        } catch (const std::exception& e) {
-          http::sendErrorResponse(downstream, e.what());
-          return;
-        }
-        http::sendOkResponse(downstream);
+          proxygen::ResponseHandler* downstream,
+          std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
+        folly::via(
+            httpProcessingExecutorPtr(),
+            [this, taskId, remoteId, downstream]() {
+              taskManager_.removeRemoteSource(taskId, remoteId);
+            })
+            .via(folly::EventBaseManager::get()->getEventBase())
+            .thenValue([downstream, handlerState](auto&& /* unused */) {
+              if (!handlerState->requestExpired()) {
+                http::sendOkResponse(downstream);
+              }
+            })
+            .thenError(
+                folly::tag_t<velox::VeloxException>{},
+                [downstream, handlerState](const velox::VeloxException& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                })
+            .thenError(
+                folly::tag_t<std::exception>{},
+                [downstream, handlerState](const std::exception& e) {
+                  if (!handlerState->requestExpired()) {
+                    http::sendErrorResponse(downstream, e.what());
+                  }
+                });
       });
 }
 } // namespace facebook::presto


### PR DESCRIPTION
Currently http requests come and are directly handled by the request receiving thread in an io thread pool. This is dangerous because if the handling io thread's work is not light enough it will block other incoming requests and requests will pile up in io threads' queues, resulting in long response time and in the worst case unresponsive server. The adoption of HTTPS makes the situation even worse because unlike HTTP's connection establishment which happens in kernel threads, HTTPS's connection establishment requires more RTT and an application io thread to handle.

This PR offloads any operations unrelated to work dispatching and response returning to another cpu thread pool called HttpProcessingExecutor to release the possible jam that might happen in the request handling io thread pool. We don't offload it directly to driverCPUPool because we don't want big volume of requests interfere with the heavy processing driver threads.

```
== NO RELEASE NOTE ==
```

