### PR TITLE
Enable timestamp type for SHOW STATS command

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.Metadata;
@@ -74,8 +75,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.SqlTimestamp.MICROSECONDS_PER_MILLISECOND;
 import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.QueryUtil.aliased;
 import static com.facebook.presto.sql.QueryUtil.selectAll;
@@ -88,6 +91,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.Math.round;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class ShowStatsRewrite
         implements StatementRewrite.Rewrite
@@ -336,12 +340,12 @@ public class ShowStatsRewrite
             return new DoubleLiteral(Double.toString(estimate.getValue()));
         }
 
-        private static Expression toStringLiteral(Type type, Optional<Double> optionalValue)
+        private Expression toStringLiteral(Type type, Optional<Double> optionalValue)
         {
             return optionalValue.map(value -> toStringLiteral(type, value)).orElse(NULL_VARCHAR);
         }
 
-        private static Expression toStringLiteral(Type type, double value)
+        private Expression toStringLiteral(Type type, double value)
         {
             if (type.equals(BigintType.BIGINT) || type.equals(IntegerType.INTEGER) || type.equals(SmallintType.SMALLINT) || type.equals(TinyintType.TINYINT)) {
                 return new StringLiteral(Long.toString(round(value)));
@@ -354,6 +358,9 @@ public class ShowStatsRewrite
             }
             if (type.equals(DATE)) {
                 return new StringLiteral(LocalDate.ofEpochDay(round(value)).toString());
+            }
+            if (type.equals(TIMESTAMP)) {
+                return new StringLiteral(new SqlTimestamp(round(value) / MICROSECONDS_PER_MILLISECOND, session.getSqlFunctionProperties().getTimeZoneKey(), MILLISECONDS).toString());
             }
             throw new IllegalArgumentException("Unexpected type: " + type);
         }


### PR DESCRIPTION
## Description
Presto issue https://github.com/prestodb/presto/issues/20929

## Motivation and Context
-Display min/max statistics for timestamp column in iceberg tables. 
-SHOW STATS will use time zone from user session's property. 
-Before fix, SHOW STATS would return error `Unexpected type: timestamp`

Note : Hive table will need additional support for min/max on timestamp column.

## Impact
Fixed  error "Unexpected type: timestamp" 

## Test Plan
- New test case in IcebergDistributedSmokeTestBase.java
- manual test 
```
CREATE TABLE timestamp_test (  "t" timestamp  ) WITH (   format = 'PARQUET'  ) ;
INSERT INTO timestamp_test values(TIMESTAMP '2001-08-22 03:04:05.321’);
INSERT INTO timestamp_test values(TIMESTAMP '2023-08-22 09:14:25.456');

presto:test> SHOW STATS FOR timestamp_test;
 column_name | data_size | distinct_values_count | nulls_fraction | row_count |        low_value        |       high_value        
-------------+-----------+-----------------------+----------------+-----------+-------------------------+-------------------------
 t           |     112.0 | NULL                  |            0.0 | NULL      | 2001-08-22 03:04:05.321 | 2023-08-22 09:14:25.456 
 NULL        | NULL      | NULL                  | NULL           |       2.0 | NULL                    | NULL                    
(2 rows)
```



## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
* SHOW STATS command will support timestamp column based on user session's time zone 


```

