### PR TITLE
Increase timeout when starting test query runner

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -318,7 +318,7 @@ public class DistributedQueryRunner
 
         long start = nanoTime();
         while (!allNodesGloballyVisible()) {
-            Assertions.assertLessThan(nanosSince(start), new Duration(30, SECONDS));
+            Assertions.assertLessThan(nanosSince(start), new Duration(60, SECONDS));
             MILLISECONDS.sleep(10);
         }
         log.info("Announced servers in %s", nanosSince(start).convertToMostSuccinctTimeUnit());


### PR DESCRIPTION
## Description
Increase timeout when starting test query runner to 60 seconds as in some testing environments query runner takes a longer time to start up. 

## Impact
N/A

## Test Plan
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```

