### PR TITLE
Avoid computation of output size if underlying stats are not confident

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoricalPlanStatisticsUtil.java
@@ -40,7 +40,10 @@ public class HistoricalPlanStatisticsUtil
         if (lastRunsStatistics.isEmpty()) {
             return PlanStatistics.empty();
         }
-
+        if (inputTableStatistics.stream().anyMatch(stat -> stat.getRowCount().isUnknown())) {
+            // return most recent run stats if input table stats were not found
+            return lastRunsStatistics.get(lastRunsStatistics.size() - 1).getPlanStatistics();
+        }
         Optional<Integer> similarStatsIndex = getSimilarStatsIndex(historicalPlanStatistics, inputTableStatistics, historyMatchingThreshold);
 
         if (similarStatsIndex.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -160,6 +160,10 @@ public class PlanNodeStatsEstimate
         if (!sourceInfo.estimateSizeUsingVariables() && !isNaN(totalSize)) {
             return totalSize;
         }
+        if (!isConfident()) {
+            // If we are not confident ( Non hbo stats + no row count info available) then we should not compute the output size
+            return NaN;
+        }
 
         return getOutputSizeForVariables(planNode.getOutputVariables());
     }

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
@@ -59,6 +59,10 @@ public class TableScanStatsRule
         Constraint<ColumnHandle> constraint = new Constraint<>(node.getCurrentConstraint());
 
         TableStatistics tableStatistics = metadata.getTableStatistics(session, node.getTable(), ImmutableList.copyOf(node.getAssignments().values()), constraint);
+        if (tableStatistics.getRowCount().isUnknown()) {
+            // Since we do not have any hms statistics, we should not be confident
+            return Optional.of(PlanNodeStatsEstimate.unknown());
+        }
         Map<VariableReferenceExpression, VariableStatsEstimate> outputVariableStats = new HashMap<>();
 
         for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : node.getAssignments().entrySet()) {

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -756,6 +756,7 @@ public class TestCostCalculator
                             .setAverageRowSize(AVERAGE_ROW_SIZE)
                             .build());
         }
+        builder.setConfident(true);
         return builder.build();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -107,7 +107,16 @@ public class RuleAssert
 
     public RuleAssert overrideStats(String nodeId, PlanNodeStatsEstimate nodeStats)
     {
-        statsCalculator.setNodeStats(new PlanNodeId(nodeId), nodeStats);
+        // For testing all stats are confident
+        return overrideStats(nodeId, nodeStats, true);
+    }
+
+    public RuleAssert overrideStats(String nodeId, PlanNodeStatsEstimate nodeStats, boolean confidence)
+    {
+        PlanNodeStatsEstimate statsWithConfidence = new PlanNodeStatsEstimate(nodeStats.getOutputRowCount(),
+                nodeStats.getTotalSize(), confidence,
+                nodeStats.getVariableStatistics(), nodeStats.getJoinNodeStatsEstimate(), nodeStats.getTableWriterNodeStatsEstimate());
+        statsCalculator.setNodeStats(new PlanNodeId(nodeId), statsWithConfidence);
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -67,7 +67,7 @@ public class TestGraphvizPrinter
             TupleDomain.all(),
             TupleDomain.all());
     private static final String TEST_TABLE_SCAN_NODE_INNER_OUTPUT = format(
-            "label=\"{TableScan | [TableHandle \\{connectorId='%s', connectorHandle='%s', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+            "label=\"{TableScan | [TableHandle \\{connectorId='%s', connectorHandle='%s', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                     "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue",
             TEST_CONNECTOR_ID,
             TEST_CONNECTOR_TABLE_HANDLE);
@@ -133,12 +133,12 @@ public class TestGraphvizPrinter
         String expected = "digraph distributed_plan {\n" +
                 "subgraph cluster_0 {\n" +
                 "label = \"SOURCE\"\n" +
-                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                 "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
                 "}\n" +
                 "subgraph cluster_1 {\n" +
                 "label = \"SOURCE\"\n" +
-                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "plannode_1[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                 "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
                 "}\n" +
                 "}\n";
@@ -175,11 +175,11 @@ public class TestGraphvizPrinter
         String expected = "digraph logical_plan {\n" +
                 "subgraph cluster_0 {\n" +
                 "label = \"SOURCE\"\n" +
-                "plannode_1[label=\"{CrossJoin[REPLICATED]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "plannode_1[label=\"{CrossJoin[REPLICATED]|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                 "}\", style=\"rounded, filled\", shape=record, fillcolor=orange];\n" +
-                "plannode_2[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "plannode_2[label=\"{TableScan | [TableHandle \\{connectorId='connector_id', connectorHandle='com.facebook.presto.testing.TestingMetadata$TestingTableHandle@1af56f7', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                 "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
-                "plannode_3[label=\"{Values|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
+                "plannode_3[label=\"{Values|Estimates: \\{rows: ? (?), cpu: ?, memory: ?, network: ?\\}\n" +
                 "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue];\n" +
                 "}\n" +
                 "plannode_1 -> plannode_3 [label = \"Build\"];\n" + //valuesNode should be the Build side


### PR DESCRIPTION
Summary: Current stats framework expects all tables to have stats. It might not be true and if there are no stats, we should not calcuate some random output size estimation which is used in cost based rules like DetermineJoinDistributionType and Reorder Joins.
 This change propagates the confidence as is downstream but we can change rules later to tailor confidence propagation downstream.

Test Plan:
Existing unit tests +
Shadow test 

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fixes output size estimation for plans with Empty table statistics 

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

