### PR TITLE
[native] Fix result for empty global grouping sets

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -147,12 +147,12 @@ public abstract class AbstractTestNativeAggregations
         // Returns a single row with the global aggregation. There are no rows for the orderkey group.
         assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((orderkey), ())");
 
-        // This is a shorthand for the above query. It returns a single row with the global aggregation.
+        // This is a shorthand for the above query. Returns a single row with the global aggregation.
         assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
 
         assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
 
-        // The following return a single row with NULL orderkey.
+        // Returns a single row with NULL orderkey.
         assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
 
         assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -136,6 +136,29 @@ public abstract class AbstractTestNativeAggregations
     }
 
     @Test
+    public void testEmptyGroupingSets()
+    {
+        // Returns  a single row with the global aggregation.
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS (())");
+
+        // Returns 2 rows with global aggregation for the global grouping sets.
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((), ())");
+
+        // Returns a single row with the global aggregation. There are no rows for the orderkey group.
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((orderkey), ())");
+
+        // This is a shorthand for the above query. It returns a single row with the global aggregation.
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
+
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
+
+        // The following return a single row with NULL orderkey.
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
+
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
+    }
+
+    @Test
     public void testStreamingAggregation()
     {
         assertQuery("SELECT name, (SELECT max(name) FROM region WHERE regionkey = nation.regionkey AND length(name) > length(nation.name)) FROM nation");


### PR DESCRIPTION
## Description
Empty global grouping sets return a row with the default global aggregation result.

This is implemented using special metadata in the AggregationNode. 
Use these new fields recently added to Velox in
 https://github.com/facebookincubator/velox/pull/7112.


## Motivation and Context
Fixes incorrect results for global grouping sets on empty input

 `SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)`

returned 0 rows before. Now it returns a single row with a null orderkey

Fixes https://github.com/prestodb/presto/issues/20911


```
== NO RELEASE NOTE ==
```

