### PR TITLE
Convert values node followed by false filter to empty values node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -402,6 +402,12 @@ public class PlanOptimizers
                                 new ImplementBernoulliSampleAsFilter(metadata.getFunctionAndTypeManager()),
                                 new ImplementOffset(metadata.getFunctionAndTypeManager()))),
                 simplifyRowExpressionOptimizer,
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new RemoveTrivialFilters())),
                 new UnaliasSymbolReferences(metadata.getFunctionAndTypeManager()),
                 new IterativeOptimizer(
                         metadata,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1255,7 +1255,7 @@ public class TestLogicalPlanner
         assertPlanWithSession(
                 "SELECT C, orderkey FROM (select orderkey as C from orders where 1=0) join orders on 1=1",
                 disableEmptyJoinOptimization, true,
-                output(node(JoinNode.class, values("orderkey_0"), values("orderkey_3"))));
+                output(node(JoinNode.class, values("orders"), anyTree(tableScan("orders")))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Run `RemoveTrivialFilters` after  `simplifyRowExpressionOptimizer`, so that queries like `select * from (values 1, 2) t(k) where 1=0` will be simplified as empty values node.

## Motivation and Context
Values node followed by false filter is not optimized:
```
presto:tpch> explain (type distributed) select * from (values 1, 2) t(k) where 1=0;
                                                       Query Plan                                                        
-------------------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]                                                                                                     
     Output layout: [field]                                                                                              
     Output partitioning: SINGLE []                                                                                      
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                       
     - Output[PlanNodeId 9][k] => [field:integer]                                                                        
             Estimates: {source: CostBasedSourceInfo, rows: 0 (0B), cpu: 20.00, memory: 0.00, network: 0.00}             
             k := field (1:28)                                                                                           
         - Filter[PlanNodeId 4][filterPredicate = BOOLEAN'false'] => [field:integer]                                     
                 Estimates: {source: CostBasedSourceInfo, rows: 0 (0B), cpu: 20.00, memory: 0.00, network: 0.00}         
             - LocalExchange[PlanNodeId 184][ROUND_ROBIN] () => [field:integer]                                          
                     Estimates: {source: CostBasedSourceInfo, rows: 2 (10B), cpu: 10.00, memory: 0.00, network: 0.00}    
                 - Values[PlanNodeId 0] => [field:integer]                                                               
                         Estimates: {source: CostBasedSourceInfo, rows: 2 (10B), cpu: 0.00, memory: 0.00, network: 0.00} 
                         (INTEGER'1')                                                                                    
                         (INTEGER'2')                                                                                    
                                                                                                                         
                                                                                                                         
(1 row)
```
With the change here:
```
presto:tpch> explain (type distributed) select * from (values 1, 2) t(k) where 1=0;
                                                   Query Plan                                                   
----------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]                                                                                            
     Output layout: [field_1]                                                                                   
     Output partitioning: SINGLE []                                                                             
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                              
     - Output[PlanNodeId 9][k] => [field_1:integer]                                                             
             Estimates: {source: CostBasedSourceInfo, rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00}     
             k := field_1 (1:28)                                                                                
         - Values[PlanNodeId 83] => [field_1:integer]                                                           
                 Estimates: {source: CostBasedSourceInfo, rows: 0 (0B), cpu: 0.00, memory: 0.00, network: 0.00} 
                                                                                                                
                                                                                                                
(1 row)
```
The following `SimplifyPlanWithEmptyInput` can further simplify the empty value nodes.

## Impact
Better performance

## Test Plan
Easy change

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Enable optimization of values node followed by false filter to empty values node
```


