### PR TITLE
Do not broadcast join if probe input is in single node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -296,6 +296,7 @@ public final class SystemSessionProperties
     public static final String ENABLE_HISTORY_BASED_SCALED_WRITER = "enable_history_based_scaled_writer";
     public static final String REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN = "remove_redundant_cast_to_varchar_in_join";
     public static final String HANDLE_COMPLEX_EQUI_JOINS = "handle_complex_equi_joins";
+    public static final String PARTITION_JOIN_IF_PROBE_IN_SINGLE_NODE = "partition_join_if_probe_in_single_node";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1781,6 +1782,11 @@ public final class SystemSessionProperties
                         HANDLE_COMPLEX_EQUI_JOINS,
                         "Handle complex equi-join conditions to open up join space for join reordering",
                         featuresConfig.getHandleComplexEquiJoins(),
+                        false),
+                booleanProperty(
+                        PARTITION_JOIN_IF_PROBE_IN_SINGLE_NODE,
+                        "If probe side is in single node, use partitioned join instead of broadcast join",
+                        featuresConfig.isPartitionJoinIfProbeInSingleNode(),
                         false));
     }
 
@@ -2969,5 +2975,10 @@ public final class SystemSessionProperties
     public static boolean shouldHandleComplexEquiJoins(Session session)
     {
         return session.getSystemProperty(HANDLE_COMPLEX_EQUI_JOINS, Boolean.class);
+    }
+
+    public static boolean usePartitionedJoinIfProbeInSingleNode(Session session)
+    {
+        return session.getSystemProperty(PARTITION_JOIN_IF_PROBE_IN_SINGLE_NODE, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -285,6 +285,7 @@ public class FeaturesConfig
     private boolean useHBOForScaledWriters;
 
     private boolean removeRedundantCastToVarcharInJoin = true;
+    private boolean partitionJoinIfProbeInSingleNode = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2843,6 +2844,19 @@ public class FeaturesConfig
     public FeaturesConfig setHandleComplexEquiJoins(boolean handleComplexEquiJoins)
     {
         this.handleComplexEquiJoins = handleComplexEquiJoins;
+        return this;
+    }
+
+    public boolean isPartitionJoinIfProbeInSingleNode()
+    {
+        return partitionJoinIfProbeInSingleNode;
+    }
+
+    @Config("optimizer.partition-join-if-probe-in-single-node")
+    @ConfigDescription("If probe side is in single node, use partitioned join instead of broadcast join")
+    public FeaturesConfig setPartitionJoinIfProbeInSingleNode(boolean partitionJoinIfProbeInSingleNode)
+    {
+        this.partitionJoinIfProbeInSingleNode = partitionJoinIfProbeInSingleNode;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -115,6 +115,7 @@ import static com.facebook.presto.SystemSessionProperties.isRedistributeWrites;
 import static com.facebook.presto.SystemSessionProperties.isScaleWriters;
 import static com.facebook.presto.SystemSessionProperties.isUseStreamingExchangeForMarkDistinctEnabled;
 import static com.facebook.presto.SystemSessionProperties.preferStreamingOperators;
+import static com.facebook.presto.SystemSessionProperties.usePartitionedJoinIfProbeInSingleNode;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.hasSingleNodeExecutionPreference;
 import static com.facebook.presto.spi.ConnectorId.isInternalSystemConnector;
@@ -818,6 +819,9 @@ public class AddExchanges
                 if (!node.getCriteria().isEmpty()
                         && isNodePartitionedOn(left.getProperties(), leftVariables) && !left.getProperties().isSingleNode()) {
                     return planPartitionedJoin(node, leftVariables, rightVariables, left);
+                }
+                else if (!node.getCriteria().isEmpty() && usePartitionedJoinIfProbeInSingleNode(session) && left.getProperties().isSingleNode()) {
+                    return planPartitionedJoin(node, leftVariables, rightVariables);
                 }
 
                 return planReplicatedJoin(node, left);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -249,6 +249,7 @@ public class TestFeaturesConfig
                 .setRewriteConstantArrayContainsToInEnabled(false)
                 .setUseHBOForScaledWriters(false)
                 .setRemoveRedundantCastToVarcharInJoin(true)
+                .setPartitionJoinIfProbeInSingleNode(true)
                 .setHandleComplexEquiJoins(false));
     }
 
@@ -446,6 +447,7 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-constant-array-contains-to-in", "true")
                 .put("optimizer.use-hbo-for-scaled-writers", "true")
                 .put("optimizer.remove-redundant-cast-to-varchar-in-join", "false")
+                .put("optimizer.partition-join-if-probe-in-single-node", "false")
                 .put("optimizer.handle-complex-equi-joins", "true")
                 .build();
 
@@ -641,6 +643,7 @@ public class TestFeaturesConfig
                 .setRewriteConstantArrayContainsToInEnabled(true)
                 .setUseHBOForScaledWriters(true)
                 .setRemoveRedundantCastToVarcharInJoin(false)
+                .setPartitionJoinIfProbeInSingleNode(false)
                 .setHandleComplexEquiJoins(true);
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
For a broadcast join, if the probe input is in single node after planning, switch to repartitioned join instead.

## Motivation and Context
This change is motivated by the query `select * from (select orderkey, partkey from lineitem union all select * from (values (1, 1)) t(orderkey, partkey)) l join orders o on l.orderkey=o.orderkey` when the join is broadcast join.
The result plan will be:
```
presto:tpch> explain (type distributed) select * from (select orderkey, partkey from lineitem union all select * from (values (1, 1)) t(orderkey, partkey)) l join orders o on l.orderkey=o.orderkey;
                                                                                                                                                                                                                   >
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                               >
     Output layout: [orderkey_16, partkey_17, orderkey_16, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment_23]                                                            >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Output[PlanNodeId 21][orderkey, partkey, orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment] => [orderkey_16:bigint, partkey_17:bigint, orderkey_16:bigint, >
             Estimates: {source: CostBasedSourceInfo, rows: 58491 (8.25MB), cpu: 34782618.67, memory: 8334208.00, network: 3708277.00}                                                                             >
             orderkey := orderkey_16 (1:28)                                                                                                                                                                        >
             partkey := partkey_17 (1:28)                                                                                                                                                                          >
             orderkey := orderkey_16 (1:28)                                                                                                                                                                        >
             comment := comment_23 (1:28)                                                                                                                                                                          >
         - InnerJoin[PlanNodeId 16][("orderkey_16" = "orderkey_22")][$hashvalue, $hashvalue_78] => [orderkey_16:bigint, partkey_17:bigint, custkey:bigint, orderstatus:varchar(1), totalprice:double, orderdate:dat>
                 Estimates: {source: CostBasedSourceInfo, rows: 58491 (8.25MB), cpu: 34782618.67, memory: 8334208.00, network: 3708277.00}                                                                         >
                 Distribution: REPLICATED                                                                                                                                                                          >
             - LocalExchange[PlanNodeId 505][ROUND_ROBIN] () => [orderkey_16:bigint, partkey_17:bigint, $hashvalue:bigint]                                                                                         >
                     Estimates: {source: CostBasedSourceInfo, rows: 60176 (15.78MB), cpu: 4332682.00, memory: 0.00, network: 1624725.00}                                                                           >
                 - Project[PlanNodeId 547][projectLocality = LOCAL] => [expr_14:bigint, expr_15:bigint, $hashvalue_75:bigint]                                                                                      >
                         Estimates: {source: CostBasedSourceInfo, rows: 1 (275B), cpu: 55.00, memory: 0.00, network: 0.00}                                                                                         >
                         $hashvalue_75 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(expr_14), BIGINT'0')) (1:108)                                                                                       >
                     - Project[PlanNodeId 9][projectLocality = LOCAL] => [expr_14:bigint, expr_15:bigint]                                                                                                          >
                             Estimates: {source: CostBasedSourceInfo, rows: 1 (275B), cpu: 28.00, memory: 0.00, network: 0.00}                                                                                     >
                             expr_14 := CAST(field AS bigint) (1:108)                                                                                                                                              >
                             expr_15 := CAST(field_4 AS bigint) (1:108)                                                                                                                                            >
                         - LocalExchange[PlanNodeId 504][ROUND_ROBIN] () => [field:integer, field_4:integer]                                                                                                       >
                                 Estimates: {source: CostBasedSourceInfo, rows: 1 (275B), cpu: 10.00, memory: 0.00, network: 0.00}                                                                                 >
                             - Values[PlanNodeId 3] => [field:integer, field_4:integer]                                                                                                                            >
                                     Estimates: {source: CostBasedSourceInfo, rows: 1 (275B), cpu: 0.00, memory: 0.00, network: 0.00}                                                                              >
                                     (INTEGER'1', INTEGER'1')                                                                                                                                                      >
                 - RemoteSource[1] => [orderkey:bigint, partkey:bigint, $hashvalue_76:bigint]                                                                                                                      >
             - LocalExchange[PlanNodeId 506][HASH][$hashvalue_78] (orderkey_22) => [orderkey_22:bigint, custkey:bigint, orderstatus:varchar(1), totalprice:double, orderdate:date, orderpriority:varchar(15), clerk>
                     Estimates: {source: CostBasedSourceInfo, rows: 15000 (2.12MB), cpu: 6115656.00, memory: 0.00, network: 2083552.00}                                                                            >
                 - RemoteSource[2] => [orderkey_22:bigint, custkey:bigint, orderstatus:varchar(1), totalprice:double, orderdate:date, orderpriority:varchar(15), clerk:varchar(15), shippriority:integer, comment_2>
                                                                                                                                                                                                                   >
 Fragment 1 [SOURCE]                                                                                                                                                                                               >
     Output layout: [orderkey, partkey, $hashvalue_77]                                                                                                                                                             >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - ScanProject[PlanNodeId 0,548][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.>
             Estimates: {source: CostBasedSourceInfo, rows: 60175 (1.55MB), cpu: 1083150.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 60175 (1.55MB), cpu: 2707875.00, memory: 0.00, networ>
             $hashvalue_77 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey), BIGINT'0')) (1:50)                                                                                                   >
             LAYOUT: tpch.lineitem{}                                                                                                                                                                               >
             orderkey := orderkey:bigint:0:REGULAR (1:73)                                                                                                                                                          >
             partkey := partkey:bigint:1:REGULAR (1:73)                                                                                                                                                            >
                                                                                                                                                                                                                   >
 Fragment 2 [SOURCE]                                                                                                                                                                                               >
     Output layout: [orderkey_22, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment_23, $hashvalue_80]                                                                      >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - ScanProject[PlanNodeId 13,549][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.o>
             Estimates: {source: CostBasedSourceInfo, rows: 15000 (1.99MB), cpu: 1948552.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 15000 (1.99MB), cpu: 4032104.00, memory: 0.00, networ>
             $hashvalue_80 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(orderkey_22), BIGINT'0')) (1:151)                                                                                               >
             LAYOUT: tpch.orders{}                                                                                                                                                                                 >
             orderpriority := orderpriority:varchar(15):5:REGULAR (1:151)                                                                                                                                          >
             orderstatus := orderstatus:varchar(1):2:REGULAR (1:151)                                                                                                                                               >
             orderdate := orderdate:date:4:REGULAR (1:151)                                                                                                                                                         >
             custkey := custkey:bigint:1:REGULAR (1:151)                                                                                                                                                           >
             comment_23 := comment:varchar(79):8:REGULAR (1:151)                                                                                                                                                   >
             clerk := clerk:varchar(15):6:REGULAR (1:151)                                                                                                                                                          >
             totalprice := totalprice:double:3:REGULAR (1:151)                                                                                                                                                     >
             orderkey_22 := orderkey:bigint:0:REGULAR (1:151)                                                                                                                                                      >
             shippriority := shippriority:int:7:REGULAR (1:151)                                                                                                                                                    >
                                                                                                                                                                                                                   >
                                                                                                                                                                                                                   >
(1 row)

```
The join will be executed in one single node, which can be slow. This is because the probe side input is single node.

In this case, we'd rather do partitioned join instead of broadcast join.

## Impact
Queries will be faster.

## Test Plan
Add unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an option to do partitioned join when broadcast join will be run in single node. It's controlled by session property `partition_join_if_probe_in_single_node` and default to true
```

