### PR TITLE
Disallow dropping partition column in Iceberg table explicitly

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -218,6 +218,23 @@ public class IcebergDistributedTestBase
     }
 
     @Test
+    public void testDropPartitionColumn()
+    {
+        assertQuerySucceeds("create table test_drop_partition_column(a int, b varchar) with (partitioning = ARRAY['a'])");
+        assertQuerySucceeds("insert into test_drop_partition_column values(1, '1001'), (2, '1002'), (3, '1003')");
+        String errorMessage = "This connector does not support dropping columns which exist in any of the table's partition specs";
+        assertQueryFails("alter table test_drop_partition_column drop column a", errorMessage);
+        assertQuerySucceeds("DROP TABLE test_drop_partition_column");
+
+        assertQuerySucceeds("create table test_drop_partition_column(a int)");
+        assertQuerySucceeds("insert into test_drop_partition_column values 1, 2, 3");
+        assertQuerySucceeds("alter table test_drop_partition_column add column b varchar with (partitioning = 'identity')");
+        assertQuerySucceeds("insert into test_drop_partition_column values(4, '1004'), (5, '1005')");
+        assertQueryFails("alter table test_drop_partition_column drop column b", errorMessage);
+        assertQuerySucceeds("DROP TABLE test_drop_partition_column");
+    }
+
+    @Test
     public void testTruncate()
     {
         // Test truncate empty table


### PR DESCRIPTION
## Description

When we try to drop a partition column in Iceberg table, we should firstly remove it from the partition spec, then drop the column in table schema. But currently Iceberg have some problems in this scenario, see issue https://github.com/apache/iceberg/issues/4563. This PR explicitly disallow drop partition column until Iceberg fixed it.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
